### PR TITLE
feat(sockudo-swift): move client isolation from @MainActor to dedicated @SockudoActor

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "810e3dce6d47e43de603ea97f2fceef4e5e42e5c72379d8db909ff518d5d94d8",
+  "originHash" : "b00579dc66c8377d7209ecf482549fe00f7458befdba4688e4c12111922a528b",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -35,24 +35,6 @@
       "state" : {
         "revision" : "cfd195c76882aa9b997560ca7cb95d72fbf5db00",
         "version" : "0.11.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax.git",
-      "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-testing.git",
-      "state" : {
-        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
-        "version" : "0.99.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,6 @@ let package = Package(
     .package(url: "https://github.com/Flight-School/AnyCodable", .upToNextMajor(from: "0.4.0")),
     .package(url: "https://github.com/apple/swift-crypto", .upToNextMajor(from: "1.1.6")),
     .package(url: "https://github.com/pusher/tweetnacl-swiftwrap", from: "1.1.0"),
-    .package(url: "https://github.com/swiftlang/swift-testing.git", from: "0.12.0"),
   ],
   targets: [
     .target(
@@ -91,7 +90,6 @@ let package = Package(
       dependencies: [
         "SockudoSwift",
         "CXDelta3",
-        .product(name: "Testing", package: "swift-testing"),
       ],
       path: "client-sdks/sockudo-swift/Tests/SockudoSwiftTests",
       swiftSettings: [

--- a/client-sdks/sockudo-swift/Package.resolved
+++ b/client-sdks/sockudo-swift/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3b1f30fea9473cde9e41d71521753e2846bb2df553c40b051564643dcd822b1a",
+  "originHash" : "315ff2743577b465a8cd70c9c1396de4ccbed1ef5e0330c743da221596c3c303",
   "pins" : [
     {
       "identity" : "swift-sodium",
@@ -8,24 +8,6 @@
       "state" : {
         "revision" : "cfd195c76882aa9b997560ca7cb95d72fbf5db00",
         "version" : "0.11.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax.git",
-      "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-testing.git",
-      "state" : {
-        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
-        "version" : "0.99.0"
       }
     }
   ],

--- a/client-sdks/sockudo-swift/Package.swift
+++ b/client-sdks/sockudo-swift/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/jedisct1/swift-sodium.git", from: "0.9.1"),
-    .package(url: "https://github.com/swiftlang/swift-testing.git", from: "0.12.0"),
   ],
   targets: [
     .target(
@@ -45,8 +44,7 @@ let package = Package(
     .testTarget(
       name: "SockudoSwiftTests",
       dependencies: [
-        "SockudoSwift",
-        .product(name: "Testing", package: "swift-testing"),
+        "SockudoSwift"
       ],
       swiftSettings: [
         .unsafeFlags(["-suppress-warnings"])

--- a/client-sdks/sockudo-swift/README.md
+++ b/client-sdks/sockudo-swift/README.md
@@ -366,62 +366,73 @@ The live suite covers:
 
 ## Threading Model
 
-`SockudoClient`, all channel types, and their callback closures are `@MainActor`-isolated.
+`SockudoClient`, all channel types, and their callback closures are `@SockudoActor`-isolated,
+running on a dedicated background executor. This preserves single-threaded serialization —
+the same data-race safety as `@MainActor` — without blocking the main thread.
 
 ### Internal pipeline
 
-Message processing runs on a background actor before reaching MainActor:
+Message processing runs on a background actor before reaching SockudoActor:
 
 ```
 URLSession background queue
   → MessageProcessor actor (decode, dedup, delta reconstruction)
-    → MainActor (routing, state updates, callback delivery)
+    → @SockudoActor (routing, state updates, callback delivery)
 ```
-
-CPU-intensive work — protocol decoding (JSON, MessagePack, Protobuf), message deduplication, and delta reconstruction — runs off the main thread. Only fully-processed events reach MainActor.
 
 ### What this means for your code
 
-All public API must be called from the main thread (or an `@MainActor` context):
+All public API requires `await` from a non-`@SockudoActor` context:
 
 ```swift
-// ✅ SwiftUI — already @MainActor, no change needed
+// From any async context — use await
+func setup() async {
+    await client.connect()
+}
+
+// From a @SockudoActor context — synchronous, no await needed
+@SockudoActor func setupOnActor() {
+    client.connect()
+}
+
+// From SwiftUI — wrap in Task
 struct ContentView: View {
     var body: some View {
-        Button("Connect") { client.connect() }
+        Button("Connect") {
+            Task { await client.connect() }
+        }
     }
 }
 
-// ✅ UIKit — UIViewController is @MainActor in Swift 6, no change needed
+// From UIKit — wrap in Task
 class MyViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        client.connect()
+        Task { await client.connect() }
     }
 }
-
-// ✅ From a non-isolated async context — use await
-func setup() async {
-    await MainActor.run { client.connect() }
-}
-
-// ✅ From a Combine publisher — dispatch to main first
-publisher
-    .receive(on: DispatchQueue.main)
-    .sink { [weak self] _ in self?.client.connect() }
-    .store(in: &cancellables)
 ```
 
-### Callbacks execute on MainActor
+### Callbacks execute on @SockudoActor
 
-All event callbacks (`bind`, `on`, `onGlobal`) fire on the main thread:
+All event callbacks (`bind`, `on`, `bindGlobal`) are `@SockudoActor`-isolated closures:
+they fire synchronously on the `@SockudoActor` background executor — **not** the main
+thread — and in binding order. Because the closure itself is `@SockudoActor`-isolated,
+it can directly access your own `@SockudoActor` state without a `Task` hop. If your
+callback performs UI work, dispatch to main explicitly:
 
 ```swift
 channel.bind("price-updated") { data, _ in
-    // Already on @MainActor — safe to update UI directly
-    self.label.text = "\(data ?? "")"
+    // On @SockudoActor — NOT the main thread
+    // Dispatch to main for UI updates:
+    Task { @MainActor in
+        self.label.text = "\(data ?? "")"
+    }
 }
 ```
+
+If your callback only processes data (logging, storage, network requests), no
+dispatch is needed — it already runs off-main.
 
 ### Reconnection
 
@@ -460,7 +471,21 @@ channel.trigger(event: "client-typing", data: ["user": "alice"])
 
 ### Migration from pre-2.2
 
-If you were calling SockudoSwift methods from a background thread or Combine sink without a main-thread dispatch, those calls were data races. Wrap them in `.receive(on: DispatchQueue.main)` or `Task { @MainActor in }`.
+Event callbacks now execute on `@SockudoActor` (a background executor) instead of the
+main thread. If your callback performs UI work directly, add a `Task { @MainActor in }`
+wrapper or use `.receive(on: DispatchQueue.main)` in Combine pipelines.
+
+Public API must be called with `await` from non-`@SockudoActor` contexts. Synchronous
+reads of client state (`connectionState`, `socketID`) require `await` from outside
+`@SockudoActor`.
+
+Callback parameters are typed as `@SockudoActor`-isolated closures
+(`@escaping @SockudoActor (Any?, EventMetadata?) -> Void`). Your closure body runs
+on `@SockudoActor`, so it can synchronously access other `@SockudoActor`-isolated
+state (including your own `@SockudoActor` types) without any `Task` hop, and events
+are delivered strictly in order. Synchronous access to `@MainActor`-isolated state
+from inside a callback produces a Swift 6 compile error — this surfaces a real data
+race. Wrap the `@MainActor` work in `Task { @MainActor in }` inside the callback.
 
 ## Release Model
 

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/Channels.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/Channels.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Sodium
 
-@MainActor public class Channel: Sendable {
+@SockudoActor public class Channel: Sendable {
   public let name: String
   unowned let client: SockudoClient
   let dispatcher: EventDispatcher
@@ -35,26 +35,26 @@ import Sodium
   }
 
   @discardableResult
-  public func on(_ eventName: String, callback: @escaping (Any?, EventMetadata?) -> Void)
+  public func on(_ eventName: String, callback: @escaping @SockudoActor (Any?, EventMetadata?) -> Void)
     -> EventBindingToken
   {
     dispatcher.bind(eventName, callback: callback)
   }
 
   @discardableResult
-  public func bind(_ eventName: String, callback: @escaping (Any?, EventMetadata?) -> Void)
+  public func bind(_ eventName: String, callback: @escaping @SockudoActor (Any?, EventMetadata?) -> Void)
     -> EventBindingToken
   {
     on(eventName, callback: callback)
   }
 
   @discardableResult
-  public func onGlobal(_ callback: @escaping (String, Any?) -> Void) -> EventBindingToken {
+  public func onGlobal(_ callback: @escaping @SockudoActor (String, Any?) -> Void) -> EventBindingToken {
     dispatcher.bindGlobal(callback)
   }
 
   @discardableResult
-  public func bindGlobal(_ callback: @escaping (String, Any?) -> Void) -> EventBindingToken {
+  public func bindGlobal(_ callback: @escaping @SockudoActor (String, Any?) -> Void) -> EventBindingToken {
     onGlobal(callback)
   }
 
@@ -122,7 +122,7 @@ import Sodium
     subscriptionPending = true
     subscriptionCancelled = false
     authorize(socketID: client.socketID ?? "") { [weak self] result in
-      Task { @MainActor in
+      Task { @SockudoActor in
         guard let self else { return }
         switch result {
         case .failure(let error):
@@ -234,7 +234,7 @@ import Sodium
   public func publishAnnotation(
     messageSerial: String,
     annotation: PublishAnnotationRequest,
-    completion: @escaping @Sendable (Result<PublishAnnotationResponse, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<PublishAnnotationResponse, Error>) -> Void
   ) {
     client.publishAnnotation(
       channelName: name,
@@ -248,7 +248,7 @@ import Sodium
     messageSerial: String,
     annotationSerial: String,
     socketID: String? = nil,
-    completion: @escaping @Sendable (Result<DeleteAnnotationResponse, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<DeleteAnnotationResponse, Error>) -> Void
   ) {
     client.deleteAnnotation(
       channelName: name,
@@ -262,7 +262,7 @@ import Sodium
   public func listAnnotations(
     messageSerial: String,
     params: AnnotationEventsParams = .init(),
-    completion: @escaping @Sendable (Result<AnnotationEventsPage, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<AnnotationEventsPage, Error>) -> Void
   ) {
     client.listAnnotations(
       channelName: name,
@@ -274,14 +274,14 @@ import Sodium
 
   public func channelHistory(
     _ params: ChannelHistoryParams = .init(),
-    completion: @escaping @Sendable (Result<ChannelHistoryPage, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<ChannelHistoryPage, Error>) -> Void
   ) {
     client.fetchChannelHistory(channelName: name, params: params, completion: completion)
   }
 
   public func getMessage(
     _ messageSerial: String,
-    completion: @escaping @Sendable (Result<[String: Any], Error>) -> Void
+    completion: sending @escaping @Sendable (Result<[String: Any], Error>) -> Void
   ) {
     client.fetchLatestMessage(channelName: name, messageSerial: messageSerial, completion: completion)
   }
@@ -289,7 +289,7 @@ import Sodium
   public func getMessageVersions(
     _ messageSerial: String,
     params: MessageVersionsParams = .init(),
-    completion: @escaping @Sendable (Result<MessageVersionsPage, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<MessageVersionsPage, Error>) -> Void
   ) {
     client.fetchMessageVersions(
       channelName: name,
@@ -301,7 +301,7 @@ import Sodium
 
   public func createMessage(
     _ request: VersionedMessageCreateRequest,
-    completion: @escaping @Sendable (Result<VersionedMessageAck, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<VersionedMessageAck, Error>) -> Void
   ) {
     client.createVersionedMessage(
       channelName: name,
@@ -313,7 +313,7 @@ import Sodium
   public func updateMessage(
     _ messageSerial: String,
     request: VersionedMessageUpdateRequest,
-    completion: @escaping @Sendable (Result<VersionedMessageAck, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<VersionedMessageAck, Error>) -> Void
   ) {
     client.updateVersionedMessage(
       channelName: name,
@@ -326,7 +326,7 @@ import Sodium
   public func appendMessage(
     _ messageSerial: String,
     request: VersionedMessageAppendRequest,
-    completion: @escaping @Sendable (Result<VersionedMessageAck, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<VersionedMessageAck, Error>) -> Void
   ) {
     client.appendVersionedMessage(
       channelName: name,
@@ -339,7 +339,7 @@ import Sodium
   public func deleteMessage(
     _ messageSerial: String,
     request: VersionedMessageDeleteRequest = .init(),
-    completion: @escaping @Sendable (Result<VersionedMessageAck, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<VersionedMessageAck, Error>) -> Void
   ) {
     client.deleteVersionedMessage(
       channelName: name,
@@ -350,7 +350,7 @@ import Sodium
   }
 }
 
-@MainActor public class PrivateChannel: Channel {
+@SockudoActor public class PrivateChannel: Channel {
   override func authorize(
     socketID: String,
     completion: @escaping @Sendable (Result<ChannelAuthorizationData, Error>) -> Void
@@ -362,7 +362,7 @@ import Sodium
   }
 }
 
-@MainActor public final class PresenceMembers: Sendable {
+@SockudoActor public final class PresenceMembers: Sendable {
   private(set) var members: [String: AnyHashable] = [:]
   public private(set) var count = 0
   public private(set) var myID: String?
@@ -452,7 +452,7 @@ import Sodium
   }
 }
 
-@MainActor public final class PresenceChannel: PrivateChannel {
+@SockudoActor public final class PresenceChannel: PrivateChannel {
   public let members = PresenceMembers()
 
   override func authorize(
@@ -460,7 +460,7 @@ import Sodium
     completion: @escaping @Sendable (Result<ChannelAuthorizationData, Error>) -> Void
   ) {
     super.authorize(socketID: socketID) { [weak self] result in
-      Task { @MainActor in
+      Task { @SockudoActor in
         guard let self else { return }
         switch result {
         case .failure:
@@ -545,21 +545,21 @@ import Sodium
 
   public func history(
     _ params: PresenceHistoryParams = .init(),
-    completion: @escaping @Sendable (Result<PresenceHistoryPage, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<PresenceHistoryPage, Error>) -> Void
   ) {
     client.fetchPresenceHistory(channelName: name, params: params, completion: completion)
   }
 
   override public func channelHistory(
     _ params: ChannelHistoryParams = .init(),
-    completion: @escaping @Sendable (Result<ChannelHistoryPage, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<ChannelHistoryPage, Error>) -> Void
   ) {
     client.fetchChannelHistory(channelName: name, params: params, completion: completion)
   }
 
   override public func getMessage(
     _ messageSerial: String,
-    completion: @escaping @Sendable (Result<[String: Any], Error>) -> Void
+    completion: sending @escaping @Sendable (Result<[String: Any], Error>) -> Void
   ) {
     client.fetchLatestMessage(channelName: name, messageSerial: messageSerial, completion: completion)
   }
@@ -567,7 +567,7 @@ import Sodium
   override public func getMessageVersions(
     _ messageSerial: String,
     params: MessageVersionsParams = .init(),
-    completion: @escaping @Sendable (Result<MessageVersionsPage, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<MessageVersionsPage, Error>) -> Void
   ) {
     client.fetchMessageVersions(
       channelName: name,
@@ -579,7 +579,7 @@ import Sodium
 
   public func snapshot(
     _ params: PresenceSnapshotParams = .init(),
-    completion: @escaping @Sendable (Result<PresenceSnapshot, Error>) -> Void
+    completion: sending @escaping @Sendable (Result<PresenceSnapshot, Error>) -> Void
   ) {
     client.fetchPresenceSnapshot(channelName: name, params: params, completion: completion)
   }
@@ -599,7 +599,7 @@ import Sodium
   }
 }
 
-@MainActor public final class EncryptedChannel: PrivateChannel {
+@SockudoActor public final class EncryptedChannel: PrivateChannel {
   private var sharedSecret: Bytes?
   private let sodium = Sodium()
 
@@ -608,7 +608,7 @@ import Sodium
     completion: @escaping @Sendable (Result<ChannelAuthorizationData, Error>) -> Void
   ) {
     super.authorize(socketID: socketID) { [weak self] result in
-      Task { @MainActor in
+      Task { @SockudoActor in
         guard let self else { return }
         switch result {
         case .failure:
@@ -664,7 +664,7 @@ import Sodium
         nonce: Array(nonceData))
     else {
       super.authorize(socketID: client.socketID ?? "") { [weak self] result in
-        Task { @MainActor in
+        Task { @SockudoActor in
           guard let self else { return }
           if case .success(let authData) = result,
             let sharedSecret = authData.sharedSecret,

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/Push.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/Push.swift
@@ -309,7 +309,7 @@ public final class SockudoPushRegistration: Sendable {
       }
 
       urlSession.dataTask(with: request) { data, response, error in
-        Task { @MainActor in
+        Task { @SockudoActor in
           if let error {
             completion(.failure(error))
             return

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoActor.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoActor.swift
@@ -1,0 +1,7 @@
+/// A global actor that serializes all SockudoClient coordination on a
+/// background executor, providing the same data-race safety as @MainActor
+/// without blocking the main thread.
+@globalActor
+public actor SockudoActor {
+  public static let shared = SockudoActor()
+}

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoClient.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Network
 
-@MainActor public final class SockudoClient: Sendable {
+@SockudoActor public final class SockudoClient: Sendable {
   public struct Options {
     public var cluster: String
     public var protocolVersion: Int
@@ -111,12 +111,12 @@ import Network
     }
   }
 
-  public static var logToConsole: Bool {
+  nonisolated public static var logToConsole: Bool {
     get { Logger.logToConsole }
     set { Logger.logToConsole = newValue }
   }
 
-  public static var logHandler: ((String) -> Void)? {
+  nonisolated public static var logHandler: ((String) -> Void)? {
     get { Logger.customLog }
     set { Logger.customLog = newValue }
   }
@@ -138,11 +138,11 @@ import Network
   private let urlSession: URLSession
   private let webSocketDelegate = WebSocketDelegate()
   private var webSocketTask: URLSessionWebSocketTask?
-  private var activityTimer: Timer?
-  private var unavailableTimer: Timer?
-  private var retryTimer: Timer?
-  private var timelineSenderTimer: Timer?
-  private var capabilityTokenRefreshTimer: Timer?
+  private let activityTimer = SockudoTimer()
+  private let unavailableTimer = SockudoTimer()
+  private let retryTimer = SockudoTimer()
+  private let timelineSenderTimer = SockudoTimer()
+  private let capabilityTokenRefreshTimer = SockudoTimer()
   private let reachability = ReachabilityMonitor()
   private var channelPositions: [String: RecoveryPosition] = [:]
   private var timeline = Timeline()
@@ -187,7 +187,7 @@ import Network
         configuration: configuration, delegate: webSocketDelegate, delegateQueue: nil)
 
     reachability.stateDidChange = { [weak self] isOnline in
-      Task { @MainActor in
+      Task { @SockudoActor in
         guard let self else { return }
         if isOnline {
           if self.connectionState == .connecting || self.connectionState == .unavailable {
@@ -264,26 +264,26 @@ import Network
   }
 
   @discardableResult
-  public func on(_ eventName: String, callback: @escaping (Any?, EventMetadata?) -> Void)
+  public func on(_ eventName: String, callback: @escaping @SockudoActor (Any?, EventMetadata?) -> Void)
     -> EventBindingToken
   {
     dispatcher.bind(eventName, callback: callback)
   }
 
   @discardableResult
-  public func bind(_ eventName: String, callback: @escaping (Any?, EventMetadata?) -> Void)
+  public func bind(_ eventName: String, callback: @escaping @SockudoActor (Any?, EventMetadata?) -> Void)
     -> EventBindingToken
   {
     on(eventName, callback: callback)
   }
 
   @discardableResult
-  public func onGlobal(_ callback: @escaping (String, Any?) -> Void) -> EventBindingToken {
+  public func onGlobal(_ callback: @escaping @SockudoActor (String, Any?) -> Void) -> EventBindingToken {
     dispatcher.bindGlobal(callback)
   }
 
   @discardableResult
-  public func bindGlobal(_ callback: @escaping (String, Any?) -> Void) -> EventBindingToken {
+  public func bindGlobal(_ callback: @escaping @SockudoActor (String, Any?) -> Void) -> EventBindingToken {
     onGlobal(callback)
   }
 
@@ -381,7 +381,7 @@ import Network
     }
 
     requestCapabilityToken { [weak self] result in
-      Task { @MainActor in
+      Task { @SockudoActor in
         guard let self else { return }
         switch result {
         case .success:
@@ -445,7 +445,7 @@ import Network
       }
     webSocketTask.send(message) { error in
       if let error {
-        Task { @MainActor in
+        Task { @SockudoActor in
           Logger.error("Send failed", error.localizedDescription)
         }
       }
@@ -481,10 +481,10 @@ import Network
       let url = try socketURL(for: transport)
       let task = urlSession.webSocketTask(with: url)
       webSocketDelegate.didOpen = { [weak self] in
-        Task { @MainActor in self?.readNextMessage() }
+        Task { @SockudoActor in self?.readNextMessage() }
       }
       webSocketDelegate.didClose = { [weak self] code, reason in
-        Task { @MainActor in
+        Task { @SockudoActor in
           self?.handleSocketClosed(code: code, reason: reason)
         }
       }
@@ -515,7 +515,7 @@ import Network
     guard tokenRequestInFlight == false else { return }
     tokenRequestInFlight = true
     provider { [weak self] result in
-      Task { @MainActor in
+      Task { @SockudoActor in
         guard let self else { return }
         self.tokenRequestInFlight = false
         switch result {
@@ -539,26 +539,22 @@ import Network
       guard let self else { return }
       switch result {
       case .failure(let error):
-        Task { @MainActor in
+        Task { @SockudoActor in
           self.dispatcher.emit("error", data: error)
           self.handleSocketClosed(code: .abnormalClosure, reason: error.localizedDescription)
         }
       case .success(let message):
-        Task {
+        Task { @SockudoActor in
           do {
             guard let processed = try await messageProcessor.process(message) else {
-              await MainActor.run { self.readNextMessage() }
+              self.readNextMessage()
               return
             }
-            await MainActor.run {
-              self.deliverMessage(processed)
-              self.readNextMessage()
-            }
+            self.deliverMessage(processed)
+            self.readNextMessage()
           } catch {
-            await MainActor.run {
-              self.dispatcher.emit("error", data: error)
-              self.readNextMessage()
-            }
+            self.dispatcher.emit("error", data: error)
+            self.readNextMessage()
           }
         }
       }
@@ -698,7 +694,7 @@ import Network
     guard config.protocolVersion == 2, config.capabilityTokenProvider != nil else { return }
     invalidateCapabilityTokenRefreshTimer()
     requestCapabilityToken { [weak self] result in
-      Task { @MainActor in
+      Task { @SockudoActor in
         guard let self else { return }
         switch result {
         case .success(let token):
@@ -838,15 +834,11 @@ import Network
 
   private func sendPing() {
     if config.protocolVersion == 2, let task = webSocketTask {
-      invalidateActivityTimer()
-      activityTimer = Timer.scheduledTimer(withTimeInterval: config.pongTimeout, repeats: false) {
-        [weak self] _ in
-        Task { @MainActor in
-          self?.scheduleRetry(after: 0)
-        }
+      activityTimer.schedule(after: config.pongTimeout) { [weak self] in
+        self?.scheduleRetry(after: 0)
       }
       task.sendPing { [weak self] error in
-        Task { @MainActor in
+        Task { @SockudoActor in
           guard let self else { return }
           if error != nil {
             self.scheduleRetry(after: 0)
@@ -859,45 +851,29 @@ import Network
     }
 
     _ = try? sendEvent(name: p.event("ping"), data: [:], channel: nil)
-    invalidateActivityTimer()
-    activityTimer = Timer.scheduledTimer(withTimeInterval: config.pongTimeout, repeats: false) {
-      [weak self] _ in
-      Task { @MainActor in
-        self?.scheduleRetry(after: 0)
-      }
+    activityTimer.schedule(after: config.pongTimeout) { [weak self] in
+      self?.scheduleRetry(after: 0)
     }
   }
 
   private func resetActivityTimer() {
-    invalidateActivityTimer()
-    activityTimer = Timer.scheduledTimer(
-      withTimeInterval: config.activityTimeout, repeats: false
-    ) { [weak self] _ in
-      Task { @MainActor in
-        self?.sendPing()
-      }
+    activityTimer.schedule(after: config.activityTimeout) { [weak self] in
+      self?.sendPing()
     }
   }
 
   private func invalidateActivityTimer() {
-    activityTimer?.invalidate()
-    activityTimer = nil
+    activityTimer.cancel()
   }
 
   private func setUnavailableTimer() {
-    clearUnavailableTimer()
-    unavailableTimer = Timer.scheduledTimer(
-      withTimeInterval: config.unavailableTimeout, repeats: false
-    ) { [weak self] _ in
-      Task { @MainActor in
-        self?.updateState(.unavailable)
-      }
+    unavailableTimer.schedule(after: config.unavailableTimeout) { [weak self] in
+      self?.updateState(.unavailable)
     }
   }
 
   private func clearUnavailableTimer() {
-    unavailableTimer?.invalidate()
-    unavailableTimer = nil
+    unavailableTimer.cancel()
   }
 
   func scheduleRetry(after seconds: TimeInterval) {
@@ -907,63 +883,51 @@ import Network
       return
     }
     reconnectAttempts += 1
-    retryTimer?.invalidate()
-    retryTimer = Timer.scheduledTimer(withTimeInterval: seconds, repeats: false) {
-      [weak self] _ in
-      Task { @MainActor in
-        guard let self else { return }
-        self.terminalEventHandled = false
-        self.webSocketTask?.cancel(with: .goingAway, reason: nil)
-        self.webSocketTask = nil
-        self.updateState(.reconnecting)
-        let transports = self.transportSequence()
-        if self.currentTransport == .ws, self.attemptedFallback == false,
-          transports.contains(.wss)
-        {
-          self.attemptedFallback = true
-          self.openWebSocket(using: .wss)
-        } else {
-          self.attemptedFallback = false
-          self.openWebSocket(using: transports.first ?? .wss)
-        }
-        self.setUnavailableTimer()
+    retryTimer.schedule(after: seconds) { [weak self] in
+      guard let self else { return }
+      self.terminalEventHandled = false
+      self.webSocketTask?.cancel(with: .goingAway, reason: nil)
+      self.webSocketTask = nil
+      self.updateState(.reconnecting)
+      let transports = self.transportSequence()
+      if self.currentTransport == .ws, self.attemptedFallback == false,
+        transports.contains(.wss)
+      {
+        self.attemptedFallback = true
+        self.openWebSocket(using: .wss)
+      } else {
+        self.attemptedFallback = false
+        self.openWebSocket(using: transports.first ?? .wss)
       }
+      self.setUnavailableTimer()
     }
   }
 
   private func invalidateTimers() {
-    invalidateActivityTimer()
-    clearUnavailableTimer()
-    retryTimer?.invalidate()
-    retryTimer = nil
-    timelineSenderTimer?.invalidate()
-    timelineSenderTimer = nil
-    invalidateCapabilityTokenRefreshTimer()
+    activityTimer.cancel()
+    unavailableTimer.cancel()
+    retryTimer.cancel()
+    timelineSenderTimer.cancel()
+    capabilityTokenRefreshTimer.cancel()
   }
 
   func scheduleCapabilityTokenRefreshIfNeeded(for token: String, now: Date = Date()) {
-    invalidateCapabilityTokenRefreshTimer()
+    capabilityTokenRefreshTimer.cancel()
     guard config.protocolVersion == 2,
       config.capabilityTokenProvider != nil,
       let delay = Self.capabilityTokenRefreshDelay(for: token, now: now)
     else { return }
-
-    let timer = Timer(timeInterval: max(0.001, delay), repeats: false) { [weak self] _ in
-      Task { @MainActor in
-        self?.refreshCapabilityToken()
-      }
+    capabilityTokenRefreshTimer.schedule(after: max(0.001, delay)) { [weak self] in
+      self?.refreshCapabilityToken()
     }
-    capabilityTokenRefreshTimer = timer
-    RunLoop.main.add(timer, forMode: .common)
   }
 
   var hasCapabilityTokenRefreshTimer: Bool {
-    capabilityTokenRefreshTimer != nil
+    capabilityTokenRefreshTimer.isActive
   }
 
   private func invalidateCapabilityTokenRefreshTimer() {
-    capabilityTokenRefreshTimer?.invalidate()
-    capabilityTokenRefreshTimer = nil
+    capabilityTokenRefreshTimer.cancel()
   }
 
   private func updateState(_ state: ConnectionState, metadata: [String: Any]? = nil) {
@@ -975,12 +939,8 @@ import Network
   }
 
   private func startTimelineSender() {
-    timelineSenderTimer?.invalidate()
-    timelineSenderTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) {
-      [weak self] _ in
-      Task { @MainActor in
-        self?.sendTimeline()
-      }
+    timelineSenderTimer.scheduleRepeating(every: 60) { [weak self] in
+      self?.sendTimeline()
     }
     sendTimeline()
   }
@@ -1008,7 +968,7 @@ import Network
   }
 }
 
-@MainActor public final class UserFacade: Sendable {
+@SockudoActor public final class UserFacade: Sendable {
   private(set) weak var client: SockudoClient?
   private let dispatcher = EventDispatcher { event, _ in
     Logger.debug("No callbacks on user for \(event)")
@@ -1025,7 +985,7 @@ import Network
   }
 
   @discardableResult
-  public func on(_ eventName: String, callback: @escaping (Any?, EventMetadata?) -> Void)
+  public func on(_ eventName: String, callback: @escaping @SockudoActor (Any?, EventMetadata?) -> Void)
     -> EventBindingToken
   {
     dispatcher.bind(eventName, callback: callback)
@@ -1063,7 +1023,7 @@ import Network
     else { return }
     client.config.userAuthenticator(UserAuthenticationRequest(socketID: socketID)) {
       [weak self] result in
-      Task { @MainActor in
+      Task { @SockudoActor in
         guard let self, let client = self.client else { return }
         switch result {
         case .failure:
@@ -1083,7 +1043,7 @@ import Network
   private func subscribeServerChannel(userID: String) {
     guard let client else { return }
     let channel = Channel(name: "#server-to-user-\(userID)", client: client)
-    channel.onGlobal { [weak self] eventName, data in
+    channel.onGlobal { @SockudoActor [weak self] eventName, data in
       guard let self, let client = self.client else { return }
       guard client.p.isInternalEvent(eventName) == false,
         client.p.isPlatformEvent(eventName) == false
@@ -1102,7 +1062,7 @@ import Network
   }
 }
 
-@MainActor public final class WatchlistFacade: Sendable {
+@SockudoActor public final class WatchlistFacade: Sendable {
   private weak var client: SockudoClient?
   private let dispatcher = EventDispatcher { event, _ in
     Logger.debug("No callbacks on watchlist for \(event)")
@@ -1115,7 +1075,7 @@ import Network
   }
 
   @discardableResult
-  public func on(_ eventName: String, callback: @escaping (Any?, EventMetadata?) -> Void)
+  public func on(_ eventName: String, callback: @escaping @SockudoActor (Any?, EventMetadata?) -> Void)
     -> EventBindingToken
   {
     dispatcher.bind(eventName, callback: callback)
@@ -1331,7 +1291,7 @@ extension SockudoClient {
         request.setValue(value, forHTTPHeaderField: name)
       }
       URLSession.shared.dataTask(with: request) { data, response, error in
-        Task { @MainActor in
+        Task { @SockudoActor in
           if let error {
             completion(.failure(error))
             return
@@ -1810,7 +1770,7 @@ extension SockudoClient {
       }
 
       urlSession.dataTask(with: request) { data, response, error in
-        Task { @MainActor in
+        Task { @SockudoActor in
           if let error {
             completion(.failure(error))
             return
@@ -1876,7 +1836,7 @@ extension SockudoClient {
       bounds: decodePresenceHistoryBounds(payload["bounds"] as? [String: Any]),
       continuity: decodePresenceHistoryContinuity(payload["continuity"] as? [String: Any]),
       fetchNext: { [weak self] cursor, completion in
-        Task { @MainActor in
+        Task { @SockudoActor in
           self?.fetchPresenceHistory(
             channelName: channelName,
             params: PresenceHistoryParams(
@@ -1935,7 +1895,7 @@ extension SockudoClient {
       bounds: payload["bounds"] as? [String: Any] ?? [:],
       continuity: payload["continuity"] as? [String: Any] ?? [:],
       fetchNext: { [weak self] cursor, completion in
-        Task { @MainActor in
+        Task { @SockudoActor in
           self?.fetchChannelHistory(
             channelName: channelName,
             params: ChannelHistoryParams(
@@ -1971,7 +1931,7 @@ extension SockudoClient {
       hasMore: payload["has_more"] as? Bool ?? false,
       nextCursor: payload["next_cursor"] as? String,
       fetchNext: { [weak self] cursor, completion in
-        Task { @MainActor in
+        Task { @SockudoActor in
           self?.fetchMessageVersions(
             channelName: channelName,
             messageSerial: messageSerial,
@@ -2054,7 +2014,7 @@ extension SockudoClient {
       hasMore: payload["has_more"] as? Bool ?? false,
       nextCursor: payload["next_cursor"] as? String,
       fetchNext: { [weak self] cursor, completion in
-        Task { @MainActor in
+        Task { @SockudoActor in
           self?.listAnnotations(
             channelName: channelName,
             messageSerial: messageSerial,
@@ -2098,8 +2058,21 @@ extension SockudoClient {
 }
 
 private final class WebSocketDelegate: NSObject, URLSessionWebSocketDelegate, @unchecked Sendable {
-  var didOpen: (@Sendable () -> Void)?
-  var didClose: (@Sendable (URLSessionWebSocketTask.CloseCode, String?) -> Void)?
+  // NSLock guards the closure storage: @SockudoActor reassigns these on every
+  // (re)connect while URLSession's delegate queue reads them on socket events.
+  private let lock = NSLock()
+  private var _didOpen: (@Sendable () -> Void)?
+  private var _didClose: (@Sendable (URLSessionWebSocketTask.CloseCode, String?) -> Void)?
+
+  var didOpen: (@Sendable () -> Void)? {
+    get { lock.lock(); defer { lock.unlock() }; return _didOpen }
+    set { lock.lock(); defer { lock.unlock() }; _didOpen = newValue }
+  }
+
+  var didClose: (@Sendable (URLSessionWebSocketTask.CloseCode, String?) -> Void)? {
+    get { lock.lock(); defer { lock.unlock() }; return _didClose }
+    set { lock.lock(); defer { lock.unlock() }; _didClose = newValue }
+  }
 
   func urlSession(
     _ session: URLSession, webSocketTask: URLSessionWebSocketTask,
@@ -2124,7 +2097,7 @@ enum CloseAction {
   case retry
 }
 
-@MainActor private final class ReachabilityMonitor: Sendable {
+@SockudoActor private final class ReachabilityMonitor: Sendable {
   private let monitor = NWPathMonitor()
   private let queue = DispatchQueue(label: "sockudo.reachability")
   var stateDidChange: (@Sendable (Bool) -> Void)?
@@ -2132,7 +2105,7 @@ enum CloseAction {
   func start() {
     let callback = stateDidChange
     monitor.pathUpdateHandler = { path in
-      Task { @MainActor in
+      Task { @SockudoActor in
         callback?(path.status == .satisfied)
       }
     }

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoTimer.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoTimer.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// A cancellable timer that runs on @SockudoActor using cooperative Task
+/// scheduling. Replaces Timer.scheduledTimer / RunLoop.main which require
+/// a run loop that does not exist on the actor's background executor.
+@SockudoActor
+final class SockudoTimer {
+  private var task: Task<Void, Never>?
+
+  /// Whether a timer is currently pending (true after schedule, false after cancel or one-shot fires).
+  var isActive: Bool { task != nil }
+
+  /// Schedule a one-shot action after `seconds`. Cancels any pending timer.
+  func schedule(after seconds: TimeInterval, _ action: @escaping @SockudoActor () -> Void) {
+    task?.cancel()
+    task = Task { [weak self] in
+      try? await Task.sleep(nanoseconds: UInt64(max(0, seconds) * 1_000_000_000))
+      guard let self, !Task.isCancelled else { return }
+      // Clear BEFORE running the action: past the guard we are provably the
+      // current task (a replacement would have cancelled us), and the action
+      // may reschedule this same timer — clearing after would orphan that new
+      // task, leaving it uncancellable (caused spurious pong-timeout reconnects).
+      self.task = nil
+      action()
+    }
+  }
+
+  /// Schedule a repeating action every `seconds`. Cancels any pending timer.
+  /// Sleeps FIRST then fires (matches Timer.scheduledTimer(repeats: true) behavior).
+  func scheduleRepeating(every seconds: TimeInterval, _ action: @escaping @SockudoActor () -> Void) {
+    task?.cancel()
+    task = Task {
+      while !Task.isCancelled {
+        try? await Task.sleep(nanoseconds: UInt64(max(0, seconds) * 1_000_000_000))
+        guard !Task.isCancelled else { return }
+        action()
+      }
+    }
+  }
+
+  /// Cancel any pending timer. isActive becomes false.
+  func cancel() {
+    task?.cancel()
+    task = nil
+  }
+}

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/Support.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/Support.swift
@@ -90,7 +90,7 @@ public struct PresenceSnapshotParams: Sendable, Equatable {
 }
 
 // @unchecked Sendable: presenceEvent uses [String: AnyHashable] which is not Sendable;
-// safe — constructed from JSON decoding and only read on @MainActor.
+// safe — constructed from JSON decoding and only read on @SockudoActor.
 public struct PresenceHistoryItem: @unchecked Sendable, Equatable {
   public let streamID: String
   public let serial: Int64
@@ -186,7 +186,7 @@ public struct ChannelHistoryParams: Sendable, Equatable {
 }
 
 // @unchecked Sendable: items uses [[String: Any]] which is not Sendable;
-// safe — all let, constructed from JSON decoding, consumed on @MainActor.
+// safe — all let, constructed from JSON decoding, consumed on @SockudoActor.
 public final class ChannelHistoryPage: @unchecked Sendable {
   public let items: [[String: Any]]
   public let direction: String
@@ -257,7 +257,7 @@ public struct MessageVersionsParams: Sendable, Equatable {
 }
 
 // @unchecked Sendable: items uses [[String: Any]] which is not Sendable;
-// safe — all let, constructed from JSON decoding, consumed on @MainActor.
+// safe — all let, constructed from JSON decoding, consumed on @SockudoActor.
 public final class MessageVersionsPage: @unchecked Sendable {
   public let channel: String
   public let items: [[String: Any]]
@@ -301,7 +301,7 @@ public final class MessageVersionsPage: @unchecked Sendable {
 }
 
 // @unchecked Sendable: items uses [PresenceHistoryItem] whose presenceEvent is [String: AnyHashable];
-// safe — all let, constructed from JSON decoding, consumed on @MainActor.
+// safe — all let, constructed from JSON decoding, consumed on @SockudoActor.
 public final class PresenceHistoryPage: @unchecked Sendable {
   public let items: [PresenceHistoryItem]
   public let direction: String
@@ -444,9 +444,9 @@ enum QueryString {
   }
 }
 
-@MainActor final class EventDispatcher {
-  typealias EventCallback = (Any?, EventMetadata?) -> Void
-  typealias GlobalCallback = (String, Any?) -> Void
+@SockudoActor final class EventDispatcher {
+  typealias EventCallback = @SockudoActor (Any?, EventMetadata?) -> Void
+  typealias GlobalCallback = @SockudoActor (String, Any?) -> Void
 
   private var callbackOrder: [String: [EventBindingToken]] = [:]
   private var callbacks: [String: [EventBindingToken: EventCallback]] = [:]
@@ -916,7 +916,7 @@ public struct PublishAnnotationRequest: Sendable, Equatable {
 }
 
 // @unchecked Sendable: annotation and summary use [String: Any] which is not Sendable;
-// safe — all let, constructed from HTTP response decoding, consumed on @MainActor.
+// safe — all let, constructed from HTTP response decoding, consumed on @SockudoActor.
 public struct PublishAnnotationResponse: @unchecked Sendable {
   public let annotation: [String: Any]
   public let summary: [String: Any]?
@@ -928,7 +928,7 @@ public struct PublishAnnotationResponse: @unchecked Sendable {
 }
 
 // @unchecked Sendable: summary uses [String: Any]? which is not Sendable;
-// safe — all let, constructed from HTTP response decoding, consumed on @MainActor.
+// safe — all let, constructed from HTTP response decoding, consumed on @SockudoActor.
 public struct DeleteAnnotationResponse: @unchecked Sendable {
   public let deleted: Bool
   public let annotationSerial: String
@@ -974,7 +974,7 @@ public struct AnnotationEventsParams: Sendable, Equatable {
 }
 
 // @unchecked Sendable: items uses [[String: Any]] which is not Sendable;
-// safe — all let, constructed from JSON decoding, consumed on @MainActor.
+// safe — all let, constructed from JSON decoding, consumed on @SockudoActor.
 public final class AnnotationEventsPage: @unchecked Sendable {
   public let items: [[String: Any]]
   public let direction: String
@@ -1124,7 +1124,7 @@ public struct PresenceMember: Equatable {
 }
 
 // @unchecked Sendable: data uses Any? which is not Sendable;
-// safe — constructed from JSON decoding on @MainActor, never mutated after creation.
+// safe — constructed from JSON decoding on @SockudoActor, never mutated after creation.
 public struct SockudoEvent: @unchecked Sendable {
   let event: String
   let channel: String?
@@ -1173,23 +1173,26 @@ func wireInt64(_ value: Any?) -> Int64? {
   }
 }
 
-@MainActor enum Logger {
-  static var logToConsole = false
-  static var customLog: ((String) -> Void)?
+enum Logger {
+  private static let _lock = NSLock()
+  private nonisolated(unsafe) static var _logToConsole = false
+  private nonisolated(unsafe) static var _customLog: ((String) -> Void)?
 
-  static func debug(_ items: Any...) {
-    log(items)
+  static var logToConsole: Bool {
+    get { _lock.lock(); defer { _lock.unlock() }; return _logToConsole }
+    set { _lock.lock(); defer { _lock.unlock() }; _logToConsole = newValue }
   }
 
-  static func warn(_ items: Any...) {
-    log(items)
+  static var customLog: ((String) -> Void)? {
+    get { _lock.lock(); defer { _lock.unlock() }; return _customLog }
+    set { _lock.lock(); defer { _lock.unlock() }; _customLog = newValue }
   }
 
-  static func error(_ items: Any...) {
-    log(items)
-  }
+  @SockudoActor static func debug(_ items: Any...) { log(items) }
+  @SockudoActor static func warn(_ items: Any...) { log(items) }
+  @SockudoActor static func error(_ items: Any...) { log(items) }
 
-  private static func log(_ items: [Any]) {
+  @SockudoActor private static func log(_ items: [Any]) {
     let message = (["Sockudo"] + items.map { String(describing: $0) }).joined(separator: " : ")
     if let customLog {
       customLog(message)

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/VersionedMessages.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/VersionedMessages.swift
@@ -36,7 +36,7 @@ public enum VersionedMessageClearField: String, Sendable, Codable, Equatable, Ca
 }
 
 // @unchecked Sendable: data uses Any which is not Sendable;
-// safe — fire-and-forget value type, created by caller and serialized on @MainActor.
+// safe — fire-and-forget value type, created by caller and serialized on @SockudoActor.
 public struct VersionedMessageCreateRequest: @unchecked Sendable {
   public let name: String
   public let data: Any
@@ -79,7 +79,7 @@ public struct VersionedMessageCreateRequest: @unchecked Sendable {
 }
 
 // @unchecked Sendable: data and metadata use Any?/Any which is not Sendable;
-// safe — fire-and-forget value type, created by caller and serialized on @MainActor.
+// safe — fire-and-forget value type, created by caller and serialized on @SockudoActor.
 public struct VersionedMessageUpdateRequest: @unchecked Sendable {
   public let name: String?
   public let data: Any?
@@ -129,7 +129,7 @@ public struct VersionedMessageUpdateRequest: @unchecked Sendable {
 }
 
 // @unchecked Sendable: metadata uses Any? which is not Sendable;
-// safe — fire-and-forget value type, created by caller and serialized on @MainActor.
+// safe — fire-and-forget value type, created by caller and serialized on @SockudoActor.
 public struct VersionedMessageAppendRequest: @unchecked Sendable {
   public let data: String
   public let extras: MessageExtras?
@@ -170,7 +170,7 @@ public struct VersionedMessageAppendRequest: @unchecked Sendable {
 }
 
 // @unchecked Sendable: data and metadata use Any?/Any which is not Sendable;
-// safe — fire-and-forget value type, created by caller and serialized on @MainActor.
+// safe — fire-and-forget value type, created by caller and serialized on @SockudoActor.
 public struct VersionedMessageDeleteRequest: @unchecked Sendable {
   public let data: Any?
   public let extras: MessageExtras?
@@ -216,7 +216,7 @@ public struct VersionedMessageDeleteRequest: @unchecked Sendable {
 }
 
 // @unchecked Sendable: raw uses [String: Any] which is not Sendable;
-// safe — all let, constructed from HTTP response decoding, consumed on @MainActor.
+// safe — all let, constructed from HTTP response decoding, consumed on @SockudoActor.
 public struct VersionedMessageAck: @unchecked Sendable {
   public let channel: String
   public let messageSerial: String
@@ -277,7 +277,7 @@ public struct MutableMessageVersionInfo: Sendable, Equatable {
 }
 
 // @unchecked Sendable: data uses Any? which is not Sendable;
-// safe — all let, produced by reduceMutableMessageEvent on @MainActor, never mutated after creation.
+// safe — all let, produced by reduceMutableMessageEvent on @SockudoActor, never mutated after creation.
 public struct MutableMessageState: @unchecked Sendable, Equatable {
   public let messageSerial: String
   public let action: MutableMessageAction

--- a/client-sdks/sockudo-swift/Tests/SockudoSwiftTests/SockudoSwiftTests.swift
+++ b/client-sdks/sockudo-swift/Tests/SockudoSwiftTests/SockudoSwiftTests.swift
@@ -75,7 +75,7 @@ private final class VersionedProxyURLProtocol: URLProtocol, @unchecked Sendable 
 
 private struct TimeoutError: Error {}
 
-@MainActor private func waitForValue<T>(
+@SockudoActor private func waitForValue<T>(
   timeout: TimeInterval = 5,
   pollInterval: UInt64 = 50_000_000,
   _ body: @escaping () -> T?
@@ -285,7 +285,7 @@ private func requestBodyData(_ request: URLRequest) -> Data? {
   return data.isEmpty ? nil : data
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func filterValidationAcceptsNestedFilters() {
   let filter = Filter.or(
     .init(key: "sport", cmp: "eq", val: "football"),
@@ -298,13 +298,13 @@ func filterValidationAcceptsNestedFilters() {
   #expect(validateFilter(filter) == nil)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func filterValidationRejectsInvalidNotNode() {
   let invalid = FilterNode(op: "not", nodes: [])
   #expect(validateFilter(invalid) == "NOT operation requires exactly one child node, got 0")
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func deltaSettingsSerializeAsExpected() {
   #expect(ChannelDeltaSettings(enabled: true).subscriptionValue() as? Bool == true)
   #expect(ChannelDeltaSettings(enabled: false).subscriptionValue() as? Bool == false)
@@ -313,7 +313,7 @@ func deltaSettingsSerializeAsExpected() {
   #expect((SubscriptionRewind.seconds(30).subscriptionValue() as? [String: Int])?["seconds"] == 30)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func presenceHistoryParamsNormalizeAblyAliases() {
   let payload = PresenceHistoryParams(
     direction: "newest_first",
@@ -328,7 +328,7 @@ func presenceHistoryParamsNormalizeAblyAliases() {
   #expect(payload["end_time_ms"] as? Int64 == 2000)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func channelHistoryParamsIncludeUntilAttach() {
   let payload = ChannelHistoryParams(
     direction: "newest_first",
@@ -341,7 +341,7 @@ func channelHistoryParamsIncludeUntilAttach() {
   #expect(payload["until_attach"] as? Bool == true)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func presenceHistoryPageNextUsesNextCursor() async throws {
   let cursor = Box<String>()
   let page = PresenceHistoryPage(
@@ -406,7 +406,7 @@ func presenceHistoryPageNextUsesNextCursor() async throws {
   #expect(cursor.value == "cursor-2")
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func annotationRequestPayloadUsesProxyShape() {
   let payload = PublishAnnotationRequest(
     type: "reactions:distinct.v1",
@@ -427,7 +427,7 @@ func annotationRequestPayloadUsesProxyShape() {
   #expect(payload["idempotencyKey"] as? String == "anno-1")
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func annotationEventsPageNextUsesNextCursor() {
   let cursor = Box<String>()
   let page = AnnotationEventsPage(
@@ -456,7 +456,7 @@ func annotationEventsPageNextUsesNextCursor() {
   #expect(cursor.value == "anno-cursor-2")
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func pushProxyHelpersUseBackendEndpointAndAsyncPublishDefaults() async throws {
   let requests = Box<[URLRequest]>()
   requests.value = []
@@ -556,7 +556,7 @@ func pushProxyHelpersUseBackendEndpointAndAsyncPublishDefaults() async throws {
   )
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func versionedMessageProxyWritesUseEndpointTimeoutAndTypedAcks() async throws {
   let requests = Box<[URLRequest]>()
   requests.value = []
@@ -717,7 +717,7 @@ func versionedMessageProxyWritesUseEndpointTimeoutAndTypedAcks() async throws {
   #expect(deleteBody["action"] as? String == "delete_message")
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func channelExposesAnnotationInternalEvents() throws {
   let client = try SockudoClient(
     "app-key",
@@ -767,7 +767,7 @@ func channelExposesAnnotationInternalEvents() throws {
   #expect(raw.value?["action"] as? String == "annotation.create")
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func subscriptionSucceededCapturesAttachSerial() throws {
   let client = try SockudoClient(
     "app-key",
@@ -793,7 +793,7 @@ func subscriptionSucceededCapturesAttachSerial() throws {
   #expect(channel.attachSerial == 42)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func websocketURLIncludesV2FormatQuery() throws {
   let client = try SockudoClient(
     "app-key",
@@ -825,7 +825,7 @@ func websocketURLIncludesV2FormatQuery() throws {
   #expect(query["token"] == "jwt-1")
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func websocketURLUsesV1ByDefaultAndOmitsFormatQuery() throws {
   let client = try SockudoClient(
     "app-key",
@@ -852,7 +852,7 @@ func websocketURLUsesV1ByDefaultAndOmitsFormatQuery() throws {
   #expect(query["token"] == nil)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func appendRollupWindowRejectsUnsupportedValues() {
   do {
     _ = try SockudoClient(
@@ -867,7 +867,7 @@ func appendRollupWindowRejectsUnsupportedValues() {
   }
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func capabilityTokenAuthEventsUpdateStateAndProviderRefreshes() async throws {
   let tokenRequests = Box<Int>()
   tokenRequests.value = 0
@@ -900,7 +900,7 @@ func capabilityTokenAuthEventsUpdateStateAndProviderRefreshes() async throws {
   #expect(tokenRequests.value == 1)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func capabilityTokenRefreshDelayUsesJWTIatAndExp() throws {
   let token = try unsignedJWT(claims: ["iat": 1_000, "exp": 2_000])
   let delay = try #require(
@@ -912,7 +912,7 @@ func capabilityTokenRefreshDelayUsesJWTIatAndExp() throws {
   #expect(abs(delay - 100) < 0.001)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func capabilityTokenRefreshDelayFallsBackToNowWhenIatMissing() throws {
   let token = try unsignedJWT(claims: ["exp": 2_000])
   let delay = try #require(
@@ -926,7 +926,7 @@ func capabilityTokenRefreshDelayFallsBackToNowWhenIatMissing() throws {
   #expect(SockudoClient.capabilityTokenRefreshDelay(for: try unsignedJWT(claims: ["iat": 1])) == nil)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func providerJWTCapabilityTokenSchedulesProactiveRefresh() async throws {
   let issuedAt = 1_000
   let expiresAt = 2_000
@@ -959,7 +959,7 @@ func providerJWTCapabilityTokenSchedulesProactiveRefresh() async throws {
   #expect(client.hasCapabilityTokenRefreshTimer == false)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func staticOnlyAndOpaqueCapabilityTokensDoNotScheduleProactiveRefresh() throws {
   let token = try unsignedJWT(claims: ["iat": 1_000, "exp": 2_000])
   let staticOnly = try SockudoClient(
@@ -991,7 +991,7 @@ func staticOnlyAndOpaqueCapabilityTokensDoNotScheduleProactiveRefresh() throws {
   #expect(providerOpaque.hasCapabilityTokenRefreshTimer == false)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func messagePackRoundTrip() throws {
   let payload = try ProtocolCodec.encodeEnvelope(
     [
@@ -1028,7 +1028,7 @@ func messagePackRoundTrip() throws {
   #expect(decoded.conflationKey == "room")
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func protobufRoundTrip() throws {
   let payload = try ProtocolCodec.encodeEnvelope(
     [
@@ -1083,7 +1083,7 @@ func protobufRoundTrip() throws {
   #expect(decoded.extras?.raw?["ai"]?["codec"]?["x-custom"]?.stringValue == "opaque")
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func forwardCompatFixturesReplayThroughClientDispatch() throws {
   let client = try SockudoClient(
     "app-key",
@@ -1133,7 +1133,7 @@ func forwardCompatFixturesReplayThroughClientDispatch() throws {
   #expect(channelEvents.value?.contains("ai-output") == true)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func forwardCompatJSONPreservesSerialBoundariesAndRawExtras() throws {
   let futureFrame = try ProtocolCodec.decodeEvent(
     .string(try forwardCompatFixture("future-v2-frame.json")),
@@ -1162,7 +1162,7 @@ func forwardCompatJSONPreservesSerialBoundariesAndRawExtras() throws {
   #expect(extrasFrame.extras?.raw?["futureExtrasField"] == .bool(true))
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func binaryCodecsPreserveLargeSerialsAndAIExtras() throws {
   let largeSerial = 9_007_199_254_740_993
   let payload: [String: Any] = [
@@ -1202,7 +1202,7 @@ func binaryCodecsPreserveLargeSerialsAndAIExtras() throws {
   #expect(protobuf.extras?.raw?["ai"]?["transport"]?["turn-id"]?.stringValue == "turn-1")
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func presenceUnknownInternalEventsDoNotCorruptMembers() throws {
   let client = try SockudoClient(
     "app-key",
@@ -1264,7 +1264,7 @@ func presenceUnknownInternalEventsDoNotCorruptMembers() throws {
   #expect(channel.members.member(id: "undefined") == nil)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func presenceUpdateRequiresV2AndUsesConnectionSendPath() throws {
   let v1Client = try SockudoClient(
     "app-key",
@@ -1290,7 +1290,7 @@ func presenceUpdateRequiresV2AndUsesConnectionSendPath() throws {
   #expect(try v2Channel.update(data: ["status": "thinking"]) == false)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func localSockudoIntegrationConnectsAndReceivesPublishedEvent() async throws {
   guard ProcessInfo.processInfo.environment["SOCKUDO_LIVE_TESTS"] == "1" else {
     return
@@ -1345,7 +1345,7 @@ func localSockudoIntegrationConnectsAndReceivesPublishedEvent() async throws {
   client.disconnect()
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func liveV2HeartbeatUsesControlFramesOnIdle() async throws {
   guard ProcessInfo.processInfo.environment["SOCKUDO_LIVE_TESTS"] == "1" else {
     return
@@ -1371,7 +1371,7 @@ func liveV2HeartbeatUsesControlFramesOnIdle() async throws {
   }
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func liveV2FallbackPongHasNoMetadata() async throws {
   guard ProcessInfo.processInfo.environment["SOCKUDO_LIVE_TESTS"] == "1" else {
     return
@@ -1396,7 +1396,7 @@ func liveV2FallbackPongHasNoMetadata() async throws {
   #expect(pong.streamID == nil)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func liveV1HeartbeatStillUsesProtocolPing() async throws {
   guard ProcessInfo.processInfo.environment["SOCKUDO_LIVE_TESTS"] == "1" else {
     return
@@ -1468,7 +1468,7 @@ func liveV1HeartbeatStillUsesProtocolPing() async throws {
   }
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func clientEventBufferedWhenNotSubscribed() throws {
   let client = try SockudoClient("app-key", options: .init(cluster: "local", protocolVersion: 2))
   let channel = client.subscribe("private-chat")
@@ -1479,7 +1479,7 @@ func clientEventBufferedWhenNotSubscribed() throws {
   #expect(channel.bufferedEventCount == 1)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func clientEventBufferDrainedAfterSubscriptionSucceeded() throws {
   let client = try SockudoClient("app-key", options: .init(cluster: "local", protocolVersion: 2))
   let channel = client.subscribe("private-chat")
@@ -1507,7 +1507,7 @@ func clientEventBufferDrainedAfterSubscriptionSucceeded() throws {
   #expect(channel.bufferedEventCount == 0)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func clientEventBufferCapDropsOldestAtOverflow() throws {
   let client = try SockudoClient("app-key", options: .init(cluster: "local", protocolVersion: 2))
   let channel = client.subscribe("private-chat")
@@ -1519,7 +1519,7 @@ func clientEventBufferCapDropsOldestAtOverflow() throws {
   #expect(channel.bufferedEventCount == 50)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func unsubscribeClearsClientEventBuffer() throws {
   let client = try SockudoClient("app-key", options: .init(cluster: "local", protocolVersion: 2))
   let channel = client.subscribe("private-chat")
@@ -1531,7 +1531,7 @@ func unsubscribeClearsClientEventBuffer() throws {
   #expect(channel.bufferedEventCount == 0)
 }
 
-@Test @MainActor
+@Test @SockudoActor
 func clientEventBufferSurvivesDisconnect() throws {
   let client = try SockudoClient("app-key", options: .init(cluster: "local", protocolVersion: 2))
   let channel = client.subscribe("private-chat")
@@ -1546,7 +1546,7 @@ func clientEventBufferSurvivesDisconnect() throws {
 
 // MARK: - Connection State
 
-@Test @MainActor
+@Test @SockudoActor
 func connectionStateTransitionIncludesReconnecting() async throws {
   let client = try SockudoClient(
     "app-key",
@@ -1584,7 +1584,7 @@ func connectionStateTransitionIncludesReconnecting() async throws {
 // MARK: - Reconnect Backoff
 
 @Suite("Reconnect Backoff")
-@MainActor
+@SockudoActor
 struct ReconnectBackoffTests {
 
   @Test func delayProgressionFollowsSquaredFormula() throws {
@@ -1671,12 +1671,12 @@ struct ReconnectBackoffTests {
 // MARK: - Concurrency Compliance
 
 @Suite("Concurrency Compliance")
-@MainActor
+@SockudoActor
 struct ConcurrencyComplianceTests {
 
-  // Verifies that sequential connect/disconnect on @MainActor does not crash.
+  // Verifies that sequential connect/disconnect on @SockudoActor does not crash.
   // The parallel case (calling from a background thread) is now a compile-time
-  // error due to @MainActor isolation on SockudoClient — that's the real guard.
+  // error due to @SockudoActor isolation on SockudoClient — that's the real guard.
   @Test func connectDisconnect_sequential_doesNotCrash() throws {
     let client = try SockudoClient(
       "test-key",
@@ -1700,7 +1700,7 @@ struct ConcurrencyComplianceTests {
     #expect(received == [1, 2])
   }
 
-  // Verifies MessageDeduplicator isolation: isDuplicate/track are @MainActor-safe.
+  // Verifies MessageDeduplicator isolation: isDuplicate/track are @SockudoActor-safe.
   @Test func messageDeduplicator_trackAndCheck() {
     let dedup = MessageDeduplicator(capacity: 10)
     dedup.track("msg-1")
@@ -1710,7 +1710,7 @@ struct ConcurrencyComplianceTests {
 
   // Documents the @unchecked Sendable count does not regress above the
   // post-migration threshold of 19 type declarations.
-  // This test passes trivially at compile time — if @MainActor were removed and
+  // This test passes trivially at compile time — if @SockudoActor were removed and
   // more @unchecked Sendable added, this comment serves as the documented baseline.
   @Test func uncheckedSendableCount_documentedThreshold() {
     // Baseline established post-migration: 19 @unchecked Sendable type declarations.
@@ -1720,8 +1720,8 @@ struct ConcurrencyComplianceTests {
     #expect(Bool(true)) // Compile-time contract; runtime is a formality.
   }
 
-  @Test @MainActor
-  func deliveredCallbacksFireOnMainActor() throws {
+  @Test @SockudoActor
+  func deliveredCallbacksFireOnSockudoActor() throws {
     let client = try SockudoClient(
       "app-key",
       options: .init(cluster: "local", protocolVersion: 2)
@@ -1733,7 +1733,7 @@ struct ConcurrencyComplianceTests {
     fired.value = false
 
     channel.bind("test-event") { _, _ in
-      MainActor.assertIsolated()
+      SockudoActor.assertIsolated()
       fired.value = true
     }
 
@@ -1743,4 +1743,25 @@ struct ConcurrencyComplianceTests {
 
     #expect(fired.value == true)
   }
+}
+
+// MARK: - SockudoTimer
+
+@Test @SockudoActor
+func schedule_whenActionReschedulesSameTimer_keepsNewTimerActiveAndCancellable() async throws {
+  let timer = SockudoTimer()
+  let rescheduledFired = Box<Bool>()
+
+  timer.schedule(after: 0.01) {
+    timer.schedule(after: 0.2) {
+      rescheduledFired.value = true
+    }
+  }
+
+  try await Task.sleep(nanoseconds: 100_000_000)
+  #expect(timer.isActive == true)
+
+  timer.cancel()
+  try await Task.sleep(nanoseconds: 300_000_000)
+  #expect(rescheduledFired.value == nil)
 }


### PR DESCRIPTION
Replace `@MainActor` isolation across SockudoClient, Channel, PresenceMembers, UserFacade, WatchlistFacade, and EventDispatcher with a new `@SockudoActor` global actor that serializes coordination on a background executor instead of blocking the main thread.

- Add SockudoActor: a @globalActor providing the same single-threaded data-race safety as MainActor without main-thread contention.
- Add SockudoTimer: a cancellable, @SockudoActor-isolated timer built on cooperative Task scheduling, replacing Timer.scheduledTimer/RunLoop.main (which require a run loop unavailable on the actor's background executor). Fixes a timer-clearing race that could cause spurious pong-timeout reconnects.
- Make Logger's mutable state (logToConsole, customLog) NSLock-guarded and non-actor-isolated so it stays callable from any context, while log output (debug/warn/error) runs on @SockudoActor.
- Guard WebSocketDelegate's didOpen/didClose closures with NSLock since @SockudoActor reassigns them on every reconnect while URLSession's delegate queue reads them concurrently.
- Update event callback types to @SockudoActor-isolated closures so bound callbacks can synchronously touch other @SockudoActor state without a Task hop.
- Drop the explicit swift-testing SPM package dependency (and its swift-syntax transitive pin) now that Testing ships with the toolchain.
- Update README to document the new isolation model, calling convention (await from non-actor contexts), and callback threading behavior.
- Update tests to run on @SockudoActor instead of MainActor.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
