### PR TITLE
Push admission fail closed

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -71,10 +71,15 @@ cleanup_interval_ms = 10000
 [database]
 
 [push]
-# memory is for local development/tests. Use a durable storage driver for clustered push.
+# memory is node-local and loses push state on restart or dead-node loss.
+# Use a durable storage driver for production and clustered push.
 storage_driver = "memory"
-# memory is for local development/tests. Durable queue driver values mirror [queue].driver.
+# memory is node-local and cannot survive queue owner loss. Durable queue driver
+# values mirror [queue].driver.
 queue_driver = "memory"
+# Production mode rejects memory push storage/queues unless this is explicitly
+# set true for local/dev acknowledgment.
+allow_memory_drivers = false
 fcm_enabled = false
 apns_enabled = true
 webpush_enabled = true

--- a/crates/sockudo-core/src/options/ai_transport.rs
+++ b/crates/sockudo-core/src/options/ai_transport.rs
@@ -144,6 +144,7 @@ mod tests {
     #[test]
     fn ai_transport_allows_single_node_memory_development_matrix() {
         let mut options = ai_transport_options();
+        options.mode = "development".to_owned();
         options.adapter.driver = AdapterDriver::Local;
         options.history.backend = HistoryBackend::Memory;
         options.versioned_messages.driver = VersionStoreDriver::Memory;

--- a/crates/sockudo-core/src/options/env/features.rs
+++ b/crates/sockudo-core/src/options/env/features.rs
@@ -26,6 +26,10 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
             "Push Queue Backend",
         );
     }
+    options.push.allow_memory_drivers = parse_bool_env(
+        "PUSH_ALLOW_MEMORY_DRIVERS",
+        options.push.allow_memory_drivers,
+    );
     options.push.fcm_enabled = parse_bool_env("PUSH_FCM_ENABLED", options.push.fcm_enabled);
     options.push.apns_enabled = parse_bool_env("PUSH_APNS_ENABLED", options.push.apns_enabled);
     options.push.webpush_enabled =

--- a/crates/sockudo-core/src/options/push.rs
+++ b/crates/sockudo-core/src/options/push.rs
@@ -72,6 +72,7 @@ impl FromStr for PushQueueDriver {
 pub struct PushConfig {
     pub storage_driver: PushStorageDriver,
     pub queue_driver: PushQueueDriver,
+    pub allow_memory_drivers: bool,
     pub fcm_enabled: bool,
     pub apns_enabled: bool,
     pub webpush_enabled: bool,
@@ -219,6 +220,7 @@ impl Default for PushConfig {
         Self {
             storage_driver: PushStorageDriver::Memory,
             queue_driver: PushQueueDriver::Memory,
+            allow_memory_drivers: false,
             fcm_enabled: false,
             apns_enabled: false,
             webpush_enabled: false,
@@ -392,6 +394,7 @@ mod tests {
 
         assert_eq!(options.push.storage_driver, PushStorageDriver::Memory);
         assert_eq!(options.push.queue_driver, PushQueueDriver::Memory);
+        assert!(!options.push.allow_memory_drivers);
         assert!(!options.push.fcm_enabled);
         assert!(!options.push.apns_enabled);
         assert!(!options.push.webpush_enabled);
@@ -408,6 +411,7 @@ mod tests {
     #[test]
     fn push_rules_default_off_and_validate_startup_shape() {
         let mut options = ServerOptions::default();
+        options.push.allow_memory_drivers = true;
         assert!(options.push_rules.is_empty());
 
         options.push_rules.push(PushRuleConfig {
@@ -430,6 +434,7 @@ mod tests {
             "PUSH_WEBPUSH_ENABLED",
             "PUSH_HMS_ENABLED",
             "PUSH_WNS_ENABLED",
+            "PUSH_ALLOW_MEMORY_DRIVERS",
             "PUSH_CREDENTIAL_ENCRYPTION_KEY",
             "PUSH_FANOUT_FAST_THRESHOLD",
             "PUSH_FANOUT_SHARD_SIZE",
@@ -458,6 +463,7 @@ mod tests {
             std::env::set_var("PUSH_WEBPUSH_ENABLED", "true");
             std::env::set_var("PUSH_HMS_ENABLED", "true");
             std::env::set_var("PUSH_WNS_ENABLED", "true");
+            std::env::set_var("PUSH_ALLOW_MEMORY_DRIVERS", "true");
             std::env::set_var("PUSH_CREDENTIAL_ENCRYPTION_KEY", "env:key:v1");
             std::env::set_var("PUSH_FANOUT_FAST_THRESHOLD", "12345");
             std::env::set_var("PUSH_FANOUT_SHARD_SIZE", "54321");
@@ -494,6 +500,7 @@ mod tests {
         assert!(options.push.webpush_enabled);
         assert!(options.push.hms_enabled);
         assert!(options.push.wns_enabled);
+        assert!(options.push.allow_memory_drivers);
         assert_eq!(
             options.push.credential_encryption_key.as_deref(),
             Some("env:key:v1")
@@ -511,5 +518,33 @@ mod tests {
         assert_eq!(options.push.default_quotas.delivery_quota_daily, 8_000);
         assert_eq!(options.push.default_quotas.fanout_max, 9_000);
         assert_eq!(options.push.default_quotas.inflight_max, 1_000);
+    }
+
+    #[test]
+    fn production_memory_push_drivers_require_explicit_allow() {
+        let mut options = ServerOptions {
+            mode: "production".to_owned(),
+            ..Default::default()
+        };
+        options.push.storage_driver = PushStorageDriver::Memory;
+        options.push.queue_driver = PushQueueDriver::Memory;
+        options.push.allow_memory_drivers = false;
+
+        let error = options.validate().unwrap_err();
+
+        assert!(error.contains("push.storage_driver=memory"));
+    }
+
+    #[test]
+    fn production_memory_push_drivers_validate_with_explicit_allow() {
+        let mut options = ServerOptions {
+            mode: "production".to_owned(),
+            ..Default::default()
+        };
+        options.push.storage_driver = PushStorageDriver::Memory;
+        options.push.queue_driver = PushQueueDriver::Memory;
+        options.push.allow_memory_drivers = true;
+
+        assert!(options.validate().is_ok());
     }
 }

--- a/crates/sockudo-core/src/options/server.rs
+++ b/crates/sockudo-core/src/options/server.rs
@@ -239,6 +239,20 @@ impl ServerOptions {
         for (index, rule) in self.push_rules.iter().enumerate() {
             rule.validate(index)?;
         }
+        if self.mode.eq_ignore_ascii_case("production") && !self.push.allow_memory_drivers {
+            if self.push.storage_driver == PushStorageDriver::Memory {
+                return Err(
+                    "push.storage_driver=memory is unsafe in production; set push.allow_memory_drivers=true only for local/dev acknowledgment"
+                        .to_string(),
+                );
+            }
+            if self.push.queue_driver == PushQueueDriver::Memory {
+                return Err(
+                    "push.queue_driver=memory is unsafe in production; set push.allow_memory_drivers=true only for local/dev acknowledgment"
+                        .to_string(),
+                );
+            }
+        }
 
         if self.adapter.nats.presence_sync_chunk_size == Some(0) {
             return Err("nats.presence_sync_chunk_size must be > 0 when set".to_string());

--- a/crates/sockudo-core/tests/docs_config_defaults.rs
+++ b/crates/sockudo-core/tests/docs_config_defaults.rs
@@ -183,6 +183,11 @@ fn documented_ai_transport_related_defaults_match_code() {
         "push.queue_driver",
         push_queue_driver_name(&options.push.queue_driver),
     );
+    assert_bool(
+        &docs,
+        "push.allow_memory_drivers",
+        options.push.allow_memory_drivers,
+    );
     assert_bool(&docs, "push.fcm_enabled", options.push.fcm_enabled);
     assert_bool(&docs, "push.apns_enabled", options.push.apns_enabled);
     assert_bool(&docs, "push.webpush_enabled", options.push.webpush_enabled);

--- a/crates/sockudo-core/tests/unix_socket_config.rs
+++ b/crates/sockudo-core/tests/unix_socket_config.rs
@@ -264,6 +264,7 @@ mod unix_socket_config_tests {
     fn test_unix_socket_security_validation_safe_paths() {
         let mut config = ServerOptions::default();
         config.unix_socket.enabled = true;
+        config.push.allow_memory_drivers = true;
 
         let safe_paths = vec![
             "/tmp/sockudo.sock",
@@ -290,6 +291,7 @@ mod unix_socket_config_tests {
         let mut config = ServerOptions::default();
         config.unix_socket.enabled = false; // Disabled
         config.unix_socket.path = "/etc/passwd.sock".to_string(); // Dangerous path
+        config.push.allow_memory_drivers = true;
 
         // Should pass validation when disabled
         let result = config.validate();
@@ -312,7 +314,8 @@ mod unix_socket_config_tests {
             }
         }"#;
 
-        let config: ServerOptions = sonic_rs::from_str(json).unwrap();
+        let mut config: ServerOptions = sonic_rs::from_str(json).unwrap();
+        config.push.allow_memory_drivers = true;
         assert!(config.unix_socket.enabled);
         assert_eq!(config.unix_socket.path, "/tmp/test-sockudo.sock");
         assert_eq!(config.unix_socket.permission_mode, 0o664);
@@ -326,6 +329,7 @@ mod unix_socket_config_tests {
         let mut config = ServerOptions::default();
         config.unix_socket.enabled = true;
         config.ssl.enabled = true; // Both Unix socket and SSL enabled
+        config.push.allow_memory_drivers = true;
 
         // Should pass validation but would log a warning (we can't easily test logging in unit tests)
         let result = config.validate();

--- a/crates/sockudo-server/src/bootstrap/mod.rs
+++ b/crates/sockudo-server/src/bootstrap/mod.rs
@@ -71,6 +71,8 @@ struct ServerState {
     push_store: sockudo_push::DynPushStore,
     #[cfg(feature = "push")]
     push_queue: sockudo_push::DynPushQueue,
+    #[cfg(feature = "push")]
+    push_admission: Arc<push::PushAdmissionSnapshot>,
 }
 
 /// Main server struct

--- a/crates/sockudo-server/src/bootstrap/push/capability.rs
+++ b/crates/sockudo-server/src/bootstrap/push/capability.rs
@@ -1,0 +1,814 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+
+use sockudo_core::options::{PushQueueDriver, PushStorageDriver, ServerOptions};
+use sockudo_push::{
+    DynPushStore, FanoutRegime, ProviderCredential, ProviderCredentialMaterial, PublishTarget,
+    PushProviderKind,
+};
+use sonic_rs::JsonValueTrait;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PushAdmissionSnapshot {
+    storage_driver: PushStorageDriver,
+    queue_driver: PushQueueDriver,
+    allow_memory_drivers: bool,
+    production_mode: bool,
+    planner_worker_count: u32,
+    shard_worker_count: u32,
+    feedback_worker_count: u32,
+    providers: BTreeMap<PushProviderKind, PushProviderCapability>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PushProviderCapability {
+    status: PushProviderStatus,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PushProviderStatus {
+    Active,
+    WorkerDisabled(&'static str),
+    UnsupportedByFeature(&'static str),
+    MissingCredentials(String),
+    StoreUnavailable(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PushAdmissionRejection {
+    PushDisabled,
+    NoProviderWorkers,
+    ProviderWorkerDisabled {
+        provider: PushProviderKind,
+        reason: &'static str,
+    },
+    ProviderUnsupported {
+        provider: PushProviderKind,
+        feature: &'static str,
+    },
+    ProviderMissingCredentials {
+        provider: PushProviderKind,
+        reason: String,
+    },
+    ProviderStoreUnavailable {
+        provider: PushProviderKind,
+        reason: String,
+    },
+    PipelineWorkerDisabled {
+        reason: &'static str,
+    },
+    StoreUnsafeForProduction {
+        reason: String,
+    },
+    QueueUnavailable {
+        reason: String,
+    },
+}
+
+impl PushAdmissionSnapshot {
+    pub(crate) async fn from_config(config: &ServerOptions, store: &DynPushStore) -> Self {
+        let mut providers = BTreeMap::new();
+        for provider in all_providers() {
+            providers.insert(
+                provider,
+                PushProviderCapability {
+                    status: provider_status(config, store, provider).await,
+                },
+            );
+        }
+
+        Self {
+            storage_driver: config.push.storage_driver.clone(),
+            queue_driver: config.push.queue_driver.clone(),
+            allow_memory_drivers: config.push.allow_memory_drivers,
+            production_mode: config.mode.eq_ignore_ascii_case("production"),
+            planner_worker_count: config.push.planner_worker_count,
+            shard_worker_count: config.push.shard_worker_count,
+            feedback_worker_count: config.push.feedback_worker_count,
+            providers,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn testing_active(providers: impl IntoIterator<Item = PushProviderKind>) -> Self {
+        let active = providers.into_iter().collect::<BTreeSet<_>>();
+        let providers = all_providers()
+            .into_iter()
+            .map(|provider| {
+                let status = if active.contains(&provider) {
+                    PushProviderStatus::Active
+                } else {
+                    PushProviderStatus::WorkerDisabled("provider worker intentionally disabled")
+                };
+                (provider, PushProviderCapability { status })
+            })
+            .collect();
+
+        Self {
+            storage_driver: PushStorageDriver::Memory,
+            queue_driver: PushQueueDriver::Memory,
+            allow_memory_drivers: true,
+            production_mode: false,
+            planner_worker_count: 1,
+            shard_worker_count: 1,
+            feedback_worker_count: 1,
+            providers,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn testing_with_memory_policy(
+        production_mode: bool,
+        allow_memory_drivers: bool,
+    ) -> Self {
+        Self {
+            production_mode,
+            allow_memory_drivers,
+            ..Self::testing_active([PushProviderKind::Fcm])
+        }
+    }
+
+    pub(crate) fn storage_driver(&self) -> &PushStorageDriver {
+        &self.storage_driver
+    }
+
+    pub(crate) fn queue_driver(&self) -> &PushQueueDriver {
+        &self.queue_driver
+    }
+
+    pub(crate) fn safe_for_admission(&self) -> bool {
+        self.storage_rejection().is_none() && self.has_active_provider()
+    }
+
+    pub(crate) fn active_providers(&self) -> Vec<PushProviderKind> {
+        self.providers
+            .iter()
+            .filter_map(|(provider, capability)| {
+                matches!(capability.status, PushProviderStatus::Active).then_some(*provider)
+            })
+            .collect()
+    }
+
+    pub(crate) fn rejection_for_targets(
+        &self,
+        targets: &[PublishTarget],
+        fanout_regime: FanoutRegime,
+    ) -> Option<PushAdmissionRejection> {
+        if let Some(rejection) = self.storage_rejection() {
+            return Some(rejection);
+        }
+        if let Some(rejection) = self.pipeline_worker_rejection(fanout_regime) {
+            return Some(rejection);
+        }
+
+        let required_providers = required_direct_providers(targets);
+        if required_providers.is_empty() {
+            return self.planned_target_rejection();
+        }
+
+        for provider in required_providers {
+            if let Some(rejection) = self.provider_rejection(provider) {
+                return Some(rejection);
+            }
+        }
+
+        None
+    }
+
+    fn pipeline_worker_rejection(
+        &self,
+        fanout_regime: FanoutRegime,
+    ) -> Option<PushAdmissionRejection> {
+        if self.planner_worker_count == 0 {
+            return Some(PushAdmissionRejection::PipelineWorkerDisabled {
+                reason: "planner_worker_count is zero",
+            });
+        }
+        if self.feedback_worker_count == 0 {
+            return Some(PushAdmissionRejection::PipelineWorkerDisabled {
+                reason: "feedback_worker_count is zero",
+            });
+        }
+        if fanout_regime == FanoutRegime::ShardPath && self.shard_worker_count == 0 {
+            return Some(PushAdmissionRejection::PipelineWorkerDisabled {
+                reason: "shard_worker_count is zero for shard-path publish",
+            });
+        }
+        None
+    }
+
+    fn storage_rejection(&self) -> Option<PushAdmissionRejection> {
+        if !self.production_mode || self.allow_memory_drivers {
+            return None;
+        }
+        if self.storage_driver == PushStorageDriver::Memory {
+            return Some(PushAdmissionRejection::StoreUnsafeForProduction {
+                reason: "push.storage_driver=memory is node-local and unsafe in production"
+                    .to_owned(),
+            });
+        }
+        if self.queue_driver == PushQueueDriver::Memory {
+            return Some(PushAdmissionRejection::StoreUnsafeForProduction {
+                reason: "push.queue_driver=memory is node-local and unsafe in production"
+                    .to_owned(),
+            });
+        }
+        None
+    }
+
+    fn planned_target_rejection(&self) -> Option<PushAdmissionRejection> {
+        if self.has_active_provider() {
+            return None;
+        }
+        if self.providers.values().all(|capability| {
+            matches!(
+                capability.status,
+                PushProviderStatus::WorkerDisabled("provider disabled in config")
+            )
+        }) {
+            return Some(PushAdmissionRejection::PushDisabled);
+        }
+        Some(PushAdmissionRejection::NoProviderWorkers)
+    }
+
+    fn provider_rejection(&self, provider: PushProviderKind) -> Option<PushAdmissionRejection> {
+        let capability = self.providers.get(&provider)?;
+        match &capability.status {
+            PushProviderStatus::Active => None,
+            PushProviderStatus::WorkerDisabled(reason) => {
+                Some(PushAdmissionRejection::ProviderWorkerDisabled { provider, reason })
+            }
+            PushProviderStatus::UnsupportedByFeature(feature) => {
+                Some(PushAdmissionRejection::ProviderUnsupported { provider, feature })
+            }
+            PushProviderStatus::MissingCredentials(reason) => {
+                Some(PushAdmissionRejection::ProviderMissingCredentials {
+                    provider,
+                    reason: reason.clone(),
+                })
+            }
+            PushProviderStatus::StoreUnavailable(reason) => {
+                Some(PushAdmissionRejection::ProviderStoreUnavailable {
+                    provider,
+                    reason: reason.clone(),
+                })
+            }
+        }
+    }
+
+    fn has_active_provider(&self) -> bool {
+        self.providers
+            .values()
+            .any(|capability| matches!(capability.status, PushProviderStatus::Active))
+    }
+}
+
+impl PushAdmissionRejection {
+    pub(crate) fn message(&self) -> String {
+        match self {
+            Self::PushDisabled => {
+                "push admission unavailable: push providers are disabled".to_owned()
+            }
+            Self::NoProviderWorkers => {
+                "push admission unavailable: no provider delivery worker is active".to_owned()
+            }
+            Self::ProviderWorkerDisabled { provider, reason } => format!(
+                "push admission unavailable: {} provider worker is disabled ({reason})",
+                provider_label(*provider)
+            ),
+            Self::ProviderUnsupported { provider, feature } => format!(
+                "push admission unavailable: {} provider worker requires feature `{feature}`",
+                provider_label(*provider)
+            ),
+            Self::ProviderMissingCredentials { provider, reason } => format!(
+                "push admission unavailable: {} provider credentials are not ready ({reason})",
+                provider_label(*provider)
+            ),
+            Self::ProviderStoreUnavailable { provider, reason } => format!(
+                "push admission unavailable: {} provider credential store is unavailable ({reason})",
+                provider_label(*provider)
+            ),
+            Self::PipelineWorkerDisabled { reason } => {
+                format!(
+                    "push admission unavailable: local push pipeline worker is disabled ({reason})"
+                )
+            }
+            Self::StoreUnsafeForProduction { reason } => format!(
+                "push admission unavailable: {reason}; set push.allow_memory_drivers=true only for local/dev acknowledgment"
+            ),
+            Self::QueueUnavailable { reason } => {
+                format!("push admission unavailable: queue is not ready ({reason})")
+            }
+        }
+    }
+}
+
+async fn provider_status(
+    config: &ServerOptions,
+    store: &DynPushStore,
+    provider: PushProviderKind,
+) -> PushProviderStatus {
+    if !provider_enabled(config, provider) {
+        return PushProviderStatus::WorkerDisabled("provider disabled in config");
+    }
+    if config.push.dispatch_worker_count == 0 {
+        return PushProviderStatus::WorkerDisabled("dispatch_worker_count is zero");
+    }
+    if !cfg!(feature = "monolith") {
+        return PushProviderStatus::UnsupportedByFeature("monolith");
+    }
+    if let Some(feature) = missing_provider_feature(provider) {
+        return PushProviderStatus::UnsupportedByFeature(feature);
+    }
+
+    match provider {
+        PushProviderKind::Fcm => fcm_status(store).await,
+        PushProviderKind::Apns => apns_status(store).await,
+        PushProviderKind::WebPush => webpush_status(),
+        PushProviderKind::Hms => hms_status(),
+        PushProviderKind::Wns => wns_status(),
+    }
+}
+
+fn provider_enabled(config: &ServerOptions, provider: PushProviderKind) -> bool {
+    match provider {
+        PushProviderKind::Fcm => config.push.fcm_enabled,
+        PushProviderKind::Apns => config.push.apns_enabled,
+        PushProviderKind::WebPush => config.push.webpush_enabled,
+        PushProviderKind::Hms => config.push.hms_enabled,
+        PushProviderKind::Wns => config.push.wns_enabled,
+    }
+}
+
+fn missing_provider_feature(provider: PushProviderKind) -> Option<&'static str> {
+    match provider {
+        PushProviderKind::Fcm if !cfg!(feature = "push-fcm") => Some("push-fcm"),
+        PushProviderKind::Apns if !cfg!(feature = "push-apns") => Some("push-apns"),
+        PushProviderKind::WebPush if !cfg!(feature = "push-webpush") => Some("push-webpush"),
+        PushProviderKind::Hms if !cfg!(feature = "push-hms") => Some("push-hms"),
+        PushProviderKind::Wns if !cfg!(feature = "push-wns") => Some("push-wns"),
+        _ => None,
+    }
+}
+
+async fn fcm_status(store: &DynPushStore) -> PushProviderStatus {
+    let configured_project_id = match optional_env_value(&["FCM_PROJECT_ID", "PUSH_FCM_PROJECT_ID"])
+    {
+        Ok(value) => value,
+        Err(reason) => return PushProviderStatus::MissingCredentials(reason),
+    };
+
+    match stored_credential(
+        store,
+        PushProviderKind::Fcm,
+        &["FCM_APP_ID", "PUSH_FCM_APP_ID"],
+        &["FCM_CREDENTIAL_ID", "PUSH_FCM_CREDENTIAL_ID"],
+        "fcm",
+    )
+    .await
+    {
+        StoredCredentialStatus::Found(credential) => {
+            return fcm_stored_credential_status(credential, configured_project_id.as_deref());
+        }
+        StoredCredentialStatus::StoreUnavailable(reason) => {
+            return PushProviderStatus::StoreUnavailable(reason);
+        }
+        StoredCredentialStatus::Missing(reason) => {
+            return PushProviderStatus::MissingCredentials(reason);
+        }
+        StoredCredentialStatus::NotConfigured => {}
+    }
+
+    match fcm_service_account_project_id(configured_project_id.as_deref()) {
+        Ok(ServiceAccountProject::Ready) => PushProviderStatus::Active,
+        Ok(ServiceAccountProject::NotConfigured) => {
+            match env_present(&["FCM_PROVIDER_TOKEN", "PUSH_FCM_PROVIDER_TOKEN"]) {
+                Ok(true) if configured_project_id.is_some() => PushProviderStatus::Active,
+                Ok(true) => PushProviderStatus::MissingCredentials(
+                    "FCM_PROJECT_ID/PUSH_FCM_PROJECT_ID is required with a static provider token"
+                        .to_owned(),
+                ),
+                Ok(false) => PushProviderStatus::MissingCredentials(
+                    "configure FCM_SERVICE_ACCOUNT_JSON_PATH/PUSH_FCM_SERVICE_ACCOUNT_JSON_PATH, FCM_SERVICE_ACCOUNT_JSON/PUSH_FCM_SERVICE_ACCOUNT_JSON, FCM_PROVIDER_TOKEN/PUSH_FCM_PROVIDER_TOKEN, or stored FCM credentials"
+                        .to_owned(),
+                ),
+                Err(reason) => PushProviderStatus::MissingCredentials(reason),
+            }
+        }
+        Err(reason) => PushProviderStatus::MissingCredentials(reason),
+    }
+}
+
+fn fcm_stored_credential_status(
+    credential: ProviderCredential,
+    configured_project_id: Option<&str>,
+) -> PushProviderStatus {
+    let ProviderCredentialMaterial::Fcm {
+        service_account_json,
+    } = credential.material
+    else {
+        return PushProviderStatus::MissingCredentials(
+            "stored credential material is not FCM".to_owned(),
+        );
+    };
+
+    if configured_project_id.is_some() {
+        return PushProviderStatus::Active;
+    }
+
+    let Ok(service_account_json) =
+        crate::push_http::decrypt_credential_secret(&service_account_json)
+    else {
+        return PushProviderStatus::MissingCredentials(
+            "stored FCM credential cannot be decrypted".to_owned(),
+        );
+    };
+    match service_account_json_project_id(&service_account_json) {
+        Ok(true) => PushProviderStatus::Active,
+        Ok(false) => PushProviderStatus::MissingCredentials(
+            "stored FCM service account JSON has no project_id and no FCM_PROJECT_ID/PUSH_FCM_PROJECT_ID is configured"
+                .to_owned(),
+        ),
+        Err(reason) => PushProviderStatus::MissingCredentials(reason),
+    }
+}
+
+async fn apns_status(store: &DynPushStore) -> PushProviderStatus {
+    if let Err(reason) = env_present(&["APNS_TOPIC", "PUSH_APNS_TOPIC"]) {
+        return PushProviderStatus::MissingCredentials(reason);
+    }
+    if !matches!(env_present(&["APNS_TOPIC", "PUSH_APNS_TOPIC"]), Ok(true)) {
+        return PushProviderStatus::MissingCredentials(
+            "APNS_TOPIC/PUSH_APNS_TOPIC is required".to_owned(),
+        );
+    }
+
+    match stored_credential(
+        store,
+        PushProviderKind::Apns,
+        &["APNS_APP_ID", "PUSH_APNS_APP_ID"],
+        &["APNS_CREDENTIAL_ID", "PUSH_APNS_CREDENTIAL_ID"],
+        "apns",
+    )
+    .await
+    {
+        StoredCredentialStatus::Found(credential) => {
+            return apns_stored_credential_status(credential);
+        }
+        StoredCredentialStatus::StoreUnavailable(reason) => {
+            return PushProviderStatus::StoreUnavailable(reason);
+        }
+        StoredCredentialStatus::Missing(reason) => {
+            return PushProviderStatus::MissingCredentials(reason);
+        }
+        StoredCredentialStatus::NotConfigured => {}
+    }
+
+    match env_present(&["APNS_PROVIDER_TOKEN", "PUSH_APNS_PROVIDER_TOKEN"]) {
+        Ok(true) => return PushProviderStatus::Active,
+        Ok(false) => {}
+        Err(reason) => return PushProviderStatus::MissingCredentials(reason),
+    }
+
+    let has_team_id = match env_present(&["APNS_TEAM_ID", "PUSH_APNS_TEAM_ID"]) {
+        Ok(value) => value,
+        Err(reason) => return PushProviderStatus::MissingCredentials(reason),
+    };
+    let has_key_id = match env_present(&["APNS_KEY_ID", "PUSH_APNS_KEY_ID"]) {
+        Ok(value) => value,
+        Err(reason) => return PushProviderStatus::MissingCredentials(reason),
+    };
+    let has_private_key = match env_present(&["APNS_PRIVATE_KEY", "PUSH_APNS_PRIVATE_KEY"]) {
+        Ok(value) => value,
+        Err(reason) => return PushProviderStatus::MissingCredentials(reason),
+    };
+    let has_private_key_path =
+        match env_present(&["APNS_PRIVATE_KEY_PATH", "PUSH_APNS_PRIVATE_KEY_PATH"]) {
+            Ok(value) => value,
+            Err(reason) => return PushProviderStatus::MissingCredentials(reason),
+        };
+    if has_team_id && has_key_id && (has_private_key || has_private_key_path) {
+        PushProviderStatus::Active
+    } else {
+        PushProviderStatus::MissingCredentials(
+            "APNS_PROVIDER_TOKEN/PUSH_APNS_PROVIDER_TOKEN or APNS_TEAM_ID/PUSH_APNS_TEAM_ID + APNS_KEY_ID/PUSH_APNS_KEY_ID + APNS_PRIVATE_KEY/PUSH_APNS_PRIVATE_KEY is required"
+                .to_owned(),
+        )
+    }
+}
+
+fn apns_stored_credential_status(credential: ProviderCredential) -> PushProviderStatus {
+    let ProviderCredentialMaterial::Apns {
+        p12,
+        pem,
+        team_id,
+        key_id,
+        private_key,
+        ..
+    } = credential.material
+    else {
+        return PushProviderStatus::MissingCredentials(
+            "stored credential material is not APNs".to_owned(),
+        );
+    };
+
+    if p12.is_some()
+        || pem.is_some()
+        || (team_id.is_some() && key_id.is_some() && private_key.is_some())
+    {
+        PushProviderStatus::Active
+    } else {
+        PushProviderStatus::MissingCredentials(
+            "stored APNs credential requires p12, pem, or teamId/keyId/privateKey material"
+                .to_owned(),
+        )
+    }
+}
+
+fn webpush_status() -> PushProviderStatus {
+    match env_present(&["VAPID_PRIVATE_KEY", "PUSH_WEBPUSH_VAPID_PRIVATE_KEY"]) {
+        Ok(true) => PushProviderStatus::Active,
+        Ok(false) => PushProviderStatus::MissingCredentials(
+            "VAPID_PRIVATE_KEY/PUSH_WEBPUSH_VAPID_PRIVATE_KEY is required".to_owned(),
+        ),
+        Err(reason) => PushProviderStatus::MissingCredentials(reason),
+    }
+}
+
+fn hms_status() -> PushProviderStatus {
+    let has_app_id = match env_present(&["HMS_APP_ID", "PUSH_HMS_APP_ID"]) {
+        Ok(value) => value,
+        Err(reason) => return PushProviderStatus::MissingCredentials(reason),
+    };
+    let has_token = match env_present(&["HMS_PROVIDER_TOKEN", "PUSH_HMS_PROVIDER_TOKEN"]) {
+        Ok(value) => value,
+        Err(reason) => return PushProviderStatus::MissingCredentials(reason),
+    };
+    if has_app_id && has_token {
+        PushProviderStatus::Active
+    } else {
+        PushProviderStatus::MissingCredentials(
+            "HMS_APP_ID/PUSH_HMS_APP_ID and HMS_PROVIDER_TOKEN/PUSH_HMS_PROVIDER_TOKEN are required"
+                .to_owned(),
+        )
+    }
+}
+
+fn wns_status() -> PushProviderStatus {
+    match env_present(&["WNS_PROVIDER_TOKEN", "PUSH_WNS_PROVIDER_TOKEN"]) {
+        Ok(true) => PushProviderStatus::Active,
+        Ok(false) => PushProviderStatus::MissingCredentials(
+            "WNS_PROVIDER_TOKEN/PUSH_WNS_PROVIDER_TOKEN is required".to_owned(),
+        ),
+        Err(reason) => PushProviderStatus::MissingCredentials(reason),
+    }
+}
+
+enum StoredCredentialStatus {
+    Found(ProviderCredential),
+    Missing(String),
+    StoreUnavailable(String),
+    NotConfigured,
+}
+
+async fn stored_credential(
+    store: &DynPushStore,
+    provider: PushProviderKind,
+    app_env_names: &[&'static str],
+    credential_env_names: &[&'static str],
+    default_credential_id: &'static str,
+) -> StoredCredentialStatus {
+    let app_id = match optional_env_value(app_env_names) {
+        Ok(Some(app_id)) => app_id,
+        Ok(None) => return StoredCredentialStatus::NotConfigured,
+        Err(reason) => return StoredCredentialStatus::Missing(reason),
+    };
+    let credential_id = match optional_env_value(credential_env_names) {
+        Ok(Some(credential_id)) => credential_id,
+        Ok(None) => default_credential_id.to_owned(),
+        Err(reason) => return StoredCredentialStatus::Missing(reason),
+    };
+
+    match store.get_credential(&app_id, &credential_id).await {
+        Ok(Some(credential)) if credential.provider == provider => {
+            StoredCredentialStatus::Found(credential)
+        }
+        Ok(Some(_)) => StoredCredentialStatus::Missing(format!(
+            "stored credential {credential_id:?} for configured app is not {}",
+            provider_label(provider)
+        )),
+        Ok(None) => StoredCredentialStatus::Missing(format!(
+            "stored credential {credential_id:?} was not found for configured app"
+        )),
+        Err(error) => StoredCredentialStatus::StoreUnavailable(error.to_string()),
+    }
+}
+
+enum ServiceAccountProject {
+    Ready,
+    NotConfigured,
+}
+
+fn fcm_service_account_project_id(
+    configured_project_id: Option<&str>,
+) -> Result<ServiceAccountProject, String> {
+    if let Some(json) =
+        optional_env_value(&["FCM_SERVICE_ACCOUNT_JSON", "PUSH_FCM_SERVICE_ACCOUNT_JSON"])?
+    {
+        return service_account_json_project_id(&json).map(|has_project| {
+            if has_project || configured_project_id.is_some() {
+                ServiceAccountProject::Ready
+            } else {
+                ServiceAccountProject::NotConfigured
+            }
+        });
+    }
+
+    let path = optional_env_value(&[
+        "FCM_SERVICE_ACCOUNT_JSON_PATH",
+        "PUSH_FCM_SERVICE_ACCOUNT_JSON_PATH",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    ])?;
+    let Some(path) = path else {
+        return Ok(ServiceAccountProject::NotConfigured);
+    };
+    let json = fs::read_to_string(&path).map_err(|error| {
+        format!("failed to read FCM service account JSON from configured path: {error}")
+    })?;
+    service_account_json_project_id(&json).map(|has_project| {
+        if has_project || configured_project_id.is_some() {
+            ServiceAccountProject::Ready
+        } else {
+            ServiceAccountProject::NotConfigured
+        }
+    })
+}
+
+fn service_account_json_project_id(json: &str) -> Result<bool, String> {
+    let value: sonic_rs::Value = sonic_rs::from_str(json)
+        .map_err(|error| format!("FCM service account JSON is invalid: {error}"))?;
+    Ok(value["project_id"]
+        .as_str()
+        .is_some_and(|project_id| !project_id.trim().is_empty()))
+}
+
+fn env_present(names: &[&'static str]) -> Result<bool, String> {
+    optional_env_value(names).map(|value| value.is_some())
+}
+
+fn optional_env_value(names: &[&'static str]) -> Result<Option<String>, String> {
+    for name in names {
+        if let Ok(value) = std::env::var(name) {
+            if value.trim().is_empty() {
+                return Err(format!("{} is set but empty", names.join("/")));
+            }
+            return Ok(Some(value));
+        }
+    }
+    Ok(None)
+}
+
+fn required_direct_providers(targets: &[PublishTarget]) -> BTreeSet<PushProviderKind> {
+    targets
+        .iter()
+        .filter_map(|target| match target {
+            PublishTarget::Recipient { recipient } => Some(recipient.provider()),
+            PublishTarget::ProviderTopic { provider, .. }
+            | PublishTarget::ProviderCondition { provider, .. } => Some(*provider),
+            _ => None,
+        })
+        .collect()
+}
+
+fn all_providers() -> Vec<PushProviderKind> {
+    vec![
+        PushProviderKind::Fcm,
+        PushProviderKind::Apns,
+        PushProviderKind::WebPush,
+        PushProviderKind::Hms,
+        PushProviderKind::Wns,
+    ]
+}
+
+fn provider_label(provider: PushProviderKind) -> &'static str {
+    match provider {
+        PushProviderKind::Fcm => "FCM",
+        PushProviderKind::Apns => "APNs",
+        PushProviderKind::WebPush => "Web Push",
+        PushProviderKind::Hms => "HMS",
+        PushProviderKind::Wns => "WNS",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use sockudo_core::options::PushQueueDriver;
+    use sockudo_push::{
+        MemoryPushStore, PublishTarget, PushProviderKind, PushRecipient, SecretString,
+    };
+
+    use super::*;
+
+    #[test]
+    fn testing_snapshot_requires_raw_provider_capability() {
+        let snapshot = PushAdmissionSnapshot::testing_active([PushProviderKind::Apns]);
+        let rejection = snapshot
+            .rejection_for_targets(
+                &[PublishTarget::Recipient {
+                    recipient: PushRecipient::Fcm {
+                        registration_token: SecretString::new("token").unwrap(),
+                    },
+                }],
+                FanoutRegime::FastPath,
+            )
+            .unwrap();
+
+        assert!(matches!(
+            rejection,
+            PushAdmissionRejection::ProviderWorkerDisabled {
+                provider: PushProviderKind::Fcm,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn planned_targets_require_any_active_provider_without_scanning_recipients() {
+        let snapshot =
+            PushAdmissionSnapshot::testing_active(std::iter::empty::<PushProviderKind>());
+        let rejection = snapshot
+            .rejection_for_targets(
+                &[PublishTarget::Channel {
+                    channel: "room".to_owned(),
+                }],
+                FanoutRegime::FastPath,
+            )
+            .unwrap();
+
+        assert_eq!(rejection, PushAdmissionRejection::NoProviderWorkers);
+    }
+
+    #[test]
+    fn production_memory_policy_blocks_admission_without_escape_hatch() {
+        let snapshot = PushAdmissionSnapshot::testing_with_memory_policy(true, false);
+
+        assert!(matches!(
+            snapshot.rejection_for_targets(
+                &[PublishTarget::Channel {
+                    channel: "room".to_owned()
+                }],
+                FanoutRegime::FastPath
+            ),
+            Some(PushAdmissionRejection::StoreUnsafeForProduction { .. })
+        ));
+    }
+
+    #[test]
+    fn shard_path_requires_shard_worker_without_planned_target_scan() {
+        let mut snapshot = PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]);
+        snapshot.shard_worker_count = 0;
+
+        assert!(
+            snapshot
+                .rejection_for_targets(
+                    &[PublishTarget::Channel {
+                        channel: "room".to_owned(),
+                    }],
+                    FanoutRegime::FastPath,
+                )
+                .is_none()
+        );
+        assert_eq!(
+            snapshot.rejection_for_targets(
+                &[PublishTarget::Channel {
+                    channel: "room".to_owned(),
+                }],
+                FanoutRegime::ShardPath,
+            ),
+            Some(PushAdmissionRejection::PipelineWorkerDisabled {
+                reason: "shard_worker_count is zero for shard-path publish",
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_config_is_reported_as_push_disabled() {
+        let mut config = ServerOptions::default();
+        config.mode = "development".to_owned();
+        config.push.queue_driver = PushQueueDriver::Memory;
+        let store: DynPushStore = Arc::new(MemoryPushStore::new());
+
+        let snapshot = PushAdmissionSnapshot::from_config(&config, &store).await;
+        assert_eq!(
+            snapshot.rejection_for_targets(
+                &[PublishTarget::Channel {
+                    channel: "room".to_owned()
+                }],
+                FanoutRegime::FastPath
+            ),
+            Some(PushAdmissionRejection::PushDisabled)
+        );
+    }
+}

--- a/crates/sockudo-server/src/bootstrap/push/mod.rs
+++ b/crates/sockudo-server/src/bootstrap/push/mod.rs
@@ -1,3 +1,4 @@
+mod capability;
 mod queue;
 mod stores;
 #[cfg(all(feature = "push", feature = "monolith"))]
@@ -8,6 +9,7 @@ use self::stores::{
     create_dynamodb_push_store, create_mysql_push_store, create_postgres_push_store,
     create_scylladb_push_store, create_surrealdb_push_store,
 };
+pub(crate) use capability::{PushAdmissionRejection, PushAdmissionSnapshot};
 use sockudo_core::error::{Error, Result};
 use sockudo_core::options::ServerOptions;
 #[cfg(feature = "push")]
@@ -17,11 +19,22 @@ use std::sync::Arc;
 use tracing::warn;
 
 #[cfg(feature = "push")]
+fn production_memory_drivers_allowed(config: &ServerOptions) -> bool {
+    !config.mode.eq_ignore_ascii_case("production") || config.push.allow_memory_drivers
+}
+
+#[cfg(feature = "push")]
 pub(crate) async fn create_push_store(
     config: &ServerOptions,
 ) -> Result<sockudo_push::DynPushStore> {
     match config.push.storage_driver {
         PushStorageDriver::Memory => {
+            if !production_memory_drivers_allowed(config) {
+                return Err(Error::Internal(
+                    "push storage driver memory is unsafe in production; set push.allow_memory_drivers=true or PUSH_ALLOW_MEMORY_DRIVERS=true only for local/dev acknowledgment"
+                        .to_owned(),
+                ));
+            }
             if config.mode.eq_ignore_ascii_case("production") {
                 warn!(
                     "Push storage driver is memory; this is intended only for tests and local development"
@@ -59,6 +72,12 @@ pub(crate) fn create_push_queue(
         .startup_check()
         .map_err(|e| Error::Internal(format!("Failed to create push queue: {e}")))?;
     if backend == sockudo_push::PushQueueBackendKind::Memory {
+        if !production_memory_drivers_allowed(config) {
+            return Err(Error::Internal(
+                "push queue driver memory is unsafe in production; set push.allow_memory_drivers=true or PUSH_ALLOW_MEMORY_DRIVERS=true only for local/dev acknowledgment"
+                    .to_owned(),
+            ));
+        }
         return Ok(Arc::new(sockudo_push::MemoryPushQueue::new()));
     }
     let queue_manager = queue_manager.ok_or_else(|| {
@@ -68,4 +87,51 @@ pub(crate) fn create_push_queue(
         ))
     })?;
     Ok(Arc::new(QueueManagerPushQueue::new(backend, queue_manager)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn production_memory_push_store_requires_explicit_allow() {
+        let mut config = ServerOptions::default();
+        config.mode = "production".to_owned();
+        config.push.storage_driver = PushStorageDriver::Memory;
+        config.push.allow_memory_drivers = false;
+
+        let error = match create_push_store(&config).await {
+            Ok(_) => panic!("memory push store should be rejected in production"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("memory is unsafe in production"));
+    }
+
+    #[test]
+    fn production_memory_push_queue_requires_explicit_allow() {
+        let mut config = ServerOptions::default();
+        config.mode = "production".to_owned();
+        config.push.queue_driver = PushQueueDriver::Memory;
+        config.push.allow_memory_drivers = false;
+
+        let error = match create_push_queue(&config, None) {
+            Ok(_) => panic!("memory push queue should be rejected in production"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("memory is unsafe in production"));
+    }
+
+    #[tokio::test]
+    async fn memory_push_drivers_can_be_explicitly_allowed_for_tests() {
+        let mut config = ServerOptions::default();
+        config.mode = "production".to_owned();
+        config.push.storage_driver = PushStorageDriver::Memory;
+        config.push.queue_driver = PushQueueDriver::Memory;
+        config.push.allow_memory_drivers = true;
+
+        create_push_store(&config).await.unwrap();
+        create_push_queue(&config, None).unwrap();
+    }
 }

--- a/crates/sockudo-server/src/bootstrap/router.rs
+++ b/crates/sockudo-server/src/bootstrap/router.rs
@@ -500,6 +500,7 @@ impl SockudoServer {
                 )
                 .layer(axum::Extension(self.state.push_queue.clone()))
                 .layer(axum::Extension(self.state.push_store.clone()))
+                .layer(axum::Extension(self.state.push_admission.clone()))
                 .layer(axum::Extension(
                     self.state.push_acceptance_rate_limiter.clone(),
                 ));

--- a/crates/sockudo-server/src/bootstrap/server.rs
+++ b/crates/sockudo-server/src/bootstrap/server.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "push", feature = "monolith"))]
 use super::push::workers::start_push_monolith_workers;
 #[cfg(feature = "push")]
-use super::push::{create_push_queue, create_push_store};
+use super::push::{PushAdmissionSnapshot, create_push_queue, create_push_store};
 use super::{MetricsFactory, ServerState, SockudoServer};
 use crate::cleanup::CleanupSender;
 use crate::cleanup::multi_worker::MultiWorkerCleanupSystem;
@@ -684,6 +684,9 @@ impl SockudoServer {
         let push_store = create_push_store(&config).await?;
         #[cfg(feature = "push")]
         let push_queue = create_push_queue(&config, queue_manager_opt.clone())?;
+        #[cfg(feature = "push")]
+        let push_admission =
+            Arc::new(PushAdmissionSnapshot::from_config(&config, &push_store).await);
 
         let state = ServerState {
             app_manager: app_manager.clone(),
@@ -710,6 +713,8 @@ impl SockudoServer {
             push_store,
             #[cfg(feature = "push")]
             push_queue,
+            #[cfg(feature = "push")]
+            push_admission,
         };
 
         #[cfg(all(feature = "push", feature = "monolith"))]

--- a/crates/sockudo-server/src/http_handler/ai/tests.rs
+++ b/crates/sockudo-server/src/http_handler/ai/tests.rs
@@ -119,6 +119,8 @@ async fn ai_batch_http_publish_returns_serial_acks_in_request_order() {
         test_push_store(),
         #[cfg(feature = "push")]
         test_push_queue(),
+        #[cfg(feature = "push")]
+        test_push_admission(),
         State(handler),
         HeaderMap::new(),
         Uri::from_static("/apps/app-1/batch_events"),
@@ -458,6 +460,8 @@ async fn events_rejects_ai_create_when_open_stream_cap_is_reached() {
         test_push_store(),
         #[cfg(feature = "push")]
         test_push_queue(),
+        #[cfg(feature = "push")]
+        test_push_admission(),
         State(handler.clone()),
         HeaderMap::new(),
         Uri::from_static("/apps/app-1/events"),
@@ -489,6 +493,8 @@ async fn events_rejects_ai_create_when_open_stream_cap_is_reached() {
         test_push_store(),
         #[cfg(feature = "push")]
         test_push_queue(),
+        #[cfg(feature = "push")]
+        test_push_admission(),
         State(handler),
         HeaderMap::new(),
         Uri::from_static("/apps/app-1/events"),

--- a/crates/sockudo-server/src/http_handler/errors.rs
+++ b/crates/sockudo-server/src/http_handler/errors.rs
@@ -44,6 +44,8 @@ pub enum AppError {
         message: String,
         retry_after_seconds: u64,
     },
+    #[error("Service unavailable: {0}")]
+    ServiceUnavailable(String),
     #[error("Payload too large: {0}")]
     PayloadTooLarge(String),
     #[error("Invalid input: {0}")]
@@ -115,6 +117,11 @@ impl IntoResponse for AppError {
                 StatusCode::SERVICE_UNAVAILABLE,
                 "backpressure",
                 message.clone(),
+            ),
+            AppError::ServiceUnavailable(msg) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "service_unavailable",
+                msg.clone(),
             ),
             AppError::PayloadTooLarge(msg) => (
                 StatusCode::PAYLOAD_TOO_LARGE,

--- a/crates/sockudo-server/src/http_handler/events/mod.rs
+++ b/crates/sockudo-server/src/http_handler/events/mod.rs
@@ -87,6 +87,9 @@ pub async fn events(
     Extension(app): Extension<App>,
     #[cfg(feature = "push")] Extension(push_store): Extension<sockudo_push::DynPushStore>,
     #[cfg(feature = "push")] Extension(push_queue): Extension<sockudo_push::DynPushQueue>,
+    #[cfg(feature = "push")] Extension(push_admission): Extension<
+        Arc<crate::bootstrap::push::PushAdmissionSnapshot>,
+    >,
     State(handler): State<Arc<ConnectionHandler>>,
     headers: HeaderMap,
     _uri: Uri,
@@ -243,6 +246,7 @@ pub async fn events(
                 extras_push,
                 &push_store,
                 &push_queue,
+                &push_admission,
             )
             .await?;
         }
@@ -254,6 +258,7 @@ pub async fn events(
                     extras_push,
                     &push_store,
                     &push_queue,
+                    &push_admission,
                 )
                 .await?;
             }
@@ -280,6 +285,7 @@ pub async fn events(
         push_rule_requests,
         push_store.clone(),
         push_queue.clone(),
+        push_admission.clone(),
     );
 
     let response_payload = if need_channel_info && !channels_info_map.is_empty() {
@@ -325,6 +331,9 @@ pub async fn batch_events(
     Extension(app_config): Extension<App>,
     #[cfg(feature = "push")] Extension(push_store): Extension<sockudo_push::DynPushStore>,
     #[cfg(feature = "push")] Extension(push_queue): Extension<sockudo_push::DynPushQueue>,
+    #[cfg(feature = "push")] Extension(push_admission): Extension<
+        Arc<crate::bootstrap::push::PushAdmissionSnapshot>,
+    >,
     State(handler): State<Arc<ConnectionHandler>>,
     headers: HeaderMap,
     _uri: Uri,
@@ -496,6 +505,7 @@ pub async fn batch_events(
                     extras_push,
                     &push_store,
                     &push_queue,
+                    &push_admission,
                 )
                 .await?;
             }
@@ -507,6 +517,7 @@ pub async fn batch_events(
                         extras_push,
                         &push_store,
                         &push_queue,
+                        &push_admission,
                     )
                     .await?;
                 }
@@ -533,6 +544,7 @@ pub async fn batch_events(
             push_rule_requests,
             push_store.clone(),
             push_queue.clone(),
+            push_admission.clone(),
         );
 
         // Store per-event idempotency key

--- a/crates/sockudo-server/src/http_handler/events/tests.rs
+++ b/crates/sockudo-server/src/http_handler/events/tests.rs
@@ -2,12 +2,13 @@ use super::*;
 use crate::http_handler::test_support::*;
 use sockudo_protocol::messages::{ApiMessageData, PusherApiMessage};
 use sockudo_push::{
-    ChannelSubscription, MemoryPushQueue, MemoryPushStore, PushDeviceStore, PushPublishLogStore,
-    PushSubscriptionStore,
+    ChannelSubscription, MemoryPushQueue, MemoryPushStore, PushDeviceStore, PushProviderKind,
+    PushPublishLogStore, PushSubscriptionStore,
 };
 
 #[tokio::test]
 async fn matching_channel_push_rule_accepts_existing_channel_subscription_fanout() {
+    let _env_guard = crate::push_http::PUSH_TEST_ENV_LOCK.lock().await;
     let handler = test_handler_with_push_rules(vec![sockudo_core::options::PushRuleConfig {
         channel_pattern: "notifications:*".to_string(),
         event_filter: vec!["agent-complete".to_string()],
@@ -16,6 +17,9 @@ async fn matching_channel_push_rule_accepts_existing_channel_subscription_fanout
     let app = test_notifications_app();
     let store = Arc::new(MemoryPushStore::new());
     let queue = Arc::new(MemoryPushQueue::new());
+    let admission = Arc::new(
+        crate::bootstrap::push::PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]),
+    );
     let device = test_push_device("device-1");
     store.upsert_device(device.clone()).await.unwrap();
     store
@@ -34,6 +38,8 @@ async fn matching_channel_push_rule_accepts_existing_channel_subscription_fanout
         Extension(store.clone() as sockudo_push::DynPushStore),
         #[cfg(feature = "push")]
         Extension(queue.clone() as sockudo_push::DynPushQueue),
+        #[cfg(feature = "push")]
+        Extension(admission),
         State(handler),
         HeaderMap::new(),
         Uri::from_static("/apps/app-1/events"),
@@ -101,6 +107,9 @@ async fn non_matching_channel_push_rule_does_not_enqueue_push() {
     let app = test_notifications_app();
     let store = Arc::new(MemoryPushStore::new());
     let queue = Arc::new(MemoryPushQueue::new());
+    let admission = Arc::new(
+        crate::bootstrap::push::PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]),
+    );
 
     let response = events(
         Path("app-1".to_string()),
@@ -110,6 +119,8 @@ async fn non_matching_channel_push_rule_does_not_enqueue_push() {
         Extension(store.clone() as sockudo_push::DynPushStore),
         #[cfg(feature = "push")]
         Extension(queue.clone() as sockudo_push::DynPushQueue),
+        #[cfg(feature = "push")]
+        Extension(admission),
         State(handler),
         HeaderMap::new(),
         Uri::from_static("/apps/app-1/events"),

--- a/crates/sockudo-server/src/http_handler/test_support.rs
+++ b/crates/sockudo-server/src/http_handler/test_support.rs
@@ -56,6 +56,16 @@ pub(crate) fn test_push_queue() -> Extension<sockudo_push::DynPushQueue> {
     Extension(Arc::new(sockudo_push::MemoryPushQueue::new()))
 }
 
+#[cfg(feature = "push")]
+pub(crate) fn test_push_admission() -> Extension<Arc<crate::bootstrap::push::PushAdmissionSnapshot>>
+{
+    Extension(Arc::new(
+        crate::bootstrap::push::PushAdmissionSnapshot::testing_active([
+            sockudo_push::PushProviderKind::Fcm,
+        ]),
+    ))
+}
+
 pub(crate) fn test_app() -> App {
     test_app_with_policy(Default::default())
 }
@@ -406,6 +416,8 @@ pub(crate) async fn publish_ai_http_event(
         test_push_store(),
         #[cfg(feature = "push")]
         test_push_queue(),
+        #[cfg(feature = "push")]
+        test_push_admission(),
         State(handler),
         headers,
         Uri::from_static("/apps/app-1/events"),

--- a/crates/sockudo-server/src/http_handler/versioned_messages/tests.rs
+++ b/crates/sockudo-server/src/http_handler/versioned_messages/tests.rs
@@ -102,6 +102,8 @@ async fn events_create_then_update_substitutes_latest_visible_history() {
         test_push_store(),
         #[cfg(feature = "push")]
         test_push_queue(),
+        #[cfg(feature = "push")]
+        test_push_admission(),
         State(handler.clone()),
         HeaderMap::new(),
         Uri::from_static("/apps/app-1/events"),
@@ -214,6 +216,8 @@ async fn events_create_then_delete_substitutes_latest_visible_history() {
         test_push_store(),
         #[cfg(feature = "push")]
         test_push_queue(),
+        #[cfg(feature = "push")]
+        test_push_admission(),
         State(handler.clone()),
         HeaderMap::new(),
         Uri::from_static("/apps/app-1/events"),
@@ -322,6 +326,8 @@ async fn events_create_then_append_substitutes_latest_visible_history() {
         test_push_store(),
         #[cfg(feature = "push")]
         test_push_queue(),
+        #[cfg(feature = "push")]
+        test_push_admission(),
         State(handler.clone()),
         HeaderMap::new(),
         Uri::from_static("/apps/app-1/events"),

--- a/crates/sockudo-server/src/push_http.rs
+++ b/crates/sockudo-server/src/push_http.rs
@@ -34,6 +34,7 @@ use sockudo_push::{
 use sonic_rs::{Value, json};
 use tracing::{info, warn};
 
+use crate::bootstrap::push::{PushAdmissionRejection, PushAdmissionSnapshot};
 use crate::http_handler::AppError;
 
 const DEFAULT_LIMIT: usize = 100;
@@ -41,6 +42,7 @@ const MAX_LIMIT: usize = 1000;
 const DEFAULT_PUSH_FANOUT_FAST_THRESHOLD: u64 = 10_000;
 const DEFAULT_PUSH_FANOUT_SHARD_SIZE: u64 = 100_000;
 const DEFAULT_PUSH_BACKPRESSURE_RETRY_AFTER_SECONDS: u64 = 5;
+const DEFAULT_PUSH_CRITICAL_QUEUE_MAX_LAG: u64 = 100_000;
 const PUSH_HTTP_DEFAULT_IDEMPOTENCY_TTL_MS: u64 = 24 * 60 * 60 * 1000;
 const QUOTA_OVERRIDE_HEADER: &str = "x-sockudo-push-quota-override";
 const PUSH_CAPABILITY_HEADER: &str = "x-sockudo-push-capability";
@@ -54,6 +56,9 @@ static PUSH_DEVICE_RATE_WINDOWS: LazyLock<Mutex<BTreeMap<String, RateWindow>>> =
 static PUSH_RULE_RATE_WINDOWS: LazyLock<Mutex<BTreeMap<String, RateWindow>>> =
     LazyLock::new(|| Mutex::new(BTreeMap::new()));
 static PUSH_HTTP_METRICS: LazyLock<PushMetrics> = LazyLock::new(PushMetrics::default);
+#[cfg(test)]
+pub(crate) static PUSH_TEST_ENV_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 #[derive(Debug)]
 pub struct Json<T>(pub T);
@@ -769,6 +774,7 @@ pub async fn publish(
     Extension(app): Extension<App>,
     Extension(store): Extension<DynPushStore>,
     Extension(queue): Extension<DynPushQueue>,
+    Extension(admission): Extension<Arc<PushAdmissionSnapshot>>,
     Extension(admission_limiter): Extension<Arc<dyn RateLimiter + Send + Sync>>,
     Json(request): Json<PublishRequest>,
 ) -> Result<impl IntoResponse, AppError> {
@@ -781,6 +787,7 @@ pub async fn publish(
         headers,
         store,
         queue,
+        admission,
         admission_limiter,
     )
     .await
@@ -792,6 +799,7 @@ pub async fn batch_publish(
     Extension(app): Extension<App>,
     Extension(store): Extension<DynPushStore>,
     Extension(queue): Extension<DynPushQueue>,
+    Extension(admission): Extension<Arc<PushAdmissionSnapshot>>,
     Extension(admission_limiter): Extension<Arc<dyn RateLimiter + Send + Sync>>,
     Json(requests): Json<Vec<PublishRequest>>,
 ) -> Result<impl IntoResponse, AppError> {
@@ -806,6 +814,7 @@ pub async fn batch_publish(
             &headers,
             &store,
             &queue,
+            &admission,
             Some(&admission_limiter),
         )
         .await?;
@@ -869,6 +878,7 @@ async fn accept_publish(
     headers: HeaderMap,
     store: DynPushStore,
     queue: DynPushQueue,
+    admission: Arc<PushAdmissionSnapshot>,
     admission_limiter: Arc<dyn RateLimiter + Send + Sync>,
 ) -> Result<impl IntoResponse, AppError> {
     let (status, body, forced_async) = accept_publish_inner(
@@ -878,6 +888,7 @@ async fn accept_publish(
         &headers,
         &store,
         &queue,
+        &admission,
         Some(&admission_limiter),
     )
     .await?;
@@ -898,11 +909,10 @@ async fn accept_publish_inner(
     headers: &HeaderMap,
     store: &DynPushStore,
     queue: &DynPushQueue,
+    admission: &PushAdmissionSnapshot,
     admission_limiter: Option<&Arc<dyn RateLimiter + Send + Sync>>,
 ) -> Result<(StatusCode, Json<PublishAcceptedResponse>, bool), AppError> {
     let started = std::time::Instant::now();
-    enforce_publish_admission_rate(app_id, admission_limiter).await?;
-    enforce_backpressure(queue).await?;
     enforce_raw_recipient_auth(&request.recipients, headers)?;
 
     let publish_id = request
@@ -932,6 +942,10 @@ async fn accept_publish_inner(
     intent
         .validate()
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+
+    enforce_push_admission_capability(admission, &request.recipients, fanout_regime, queue).await?;
+    enforce_publish_admission_rate(app_id, admission_limiter).await?;
+    enforce_backpressure(queue, admission).await?;
 
     let quota_override = quota_override_requested(headers)?;
     if quota_override {
@@ -1054,6 +1068,21 @@ async fn accept_publish_inner(
         ));
     }
 
+    if status_state == PublishLifecycleState::QuotaExceeded {
+        PUSH_HTTP_METRICS.publish_accepted(app_id, "quota_exceeded", started.elapsed());
+        return Ok((
+            StatusCode::ACCEPTED,
+            Json(PublishAcceptedResponse {
+                publish_id,
+                status: "quota_exceeded",
+                expected_recipients,
+                fanout_regime,
+                rendered_payloads,
+            }),
+            forced_async,
+        ));
+    }
+
     let publish_event = PublishLogEvent {
         app_id: app_id.to_owned(),
         publish_id: publish_id.clone(),
@@ -1077,15 +1106,7 @@ async fn accept_publish_inner(
         )
         .await
         .map_err(|error| AppError::InternalError(error.to_string()))?;
-    PUSH_HTTP_METRICS.publish_accepted(
-        app_id,
-        if status_state == PublishLifecycleState::QuotaExceeded {
-            "quota_exceeded"
-        } else {
-            "accepted"
-        },
-        started.elapsed(),
-    );
+    PUSH_HTTP_METRICS.publish_accepted(app_id, "accepted", started.elapsed());
     PUSH_HTTP_METRICS.fanout_size(app_id, expected_recipients);
     emit_push_meta_event(PushMetaEvent::accepted(
         app_id,
@@ -1104,11 +1125,7 @@ async fn accept_publish_inner(
         StatusCode::ACCEPTED,
         Json(PublishAcceptedResponse {
             publish_id,
-            status: if status_state == PublishLifecycleState::QuotaExceeded {
-                "quota_exceeded"
-            } else {
-                "accepted"
-            },
+            status: "accepted",
             expected_recipients,
             fanout_regime,
             rendered_payloads,
@@ -1627,35 +1644,132 @@ async fn enforce_publish_admission_rate(
     Ok(())
 }
 
-async fn enforce_backpressure(queue: &DynPushQueue) -> Result<(), AppError> {
+async fn enforce_push_admission_capability(
+    admission: &PushAdmissionSnapshot,
+    recipients: &[PublishTarget],
+    fanout_regime: FanoutRegime,
+    queue: &DynPushQueue,
+) -> Result<(), AppError> {
+    if let Some(rejection) = admission.rejection_for_targets(recipients, fanout_regime) {
+        warn!(
+            storage_driver = ?admission.storage_driver(),
+            queue_driver = ?admission.queue_driver(),
+            safe_for_admission = admission.safe_for_admission(),
+            reason = %rejection.message(),
+            "push publish rejected by admission capability guard"
+        );
+        return Err(AppError::ServiceUnavailable(rejection.message()));
+    }
+
+    let health = queue.health().await.map_err(|error| {
+        let rejection = PushAdmissionRejection::QueueUnavailable {
+            reason: error.to_string(),
+        };
+        warn!(
+            queue_driver = ?admission.queue_driver(),
+            reason = %rejection.message(),
+            "push publish rejected because push queue health check failed"
+        );
+        AppError::ServiceUnavailable(rejection.message())
+    })?;
+    if !health.healthy {
+        let rejection = PushAdmissionRejection::QueueUnavailable {
+            reason: health.details,
+        };
+        warn!(
+            backend = ?health.backend,
+            reason = %rejection.message(),
+            "push publish rejected because push queue is unhealthy"
+        );
+        return Err(AppError::ServiceUnavailable(rejection.message()));
+    }
+
+    Ok(())
+}
+
+async fn enforce_backpressure(
+    queue: &DynPushQueue,
+    admission: &PushAdmissionSnapshot,
+) -> Result<(), AppError> {
     if env_bool("PUSH_BACKPRESSURE") {
         warn!("push publish rejected by configured backpressure");
-        return Err(AppError::Backpressure {
+        return Err(AppError::TooManyRequests {
             message: "push pipeline is applying backpressure".to_owned(),
             retry_after_seconds: env_u64("PUSH_BACKPRESSURE_RETRY_AFTER_SECONDS")
                 .unwrap_or(DEFAULT_PUSH_BACKPRESSURE_RETRY_AFTER_SECONDS),
         });
     }
-    let max_lag = env_u64("PUSH_PUBLISH_LOG_MAX_LAG").unwrap_or(100_000);
+    let max_publish_log_lag =
+        env_u64("PUSH_PUBLISH_LOG_MAX_LAG").unwrap_or(DEFAULT_PUSH_CRITICAL_QUEUE_MAX_LAG);
+    reject_on_stage_lag(queue, PushQueueStage::PublishLog, max_publish_log_lag).await?;
+
+    let max_critical_lag =
+        env_u64("PUSH_CRITICAL_QUEUE_MAX_LAG").unwrap_or(DEFAULT_PUSH_CRITICAL_QUEUE_MAX_LAG);
+    for stage in critical_backpressure_stages(admission) {
+        reject_on_stage_lag(queue, stage, max_critical_lag).await?;
+    }
+
+    Ok(())
+}
+
+async fn reject_on_stage_lag(
+    queue: &DynPushQueue,
+    stage: PushQueueStage,
+    max_lag: u64,
+) -> Result<(), AppError> {
     let lag = queue
-        .lag(PushQueueStage::PublishLog)
+        .lag(stage)
         .await
         .map_err(|error| AppError::InternalError(error.to_string()))?;
-    PUSH_HTTP_METRICS.publish_log_lag_seconds(lag.ready_depth as f64);
+    if stage == PushQueueStage::PublishLog {
+        PUSH_HTTP_METRICS.publish_log_lag_seconds(lag.ready_depth as f64);
+    }
     if lag.ready_depth.saturating_add(lag.delayed_depth) >= max_lag {
         warn!(
+            stage = %queue_stage_label(stage),
             ready_depth = lag.ready_depth,
             delayed_depth = lag.delayed_depth,
             max_lag = max_lag,
-            "push publish rejected by publish-log backpressure"
+            "push publish rejected by queue-stage backpressure"
         );
-        return Err(AppError::Backpressure {
-            message: "push publish_log lag exceeded".to_owned(),
+        return Err(AppError::TooManyRequests {
+            message: format!("push {} lag exceeded", queue_stage_label(stage)),
             retry_after_seconds: env_u64("PUSH_BACKPRESSURE_RETRY_AFTER_SECONDS")
                 .unwrap_or(DEFAULT_PUSH_BACKPRESSURE_RETRY_AFTER_SECONDS),
         });
     }
     Ok(())
+}
+
+fn critical_backpressure_stages(admission: &PushAdmissionSnapshot) -> Vec<PushQueueStage> {
+    let mut stages = Vec::with_capacity(4 + admission.active_providers().len());
+    stages.push(PushQueueStage::ShardJobs);
+    stages.push(PushQueueStage::DeliveryResults);
+    stages.push(PushQueueStage::RetrySchedule);
+    stages.push(PushQueueStage::DeadLetters);
+    stages.extend(
+        admission
+            .active_providers()
+            .into_iter()
+            .map(PushQueueStage::DeliveryJobs),
+    );
+    stages
+}
+
+fn queue_stage_label(stage: PushQueueStage) -> String {
+    match stage {
+        PushQueueStage::PublishLog => "publish_log".to_owned(),
+        PushQueueStage::ShardJobs => "shard_jobs".to_owned(),
+        PushQueueStage::DeliveryJobs(provider) => {
+            format!(
+                "delivery_jobs_{}",
+                provider_env_key(provider).to_ascii_lowercase()
+            )
+        }
+        PushQueueStage::DeliveryResults => "delivery_results".to_owned(),
+        PushQueueStage::DeadLetters => "dead_letters".to_owned(),
+        PushQueueStage::RetrySchedule => "retry_schedule".to_owned(),
+    }
 }
 
 fn audit_log(app_id: &str, action: &'static str, subject: Option<&str>) {
@@ -1834,6 +1948,7 @@ pub async fn enqueue_v2_channel_push_from_extras(
     extras_push: &sonic_rs::Value,
     store: &DynPushStore,
     queue: &DynPushQueue,
+    admission: &PushAdmissionSnapshot,
 ) -> Result<Option<String>, AppError> {
     let payload: PushPayload = sonic_rs::from_slice(
         &sonic_rs::to_vec(extras_push)
@@ -1853,7 +1968,10 @@ pub async fn enqueue_v2_channel_push_from_extras(
         expires_at_ms: None,
     };
     let headers = HeaderMap::new();
-    let _ = accept_publish_inner(app_id, request, false, &headers, store, queue, None).await?;
+    let _ = accept_publish_inner(
+        app_id, request, false, &headers, store, queue, admission, None,
+    )
+    .await?;
     PUSH_HTTP_METRICS.channel_publish(channel);
     Ok(Some(publish_id))
 }
@@ -1908,11 +2026,13 @@ pub fn spawn_channel_push_rule_requests(
     requests: Vec<PublishRequest>,
     store: DynPushStore,
     queue: DynPushQueue,
+    admission: Arc<PushAdmissionSnapshot>,
 ) {
     for request in requests {
         let app_id = app_id.clone();
         let store = store.clone();
         let queue = queue.clone();
+        let admission = admission.clone();
         tokio::spawn(async move {
             let headers = HeaderMap::new();
             let publish_id = request.publish_id.clone().unwrap_or_default();
@@ -1925,8 +2045,10 @@ pub fn spawn_channel_push_rule_requests(
                 })
                 .unwrap_or("<unknown>")
                 .to_owned();
-            match accept_publish_inner(&app_id, request, false, &headers, &store, &queue, None)
-                .await
+            match accept_publish_inner(
+                &app_id, request, false, &headers, &store, &queue, &admission, None,
+            )
+            .await
             {
                 Ok(_) => {
                     PUSH_HTTP_METRICS.channel_publish(&channel);
@@ -2023,14 +2145,40 @@ mod tests {
     use super::*;
     use axum::http::HeaderValue;
     use sockudo_push::{
-        DevicePushDetails, DevicePushState, FormFactor, MemoryPushStore, Platform, PushDeviceStore,
+        DevicePushDetails, DevicePushState, FormFactor, IdempotencyRecord, MemoryPushQueue,
+        MemoryPushStore, Platform, PublishIntent, PublishLifecycleState, PushDeviceStore,
+        PushIdempotencyStore, PushPublishLogStore, PushPublishStatusStore, PushQueue,
         PushRecipient,
     };
     use sonic_rs::{JsonValueTrait, json};
-    use std::sync::Arc;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(previous) = self.previous.as_ref() {
+                    std::env::set_var(self.key, previous);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
 
     fn hashed_token(raw: &str) -> SecretString {
         hash_device_identity_token(&SecretString::new(raw).unwrap())
@@ -2058,6 +2206,100 @@ mod tests {
             },
             push_rate_policy: None,
         }
+    }
+
+    fn sample_payload() -> PushPayload {
+        PushPayload {
+            template_id: None,
+            template_data: json!({"kind": "test"}),
+            title: Some("Hello".to_owned()),
+            body: Some("World".to_owned()),
+            icon: None,
+            sound: None,
+            collapse_key: None,
+        }
+    }
+
+    fn sample_publish_request(publish_id: &str) -> PublishRequest {
+        PublishRequest {
+            publish_id: Some(publish_id.to_owned()),
+            recipients: vec![PublishTarget::Device {
+                device_id: "device-1".to_owned(),
+            }],
+            payload: sample_payload(),
+            provider_overrides: vec![],
+            sync: false,
+            not_before_ms: None,
+            expires_at_ms: None,
+        }
+    }
+
+    fn idempotency_record_for_request(
+        app_id: &str,
+        publish_id: &str,
+        request: &PublishRequest,
+    ) -> IdempotencyRecord {
+        let intent = PublishIntent {
+            app_id: app_id.to_owned(),
+            publish_id: publish_id.to_owned(),
+            targets: request.recipients.clone(),
+            payload: request.payload.clone(),
+            provider_overrides: request.provider_overrides.clone(),
+            not_before_ms: request.not_before_ms,
+            expires_at_ms: request.expires_at_ms,
+        };
+        IdempotencyRecord {
+            app_id: app_id.to_owned(),
+            key: intent.idempotency_key(),
+            publish_id: publish_id.to_owned(),
+            expires_at_ms: request.expires_at_ms.unwrap_or(u64::MAX),
+        }
+    }
+
+    fn sample_queue_payload(publish_id: &str) -> PushQueuePayload {
+        let request = sample_publish_request(publish_id);
+        let intent = PublishIntent {
+            app_id: "app-1".to_owned(),
+            publish_id: publish_id.to_owned(),
+            targets: request.recipients,
+            payload: request.payload,
+            provider_overrides: request.provider_overrides,
+            not_before_ms: request.not_before_ms,
+            expires_at_ms: request.expires_at_ms,
+        };
+        PushQueuePayload::PublishLog(Box::new(PublishLogEvent {
+            app_id: "app-1".to_owned(),
+            publish_id: publish_id.to_owned(),
+            event_id: format!("event-{publish_id}"),
+            occurred_at_ms: 1,
+            intent,
+            fanout_regime: FanoutRegime::FastPath,
+            expected_recipients: 1,
+            fast_threshold: 10,
+            shard_size: 100,
+        }))
+    }
+
+    async fn assert_stage_backpressure(stage: PushQueueStage, env_name: &'static str) {
+        let _guard = PUSH_TEST_ENV_LOCK.lock().await;
+        let _threshold = EnvVarGuard::set(env_name, "1");
+        let queue = Arc::new(MemoryPushQueue::new());
+        queue
+            .produce(
+                stage,
+                format!("key-{stage:?}"),
+                sample_queue_payload(&format!("publish-{stage:?}")),
+            )
+            .await
+            .unwrap();
+        let dyn_queue: DynPushQueue = queue;
+        let admission = PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]);
+
+        let error = enforce_backpressure(&dyn_queue, &admission)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, AppError::TooManyRequests { .. }));
     }
 
     #[test]
@@ -2231,6 +2473,229 @@ mod tests {
     #[tokio::test]
     async fn publish_admission_skips_internal_without_limiter() {
         enforce_publish_admission_rate("app-1", None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn quota_rejection_persists_terminal_status_without_pipeline_work() {
+        let _guard = PUSH_TEST_ENV_LOCK.lock().await;
+        let _quota = EnvVarGuard::set("PUSH_FANOUT_MAX", "0");
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.upsert_device(sample_device()).await.unwrap();
+        let dyn_store: DynPushStore = store.clone();
+        let dyn_queue: DynPushQueue = queue.clone();
+        let admission = PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]);
+
+        let request = sample_publish_request("quota-publish-1");
+        let (status, Json(body), _) = accept_publish_inner(
+            "app-1",
+            request,
+            false,
+            &HeaderMap::new(),
+            &dyn_store,
+            &dyn_queue,
+            &admission,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(body.status, "quota_exceeded");
+        let status = store
+            .get_publish_status("app-1", "quota-publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.state, PublishLifecycleState::QuotaExceeded);
+        assert_eq!(status.counters.planned, 1);
+        let idempotency = idempotency_record_for_request(
+            "app-1",
+            "quota-publish-1",
+            &sample_publish_request("quota-publish-1"),
+        );
+        assert!(
+            store
+                .get_idempotency_record("app-1", &idempotency.key)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            store
+                .list_publish_log_events("app-1", 10, None)
+                .await
+                .unwrap()
+                .items
+                .is_empty()
+        );
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::PublishLog)
+                .await
+                .unwrap()
+                .ready_depth,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn quota_rejection_idempotent_replay_does_not_enqueue_pipeline_work() {
+        let _guard = PUSH_TEST_ENV_LOCK.lock().await;
+        let _quota = EnvVarGuard::set("PUSH_FANOUT_MAX", "0");
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.upsert_device(sample_device()).await.unwrap();
+        let dyn_store: DynPushStore = store.clone();
+        let dyn_queue: DynPushQueue = queue.clone();
+        let admission = PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]);
+
+        for _ in 0..2 {
+            let (_, Json(body), _) = accept_publish_inner(
+                "app-1",
+                sample_publish_request("quota-publish-replay"),
+                false,
+                &HeaderMap::new(),
+                &dyn_store,
+                &dyn_queue,
+                &admission,
+                None,
+            )
+            .await
+            .unwrap();
+            assert_eq!(body.publish_id, "quota-publish-replay");
+            assert_eq!(body.status, "quota_exceeded");
+        }
+
+        assert!(
+            store
+                .list_publish_log_events("app-1", 10, None)
+                .await
+                .unwrap()
+                .items
+                .is_empty()
+        );
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::PublishLog)
+                .await
+                .unwrap()
+                .ready_depth,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_rejects_when_no_provider_worker_is_available() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.upsert_device(sample_device()).await.unwrap();
+        let dyn_store: DynPushStore = store;
+        let dyn_queue: DynPushQueue = queue;
+        let admission =
+            PushAdmissionSnapshot::testing_active(std::iter::empty::<PushProviderKind>());
+
+        let error = accept_publish_inner(
+            "app-1",
+            sample_publish_request("providerless-publish"),
+            false,
+            &HeaderMap::new(),
+            &dyn_store,
+            &dyn_queue,
+            &admission,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, AppError::ServiceUnavailable(_)));
+    }
+
+    #[tokio::test]
+    async fn raw_fcm_publish_requires_fcm_worker_capability() {
+        let store: DynPushStore = Arc::new(MemoryPushStore::new());
+        let queue: DynPushQueue = Arc::new(MemoryPushQueue::new());
+        let admission = PushAdmissionSnapshot::testing_active([PushProviderKind::Apns]);
+        let mut request = sample_publish_request("raw-fcm-publish");
+        request.recipients = vec![PublishTarget::Recipient {
+            recipient: PushRecipient::Fcm {
+                registration_token: SecretString::new("raw-fcm-token").unwrap(),
+            },
+        }];
+
+        let error = accept_publish_inner(
+            "app-1",
+            request,
+            false,
+            &HeaderMap::new(),
+            &store,
+            &queue,
+            &admission,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, AppError::ServiceUnavailable(_)));
+    }
+
+    #[tokio::test]
+    async fn raw_apns_publish_requires_apns_worker_capability() {
+        let store: DynPushStore = Arc::new(MemoryPushStore::new());
+        let queue: DynPushQueue = Arc::new(MemoryPushQueue::new());
+        let admission = PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]);
+        let mut request = sample_publish_request("raw-apns-publish");
+        request.recipients = vec![PublishTarget::Recipient {
+            recipient: PushRecipient::Apns {
+                device_token: SecretString::new("raw-apns-token").unwrap(),
+            },
+        }];
+
+        let error = accept_publish_inner(
+            "app-1",
+            request,
+            false,
+            &HeaderMap::new(),
+            &store,
+            &queue,
+            &admission,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, AppError::ServiceUnavailable(_)));
+    }
+
+    #[tokio::test]
+    async fn critical_stage_backpressure_rejects_admission() {
+        for (stage, env_name) in [
+            (PushQueueStage::PublishLog, "PUSH_PUBLISH_LOG_MAX_LAG"),
+            (PushQueueStage::ShardJobs, "PUSH_CRITICAL_QUEUE_MAX_LAG"),
+            (
+                PushQueueStage::DeliveryJobs(PushProviderKind::Fcm),
+                "PUSH_CRITICAL_QUEUE_MAX_LAG",
+            ),
+            (
+                PushQueueStage::DeliveryResults,
+                "PUSH_CRITICAL_QUEUE_MAX_LAG",
+            ),
+            (PushQueueStage::RetrySchedule, "PUSH_CRITICAL_QUEUE_MAX_LAG"),
+            (PushQueueStage::DeadLetters, "PUSH_CRITICAL_QUEUE_MAX_LAG"),
+        ] {
+            assert_stage_backpressure(stage, env_name).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn healthy_backpressure_lag_admits() {
+        let _guard = PUSH_TEST_ENV_LOCK.lock().await;
+        let _publish_log_threshold = EnvVarGuard::set("PUSH_PUBLISH_LOG_MAX_LAG", "1");
+        let _critical_threshold = EnvVarGuard::set("PUSH_CRITICAL_QUEUE_MAX_LAG", "1");
+        let queue: DynPushQueue = Arc::new(MemoryPushQueue::new());
+        let admission = PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]);
+
+        enforce_backpressure(&queue, &admission).await.unwrap();
     }
 
     #[test]

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -176,6 +176,7 @@ shards = 64
 [push]
 storage_driver = "memory"
 queue_driver = "memory"
+allow_memory_drivers = false
 fcm_enabled = false
 apns_enabled = false
 webpush_enabled = false
@@ -239,6 +240,12 @@ include_remaining_fields = true
 
 `max_messages_per_channel`, `max_bytes_per_channel`, `max_events_per_channel`, credential refs, and
 external key refs default to unset and are omitted from the checked block.
+
+`storage_driver = "memory"` and `queue_driver = "memory"` are node-local development drivers. In
+`mode = "production"`, Sockudo rejects them unless `allow_memory_drivers = true` is set explicitly.
+Push publish admission also requires a healthy queue, a safe store, local pipeline workers, and
+local provider-worker capability. Raw provider-specific recipients require the matching provider
+worker before the request is accepted; shard-path publishes also require a local shard worker.
 
 ## Observability
 

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -371,6 +371,7 @@ This page lists every runtime environment variable referenced by the server, cor
 | --- | --- |
 | `PUSH_STORAGE_DRIVER` | Push storage backend driver. |
 | `PUSH_QUEUE_DRIVER` | Push queue backend driver. |
+| `PUSH_ALLOW_MEMORY_DRIVERS` | Explicitly allows node-local memory push store/queue in production; use only for local/dev acknowledgment. |
 | `PUSH_CREDENTIAL_ENCRYPTION_KEY` | Master key for encrypted push credential material. |
 | `PUSH_ACCEPTANCE_RATE_LIMIT` | Admission rate limit for push publish requests. |
 | `PUSH_ANALYTICS_ENABLED` | Enables push analytics collection. |
@@ -381,6 +382,7 @@ This page lists every runtime environment variable referenced by the server, cor
 | `PUSH_BACKPRESSURE` | Forces push backpressure responses in the HTTP layer. |
 | `PUSH_BACKPRESSURE_RETRY_AFTER_SECONDS` | Retry-After value emitted for push backpressure. |
 | `PUSH_PUBLISH_LOG_MAX_LAG` | Maximum publish-log lag tolerated before push backpressure. |
+| `PUSH_CRITICAL_QUEUE_MAX_LAG` | Maximum lag tolerated for shard, delivery result, retry, dead-letter, and active provider delivery stages. |
 | `PUSH_PUBLISH_STATUS_TTL_DAYS` | Retention for push publish status records. |
 | `PUSH_FAILURE_THRESHOLD` | Push circuit-breaker failure threshold. |
 | `PUSH_SCHEDULER_INTERVAL_SECS` | Scheduled push scan interval. |

--- a/docs/content/docs/server/push-notifications.mdx
+++ b/docs/content/docs/server/push-notifications.mdx
@@ -48,6 +48,24 @@ flowchart LR
 
 Sockudo normalizes admission, idempotency, queueing, retries, status retention, and feedback. Provider-specific limits still apply after the request leaves Sockudo.
 
+## Admission readiness
+
+Sockudo fails closed before accepting publish work it already knows cannot be processed safely. The
+push publish API requires a healthy push queue, production-safe storage, local pipeline workers, and
+local provider-worker capability. Raw FCM/APNs/Web Push/HMS/WNS recipients require the matching
+provider worker in this process. Channel, client, and device targets require at least one active
+provider worker without scanning large channel subscription sets during admission; shard-path
+publishes also require a local shard worker. The planner still resolves exact devices
+asynchronously.
+
+In `mode = "production"`, `storage_driver = "memory"` and `queue_driver = "memory"` are rejected
+unless `allow_memory_drivers = true` or `PUSH_ALLOW_MEMORY_DRIVERS=true` is set explicitly. Memory
+drivers are node-local and lose state on restart or dead-node loss.
+
+Readiness failures return `503`. Queue pressure returns `429` with `Retry-After`. Quota rejection
+persists a terminal `quota_exceeded` publish status and idempotency record without appending publish
+log work or enqueueing the pipeline.
+
 ## Configure providers
 
 ```toml
@@ -251,5 +269,7 @@ Track accepted publishes, queue depth, provider dispatch latency, provider error
 | FCM unauthorized | Verify service account and project. |
 | Channel push misses users | Verify channel push subscriptions and `client_id` mapping. |
 | Large push is rejected | Check platform payload limits and remove nonessential data. |
+| Push publish returns `503` | Check push queue health, memory-driver production guard, provider feature flags, provider credentials, and dispatch worker count. |
+| Push publish returns `429` | Check publish-log, shard, delivery result, retry, dead-letter, and active provider delivery queue lag. |
 
 Push payloads should wake the app and include stable IDs. Fetch authoritative application state after the user opens the notification.


### PR DESCRIPTION
## Disaster scenario made safe

This PR makes push admission fail closed when Sockudo already knows a publish cannot be processed safely. It protects buyers running many nodes and large push fanouts from accepting work that would otherwise be stranded by quota terminal state, missing local workers/providers, unsafe memory drivers, unhealthy queues, or downstream queue pressure.

## What changed

- Persist `quota_exceeded` as a terminal publish status with its idempotency record and return the existing quota response without appending a `PublishLogEvent` or enqueueing publish-log work.
- Add a boot-time push admission capability snapshot covering storage driver, queue driver, local pipeline workers, provider worker readiness, compiled provider features, and credential readiness.
- Require raw provider recipients to have matching local provider capability; planned channel/client/device targets require at least one active provider without scanning huge subscription sets during admission.
- Reject production memory push storage/queues unless `push.allow_memory_drivers = true` or `PUSH_ALLOW_MEMORY_DRIVERS=true` is explicitly set.
- Expand HTTP admission backpressure to include publish log, shard jobs, delivery results, retry schedule, dead letters, and active provider delivery-job stages.
- Return 503 for provider/queue/store readiness failures and 429 with `Retry-After` for quota/backpressure.
- Update config, env-var docs, and push-notification docs for the new fail-closed behavior.

## What intentionally did not change

- No retry redesign.
- No provider failure classification changes.
- No queue ownership redesign or new queue backend.
- No Protocol V1 wire behavior changes.
- Planned target admission still avoids scanning large channel subscription sets; exact device/provider resolution remains in the planner.

## Verification

- `cargo fmt --all`
- `cargo test -p sockudo-push quota`
- `cargo test -p sockudo-push`
- `cargo test -p sockudo-core`
- `cargo test -p sockudo --features push capability`
- `cargo test -p sockudo --features push push`
- `cargo test -p sockudo --features push`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cd docs && npm run types:check && npm run build`
- `git diff --check`

## Remaining disaster modes deferred

- Dynamic admission refresh after credential rotation or worker death.
- Deeper dead-node queue ownership recovery.
- Retry semantics.
- Provider outage classification.

Note: the docs build emits the existing Next.js multiple-lockfile root inference warning, but completes successfully.
