### PR TITLE
add deterministic simulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8299,6 +8299,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sockudo-simulator"
+version = "4.7.0"
+dependencies = [
+ "bytes",
+ "clap",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "sockudo-core",
+ "sockudo-protocol",
+ "sonic-rs",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "sockudo-webhook"
 version = "4.7.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,14 +103,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
 dependencies = [
  "cssparser",
  "html5ever",
  "maplit",
- "tendril",
  "url",
 ]
 
@@ -231,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -246,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -626,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -637,14 +636,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "1.128.0"
+version = "1.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77979423208542b4bc85901eceb2757b5cffe976ecd38a863b87eae6bce35cb"
+checksum = "33489208bd2568aa0189cdb640343d56d6bc7fd5ba01b9e1e34d4c2a4a2bda6d"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1402,9 +1402,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-unit"
-version = "5.2.3"
+version = "5.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bcaa4a0975bed4a760af3efe4368825098ce5f9d37a30c5a021d635dc63d8f"
+checksum = "4a813de7f2bbedb7dce265b64f1cf5908ebe4d56281ece8d847e98113788b9b0"
 dependencies = [
  "rust_decimal",
  "schemars 1.2.1",
@@ -1535,9 +1535,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -2133,9 +2133,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossfire"
-version = "3.1.16"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8c4de3db833e7ef74050bae09d5f3fa8f9d1507d3c2689c6e8c50b71208b18"
+checksum = "df981decccf9b846c396ae513b3d2c6a1770d9593c8e47853d8fdb336c7bcb46"
 dependencies = [
  "crossbeam-utils",
  "embed-collections",
@@ -2185,25 +2185,13 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
- "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.3",
  "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -2725,9 +2713,9 @@ dependencies = [
 
 [[package]]
 name = "embed-collections"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9ac53891f56267deec18b66e7775be60318278a33217268bd42bfe9ef48eb8"
+checksum = "f49c327886cdc0e7eda24cd0827f195db19a5f941425914bc6db76c79c64bc21"
 
 [[package]]
 name = "endian-type"
@@ -2764,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -2774,9 +2762,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3115,16 +3103,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
 
 [[package]]
 name = "futures"
@@ -3894,13 +3872,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
- "match_token",
 ]
 
 [[package]]
@@ -3984,9 +3961,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -4389,9 +4366,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+checksum = "9080b15e63775b9a2ac7dca720f7050a8b955e092ea0f6020a4a80f69998cdc0"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -4472,9 +4449,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -4486,9 +4463,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4581,9 +4558,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4787,12 +4764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "macro_rules_attribute"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4816,24 +4787,13 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -5497,9 +5457,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -5744,43 +5704,23 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -5790,20 +5730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "phf_shared",
 ]
 
 [[package]]
@@ -5812,21 +5739,12 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
  "unicase",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -6333,9 +6251,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.23"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3db184a8b66cfe87f0263a1de147a6b554c864d1767c6f7fa4eb0e5497b565"
+checksum = "b9c6658afe513a3b484e3abfdaa0d03ef3c0bbf017542c178dd55f94eb3051f9"
 dependencies = [
  "ahash 0.8.12",
  "equivalent",
@@ -6564,9 +6482,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
 dependencies = [
  "rustversion",
 ]
@@ -6668,9 +6586,9 @@ checksum = "bbc4a4ea2a66a41a1152c4b3d86e8954dc087bdf33af35446e6e176db4e73c8c"
 
 [[package]]
 name = "redis"
-version = "1.2.4"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae41a63fd0b8a5372f82b21e810e09a316f5dd7efd96bf08e678fb240fc1918"
+checksum = "2fa6f8e4b491d7a8ef3a9550a4d71969bd0064f46e32b8dbbcc7fc60dad94fed"
 dependencies = [
  "arc-swap",
  "arcstr",
@@ -7268,9 +7186,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -8648,25 +8566,24 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.11.3",
+ "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -8814,7 +8731,7 @@ dependencies = [
  "parking_lot",
  "path-clean",
  "pbkdf2",
- "phf 0.13.1",
+ "phf",
  "pin-project-lite",
  "quick_cache",
  "radix_trie 0.3.0",
@@ -9061,12 +8978,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
- "futf",
- "mac",
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -9163,9 +9079,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -9183,9 +9099,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -9845,9 +9761,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -9923,9 +9839,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9937,9 +9853,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9947,9 +9863,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9957,9 +9873,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9970,9 +9886,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -10020,9 +9936,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10040,11 +9956,11 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
- "phf 0.11.3",
+ "phf",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -10577,9 +10493,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yasna"
@@ -10696,9 +10612,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/sockudo-ai-transport",
   "crates/sockudo-adapter",
   "crates/sockudo-server",
+  "crates/sockudo-simulator",
   "benches/ai",
 ]
 exclude = [

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ COMPOSE_FILE ?= docker-compose.yml
 COMPOSE_DASHBOARD ?= docker-compose.dashboard.yml
 PROJECT_NAME ?= sockudo
 
+# Deterministic simulator defaults. Override on the command line, e.g.
+# `make simulator SIM_SEED=42 SIM_TICKS=10000`.
+SIM_SEED ?= 12648430
+SIM_TICKS ?= 5000
+SIM_ARGS ?=
+
 # Compose file set per environment (dashboard included for dev/prod)
 ifeq ($(ENV),dev)
 COMPOSE_ARGS := -f $(COMPOSE_FILE) -f docker-compose.dev.yml -f $(COMPOSE_DASHBOARD)
@@ -175,6 +181,11 @@ test: ## Run basic connectivity tests
 	@curl -f http://localhost:3460/health || echo "$(RED)Dashboard API test failed$(RESET)"
 	@echo "$(YELLOW)Testing dashboard UI...$(RESET)"
 	@curl -f http://localhost:5174/ || echo "$(RED)Dashboard UI test failed$(RESET)"
+
+.PHONY: simulator
+simulator: ## Run deterministic indestructibility simulator (override SIM_SEED/SIM_TICKS/SIM_ARGS)
+	@echo "$(BLUE)Running Sockudo deterministic simulator seed=$(SIM_SEED) ticks=$(SIM_TICKS)...$(RESET)"
+	@cargo run -p sockudo-simulator --bin sockudo-sim -- --seed $(SIM_SEED) --ticks $(SIM_TICKS) $(SIM_ARGS)
 
 .PHONY: sentinel-tls-up
 sentinel-tls-up: ## Start the opt-in Redis Sentinel + TLS test fixture

--- a/crates/sockudo-simulator/Cargo.toml
+++ b/crates/sockudo-simulator/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "sockudo-simulator"
+description = "Deterministic workload simulator for Sockudo durable realtime invariants"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license-file.workspace = true
+publish = false
+
+[[bin]]
+name = "sockudo-sim"
+path = "src/main.rs"
+
+[dependencies]
+bytes = { workspace = true }
+clap = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sockudo-core = { workspace = true }
+sockudo-protocol = { workspace = true }
+sonic-rs = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+

--- a/crates/sockudo-simulator/src/config.rs
+++ b/crates/sockudo-simulator/src/config.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 use crate::error::{SimulatorError, SimulatorResult};
+use crate::workload::WorkloadConfig;
 
 /// Deterministic simulator configuration.
 ///
@@ -20,6 +21,7 @@ pub struct SimulatorConfig {
     pub page_limit: usize,
     pub history_retention_messages: Option<usize>,
     pub presence_retention_events: Option<usize>,
+    pub workload: WorkloadConfig,
     pub fault: FaultConfig,
 }
 
@@ -36,6 +38,7 @@ impl Default for SimulatorConfig {
             page_limit: 7,
             history_retention_messages: Some(512),
             presence_retention_events: Some(512),
+            workload: WorkloadConfig::default(),
             fault: FaultConfig::default(),
         }
     }
@@ -83,6 +86,7 @@ impl SimulatorConfig {
                 "presence_retention_events must be greater than 0 when set".into(),
             ));
         }
+        self.workload.validate()?;
         self.fault.validate()
     }
 

--- a/crates/sockudo-simulator/src/config.rs
+++ b/crates/sockudo-simulator/src/config.rs
@@ -1,0 +1,147 @@
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use crate::error::{SimulatorError, SimulatorResult};
+
+/// Deterministic simulator configuration.
+///
+/// All workload choices, fault choices, fanout delays, and recovery probes are
+/// derived from `seed`. A failure should reproduce with the same configuration
+/// and seed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimulatorConfig {
+    pub seed: u64,
+    pub ticks: u64,
+    pub nodes: usize,
+    pub clients: usize,
+    pub channels: usize,
+    pub users: usize,
+    pub oracle_every: u64,
+    pub page_limit: usize,
+    pub history_retention_messages: Option<usize>,
+    pub presence_retention_events: Option<usize>,
+    pub fault: FaultConfig,
+}
+
+impl Default for SimulatorConfig {
+    fn default() -> Self {
+        Self {
+            seed: 0x5eed_5eed_cafe_f00d,
+            ticks: 5_000,
+            nodes: 5,
+            clients: 8,
+            channels: 4,
+            users: 16,
+            oracle_every: 25,
+            page_limit: 7,
+            history_retention_messages: Some(512),
+            presence_retention_events: Some(512),
+            fault: FaultConfig::default(),
+        }
+    }
+}
+
+impl SimulatorConfig {
+    pub(crate) fn validate(&self) -> SimulatorResult<()> {
+        if self.ticks == 0 {
+            return Err(SimulatorError::Config(
+                "ticks must be greater than 0".into(),
+            ));
+        }
+        if self.nodes == 0 {
+            return Err(SimulatorError::Config(
+                "nodes must be greater than 0".into(),
+            ));
+        }
+        if self.clients == 0 {
+            return Err(SimulatorError::Config(
+                "clients must be greater than 0".into(),
+            ));
+        }
+        if self.channels == 0 {
+            return Err(SimulatorError::Config(
+                "channels must be greater than 0".into(),
+            ));
+        }
+        if self.users == 0 {
+            return Err(SimulatorError::Config(
+                "users must be greater than 0".into(),
+            ));
+        }
+        if self.page_limit == 0 {
+            return Err(SimulatorError::Config(
+                "page_limit must be greater than 0".into(),
+            ));
+        }
+        if self.history_retention_messages == Some(0) {
+            return Err(SimulatorError::Config(
+                "history_retention_messages must be greater than 0 when set".into(),
+            ));
+        }
+        if self.presence_retention_events == Some(0) {
+            return Err(SimulatorError::Config(
+                "presence_retention_events must be greater than 0 when set".into(),
+            ));
+        }
+        self.fault.validate()
+    }
+
+    pub(crate) fn retention_window(&self) -> Duration {
+        Duration::from_secs(10 * 365 * 24 * 60 * 60)
+    }
+}
+
+/// Fault injection probabilities and network delay knobs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FaultConfig {
+    pub fanout_drop_probability: f64,
+    pub fanout_duplicate_probability: f64,
+    pub max_fanout_delay_ticks: u64,
+    pub node_crash_probability: f64,
+    pub node_restart_probability: f64,
+    pub node_partition_probability: f64,
+    pub node_heal_probability: f64,
+    pub stream_reset_probability: f64,
+}
+
+impl Default for FaultConfig {
+    fn default() -> Self {
+        Self {
+            fanout_drop_probability: 0.08,
+            fanout_duplicate_probability: 0.03,
+            max_fanout_delay_ticks: 12,
+            node_crash_probability: 0.002,
+            node_restart_probability: 0.020,
+            node_partition_probability: 0.003,
+            node_heal_probability: 0.020,
+            stream_reset_probability: 0.0005,
+        }
+    }
+}
+
+impl FaultConfig {
+    fn validate(&self) -> SimulatorResult<()> {
+        for (name, value) in [
+            ("fanout_drop_probability", self.fanout_drop_probability),
+            (
+                "fanout_duplicate_probability",
+                self.fanout_duplicate_probability,
+            ),
+            ("node_crash_probability", self.node_crash_probability),
+            ("node_restart_probability", self.node_restart_probability),
+            (
+                "node_partition_probability",
+                self.node_partition_probability,
+            ),
+            ("node_heal_probability", self.node_heal_probability),
+            ("stream_reset_probability", self.stream_reset_probability),
+        ] {
+            if !(0.0..=1.0).contains(&value) {
+                return Err(SimulatorError::Config(format!(
+                    "{name} must be between 0.0 and 1.0"
+                )));
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/sockudo-simulator/src/error.rs
+++ b/crates/sockudo-simulator/src/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+pub type SimulatorResult<T> = std::result::Result<T, SimulatorError>;
+
+#[derive(Debug, Error)]
+pub enum SimulatorError {
+    #[error("invalid simulator config: {0}")]
+    Config(String),
+    #[error("simulator invariant failed at tick {tick} (seed={seed}): {message}")]
+    Invariant {
+        seed: u64,
+        tick: u64,
+        message: String,
+    },
+    #[error(transparent)]
+    Core(#[from] sockudo_core::error::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}

--- a/crates/sockudo-simulator/src/lib.rs
+++ b/crates/sockudo-simulator/src/lib.rs
@@ -1,0 +1,14 @@
+//! Deterministic workload simulator for Sockudo durable realtime invariants.
+//!
+//! The simulator is deliberately seed-driven. It drives real Sockudo durable
+//! core stores, injects deterministic node/network/operator faults, maintains a
+//! predictive shadow model, and checks cheap oracles during the run plus a full
+//! quiesce oracle at the end.
+
+mod config;
+mod error;
+mod simulator;
+
+pub use config::{FaultConfig, SimulatorConfig};
+pub use error::{SimulatorError, SimulatorResult};
+pub use simulator::{DeterministicSimulator, SimulationReport};

--- a/crates/sockudo-simulator/src/lib.rs
+++ b/crates/sockudo-simulator/src/lib.rs
@@ -8,7 +8,9 @@
 mod config;
 mod error;
 mod simulator;
+mod workload;
 
 pub use config::{FaultConfig, SimulatorConfig};
 pub use error::{SimulatorError, SimulatorResult};
 pub use simulator::{DeterministicSimulator, SimulationReport};
+pub use workload::{ActionWeights, WorkloadAction, WorkloadActionCounts, WorkloadConfig};

--- a/crates/sockudo-simulator/src/main.rs
+++ b/crates/sockudo-simulator/src/main.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
-use sockudo_simulator::{DeterministicSimulator, FaultConfig, SimulatorConfig};
+use sockudo_simulator::{
+    ActionWeights, DeterministicSimulator, FaultConfig, SimulatorConfig, WorkloadConfig,
+};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -28,6 +30,20 @@ struct Cli {
     history_retention_messages: Option<usize>,
     #[arg(long)]
     presence_retention_events: Option<usize>,
+    #[arg(long, default_value_t = 35)]
+    weight_publish: u32,
+    #[arg(long, default_value_t = 15)]
+    weight_create_versioned: u32,
+    #[arg(long, default_value_t = 20)]
+    weight_mutate_versioned: u32,
+    #[arg(long, default_value_t = 20)]
+    weight_presence: u32,
+    #[arg(long, default_value_t = 7)]
+    weight_recovery: u32,
+    #[arg(long, default_value_t = 2)]
+    weight_purge: u32,
+    #[arg(long, default_value_t = 1)]
+    weight_oracle: u32,
     #[arg(long, default_value_t = 0.08)]
     drop_prob: f64,
     #[arg(long, default_value_t = 0.03)]
@@ -63,6 +79,17 @@ impl Cli {
             page_limit: self.page_limit,
             history_retention_messages: self.history_retention_messages.or(Some(512)),
             presence_retention_events: self.presence_retention_events.or(Some(512)),
+            workload: WorkloadConfig {
+                weights: ActionWeights {
+                    publish_message: self.weight_publish,
+                    create_versioned_message: self.weight_create_versioned,
+                    mutate_versioned_message: self.weight_mutate_versioned,
+                    presence_transition: self.weight_presence,
+                    recovery_probe: self.weight_recovery,
+                    purge_history: self.weight_purge,
+                    oracle_check: self.weight_oracle,
+                },
+            },
             fault: FaultConfig {
                 fanout_drop_probability: self.drop_prob,
                 fanout_duplicate_probability: self.duplicate_prob,

--- a/crates/sockudo-simulator/src/main.rs
+++ b/crates/sockudo-simulator/src/main.rs
@@ -1,0 +1,130 @@
+use clap::Parser;
+use sockudo_simulator::{DeterministicSimulator, FaultConfig, SimulatorConfig};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "sockudo-sim",
+    about = "Run Sockudo's deterministic indestructibility simulator"
+)]
+struct Cli {
+    /// Replay seed. If omitted, a random seed is printed at startup.
+    #[arg(long)]
+    seed: Option<u64>,
+    #[arg(long, default_value_t = 5_000)]
+    ticks: u64,
+    #[arg(long, default_value_t = 5)]
+    nodes: usize,
+    #[arg(long, default_value_t = 8)]
+    clients: usize,
+    #[arg(long, default_value_t = 4)]
+    channels: usize,
+    #[arg(long, default_value_t = 16)]
+    users: usize,
+    #[arg(long, default_value_t = 25)]
+    oracle_every: u64,
+    #[arg(long, default_value_t = 7)]
+    page_limit: usize,
+    #[arg(long)]
+    history_retention_messages: Option<usize>,
+    #[arg(long)]
+    presence_retention_events: Option<usize>,
+    #[arg(long, default_value_t = 0.08)]
+    drop_prob: f64,
+    #[arg(long, default_value_t = 0.03)]
+    duplicate_prob: f64,
+    #[arg(long, default_value_t = 12)]
+    max_delay_ticks: u64,
+    #[arg(long, default_value_t = 0.002)]
+    crash_prob: f64,
+    #[arg(long, default_value_t = 0.020)]
+    restart_prob: f64,
+    #[arg(long, default_value_t = 0.003)]
+    partition_prob: f64,
+    #[arg(long, default_value_t = 0.020)]
+    heal_prob: f64,
+    #[arg(long, default_value_t = 0.0005)]
+    stream_reset_prob: f64,
+    /// Emit the final report as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+impl Cli {
+    fn into_config(self) -> (SimulatorConfig, bool) {
+        let seed = self.seed.unwrap_or_else(rand::random);
+        let config = SimulatorConfig {
+            seed,
+            ticks: self.ticks,
+            nodes: self.nodes,
+            clients: self.clients,
+            channels: self.channels,
+            users: self.users,
+            oracle_every: self.oracle_every,
+            page_limit: self.page_limit,
+            history_retention_messages: self.history_retention_messages.or(Some(512)),
+            presence_retention_events: self.presence_retention_events.or(Some(512)),
+            fault: FaultConfig {
+                fanout_drop_probability: self.drop_prob,
+                fanout_duplicate_probability: self.duplicate_prob,
+                max_fanout_delay_ticks: self.max_delay_ticks,
+                node_crash_probability: self.crash_prob,
+                node_restart_probability: self.restart_prob,
+                node_partition_probability: self.partition_prob,
+                node_heal_probability: self.heal_prob,
+                stream_reset_probability: self.stream_reset_prob,
+            },
+        };
+        (config, self.json)
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let (config, json) = Cli::parse().into_config();
+    println!(
+        "sockudo-sim: seed={} ticks={} nodes={} clients={} channels={}",
+        config.seed, config.ticks, config.nodes, config.clients, config.channels
+    );
+
+    let seed = config.seed;
+    let mut simulator = match DeterministicSimulator::new(config) {
+        Ok(simulator) => simulator,
+        Err(error) => {
+            eprintln!("sockudo-sim: invalid configuration: {error}");
+            std::process::exit(2);
+        }
+    };
+
+    match simulator.run().await {
+        Ok(report) => {
+            if json {
+                match serde_json::to_string_pretty(&report) {
+                    Ok(encoded) => println!("{encoded}"),
+                    Err(error) => {
+                        eprintln!("sockudo-sim: failed to encode report: {error}");
+                        std::process::exit(1);
+                    }
+                }
+            } else {
+                println!(
+                    "sockudo-sim: OK seed={} ticks={} operations={} oracles={} history_commits={} version_commits={} presence_events={} recovered={} dropped={} duplicated={} resets={}",
+                    report.seed,
+                    report.ticks,
+                    report.operations,
+                    report.oracle_checks,
+                    report.history_commits,
+                    report.version_commits,
+                    report.presence_events,
+                    report.recovered_messages,
+                    report.dropped_fanout,
+                    report.duplicated_fanout,
+                    report.stream_resets,
+                );
+            }
+        }
+        Err(error) => {
+            eprintln!("sockudo-sim: FAILED - reproduce with --seed {seed}\n{error}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/sockudo-simulator/src/simulator.rs
+++ b/crates/sockudo-simulator/src/simulator.rs
@@ -27,6 +27,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use crate::config::SimulatorConfig;
 use crate::error::{SimulatorError, SimulatorResult};
+use crate::workload::{ActionWeights, WorkloadAction, WorkloadActionCounts, WorkloadGenerator};
 
 const APP_ID: &str = "sim-app";
 const BASE_TIME_MS: i64 = 1_893_456_000_000;
@@ -57,6 +58,8 @@ pub struct SimulationReport {
     pub live_nodes: usize,
     pub partitioned_nodes: usize,
     pub queued_fanout: usize,
+    pub workload_weights: ActionWeights,
+    pub workload_actions: WorkloadActionCounts,
 }
 
 /// Seed-deterministic simulator over Sockudo's durable core primitives.
@@ -72,6 +75,7 @@ pub struct DeterministicSimulator {
     channels: Vec<String>,
     network: Vec<NetworkEvent>,
     shadow: Shadow,
+    workload: WorkloadGenerator,
     stats: Stats,
     next_message_serial: u64,
     next_version_serial: u64,
@@ -80,6 +84,7 @@ pub struct DeterministicSimulator {
 impl DeterministicSimulator {
     pub fn new(config: SimulatorConfig) -> SimulatorResult<Self> {
         config.validate()?;
+        let workload = WorkloadGenerator::new(config.seed, config.workload.clone())?;
         let channels = (0..config.channels)
             .map(|idx| format!("sim-channel-{idx}"))
             .collect::<Vec<_>>();
@@ -116,6 +121,7 @@ impl DeterministicSimulator {
             channels,
             network: Vec::new(),
             stats: Stats::default(),
+            workload,
             next_message_serial: 1,
             next_version_serial: 1,
         })
@@ -163,24 +169,27 @@ impl DeterministicSimulator {
             live_nodes: self.nodes.iter().filter(|node| node.alive).count(),
             partitioned_nodes: self.nodes.iter().filter(|node| node.partitioned).count(),
             queued_fanout: self.network.len(),
+            workload_weights: self.workload.weights(),
+            workload_actions: self.workload.selected().clone(),
         }
     }
 
     async fn drive_workload(&mut self) -> SimulatorResult<()> {
         self.stats.operations = self.stats.operations.saturating_add(1);
+        let action = self.workload.next_action();
         if self.route_rejects() {
             self.stats.rejected_operations = self.stats.rejected_operations.saturating_add(1);
             return Ok(());
         }
 
-        match self.rng.random_range(0..100) {
-            0..=34 => self.publish_message().await,
-            35..=49 => self.create_versioned_message().await,
-            50..=69 => self.mutate_versioned_message().await,
-            70..=89 => self.record_presence_transition().await,
-            90..=96 => self.recovery_probe().await,
-            97..=98 => self.purge_history_prefix().await,
-            _ => self.check_oracles().await,
+        match action {
+            WorkloadAction::PublishMessage => self.publish_message().await,
+            WorkloadAction::CreateVersionedMessage => self.create_versioned_message().await,
+            WorkloadAction::MutateVersionedMessage => self.mutate_versioned_message().await,
+            WorkloadAction::PresenceTransition => self.record_presence_transition().await,
+            WorkloadAction::RecoveryProbe => self.recovery_probe().await,
+            WorkloadAction::PurgeHistory => self.purge_history_prefix().await,
+            WorkloadAction::OracleCheck => self.check_oracles().await,
         }
     }
 
@@ -1696,6 +1705,7 @@ mod tests {
             page_limit: 3,
             history_retention_messages: Some(128),
             presence_retention_events: Some(128),
+            workload: crate::WorkloadConfig::default(),
             fault: crate::FaultConfig {
                 fanout_drop_probability: 0.20,
                 fanout_duplicate_probability: 0.10,

--- a/crates/sockudo-simulator/src/simulator.rs
+++ b/crates/sockudo-simulator/src/simulator.rs
@@ -1,0 +1,1743 @@
+use bytes::Bytes;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use serde::Serialize;
+use sockudo_core::history::{
+    HistoryAppendRecord, HistoryCursor, HistoryDirection, HistoryItem, HistoryPurgeMode,
+    HistoryPurgeRequest, HistoryQueryBounds, HistoryReadRequest, HistoryRetentionPolicy,
+    HistoryStore, MemoryHistoryStore, MemoryHistoryStoreConfig,
+};
+use sockudo_core::presence_history::{
+    MemoryPresenceHistoryStore, MemoryPresenceHistoryStoreConfig, PresenceHistoryCursor,
+    PresenceHistoryDirection, PresenceHistoryEventCause, PresenceHistoryEventKind,
+    PresenceHistoryItem, PresenceHistoryQueryBounds, PresenceHistoryReadRequest,
+    PresenceHistoryRetentionPolicy, PresenceHistoryStore, PresenceHistoryTransitionRecord,
+    PresenceSnapshotRequest,
+};
+use sockudo_core::version_store::{
+    MemoryVersionStore, StoredVersionRecord, VersionReplayRequest, VersionStore,
+    VersionStoreCursor, VersionStoreDirection, VersionStoreReadRequest,
+};
+use sockudo_core::versioned_messages::{
+    FieldPatch, MessageAction, MessageAppend, MessageFieldDelta, MessageSerial, VersionMetadata,
+    VersionSerial, VersionedMessage,
+};
+use sockudo_protocol::messages::{MessageData, MessageExtras};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use crate::config::SimulatorConfig;
+use crate::error::{SimulatorError, SimulatorResult};
+
+const APP_ID: &str = "sim-app";
+const BASE_TIME_MS: i64 = 1_893_456_000_000;
+
+/// Summary emitted by a successful simulator run.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SimulationReport {
+    pub seed: u64,
+    pub ticks: u64,
+    pub operations: u64,
+    pub rejected_operations: u64,
+    pub oracle_checks: u64,
+    pub history_commits: u64,
+    pub version_commits: u64,
+    pub presence_events: u64,
+    pub dropped_fanout: u64,
+    pub duplicated_fanout: u64,
+    pub delivered_messages: u64,
+    pub recovered_messages: u64,
+    pub recovery_truncations: u64,
+    pub stale_deliveries: u64,
+    pub node_crashes: u64,
+    pub node_restarts: u64,
+    pub node_partitions: u64,
+    pub node_heals: u64,
+    pub stream_resets: u64,
+    pub purges: u64,
+    pub live_nodes: usize,
+    pub partitioned_nodes: usize,
+    pub queued_fanout: usize,
+}
+
+/// Seed-deterministic simulator over Sockudo's durable core primitives.
+pub struct DeterministicSimulator {
+    config: SimulatorConfig,
+    rng: StdRng,
+    tick: u64,
+    history_store: MemoryHistoryStore,
+    version_store: MemoryVersionStore,
+    presence_store: MemoryPresenceHistoryStore,
+    nodes: Vec<NodeState>,
+    clients: Vec<ClientState>,
+    channels: Vec<String>,
+    network: Vec<NetworkEvent>,
+    shadow: Shadow,
+    stats: Stats,
+    next_message_serial: u64,
+    next_version_serial: u64,
+}
+
+impl DeterministicSimulator {
+    pub fn new(config: SimulatorConfig) -> SimulatorResult<Self> {
+        config.validate()?;
+        let channels = (0..config.channels)
+            .map(|idx| format!("sim-channel-{idx}"))
+            .collect::<Vec<_>>();
+        let clients = (0..config.clients)
+            .map(|idx| ClientState::new(idx, &channels))
+            .collect();
+        let nodes = (0..config.nodes).map(NodeState::new).collect();
+        let history_store = MemoryHistoryStore::new(MemoryHistoryStoreConfig {
+            retention_window: config.retention_window(),
+            max_messages_per_channel: config.history_retention_messages,
+            max_bytes_per_channel: None,
+        });
+        let presence_store = MemoryPresenceHistoryStore::new(MemoryPresenceHistoryStoreConfig {
+            retention_window: config.retention_window(),
+            max_events_per_channel: config.presence_retention_events,
+            max_bytes_per_channel: None,
+            metrics: None,
+        });
+
+        Ok(Self {
+            rng: StdRng::seed_from_u64(config.seed),
+            shadow: Shadow::new(
+                &channels,
+                config.history_retention_messages,
+                config.presence_retention_events,
+            ),
+            config,
+            tick: 0,
+            history_store,
+            version_store: MemoryVersionStore::new(),
+            presence_store,
+            nodes,
+            clients,
+            channels,
+            network: Vec::new(),
+            stats: Stats::default(),
+            next_message_serial: 1,
+            next_version_serial: 1,
+        })
+    }
+
+    pub async fn run(&mut self) -> SimulatorResult<SimulationReport> {
+        for tick in 0..self.config.ticks {
+            self.tick = tick;
+            self.deliver_due_fanout();
+            self.inject_faults().await?;
+            self.drive_workload().await?;
+            if self.config.oracle_every > 0 && tick % self.config.oracle_every == 0 {
+                self.check_oracles().await?;
+            }
+        }
+
+        self.quiesce().await?;
+        self.recover_all_clients().await?;
+        self.check_oracles().await?;
+        Ok(self.report())
+    }
+
+    fn report(&self) -> SimulationReport {
+        SimulationReport {
+            seed: self.config.seed,
+            ticks: self.tick.saturating_add(1),
+            operations: self.stats.operations,
+            rejected_operations: self.stats.rejected_operations,
+            oracle_checks: self.stats.oracle_checks,
+            history_commits: self.stats.history_commits,
+            version_commits: self.stats.version_commits,
+            presence_events: self.stats.presence_events,
+            dropped_fanout: self.stats.dropped_fanout,
+            duplicated_fanout: self.stats.duplicated_fanout,
+            delivered_messages: self.stats.delivered_messages,
+            recovered_messages: self.stats.recovered_messages,
+            recovery_truncations: self.stats.recovery_truncations,
+            stale_deliveries: self.stats.stale_deliveries,
+            node_crashes: self.stats.node_crashes,
+            node_restarts: self.stats.node_restarts,
+            node_partitions: self.stats.node_partitions,
+            node_heals: self.stats.node_heals,
+            stream_resets: self.stats.stream_resets,
+            purges: self.stats.purges,
+            live_nodes: self.nodes.iter().filter(|node| node.alive).count(),
+            partitioned_nodes: self.nodes.iter().filter(|node| node.partitioned).count(),
+            queued_fanout: self.network.len(),
+        }
+    }
+
+    async fn drive_workload(&mut self) -> SimulatorResult<()> {
+        self.stats.operations = self.stats.operations.saturating_add(1);
+        if self.route_rejects() {
+            self.stats.rejected_operations = self.stats.rejected_operations.saturating_add(1);
+            return Ok(());
+        }
+
+        match self.rng.random_range(0..100) {
+            0..=34 => self.publish_message().await,
+            35..=49 => self.create_versioned_message().await,
+            50..=69 => self.mutate_versioned_message().await,
+            70..=89 => self.record_presence_transition().await,
+            90..=96 => self.recovery_probe().await,
+            97..=98 => self.purge_history_prefix().await,
+            _ => self.check_oracles().await,
+        }
+    }
+
+    fn route_rejects(&mut self) -> bool {
+        if !self.nodes.iter().any(NodeState::can_accept_traffic) {
+            return true;
+        }
+        let node_idx = self.rng.random_range(0..self.nodes.len());
+        !self.nodes[node_idx].can_accept_traffic()
+    }
+
+    async fn inject_faults(&mut self) -> SimulatorResult<()> {
+        if self.roll(self.config.fault.node_crash_probability) {
+            self.crash_random_node();
+        }
+        if self.roll(self.config.fault.node_restart_probability) {
+            self.restart_random_node();
+        }
+        if self.roll(self.config.fault.node_partition_probability) {
+            self.partition_random_node();
+        }
+        if self.roll(self.config.fault.node_heal_probability) {
+            self.heal_random_node();
+        }
+        if self.roll(self.config.fault.stream_reset_probability) {
+            self.reset_random_stream().await?;
+        }
+        Ok(())
+    }
+
+    fn crash_random_node(&mut self) {
+        let live = self
+            .nodes
+            .iter()
+            .filter(|node| node.alive)
+            .map(|node| node.id)
+            .collect::<Vec<_>>();
+        if live.len() <= 1 {
+            return;
+        }
+        let victim = live[self.rng.random_range(0..live.len())];
+        if let Some(node) = self.nodes.get_mut(victim) {
+            node.alive = false;
+            node.partitioned = false;
+            self.stats.node_crashes = self.stats.node_crashes.saturating_add(1);
+        }
+    }
+
+    fn restart_random_node(&mut self) {
+        let down = self
+            .nodes
+            .iter()
+            .filter(|node| !node.alive)
+            .map(|node| node.id)
+            .collect::<Vec<_>>();
+        if down.is_empty() {
+            return;
+        }
+        let node_idx = down[self.rng.random_range(0..down.len())];
+        if let Some(node) = self.nodes.get_mut(node_idx) {
+            node.alive = true;
+            self.stats.node_restarts = self.stats.node_restarts.saturating_add(1);
+        }
+    }
+
+    fn partition_random_node(&mut self) {
+        let eligible = self
+            .nodes
+            .iter()
+            .filter(|node| node.alive && !node.partitioned)
+            .map(|node| node.id)
+            .collect::<Vec<_>>();
+        if eligible.len() <= 1 {
+            return;
+        }
+        let node_idx = eligible[self.rng.random_range(0..eligible.len())];
+        if let Some(node) = self.nodes.get_mut(node_idx) {
+            node.partitioned = true;
+            self.stats.node_partitions = self.stats.node_partitions.saturating_add(1);
+        }
+    }
+
+    fn heal_random_node(&mut self) {
+        let partitioned = self
+            .nodes
+            .iter()
+            .filter(|node| node.partitioned)
+            .map(|node| node.id)
+            .collect::<Vec<_>>();
+        if partitioned.is_empty() {
+            return;
+        }
+        let node_idx = partitioned[self.rng.random_range(0..partitioned.len())];
+        if let Some(node) = self.nodes.get_mut(node_idx) {
+            node.partitioned = false;
+            self.stats.node_heals = self.stats.node_heals.saturating_add(1);
+        }
+    }
+
+    async fn reset_random_stream(&mut self) -> SimulatorResult<()> {
+        let channel = self.random_channel();
+        let history = self
+            .history_store
+            .reset_stream(
+                APP_ID,
+                &channel,
+                "simulated operator reset",
+                Some("sockudo-sim"),
+            )
+            .await?;
+        self.shadow
+            .channel_mut(&channel)
+            .reset_history(history.new_stream_id.clone());
+
+        let presence = self
+            .presence_store
+            .reset_stream(
+                APP_ID,
+                &channel,
+                "simulated operator reset",
+                Some("sockudo-sim"),
+            )
+            .await?;
+        self.shadow
+            .channel_mut(&channel)
+            .reset_presence(presence.new_stream_id.clone());
+
+        for client in &mut self.clients {
+            client.reset_channel(&channel, history.inspection.stream_id.clone());
+        }
+        self.network.retain(|event| event.channel != channel);
+        self.stats.stream_resets = self.stats.stream_resets.saturating_add(1);
+        Ok(())
+    }
+
+    async fn publish_message(&mut self) -> SimulatorResult<()> {
+        let channel = self.random_channel();
+        let payload = Bytes::from(format!(
+            "payload:{}:{}",
+            self.tick, self.stats.history_commits
+        ));
+        let message = self
+            .append_history(&channel, "client-event", "publish", payload)
+            .await?;
+        self.schedule_fanout(&channel, &message);
+        Ok(())
+    }
+
+    async fn create_versioned_message(&mut self) -> SimulatorResult<()> {
+        let channel = self.random_channel();
+        let history = self
+            .append_history(
+                &channel,
+                "sockudo:message.create",
+                MessageAction::Create.as_str(),
+                Bytes::from(format!("version-create:{}", self.tick)),
+            )
+            .await?;
+        let delivery = self
+            .version_store
+            .reserve_delivery_position(APP_ID, &channel)
+            .await?;
+        let message_serial = MessageSerial::new(format!("msg-{:020}", self.next_message_serial))?;
+        self.next_message_serial = self.next_message_serial.saturating_add(1);
+        let version = self.next_version_metadata()?;
+        let message = VersionedMessage::new_create(
+            message_serial,
+            version,
+            history.serial,
+            delivery.delivery_serial,
+            Some("sockudo:message.create".to_string()),
+            Some(MessageData::String(format!(
+                "created at tick {}",
+                self.tick
+            ))),
+            Some(MessageExtras::default()),
+        );
+        let record = StoredVersionRecord {
+            app_id: APP_ID.to_string(),
+            channel: channel.clone(),
+            original_client_id: Some(format!(
+                "client-{}",
+                self.rng.random_range(0..self.config.clients)
+            )),
+            message: message.clone(),
+        };
+        self.version_store.append_version(record.clone()).await?;
+        self.shadow.channel_mut(&channel).append_version(record);
+        self.stats.version_commits = self.stats.version_commits.saturating_add(1);
+        self.schedule_fanout(&channel, &history);
+        Ok(())
+    }
+
+    async fn mutate_versioned_message(&mut self) -> SimulatorResult<()> {
+        let channel = self.random_channel();
+        let Some(current) = self
+            .shadow
+            .channel(&channel)
+            .random_live_version(&mut self.rng)
+        else {
+            return self.create_versioned_message().await;
+        };
+
+        let action_roll = self.rng.random_range(0..100);
+        let (action, payload) = if action_roll < 40 {
+            (MessageAction::Update, "message.update")
+        } else if action_roll < 75 {
+            (MessageAction::Append, "message.append")
+        } else {
+            (MessageAction::Delete, "message.delete")
+        };
+        let history = self
+            .append_history(
+                &channel,
+                action.as_str(),
+                action.as_str(),
+                Bytes::from(format!("{payload}:{}", self.tick)),
+            )
+            .await?;
+        let delivery = self
+            .version_store
+            .reserve_delivery_position_after(
+                APP_ID,
+                &channel,
+                current.message.replay_position.delivery_serial,
+            )
+            .await?;
+        let version = self.next_version_metadata()?;
+        let next = match action {
+            MessageAction::Update => current.message.apply_mutation(
+                action,
+                version,
+                delivery.delivery_serial,
+                MessageFieldDelta {
+                    data: FieldPatch::Replace(MessageData::String(format!(
+                        "updated at tick {}",
+                        self.tick
+                    ))),
+                    ..Default::default()
+                },
+            )?,
+            MessageAction::Delete => current.message.apply_mutation(
+                action,
+                version,
+                delivery.delivery_serial,
+                MessageFieldDelta {
+                    data: FieldPatch::Clear,
+                    extras: FieldPatch::Clear,
+                    ..Default::default()
+                },
+            )?,
+            MessageAction::Append => current.message.apply_append(
+                version,
+                delivery.delivery_serial,
+                MessageAppend {
+                    data_fragment: format!("|{}", self.tick),
+                    extras: None,
+                },
+            )?,
+            MessageAction::Create | MessageAction::Summary => unreachable!("unsupported mutation"),
+        };
+        let record = StoredVersionRecord {
+            app_id: APP_ID.to_string(),
+            channel: channel.clone(),
+            original_client_id: current.original_client_id.clone(),
+            message: next,
+        };
+        self.version_store.append_version(record.clone()).await?;
+        self.shadow.channel_mut(&channel).append_version(record);
+        self.stats.version_commits = self.stats.version_commits.saturating_add(1);
+        self.schedule_fanout(&channel, &history);
+        Ok(())
+    }
+
+    async fn record_presence_transition(&mut self) -> SimulatorResult<()> {
+        let channel = self.random_channel();
+        let user_id = format!("user-{}", self.rng.random_range(0..self.config.users));
+        let event = if self.rng.random::<bool>() {
+            PresenceHistoryEventKind::MemberAdded
+        } else {
+            PresenceHistoryEventKind::MemberRemoved
+        };
+        let cause = match event {
+            PresenceHistoryEventKind::MemberAdded | PresenceHistoryEventKind::MemberUpdated => {
+                PresenceHistoryEventCause::Join
+            }
+            PresenceHistoryEventKind::MemberRemoved => PresenceHistoryEventCause::Disconnect,
+        };
+        let should_record = self
+            .shadow
+            .channel(&channel)
+            .presence_would_record(event, &user_id);
+        let record = PresenceHistoryTransitionRecord {
+            app_id: APP_ID.to_string(),
+            channel: channel.clone(),
+            event_kind: event,
+            cause,
+            user_id: user_id.clone(),
+            connection_id: Some(format!("socket-{user_id}")),
+            user_info: None,
+            dead_node_id: None,
+            dedupe_key: format!("presence:{}:{}:{user_id}", self.tick, self.stats.operations),
+            published_at_ms: self.timestamp_ms(),
+            retention: self.presence_retention_policy(),
+        };
+        self.presence_store.record_transition(record).await?;
+        if should_record {
+            let newest = self
+                .read_presence_page(&channel, PresenceHistoryDirection::NewestFirst)
+                .await?;
+            let Some(item) = newest.first() else {
+                return Err(self.fail(format!(
+                    "presence transition for {channel}/{user_id} was predicted to record but store returned no newest item"
+                )));
+            };
+            self.shadow
+                .channel_mut(&channel)
+                .append_presence(item.clone());
+            self.stats.presence_events = self.stats.presence_events.saturating_add(1);
+        }
+        Ok(())
+    }
+
+    async fn purge_history_prefix(&mut self) -> SimulatorResult<()> {
+        let channel = self.random_channel();
+        let shadow = self.shadow.channel(&channel);
+        if shadow.history.len() < 4 {
+            return Ok(());
+        }
+        let idx = self.rng.random_range(1..shadow.history.len());
+        let before_serial = shadow.history[idx].serial;
+        self.history_store
+            .purge_stream(
+                APP_ID,
+                &channel,
+                HistoryPurgeRequest {
+                    mode: HistoryPurgeMode::BeforeSerial,
+                    before_serial: Some(before_serial),
+                    before_time_ms: None,
+                    reason: "simulated retention purge".to_string(),
+                    requested_by: Some("sockudo-sim".to_string()),
+                },
+            )
+            .await?;
+        self.shadow
+            .channel_mut(&channel)
+            .purge_history_before(before_serial);
+        for client in &mut self.clients {
+            client.rewind_below(&channel, before_serial.saturating_sub(1));
+        }
+        self.stats.purges = self.stats.purges.saturating_add(1);
+        Ok(())
+    }
+
+    async fn append_history(
+        &mut self,
+        channel: &str,
+        event_name: &str,
+        operation_kind: &str,
+        payload: Bytes,
+    ) -> SimulatorResult<ShadowHistoryMessage> {
+        let reservation = self
+            .history_store
+            .reserve_publish_position(APP_ID, channel)
+            .await?;
+        let record = HistoryAppendRecord {
+            app_id: APP_ID.to_string(),
+            channel: channel.to_string(),
+            stream_id: reservation.stream_id.clone(),
+            serial: reservation.serial,
+            published_at_ms: self.timestamp_ms(),
+            message_id: Some(format!("hist-{:020}", self.stats.history_commits + 1)),
+            event_name: Some(event_name.to_string()),
+            operation_kind: operation_kind.to_string(),
+            payload_bytes: payload.clone(),
+            retention: self.history_retention_policy(),
+        };
+        self.history_store.append(record.clone()).await?;
+        let message = ShadowHistoryMessage {
+            stream_id: record.stream_id,
+            serial: record.serial,
+            published_at_ms: record.published_at_ms,
+            message_id: record.message_id,
+            event_name: record.event_name,
+            operation_kind: record.operation_kind,
+            payload,
+        };
+        self.shadow
+            .channel_mut(channel)
+            .append_history(message.clone());
+        self.stats.history_commits = self.stats.history_commits.saturating_add(1);
+        Ok(message)
+    }
+
+    fn schedule_fanout(&mut self, channel: &str, message: &ShadowHistoryMessage) {
+        for client_idx in 0..self.clients.len() {
+            if self.roll(self.config.fault.fanout_drop_probability) {
+                self.stats.dropped_fanout = self.stats.dropped_fanout.saturating_add(1);
+                continue;
+            }
+            let event = NetworkEvent {
+                deliver_at: self.tick.saturating_add(self.random_delay()),
+                client_idx,
+                channel: channel.to_string(),
+                stream_id: message.stream_id.clone(),
+                serial: message.serial,
+            };
+            self.network.push(event.clone());
+            if self.roll(self.config.fault.fanout_duplicate_probability) {
+                let mut duplicate = event;
+                duplicate.deliver_at = duplicate.deliver_at.saturating_add(self.random_delay());
+                self.network.push(duplicate);
+                self.stats.duplicated_fanout = self.stats.duplicated_fanout.saturating_add(1);
+            }
+        }
+    }
+
+    fn deliver_due_fanout(&mut self) {
+        let mut pending = Vec::with_capacity(self.network.len());
+        let due = std::mem::take(&mut self.network);
+        for event in due {
+            if event.deliver_at <= self.tick {
+                let accepted = self.clients[event.client_idx].deliver(&event);
+                if accepted {
+                    self.stats.delivered_messages = self.stats.delivered_messages.saturating_add(1);
+                } else {
+                    self.stats.stale_deliveries = self.stats.stale_deliveries.saturating_add(1);
+                }
+            } else {
+                pending.push(event);
+            }
+        }
+        self.network = pending;
+    }
+
+    async fn quiesce(&mut self) -> SimulatorResult<()> {
+        let settle = self
+            .config
+            .fault
+            .max_fanout_delay_ticks
+            .saturating_add(5)
+            .max(16);
+        for _ in 0..settle {
+            self.tick = self.tick.saturating_add(1);
+            self.deliver_due_fanout();
+        }
+        Ok(())
+    }
+
+    async fn recovery_probe(&mut self) -> SimulatorResult<()> {
+        let client_idx = self.rng.random_range(0..self.clients.len());
+        let channel = self.random_channel();
+        self.recover_client_channel(client_idx, &channel).await
+    }
+
+    async fn recover_all_clients(&mut self) -> SimulatorResult<()> {
+        let channels = self.channels.clone();
+        for client_idx in 0..self.clients.len() {
+            for channel in &channels {
+                self.recover_client_channel(client_idx, channel).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn recover_client_channel(
+        &mut self,
+        client_idx: usize,
+        channel: &str,
+    ) -> SimulatorResult<()> {
+        let shadow = self.shadow.channel(channel);
+        let Some(current_stream_id) = shadow.history_stream_id.clone() else {
+            return Ok(());
+        };
+        let (client_stream_id, last_contiguous) =
+            self.clients[client_idx].recovery_position(channel);
+        if client_stream_id.as_deref() != Some(current_stream_id.as_str()) {
+            self.clients[client_idx].reset_channel(channel, Some(current_stream_id));
+            return Ok(());
+        }
+
+        let oldest = shadow.history.front().map(|message| message.serial);
+        if let Some(oldest_serial) = oldest
+            && last_contiguous.saturating_add(1) < oldest_serial
+        {
+            self.stats.recovery_truncations = self.stats.recovery_truncations.saturating_add(1);
+            self.clients[client_idx].rewind_below(channel, oldest_serial.saturating_sub(1));
+            return Ok(());
+        }
+
+        let recovered = self
+            .read_history_bounded(channel, last_contiguous.saturating_add(1))
+            .await?;
+        let expected = shadow
+            .history
+            .iter()
+            .filter(|message| message.serial > last_contiguous)
+            .map(|message| message.serial)
+            .collect::<Vec<_>>();
+        let actual = recovered.iter().map(|item| item.serial).collect::<Vec<_>>();
+        if actual != expected {
+            return Err(self.fail(format!(
+                "client recovery mismatch on {channel}: expected serials {expected:?}, got {actual:?}"
+            )));
+        }
+        for item in recovered {
+            let event = NetworkEvent {
+                deliver_at: self.tick,
+                client_idx,
+                channel: channel.to_string(),
+                stream_id: item.stream_id,
+                serial: item.serial,
+            };
+            if self.clients[client_idx].deliver(&event) {
+                self.stats.recovered_messages = self.stats.recovered_messages.saturating_add(1);
+            }
+        }
+        Ok(())
+    }
+
+    async fn check_oracles(&mut self) -> SimulatorResult<()> {
+        self.stats.oracle_checks = self.stats.oracle_checks.saturating_add(1);
+        let channels = self.channels.clone();
+        for channel in &channels {
+            self.check_history_oracle(channel).await?;
+            self.check_version_oracle(channel).await?;
+            self.check_presence_oracle(channel).await?;
+            self.check_client_recovery_oracle(channel)?;
+        }
+        Ok(())
+    }
+
+    async fn check_history_oracle(&self, channel: &str) -> SimulatorResult<()> {
+        let shadow = self.shadow.channel(channel);
+        let oldest = self
+            .read_history_page(channel, HistoryDirection::OldestFirst)
+            .await?;
+        let newest = self
+            .read_history_page(channel, HistoryDirection::NewestFirst)
+            .await?;
+        let expected = shadow.history.iter().collect::<Vec<_>>();
+
+        if oldest.len() != expected.len() {
+            return Err(self.fail(format!(
+                "history length mismatch on {channel}: expected {}, got {}",
+                expected.len(),
+                oldest.len()
+            )));
+        }
+        for (actual, expected) in oldest.iter().zip(expected.iter()) {
+            self.assert_history_item(channel, actual, expected)?;
+        }
+
+        let newest_serials = newest.iter().map(|item| item.serial).collect::<Vec<_>>();
+        let expected_newest = expected
+            .iter()
+            .rev()
+            .map(|message| message.serial)
+            .collect::<Vec<_>>();
+        if newest_serials != expected_newest {
+            return Err(self.fail(format!(
+                "newest-first history mismatch on {channel}: expected {expected_newest:?}, got {newest_serials:?}"
+            )));
+        }
+
+        for pair in oldest.windows(2) {
+            if pair[0].serial.saturating_add(1) != pair[1].serial {
+                return Err(self.fail(format!(
+                    "history serial gap on {channel}: {} then {}",
+                    pair[0].serial, pair[1].serial
+                )));
+            }
+        }
+
+        let head = self.history_store.channel_head(APP_ID, channel).await?;
+        if head.retained_messages != expected.len() as u64 {
+            return Err(self.fail(format!(
+                "history retained_messages mismatch on {channel}: expected {}, got {}",
+                expected.len(),
+                head.retained_messages
+            )));
+        }
+        let expected_bytes = expected
+            .iter()
+            .map(|message| message.payload.len() as u64)
+            .sum::<u64>();
+        if head.retained_bytes != expected_bytes {
+            return Err(self.fail(format!(
+                "history retained_bytes mismatch on {channel}: expected {expected_bytes}, got {}",
+                head.retained_bytes
+            )));
+        }
+        if head.stream_id != shadow.history_stream_id {
+            return Err(self.fail(format!(
+                "history stream mismatch on {channel}: expected {:?}, got {:?}",
+                shadow.history_stream_id, head.stream_id
+            )));
+        }
+        if head.oldest_serial != expected.first().map(|message| message.serial)
+            || head.newest_serial != expected.last().map(|message| message.serial)
+        {
+            return Err(self.fail(format!(
+                "history head serial bounds mismatch on {channel}: head={head:?}"
+            )));
+        }
+        if shadow.history_stream_id.is_some() {
+            let inspection = self
+                .history_store
+                .stream_inspection(APP_ID, channel)
+                .await?;
+            let expected_next = expected
+                .last()
+                .map_or(1, |message| message.serial.saturating_add(1));
+            if inspection.next_serial != Some(expected_next) {
+                return Err(self.fail(format!(
+                    "history next_serial mismatch on {channel}: expected {expected_next}, got {:?}",
+                    inspection.next_serial
+                )));
+            }
+            if !inspection.state.recovery_allowed {
+                return Err(self.fail(format!(
+                    "history recovery unexpectedly disallowed on {channel}: {:?}",
+                    inspection.state
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn assert_history_item(
+        &self,
+        channel: &str,
+        actual: &HistoryItem,
+        expected: &ShadowHistoryMessage,
+    ) -> SimulatorResult<()> {
+        if actual.stream_id != expected.stream_id
+            || actual.serial != expected.serial
+            || actual.published_at_ms != expected.published_at_ms
+            || actual.message_id != expected.message_id
+            || actual.event_name != expected.event_name
+            || actual.operation_kind != expected.operation_kind
+            || actual.payload_bytes != expected.payload
+        {
+            return Err(self.fail(format!(
+                "history item mismatch on {channel}: expected {expected:?}, got {actual:?}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn check_version_oracle(&self, channel: &str) -> SimulatorResult<()> {
+        let shadow = self.shadow.channel(channel);
+        let replay = self
+            .version_store
+            .replay_after(VersionReplayRequest {
+                app_id: APP_ID.to_string(),
+                channel: channel.to_string(),
+                after_delivery_serial: 0,
+                limit: usize::MAX / 2,
+            })
+            .await?;
+        let expected_replay = shadow.version_replay.values().collect::<Vec<_>>();
+        if replay.len() != expected_replay.len() {
+            return Err(self.fail(format!(
+                "version replay length mismatch on {channel}: expected {}, got {}",
+                expected_replay.len(),
+                replay.len()
+            )));
+        }
+        for (actual, expected) in replay.iter().zip(expected_replay.iter()) {
+            self.assert_stored_version(channel, actual, expected)?;
+        }
+        for pair in replay.windows(2) {
+            if pair[0].delivery_serial().saturating_add(1) != pair[1].delivery_serial() {
+                return Err(self.fail(format!(
+                    "version replay gap on {channel}: {} then {}",
+                    pair[0].delivery_serial(),
+                    pair[1].delivery_serial()
+                )));
+            }
+        }
+
+        let state = self.version_store.stream_state(APP_ID, channel).await?;
+        if shadow.version_replay.is_empty() {
+            if state.newest_available_delivery_serial.is_some() {
+                return Err(self.fail(format!(
+                    "empty version shadow but store has stream state on {channel}: {state:?}"
+                )));
+            }
+        } else {
+            let newest = shadow.version_replay.keys().next_back().copied();
+            if state.newest_available_delivery_serial != newest
+                || state.next_delivery_serial != newest.map(|serial| serial.saturating_add(1))
+            {
+                return Err(self.fail(format!(
+                    "version stream state mismatch on {channel}: expected newest {newest:?}, got {state:?}"
+                )));
+            }
+        }
+
+        for (message_serial, chain) in &shadow.version_messages {
+            let latest = self
+                .version_store
+                .get_latest(
+                    APP_ID,
+                    channel,
+                    &MessageSerial::new(message_serial.clone())?,
+                )
+                .await?;
+            let Some(latest) = latest else {
+                return Err(self.fail(format!(
+                    "missing latest version for {channel}/{message_serial}"
+                )));
+            };
+            self.assert_stored_version(
+                channel,
+                &latest,
+                chain.latest().ok_or_else(|| {
+                    self.fail(format!("empty shadow chain for {channel}/{message_serial}"))
+                })?,
+            )?;
+
+            let oldest_page = self
+                .read_versions(channel, message_serial, VersionStoreDirection::OldestFirst)
+                .await?;
+            if oldest_page.len() != chain.versions.len() {
+                return Err(self.fail(format!(
+                    "version chain length mismatch on {channel}/{message_serial}: expected {}, got {}",
+                    chain.versions.len(),
+                    oldest_page.len()
+                )));
+            }
+            for (actual, expected) in oldest_page.iter().zip(chain.versions.iter()) {
+                self.assert_stored_version(channel, actual, expected)?;
+            }
+            let newest_page = self
+                .read_versions(channel, message_serial, VersionStoreDirection::NewestFirst)
+                .await?;
+            let newest_serials = newest_page
+                .iter()
+                .map(|record| record.version_serial().as_str().to_string())
+                .collect::<Vec<_>>();
+            let expected_newest = chain
+                .versions
+                .iter()
+                .rev()
+                .map(|record| record.version_serial().as_str().to_string())
+                .collect::<Vec<_>>();
+            if newest_serials != expected_newest {
+                return Err(self.fail(format!(
+                    "newest-first version page mismatch on {channel}/{message_serial}: expected {expected_newest:?}, got {newest_serials:?}"
+                )));
+            }
+        }
+
+        let latest_by_history = self
+            .version_store
+            .latest_by_history(APP_ID, channel)
+            .await?;
+        let expected_latest = shadow.latest_versions_by_history();
+        if latest_by_history.len() != expected_latest.len() {
+            return Err(self.fail(format!(
+                "latest_by_history length mismatch on {channel}: expected {}, got {}",
+                expected_latest.len(),
+                latest_by_history.len()
+            )));
+        }
+        for (actual, expected) in latest_by_history.iter().zip(expected_latest.iter()) {
+            self.assert_stored_version(channel, actual, expected)?;
+        }
+        Ok(())
+    }
+
+    fn assert_stored_version(
+        &self,
+        channel: &str,
+        actual: &StoredVersionRecord,
+        expected: &StoredVersionRecord,
+    ) -> SimulatorResult<()> {
+        let actual_msg = &actual.message;
+        let expected_msg = &expected.message;
+        if actual.app_id != expected.app_id
+            || actual.channel != expected.channel
+            || actual.original_client_id != expected.original_client_id
+            || actual_msg.action != expected_msg.action
+            || actual_msg.identity.message_serial != expected_msg.identity.message_serial
+            || actual_msg.identity.history_serial != expected_msg.identity.history_serial
+            || actual_msg.replay_position.delivery_serial
+                != expected_msg.replay_position.delivery_serial
+            || actual_msg.version.serial != expected_msg.version.serial
+            || actual_msg.version.client_id != expected_msg.version.client_id
+            || actual_msg.version.timestamp_ms != expected_msg.version.timestamp_ms
+            || actual_msg.version.description != expected_msg.version.description
+            || actual_msg.name != expected_msg.name
+            || actual_msg.data != expected_msg.data
+            || actual_msg.extras != expected_msg.extras
+        {
+            return Err(self.fail(format!(
+                "stored version mismatch on {channel}: expected {expected:?}, got {actual:?}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn check_presence_oracle(&self, channel: &str) -> SimulatorResult<()> {
+        let shadow = self.shadow.channel(channel);
+        let oldest = self
+            .read_presence_page(channel, PresenceHistoryDirection::OldestFirst)
+            .await?;
+        let newest = self
+            .read_presence_page(channel, PresenceHistoryDirection::NewestFirst)
+            .await?;
+        let expected = shadow.presence_events.iter().collect::<Vec<_>>();
+        if oldest.len() != expected.len() {
+            return Err(self.fail(format!(
+                "presence history length mismatch on {channel}: expected {}, got {}",
+                expected.len(),
+                oldest.len()
+            )));
+        }
+        for (actual, expected) in oldest.iter().zip(expected.iter()) {
+            self.assert_presence_item(channel, actual, expected)?;
+        }
+        let newest_serials = newest.iter().map(|item| item.serial).collect::<Vec<_>>();
+        let expected_newest = expected
+            .iter()
+            .rev()
+            .map(|event| event.serial)
+            .collect::<Vec<_>>();
+        if newest_serials != expected_newest {
+            return Err(self.fail(format!(
+                "newest-first presence history mismatch on {channel}: expected {expected_newest:?}, got {newest_serials:?}"
+            )));
+        }
+        for pair in oldest.windows(2) {
+            if pair[0].serial.saturating_add(1) != pair[1].serial {
+                return Err(self.fail(format!(
+                    "presence serial gap on {channel}: {} then {}",
+                    pair[0].serial, pair[1].serial
+                )));
+            }
+        }
+
+        let snapshot = self
+            .presence_store
+            .snapshot_at(PresenceSnapshotRequest {
+                app_id: APP_ID.to_string(),
+                channel: channel.to_string(),
+                at_time_ms: None,
+                at_serial: None,
+            })
+            .await?;
+        let actual_members = snapshot
+            .members
+            .iter()
+            .map(|member| member.user_id.clone())
+            .collect::<BTreeSet<_>>();
+        let expected_members = shadow
+            .presence_members
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if actual_members != expected_members {
+            return Err(self.fail(format!(
+                "presence snapshot mismatch on {channel}: expected {expected_members:?}, got {actual_members:?}"
+            )));
+        }
+        if snapshot.events_replayed != expected.len() as u64 {
+            return Err(self.fail(format!(
+                "presence snapshot replay count mismatch on {channel}: expected {}, got {}",
+                expected.len(),
+                snapshot.events_replayed
+            )));
+        }
+
+        if shadow.presence_stream_id.is_some() {
+            let inspection = self
+                .presence_store
+                .stream_inspection(APP_ID, channel)
+                .await?;
+            let expected_next = expected
+                .last()
+                .map_or(1, |event| event.serial.saturating_add(1));
+            if inspection.next_serial != Some(expected_next) {
+                return Err(self.fail(format!(
+                    "presence next_serial mismatch on {channel}: expected {expected_next}, got {:?}",
+                    inspection.next_serial
+                )));
+            }
+            if !inspection.state.continuity_proven {
+                return Err(self.fail(format!(
+                    "presence continuity unexpectedly unproven on {channel}: {:?}",
+                    inspection.state
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn assert_presence_item(
+        &self,
+        channel: &str,
+        actual: &PresenceHistoryItem,
+        expected: &ShadowPresenceEvent,
+    ) -> SimulatorResult<()> {
+        if actual.stream_id != expected.stream_id
+            || actual.serial != expected.serial
+            || actual.published_at_ms != expected.published_at_ms
+            || actual.event != expected.event
+            || actual.cause != expected.cause
+            || actual.user_id != expected.user_id
+            || actual.connection_id != expected.connection_id
+            || actual.dead_node_id != expected.dead_node_id
+        {
+            return Err(self.fail(format!(
+                "presence item mismatch on {channel}: expected {expected:?}, got {actual:?}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn check_client_recovery_oracle(&self, channel: &str) -> SimulatorResult<()> {
+        let shadow = self.shadow.channel(channel);
+        let Some(stream_id) = shadow.history_stream_id.as_deref() else {
+            return Ok(());
+        };
+        let newest = shadow.history.back().map_or(0, |message| message.serial);
+        let oldest = shadow
+            .history
+            .front()
+            .map(|message| message.serial)
+            .unwrap_or(1);
+        for client in &self.clients {
+            let (client_stream, last) = client.recovery_position(channel);
+            if client_stream.as_deref() != Some(stream_id) {
+                continue;
+            }
+            if last > newest {
+                return Err(self.fail(format!(
+                    "client {} is ahead of history on {channel}: last={last}, newest={newest}",
+                    client.id
+                )));
+            }
+            if last.saturating_add(1) < oldest {
+                continue;
+            }
+            let missing = shadow
+                .history
+                .iter()
+                .filter(|message| message.serial <= last)
+                .any(|message| !client.has_delivery(channel, message.serial));
+            if missing {
+                return Err(self.fail(format!(
+                    "client {} has contiguous recovery position {last} on {channel} but is missing a delivered serial",
+                    client.id
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    async fn read_history_page(
+        &self,
+        channel: &str,
+        direction: HistoryDirection,
+    ) -> SimulatorResult<Vec<HistoryItem>> {
+        let mut items = Vec::new();
+        let mut cursor: Option<HistoryCursor> = None;
+        loop {
+            let page = self
+                .history_store
+                .read_page(HistoryReadRequest {
+                    app_id: APP_ID.to_string(),
+                    channel: channel.to_string(),
+                    direction,
+                    limit: self.config.page_limit,
+                    cursor: cursor.clone(),
+                    bounds: HistoryQueryBounds::default(),
+                })
+                .await?;
+            items.extend(page.items);
+            if !page.has_more {
+                break;
+            }
+            let Some(next) = page.next_cursor else {
+                return Err(self.fail(format!(
+                    "history page on {channel} had has_more=true without a cursor"
+                )));
+            };
+            let encoded = next.encode()?;
+            let decoded = HistoryCursor::decode(&encoded)?;
+            if decoded != next {
+                return Err(self.fail(format!("history cursor round-trip mismatch on {channel}")));
+            }
+            cursor = Some(next);
+        }
+        Ok(items)
+    }
+
+    async fn read_history_bounded(
+        &self,
+        channel: &str,
+        start_serial: u64,
+    ) -> SimulatorResult<Vec<HistoryItem>> {
+        let mut items = Vec::new();
+        let mut cursor: Option<HistoryCursor> = None;
+        let bounds = HistoryQueryBounds {
+            start_serial: Some(start_serial),
+            ..Default::default()
+        };
+        loop {
+            let page = self
+                .history_store
+                .read_page(HistoryReadRequest {
+                    app_id: APP_ID.to_string(),
+                    channel: channel.to_string(),
+                    direction: HistoryDirection::OldestFirst,
+                    limit: self.config.page_limit,
+                    cursor: cursor.clone(),
+                    bounds: bounds.clone(),
+                })
+                .await?;
+            if page.truncated_by_retention {
+                return Ok(Vec::new());
+            }
+            items.extend(page.items);
+            if !page.has_more {
+                break;
+            }
+            cursor = page.next_cursor;
+        }
+        Ok(items)
+    }
+
+    async fn read_versions(
+        &self,
+        channel: &str,
+        message_serial: &str,
+        direction: VersionStoreDirection,
+    ) -> SimulatorResult<Vec<StoredVersionRecord>> {
+        let mut items = Vec::new();
+        let mut cursor: Option<VersionStoreCursor> = None;
+        loop {
+            let page = self
+                .version_store
+                .get_versions(VersionStoreReadRequest {
+                    app_id: APP_ID.to_string(),
+                    channel: channel.to_string(),
+                    message_serial: MessageSerial::new(message_serial.to_string())?,
+                    direction,
+                    limit: self.config.page_limit,
+                    cursor: cursor.clone(),
+                })
+                .await?;
+            items.extend(page.items);
+            if !page.has_more {
+                break;
+            }
+            let Some(next) = page.next_cursor else {
+                return Err(self.fail(format!(
+                    "version page on {channel}/{message_serial} had has_more=true without a cursor"
+                )));
+            };
+            cursor = Some(next);
+        }
+        Ok(items)
+    }
+
+    async fn read_presence_page(
+        &self,
+        channel: &str,
+        direction: PresenceHistoryDirection,
+    ) -> SimulatorResult<Vec<PresenceHistoryItem>> {
+        let mut items = Vec::new();
+        let mut cursor: Option<PresenceHistoryCursor> = None;
+        loop {
+            let page = self
+                .presence_store
+                .read_page(PresenceHistoryReadRequest {
+                    app_id: APP_ID.to_string(),
+                    channel: channel.to_string(),
+                    direction,
+                    limit: self.config.page_limit,
+                    cursor: cursor.clone(),
+                    bounds: PresenceHistoryQueryBounds::default(),
+                })
+                .await?;
+            items.extend(page.items);
+            if !page.has_more {
+                break;
+            }
+            let Some(next) = page.next_cursor else {
+                return Err(self.fail(format!(
+                    "presence page on {channel} had has_more=true without a cursor"
+                )));
+            };
+            let encoded = next.encode()?;
+            let decoded = PresenceHistoryCursor::decode(&encoded)?;
+            if decoded != next {
+                return Err(self.fail(format!("presence cursor round-trip mismatch on {channel}")));
+            }
+            cursor = Some(next);
+        }
+        Ok(items)
+    }
+
+    fn history_retention_policy(&self) -> HistoryRetentionPolicy {
+        HistoryRetentionPolicy {
+            retention_window_seconds: self.config.retention_window().as_secs(),
+            max_messages_per_channel: self.config.history_retention_messages,
+            max_bytes_per_channel: None,
+        }
+    }
+
+    fn presence_retention_policy(&self) -> PresenceHistoryRetentionPolicy {
+        PresenceHistoryRetentionPolicy {
+            retention_window_seconds: self.config.retention_window().as_secs(),
+            max_events_per_channel: self.config.presence_retention_events,
+            max_bytes_per_channel: None,
+        }
+    }
+
+    fn next_version_metadata(&mut self) -> SimulatorResult<VersionMetadata> {
+        let serial = VersionSerial::new(format!("ver-{:020}", self.next_version_serial))?;
+        self.next_version_serial = self.next_version_serial.saturating_add(1);
+        Ok(VersionMetadata {
+            serial,
+            client_id: Some(format!(
+                "client-{}",
+                self.rng.random_range(0..self.config.clients)
+            )),
+            timestamp_ms: self.timestamp_ms(),
+            description: None,
+            metadata: None,
+        })
+    }
+
+    fn random_channel(&mut self) -> String {
+        self.channels[self.rng.random_range(0..self.channels.len())].clone()
+    }
+
+    fn random_delay(&mut self) -> u64 {
+        if self.config.fault.max_fanout_delay_ticks == 0 {
+            0
+        } else {
+            self.rng
+                .random_range(0..=self.config.fault.max_fanout_delay_ticks)
+        }
+    }
+
+    fn roll(&mut self, probability: f64) -> bool {
+        probability > 0.0 && self.rng.random::<f64>() < probability
+    }
+
+    fn timestamp_ms(&self) -> i64 {
+        BASE_TIME_MS.saturating_add(self.tick as i64)
+    }
+
+    fn fail(&self, message: String) -> SimulatorError {
+        SimulatorError::Invariant {
+            seed: self.config.seed,
+            tick: self.tick,
+            message,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NodeState {
+    id: usize,
+    alive: bool,
+    partitioned: bool,
+}
+
+impl NodeState {
+    fn new(id: usize) -> Self {
+        Self {
+            id,
+            alive: true,
+            partitioned: false,
+        }
+    }
+
+    fn can_accept_traffic(&self) -> bool {
+        self.alive && !self.partitioned
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NetworkEvent {
+    deliver_at: u64,
+    client_idx: usize,
+    channel: String,
+    stream_id: String,
+    serial: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ClientState {
+    id: usize,
+    channels: BTreeMap<String, ClientChannelState>,
+}
+
+impl ClientState {
+    fn new(id: usize, channels: &[String]) -> Self {
+        Self {
+            id,
+            channels: channels
+                .iter()
+                .map(|channel| (channel.clone(), ClientChannelState::default()))
+                .collect(),
+        }
+    }
+
+    fn deliver(&mut self, event: &NetworkEvent) -> bool {
+        let state = self.channels.entry(event.channel.clone()).or_default();
+        if state.stream_id.is_none() {
+            state.stream_id = Some(event.stream_id.clone());
+        }
+        if state.stream_id.as_deref() != Some(event.stream_id.as_str()) {
+            return false;
+        }
+        state.delivered.insert(event.serial);
+        while state
+            .delivered
+            .contains(&state.last_contiguous.saturating_add(1))
+        {
+            state.last_contiguous = state.last_contiguous.saturating_add(1);
+        }
+        true
+    }
+
+    fn reset_channel(&mut self, channel: &str, stream_id: Option<String>) {
+        self.channels.insert(
+            channel.to_string(),
+            ClientChannelState {
+                stream_id,
+                delivered: BTreeSet::new(),
+                last_contiguous: 0,
+            },
+        );
+    }
+
+    fn rewind_below(&mut self, channel: &str, serial: u64) {
+        let state = self.channels.entry(channel.to_string()).or_default();
+        state.delivered.retain(|delivered| *delivered >= serial);
+        state.last_contiguous = state.last_contiguous.max(serial);
+    }
+
+    fn recovery_position(&self, channel: &str) -> (Option<String>, u64) {
+        self.channels
+            .get(channel)
+            .map(|state| (state.stream_id.clone(), state.last_contiguous))
+            .unwrap_or((None, 0))
+    }
+
+    fn has_delivery(&self, channel: &str, serial: u64) -> bool {
+        self.channels
+            .get(channel)
+            .is_some_and(|state| state.delivered.contains(&serial))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct ClientChannelState {
+    stream_id: Option<String>,
+    delivered: BTreeSet<u64>,
+    last_contiguous: u64,
+}
+
+#[derive(Debug, Clone)]
+struct Shadow {
+    channels: BTreeMap<String, ShadowChannel>,
+}
+
+impl Shadow {
+    fn new(
+        channels: &[String],
+        history_limit: Option<usize>,
+        presence_limit: Option<usize>,
+    ) -> Self {
+        Self {
+            channels: channels
+                .iter()
+                .map(|channel| {
+                    (
+                        channel.clone(),
+                        ShadowChannel::new(history_limit, presence_limit),
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn channel(&self, channel: &str) -> &ShadowChannel {
+        self.channels
+            .get(channel)
+            .expect("simulator channel must exist in shadow")
+    }
+
+    fn channel_mut(&mut self, channel: &str) -> &mut ShadowChannel {
+        self.channels
+            .get_mut(channel)
+            .expect("simulator channel must exist in shadow")
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ShadowChannel {
+    history_stream_id: Option<String>,
+    history: VecDeque<ShadowHistoryMessage>,
+    history_limit: Option<usize>,
+    version_messages: BTreeMap<String, ShadowVersionChain>,
+    version_replay: BTreeMap<u64, StoredVersionRecord>,
+    presence_stream_id: Option<String>,
+    presence_events: VecDeque<ShadowPresenceEvent>,
+    presence_latest_event_by_user: BTreeMap<String, PresenceHistoryEventKind>,
+    presence_members: BTreeMap<String, PresenceHistoryEventKind>,
+    presence_limit: Option<usize>,
+}
+
+impl ShadowChannel {
+    fn new(history_limit: Option<usize>, presence_limit: Option<usize>) -> Self {
+        Self {
+            history_stream_id: None,
+            history: VecDeque::new(),
+            history_limit,
+            version_messages: BTreeMap::new(),
+            version_replay: BTreeMap::new(),
+            presence_stream_id: None,
+            presence_events: VecDeque::new(),
+            presence_latest_event_by_user: BTreeMap::new(),
+            presence_members: BTreeMap::new(),
+            presence_limit,
+        }
+    }
+
+    fn append_history(&mut self, message: ShadowHistoryMessage) {
+        self.history_stream_id = Some(message.stream_id.clone());
+        self.history.push_back(message);
+        if let Some(limit) = self.history_limit {
+            while self.history.len() > limit {
+                self.history.pop_front();
+            }
+        }
+    }
+
+    fn reset_history(&mut self, stream_id: String) {
+        self.history_stream_id = Some(stream_id);
+        self.history.clear();
+    }
+
+    fn purge_history_before(&mut self, serial: u64) {
+        self.history.retain(|message| message.serial >= serial);
+    }
+
+    fn append_version(&mut self, record: StoredVersionRecord) {
+        let message_serial = record.message_serial().as_str().to_string();
+        self.version_replay
+            .insert(record.delivery_serial(), record.clone());
+        self.version_messages
+            .entry(message_serial)
+            .or_default()
+            .versions
+            .push(record);
+    }
+
+    fn random_live_version(&self, rng: &mut StdRng) -> Option<StoredVersionRecord> {
+        let candidates = self
+            .version_messages
+            .values()
+            .filter_map(ShadowVersionChain::latest)
+            .filter(|record| record.message.action != MessageAction::Delete)
+            .cloned()
+            .collect::<Vec<_>>();
+        if candidates.is_empty() {
+            None
+        } else {
+            Some(candidates[rng.random_range(0..candidates.len())].clone())
+        }
+    }
+
+    fn latest_versions_by_history(&self) -> Vec<&StoredVersionRecord> {
+        let mut latest = self
+            .version_messages
+            .values()
+            .filter_map(ShadowVersionChain::latest)
+            .collect::<Vec<_>>();
+        latest.sort_by_key(|record| record.history_serial());
+        latest
+    }
+
+    fn presence_would_record(&self, event: PresenceHistoryEventKind, user_id: &str) -> bool {
+        self.presence_latest_event_by_user.get(user_id) != Some(&event)
+    }
+
+    fn append_presence(&mut self, item: PresenceHistoryItem) {
+        self.presence_stream_id = Some(item.stream_id.clone());
+        self.presence_events.push_back(ShadowPresenceEvent {
+            stream_id: item.stream_id,
+            serial: item.serial,
+            published_at_ms: item.published_at_ms,
+            event: item.event,
+            cause: item.cause,
+            user_id: item.user_id,
+            connection_id: item.connection_id,
+            dead_node_id: item.dead_node_id,
+        });
+        self.rebuild_presence_members();
+        if let Some(limit) = self.presence_limit {
+            while self.presence_events.len() > limit {
+                self.presence_events.pop_front();
+            }
+            self.rebuild_presence_members();
+        }
+    }
+
+    fn reset_presence(&mut self, stream_id: String) {
+        self.presence_stream_id = Some(stream_id);
+        self.presence_events.clear();
+        self.presence_latest_event_by_user.clear();
+        self.presence_members.clear();
+    }
+
+    fn rebuild_presence_members(&mut self) {
+        self.presence_latest_event_by_user.clear();
+        self.presence_members.clear();
+        for event in &self.presence_events {
+            self.presence_latest_event_by_user
+                .insert(event.user_id.clone(), event.event);
+            match event.event {
+                PresenceHistoryEventKind::MemberAdded | PresenceHistoryEventKind::MemberUpdated => {
+                    self.presence_members
+                        .insert(event.user_id.clone(), event.event);
+                }
+                PresenceHistoryEventKind::MemberRemoved => {
+                    self.presence_members.remove(&event.user_id);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ShadowHistoryMessage {
+    stream_id: String,
+    serial: u64,
+    published_at_ms: i64,
+    message_id: Option<String>,
+    event_name: Option<String>,
+    operation_kind: String,
+    payload: Bytes,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ShadowVersionChain {
+    versions: Vec<StoredVersionRecord>,
+}
+
+impl ShadowVersionChain {
+    fn latest(&self) -> Option<&StoredVersionRecord> {
+        self.versions.last()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ShadowPresenceEvent {
+    stream_id: String,
+    serial: u64,
+    published_at_ms: i64,
+    event: PresenceHistoryEventKind,
+    cause: PresenceHistoryEventCause,
+    user_id: String,
+    connection_id: Option<String>,
+    dead_node_id: Option<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+struct Stats {
+    operations: u64,
+    rejected_operations: u64,
+    oracle_checks: u64,
+    history_commits: u64,
+    version_commits: u64,
+    presence_events: u64,
+    dropped_fanout: u64,
+    duplicated_fanout: u64,
+    delivered_messages: u64,
+    recovered_messages: u64,
+    recovery_truncations: u64,
+    stale_deliveries: u64,
+    node_crashes: u64,
+    node_restarts: u64,
+    node_partitions: u64,
+    node_heals: u64,
+    stream_resets: u64,
+    purges: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(seed: u64) -> SimulatorConfig {
+        SimulatorConfig {
+            seed,
+            ticks: 300,
+            nodes: 4,
+            clients: 4,
+            channels: 3,
+            users: 6,
+            oracle_every: 10,
+            page_limit: 3,
+            history_retention_messages: Some(128),
+            presence_retention_events: Some(128),
+            fault: crate::FaultConfig {
+                fanout_drop_probability: 0.20,
+                fanout_duplicate_probability: 0.10,
+                max_fanout_delay_ticks: 6,
+                node_crash_probability: 0.01,
+                node_restart_probability: 0.05,
+                node_partition_probability: 0.01,
+                node_heal_probability: 0.05,
+                stream_reset_probability: 0.001,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn same_seed_produces_same_report() {
+        let config = test_config(0xdeca_fbad);
+        let mut left = DeterministicSimulator::new(config.clone()).unwrap();
+        let mut right = DeterministicSimulator::new(config).unwrap();
+
+        let left_report = left.run().await.unwrap();
+        let right_report = right.run().await.unwrap();
+
+        assert_eq!(left_report, right_report);
+    }
+
+    #[tokio::test]
+    async fn dropped_fanout_recovers_from_history() {
+        let mut config = test_config(0xc0ffee);
+        config.ticks = 120;
+        config.fault.fanout_drop_probability = 1.0;
+        config.fault.fanout_duplicate_probability = 0.0;
+        config.fault.stream_reset_probability = 0.0;
+        let mut simulator = DeterministicSimulator::new(config).unwrap();
+
+        let report = simulator.run().await.unwrap();
+
+        assert_eq!(report.delivered_messages, 0);
+        assert!(
+            report.recovered_messages > 0,
+            "history recovery should catch clients up after dropped fanout"
+        );
+        assert!(report.history_commits > 0);
+        assert!(report.oracle_checks > 0);
+    }
+}

--- a/crates/sockudo-simulator/src/simulator.rs
+++ b/crates/sockudo-simulator/src/simulator.rs
@@ -626,15 +626,20 @@ impl DeterministicSimulator {
     }
 
     async fn quiesce(&mut self) -> SimulatorResult<()> {
-        let settle = self
-            .config
-            .fault
-            .max_fanout_delay_ticks
-            .saturating_add(5)
-            .max(16);
-        for _ in 0..settle {
-            self.tick = self.tick.saturating_add(1);
+        let max_steps = self.network.len();
+        for _ in 0..max_steps {
+            let Some(next_delivery_tick) = self.network.iter().map(|event| event.deliver_at).min()
+            else {
+                return Ok(());
+            };
+            self.tick = self.tick.saturating_add(1).max(next_delivery_tick);
             self.deliver_due_fanout();
+        }
+        if !self.network.is_empty() {
+            return Err(self.fail(format!(
+                "quiesce did not drain fanout queue after {max_steps} steps (remaining={})",
+                self.network.len()
+            )));
         }
         Ok(())
     }
@@ -1729,6 +1734,7 @@ mod tests {
         let right_report = right.run().await.unwrap();
 
         assert_eq!(left_report, right_report);
+        assert_eq!(left_report.queued_fanout, 0);
     }
 
     #[tokio::test]

--- a/crates/sockudo-simulator/src/workload.rs
+++ b/crates/sockudo-simulator/src/workload.rs
@@ -1,0 +1,278 @@
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SimulatorError, SimulatorResult};
+
+const WORKLOAD_SEED_DOMAIN: u64 = 0x57f4_d04d_100d_f177;
+
+/// One operation family the deterministic workload generator can emit.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkloadAction {
+    PublishMessage,
+    CreateVersionedMessage,
+    MutateVersionedMessage,
+    PresenceTransition,
+    RecoveryProbe,
+    PurgeHistory,
+    OracleCheck,
+}
+
+impl WorkloadAction {
+    pub const ALL: [Self; 7] = [
+        Self::PublishMessage,
+        Self::CreateVersionedMessage,
+        Self::MutateVersionedMessage,
+        Self::PresenceTransition,
+        Self::RecoveryProbe,
+        Self::PurgeHistory,
+        Self::OracleCheck,
+    ];
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PublishMessage => "publish_message",
+            Self::CreateVersionedMessage => "create_versioned_message",
+            Self::MutateVersionedMessage => "mutate_versioned_message",
+            Self::PresenceTransition => "presence_transition",
+            Self::RecoveryProbe => "recovery_probe",
+            Self::PurgeHistory => "purge_history",
+            Self::OracleCheck => "oracle_check",
+        }
+    }
+}
+
+/// Weighted workload profile.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActionWeights {
+    pub publish_message: u32,
+    pub create_versioned_message: u32,
+    pub mutate_versioned_message: u32,
+    pub presence_transition: u32,
+    pub recovery_probe: u32,
+    pub purge_history: u32,
+    pub oracle_check: u32,
+}
+
+impl Default for ActionWeights {
+    fn default() -> Self {
+        Self {
+            publish_message: 35,
+            create_versioned_message: 15,
+            mutate_versioned_message: 20,
+            presence_transition: 20,
+            recovery_probe: 7,
+            purge_history: 2,
+            oracle_check: 1,
+        }
+    }
+}
+
+impl ActionWeights {
+    #[must_use]
+    pub fn total(self) -> u32 {
+        WorkloadAction::ALL
+            .iter()
+            .map(|&action| self.weight(action))
+            .sum()
+    }
+
+    #[must_use]
+    pub fn weight(self, action: WorkloadAction) -> u32 {
+        match action {
+            WorkloadAction::PublishMessage => self.publish_message,
+            WorkloadAction::CreateVersionedMessage => self.create_versioned_message,
+            WorkloadAction::MutateVersionedMessage => self.mutate_versioned_message,
+            WorkloadAction::PresenceTransition => self.presence_transition,
+            WorkloadAction::RecoveryProbe => self.recovery_probe,
+            WorkloadAction::PurgeHistory => self.purge_history,
+            WorkloadAction::OracleCheck => self.oracle_check,
+        }
+    }
+
+    pub(crate) fn validate(self) -> SimulatorResult<()> {
+        if self.total() == 0 {
+            return Err(SimulatorError::Config(
+                "at least one workload action weight must be greater than 0".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Workload generator configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkloadConfig {
+    pub weights: ActionWeights,
+}
+
+impl WorkloadConfig {
+    pub(crate) fn validate(&self) -> SimulatorResult<()> {
+        self.weights.validate()
+    }
+}
+
+/// Per-action sample counts emitted by the generator.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkloadActionCounts {
+    pub publish_message: u64,
+    pub create_versioned_message: u64,
+    pub mutate_versioned_message: u64,
+    pub presence_transition: u64,
+    pub recovery_probe: u64,
+    pub purge_history: u64,
+    pub oracle_check: u64,
+}
+
+impl WorkloadActionCounts {
+    fn increment(&mut self, action: WorkloadAction) {
+        match action {
+            WorkloadAction::PublishMessage => {
+                self.publish_message = self.publish_message.saturating_add(1);
+            }
+            WorkloadAction::CreateVersionedMessage => {
+                self.create_versioned_message = self.create_versioned_message.saturating_add(1);
+            }
+            WorkloadAction::MutateVersionedMessage => {
+                self.mutate_versioned_message = self.mutate_versioned_message.saturating_add(1);
+            }
+            WorkloadAction::PresenceTransition => {
+                self.presence_transition = self.presence_transition.saturating_add(1);
+            }
+            WorkloadAction::RecoveryProbe => {
+                self.recovery_probe = self.recovery_probe.saturating_add(1);
+            }
+            WorkloadAction::PurgeHistory => {
+                self.purge_history = self.purge_history.saturating_add(1);
+            }
+            WorkloadAction::OracleCheck => {
+                self.oracle_check = self.oracle_check.saturating_add(1);
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn count(&self, action: WorkloadAction) -> u64 {
+        match action {
+            WorkloadAction::PublishMessage => self.publish_message,
+            WorkloadAction::CreateVersionedMessage => self.create_versioned_message,
+            WorkloadAction::MutateVersionedMessage => self.mutate_versioned_message,
+            WorkloadAction::PresenceTransition => self.presence_transition,
+            WorkloadAction::RecoveryProbe => self.recovery_probe,
+            WorkloadAction::PurgeHistory => self.purge_history,
+            WorkloadAction::OracleCheck => self.oracle_check,
+        }
+    }
+}
+
+/// Deterministic weighted workload generator.
+#[derive(Debug, Clone)]
+pub struct WorkloadGenerator {
+    weights: ActionWeights,
+    rng: StdRng,
+    selected: WorkloadActionCounts,
+}
+
+impl WorkloadGenerator {
+    pub(crate) fn new(seed: u64, config: WorkloadConfig) -> SimulatorResult<Self> {
+        config.validate()?;
+        Ok(Self {
+            weights: config.weights,
+            rng: StdRng::seed_from_u64(seed ^ WORKLOAD_SEED_DOMAIN),
+            selected: WorkloadActionCounts::default(),
+        })
+    }
+
+    pub(crate) fn next_action(&mut self) -> WorkloadAction {
+        let mut roll = self.rng.random_range(0..self.weights.total());
+        for action in WorkloadAction::ALL {
+            let weight = self.weights.weight(action);
+            if weight == 0 {
+                continue;
+            }
+            if roll < weight {
+                self.selected.increment(action);
+                return action;
+            }
+            roll -= weight;
+        }
+        unreachable!("validated action weights must contain at least one non-zero entry")
+    }
+
+    #[must_use]
+    pub fn weights(&self) -> ActionWeights {
+        self.weights
+    }
+
+    #[must_use]
+    pub fn selected(&self) -> &WorkloadActionCounts {
+        &self.selected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generator_is_seed_deterministic() {
+        let config = WorkloadConfig::default();
+        let mut left = WorkloadGenerator::new(42, config.clone()).unwrap();
+        let mut right = WorkloadGenerator::new(42, config).unwrap();
+
+        let left_actions = (0..100).map(|_| left.next_action()).collect::<Vec<_>>();
+        let right_actions = (0..100).map(|_| right.next_action()).collect::<Vec<_>>();
+
+        assert_eq!(left_actions, right_actions);
+        assert_eq!(left.selected(), right.selected());
+    }
+
+    #[test]
+    fn zero_weight_actions_are_never_selected() {
+        let config = WorkloadConfig {
+            weights: ActionWeights {
+                publish_message: 0,
+                create_versioned_message: 0,
+                mutate_versioned_message: 0,
+                presence_transition: 5,
+                recovery_probe: 0,
+                purge_history: 0,
+                oracle_check: 0,
+            },
+        };
+        let mut generator = WorkloadGenerator::new(7, config).unwrap();
+
+        for _ in 0..100 {
+            assert_eq!(generator.next_action(), WorkloadAction::PresenceTransition);
+        }
+        assert_eq!(
+            generator
+                .selected()
+                .count(WorkloadAction::PresenceTransition),
+            100
+        );
+    }
+
+    #[test]
+    fn rejects_empty_weight_profiles() {
+        let error = WorkloadGenerator::new(
+            7,
+            WorkloadConfig {
+                weights: ActionWeights {
+                    publish_message: 0,
+                    create_versioned_message: 0,
+                    mutate_versioned_message: 0,
+                    presence_transition: 0,
+                    recovery_probe: 0,
+                    purge_history: 0,
+                    oracle_check: 0,
+                },
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("at least one workload action"));
+    }
+}

--- a/docs/content/docs/server/indestructibility-simulator.mdx
+++ b/docs/content/docs/server/indestructibility-simulator.mdx
@@ -40,7 +40,24 @@ deterministic inner loop for the durable primitives those tests rely on.
 
 ## Fault Model
 
-The default run injects:
+The default workload is a weighted deterministic generator, not an ad hoc random branch in the
+runner. Each tick samples one action from these weights:
+
+| Flag | Default | Action |
+| --- | ---: | --- |
+| `--weight-publish` | `35` | Append a durable history message and fan it out to clients. |
+| `--weight-create-versioned` | `15` | Create a new mutable Protocol V2 message. |
+| `--weight-mutate-versioned` | `20` | Update, append to, or delete an existing mutable message. |
+| `--weight-presence` | `20` | Record a presence join/leave transition. |
+| `--weight-recovery` | `7` | Probe durable recovery for one simulated client/channel. |
+| `--weight-purge` | `2` | Purge an older retained history prefix. |
+| `--weight-oracle` | `1` | Force a full oracle sweep outside the periodic cadence. |
+
+Set a weight to `0` to disable that action family. At least one action weight must be non-zero.
+The final JSON report includes the weights and selected action counts so coverage is visible for a
+seed.
+
+The default fault model injects:
 
 | Flag | Default | Meaning |
 | --- | ---: | --- |

--- a/docs/content/docs/server/indestructibility-simulator.mdx
+++ b/docs/content/docs/server/indestructibility-simulator.mdx
@@ -1,0 +1,101 @@
+---
+title: Indestructibility simulator
+description: Run Sockudo's deterministic workload simulator for durable history, recovery, presence history, and mutable messages.
+icon: ShieldCheck
+---
+
+The Sockudo simulator is a seed-replayable workload fuzzer for durable Protocol V2 state. It runs
+inside one process, drives real `sockudo-core` memory stores, injects node and fanout faults, and
+checks a shadow model continuously.
+
+Use it to prove that core durability contracts survive dropped live fanout, duplicated delivery,
+node crashes, partitions, stream resets, retention purges, and reconnect recovery.
+
+```bash
+cargo run -p sockudo-simulator --bin sockudo-sim -- --seed 42 --ticks 10000
+```
+
+or through the Makefile wrapper:
+
+```bash
+make simulator SIM_SEED=42 SIM_TICKS=10000
+```
+
+Every failure prints a replay command with the seed. Keep the seed, tick count, and fault arguments
+unchanged when reducing a failure.
+
+## What It Exercises
+
+The simulator currently covers four high-value durability surfaces:
+
+| Surface | Oracle |
+| --- | --- |
+| Durable history | Reserved serials, retained rows, page cursors, stream inspection, retention purges, and reset behavior match the shadow model. |
+| Connection recovery | Simulated clients recover dropped live fanout from durable history unless retention has legitimately truncated the gap. |
+| Versioned messages | Delivery serial replay is contiguous, version chains page in both directions, latest reads match the shadow, and `latest_by_history` preserves original history ordering. |
+| Presence history | Transition dedupe, retained events, cursor paging, stream inspection, and reconstructed snapshots match the shadow model. |
+
+It does not replace live multi-node integration or Jepsen-style external testing. It is the fast,
+deterministic inner loop for the durable primitives those tests rely on.
+
+## Fault Model
+
+The default run injects:
+
+| Flag | Default | Meaning |
+| --- | ---: | --- |
+| `--drop-prob` | `0.08` | Probability that a live fanout message is dropped before reaching a simulated client. |
+| `--duplicate-prob` | `0.03` | Probability that a fanout message is duplicated. |
+| `--max-delay-ticks` | `12` | Maximum deterministic fanout delay. |
+| `--crash-prob` | `0.002` | Per-tick probability that one live node crashes. |
+| `--restart-prob` | `0.020` | Per-tick probability that one crashed node restarts. |
+| `--partition-prob` | `0.003` | Per-tick probability that one live node is isolated from traffic. |
+| `--heal-prob` | `0.020` | Per-tick probability that one partitioned node heals. |
+| `--stream-reset-prob` | `0.0005` | Per-tick probability of an operator history/presence stream reset. |
+
+Rejected operations are part of the model: a workload request may route to a crashed or partitioned
+node and fail before it reaches durable storage. The shadow only advances after durable Sockudo
+stores accept the operation.
+
+## CI Profile
+
+A good pull-request smoke profile is:
+
+```bash
+cargo test -p sockudo-simulator
+cargo run -p sockudo-simulator --bin sockudo-sim -- \
+  --seed 12648430 \
+  --ticks 5000 \
+  --json
+```
+
+For nightly burn-in, run multiple fixed seeds and keep any new failing seed as a regression test:
+
+```bash
+for seed in 1 2 3 4 5 12648430 3735928559; do
+  cargo run -p sockudo-simulator --bin sockudo-sim -- --seed "$seed" --ticks 50000
+done
+```
+
+## Reading Failures
+
+Invariant failures include the seed and simulator tick:
+
+```text
+sockudo-sim: FAILED - reproduce with --seed 42
+simulator invariant failed at tick 812 (seed=42): history serial gap on sim-channel-1: 41 then 43
+```
+
+Treat these as product bugs unless the invariant is deliberately stronger than the subsystem's
+documented contract. If the contract changes, update the simulator shadow and this page in the same
+change.
+
+## Extending It
+
+Add new workloads by following the existing pattern:
+
+1. Generate the operation from the seeded RNG.
+2. Apply it to the real Sockudo store or subsystem first.
+3. Advance the shadow only after the real operation succeeds.
+4. Add a cheap per-run oracle and a quiesce oracle.
+5. Add or pin a seed that fails before the fix and passes after it.

--- a/docs/content/docs/server/meta.json
+++ b/docs/content/docs/server/meta.json
@@ -9,6 +9,7 @@
     "security",
     "observability",
     "history-recovery",
+    "indestructibility-simulator",
     "mutable-messages",
     "webhooks",
     "push-notifications",


### PR DESCRIPTION
## Summary

- Adds a new `sockudo-simulator` workspace crate with a deterministic seed-replay workload simulator.
- Exercises Sockudo durable history, recovery, versioned messages, and presence history using real `sockudo-core` memory stores plus a shadow-model oracle.
- Adds `sockudo-sim` CLI, `make simulator`, and docs for running CI/nightly burn-in profiles.

## Validation

- `cargo fmt --all`
- `cargo test -p sockudo-simulator`
- `cargo clippy -p sockudo-simulator --all-targets -- -D warnings`
- `cargo run -p sockudo-simulator --bin sockudo-sim -- --seed 12648430 --ticks 5000`
- `cd docs && npm run types:check`
- `cd docs && npm run build`

## Notes

- The docs build passed with a Next.js warning about multiple lockfiles/root inference.
- This is a deterministic inner-loop simulator for durable primitives; it complements but does not replace live multi-node integration or external Jepsen-style testing.
