### PR TITLE
Add Ably protocol discovery baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7877,6 +7877,7 @@ dependencies = [
  "jsonwebtoken",
  "num_cpus",
  "redis",
+ "rmp-serde",
  "rustls",
  "scylla",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ rdkafka = { version = "0.39.0", default-features = false, features = [
   "libz",
 ] }
 ring = "0.17.14"
+rmp-serde = "1.3.0"
 iggy = "0.10.0"
 jsonwebtoken = { version = "=10.3.0", default-features = false, features = ["aws_lc_rs", "use_pem"] }
 reqwest = { version = "^0.12", default-features = false, features = [

--- a/Makefile
+++ b/Makefile
@@ -409,6 +409,10 @@ ai-docker-builds: ## Build Docker images with and without AI Transport
 ably-compat-test: ## Run Ably Pub/Sub subset smoke tests against Sockudo built with ably-compat
 	@cd tests/ably-compat && npm ci --silent && npm run test
 
+.PHONY: ably-protocol-discovery
+ably-protocol-discovery: ## Probe broader stock ably-js protocol compatibility and report current gaps
+	@cd tests/ably-compat && npm ci --silent && npm run protocol:discovery
+
 .PHONY: ably-ai-transport-test
 ably-ai-transport-test: ## Run stock @ably/ai-transport smoke test against Sockudo built with ably-compat
 	@cd tests/ably-compat && npm ci --silent && npm run ait:chat

--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ ably-compat-test: ## Run Ably Pub/Sub subset smoke tests against Sockudo built w
 
 .PHONY: ably-protocol-discovery
 ably-protocol-discovery: ## Probe broader stock ably-js protocol compatibility and report current gaps
-	@cd tests/ably-compat && npm ci --silent && npm run protocol:discovery
+	@cd tests/ably-compat && npm ci --silent && npx playwright install chromium >/dev/null && npm run protocol:discovery
 
 .PHONY: ably-ai-transport-test
 ably-ai-transport-test: ## Run stock @ably/ai-transport smoke test against Sockudo built with ably-compat

--- a/crates/sockudo-core/src/options/cors.rs
+++ b/crates/sockudo-core/src/options/cors.rs
@@ -43,6 +43,14 @@ impl Default for CorsConfig {
                 "Content-Type".to_string(),
                 "X-Requested-With".to_string(),
                 "Accept".to_string(),
+                "X-Ably-ClientId".to_string(),
+                "X-Ably-Version".to_string(),
+                "X-Ably-Lib".to_string(),
+                "X-Ably-DeviceToken".to_string(),
+                "Ably-Agent".to_string(),
+                "Ably-Version".to_string(),
+                "Ably-ClientId".to_string(),
+                "X-Idempotency-Key".to_string(),
             ],
         }
     }
@@ -90,5 +98,25 @@ mod cors_config_tests {
     #[test]
     fn test_deserialize_rejects_mixed_valid_and_invalid() {
         assert!(cors_from_json(r#"{"origin": ["https://good.com", "*.*bad"]}"#).is_err());
+    }
+
+    #[test]
+    fn default_allows_ably_browser_headers() {
+        let config = CorsConfig::default();
+        for header in [
+            "X-Ably-ClientId",
+            "X-Ably-Version",
+            "X-Ably-Lib",
+            "X-Ably-DeviceToken",
+            "Ably-Agent",
+            "Ably-Version",
+            "Ably-ClientId",
+            "X-Idempotency-Key",
+        ] {
+            assert!(
+                config.allowed_headers.iter().any(|value| value == header),
+                "missing default CORS header {header}"
+            );
+        }
     }
 }

--- a/crates/sockudo-server/Cargo.toml
+++ b/crates/sockudo-server/Cargo.toml
@@ -11,7 +11,7 @@ license-file.workspace = true
 default = ["local", "v2"]
 versioned-messages = []
 ai-transport = ["sockudo-core/ai-transport", "sockudo-protocol/ai-transport", "sockudo-adapter/ai-transport", "versioned-messages"]
-ably-compat = ["ai-transport", "dep:base64"]
+ably-compat = ["ai-transport", "dep:base64", "dep:rmp-serde"]
 local = []
 v2 = ["delta", "tag-filtering", "recovery"]
 delta = ["sockudo-adapter/delta", "sockudo-delta"]
@@ -144,6 +144,7 @@ aws-config = { workspace = true, optional = true }
 aws-sdk-dynamodb = { workspace = true, optional = true }
 jsonwebtoken = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
+rmp-serde = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/crates/sockudo-server/src/bootstrap/router.rs
+++ b/crates/sockudo-server/src/bootstrap/router.rs
@@ -1,8 +1,9 @@
 use super::SockudoServer;
 #[cfg(feature = "ably-compat")]
 use crate::http_handler::{
-    ably_channel_history, ably_channel_message, ably_channel_message_versions, ably_channel_status,
-    ably_request_token, ably_time, handle_ably_realtime_upgrade,
+    ably_channel_history, ably_channel_message, ably_channel_message_versions,
+    ably_channel_publish, ably_channel_status, ably_request_token, ably_time,
+    handle_ably_realtime_upgrade,
 };
 use crate::http_handler::{
     append_message, batch_events, channel, channel_history, channel_history_purge,
@@ -379,7 +380,7 @@ impl SockudoServer {
                 .route("/channels/{channelName}", get(ably_channel_status))
                 .route(
                     "/channels/{channelName}/messages",
-                    get(ably_channel_history),
+                    get(ably_channel_history).post(ably_channel_publish),
                 )
                 .route(
                     "/channels/{channelName}/messages/{messageSerial}",

--- a/crates/sockudo-server/src/http_handler/ably_compat.rs
+++ b/crates/sockudo-server/src/http_handler/ably_compat.rs
@@ -7,6 +7,7 @@
 
 use axum::{
     Json,
+    body::Bytes,
     extract::{Path, Query, State},
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
@@ -90,6 +91,12 @@ enum AblyMessageProjection {
     Aggregate,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AblyFormat {
+    Json,
+    MsgPack,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AblyConnectQuery {
@@ -98,6 +105,7 @@ pub struct AblyConnectQuery {
     client_id: Option<String>,
     resume: Option<String>,
     recover: Option<String>,
+    format: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -231,6 +239,12 @@ struct AblyMessageVersion {
     description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AblyPublishResponse {
+    serials: Vec<Option<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -783,6 +797,10 @@ pub async fn handle_ably_realtime_upgrade(
     if !handler.is_accepting() {
         return StatusCode::SERVICE_UNAVAILABLE.into_response();
     }
+    let format = match parse_ably_format(params.format.as_deref()) {
+        Ok(format) => format,
+        Err(message) => return ably_error_response(StatusCode::BAD_REQUEST, 40000, message),
+    };
 
     let resolved = match resolve_ably_auth(
         &handler,
@@ -831,6 +849,7 @@ pub async fn handle_ably_realtime_upgrade(
                 resolved.client_id,
                 resume,
                 recover,
+                format,
             )
             .await
             {
@@ -848,6 +867,7 @@ async fn run_ably_realtime_socket(
     client_id: Option<String>,
     resume: Option<String>,
     recover: Option<String>,
+    format: AblyFormat,
 ) -> SockudoResult<()> {
     let connection_start = hub.begin_connection(
         &app.id,
@@ -877,14 +897,14 @@ async fn run_ably_realtime_socket(
     let (sender, mut outbound) = mpsc::unbounded_channel::<AblyProtocolMessage>();
     let writer_task = tokio::spawn(async move {
         while let Some(message) = outbound.recv().await {
-            let payload = match sonic_rs::to_string(&message) {
-                Ok(payload) => payload,
+            let frame = match encode_ably_protocol_message(&message, format) {
+                Ok(frame) => frame,
                 Err(error) => {
                     warn!(error = %error, "failed to serialize Ably ProtocolMessage");
                     continue;
                 }
             };
-            if let Err(error) = writer.send(Message::text(payload)).await {
+            if let Err(error) = writer.send(frame).await {
                 debug!(error = %error, "Ably compatibility socket writer closed");
                 break;
             }
@@ -931,7 +951,7 @@ async fn run_ably_realtime_socket(
             Message::Pong(_) => continue,
             Message::Close(_) => break,
         };
-        let inbound: AblyProtocolMessage = sonic_rs::from_slice(bytes.as_ref())
+        let inbound = decode_ably_protocol_message(bytes.as_ref(), format)
             .map_err(|error| SockudoError::InvalidMessageFormat(error.to_string()))?;
         handle_ably_protocol_message(
             &handler,
@@ -1382,21 +1402,8 @@ async fn handle_ably_publish(
     let messages = inbound.messages.clone().unwrap_or_default();
     let mut serials = Vec::with_capacity(messages.len());
     for (index, message) in messages.into_iter().enumerate() {
-        let action = message.action.unwrap_or(MESSAGE_CREATE);
-        let result = match action {
-            MESSAGE_CREATE => {
-                publish_ably_create(handler, app, &channel, connection_id, client_id, message).await
-            }
-            MESSAGE_APPEND => publish_ably_append(handler, app, &channel, client_id, message).await,
-            MESSAGE_UPDATE => publish_ably_update(handler, app, &channel, client_id, message).await,
-            MESSAGE_DELETE => publish_ably_delete(handler, app, &channel, client_id, message).await,
-            MESSAGE_SUMMARY => Err(AppError::InvalidInput(format!(
-                "Ably message action {action} is not implemented by this compatibility layer"
-            ))),
-            other => Err(AppError::InvalidInput(format!(
-                "Unsupported Ably message action {other}"
-            ))),
-        };
+        let result =
+            publish_ably_message(handler, app, &channel, connection_id, client_id, message).await;
 
         match result {
             Ok(serial) => serials.push(serial),
@@ -1421,6 +1428,31 @@ async fn handle_ably_publish(
         ..empty_protocol_message(ACTION_ACK)
     });
     Ok(())
+}
+
+async fn publish_ably_message(
+    handler: &Arc<ConnectionHandler>,
+    app: &App,
+    channel: &str,
+    connection_id: &str,
+    client_id: Option<&str>,
+    message: AblyMessage,
+) -> Result<String, AppError> {
+    let action = message.action.unwrap_or(MESSAGE_CREATE);
+    match action {
+        MESSAGE_CREATE => {
+            publish_ably_create(handler, app, channel, connection_id, client_id, message).await
+        }
+        MESSAGE_APPEND => publish_ably_append(handler, app, channel, client_id, message).await,
+        MESSAGE_UPDATE => publish_ably_update(handler, app, channel, client_id, message).await,
+        MESSAGE_DELETE => publish_ably_delete(handler, app, channel, client_id, message).await,
+        MESSAGE_SUMMARY => Err(AppError::InvalidInput(format!(
+            "Ably message action {action} is not implemented by this compatibility layer"
+        ))),
+        other => Err(AppError::InvalidInput(format!(
+            "Unsupported Ably message action {other}"
+        ))),
+    }
 }
 
 async fn publish_ably_create(
@@ -1648,12 +1680,80 @@ pub async fn ably_channel_history(
     }
 }
 
+pub async fn ably_channel_publish(
+    Path(channel_name): Path<String>,
+    Query(query): Query<AblyRestQuery>,
+    headers: HeaderMap,
+    State(handler): State<Arc<ConnectionHandler>>,
+    body: Bytes,
+) -> Response {
+    match ably_channel_publish_inner(channel_name, query, headers, handler, body).await {
+        Ok(response) => response,
+        Err(error) => ably_app_error_response(error),
+    }
+}
+
+async fn ably_channel_publish_inner(
+    channel_name: String,
+    query: AblyRestQuery,
+    headers: HeaderMap,
+    handler: Arc<ConnectionHandler>,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let request_format = ably_rest_request_format(&headers);
+    let response_format = ably_rest_response_format(&headers, request_format);
+    let resolved = resolve_ably_auth(
+        &handler,
+        &headers,
+        query.key.as_deref(),
+        query.access_token.as_deref(),
+        query.client_id.as_deref(),
+    )
+    .await
+    .map_err(|error| AppError::ApiAuthFailed(error.message))?;
+    validate_channel_name(&resolved.app, &channel_name).await?;
+
+    let messages = decode_ably_publish_payload(body.as_ref(), request_format)?;
+    if messages.is_empty() {
+        return Err(AppError::InvalidInput(
+            "Ably REST publish requires at least one message".to_string(),
+        ));
+    }
+
+    let connection_id = format!("rest-{}", Uuid::new_v4().simple());
+    let mut serials = Vec::with_capacity(messages.len());
+    for (index, message) in messages.into_iter().enumerate() {
+        let effective_client_id =
+            effective_ably_client_id(resolved.client_id.as_deref(), &message)?;
+        let serial = publish_ably_message(
+            &handler,
+            &resolved.app,
+            &channel_name,
+            &connection_id,
+            effective_client_id.as_deref(),
+            message,
+        )
+        .await
+        .map_err(|error| {
+            AppError::InvalidInput(format!("Failed to publish message {index}: {error}"))
+        })?;
+        serials.push(Some(serial));
+    }
+
+    encode_ably_rest_response(
+        StatusCode::CREATED,
+        response_format,
+        &AblyPublishResponse { serials },
+    )
+}
+
 async fn ably_channel_history_inner(
     channel_name: String,
     query: AblyHistoryQuery,
     headers: HeaderMap,
     handler: Arc<ConnectionHandler>,
 ) -> Result<Response, AppError> {
+    let response_format = ably_rest_response_format(&headers, AblyFormat::Json);
     let resolved = resolve_ably_auth(
         &handler,
         &headers,
@@ -1668,7 +1768,11 @@ async fn ably_channel_history_inner(
         .app
         .resolved_history(&channel_name, &handler.server_options().history);
     if !history_policy.enabled {
-        return Ok((StatusCode::OK, Json(Vec::<AblyMessage>::new())).into_response());
+        return encode_ably_rest_response(
+            StatusCode::OK,
+            response_format,
+            &Vec::<AblyMessage>::new(),
+        );
     }
     let limit = query
         .limit
@@ -1729,7 +1833,7 @@ async fn ably_channel_history_inner(
                 .map_err(AppError::InvalidInput)?,
         );
     }
-    Ok((StatusCode::OK, Json(items)).into_response())
+    encode_ably_rest_response(StatusCode::OK, response_format, &items)
 }
 
 pub async fn ably_channel_status(
@@ -2140,6 +2244,370 @@ fn bearer_token(headers: &HeaderMap) -> Option<&str> {
         .and_then(|value| value.strip_prefix("Bearer "))
 }
 
+fn ably_rest_request_format(headers: &HeaderMap) -> AblyFormat {
+    if header_contains(headers, header::CONTENT_TYPE, "msgpack") {
+        AblyFormat::MsgPack
+    } else {
+        AblyFormat::Json
+    }
+}
+
+fn ably_rest_response_format(headers: &HeaderMap, fallback: AblyFormat) -> AblyFormat {
+    if header_contains(headers, header::ACCEPT, "msgpack") {
+        AblyFormat::MsgPack
+    } else if header_contains(headers, header::ACCEPT, "json") {
+        AblyFormat::Json
+    } else {
+        fallback
+    }
+}
+
+fn header_contains(headers: &HeaderMap, name: header::HeaderName, needle: &str) -> bool {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.to_ascii_lowercase().contains(needle))
+}
+
+fn parse_ably_format(raw: Option<&str>) -> Result<AblyFormat, String> {
+    match raw.unwrap_or("json").trim().to_ascii_lowercase().as_str() {
+        "" | "json" => Ok(AblyFormat::Json),
+        "msgpack" | "messagepack" => Ok(AblyFormat::MsgPack),
+        other => Err(format!("Unsupported Ably protocol format '{other}'")),
+    }
+}
+
+fn encode_ably_protocol_message(
+    message: &AblyProtocolMessage,
+    format: AblyFormat,
+) -> Result<Message, String> {
+    match format {
+        AblyFormat::Json => sonic_rs::to_string(message)
+            .map(Message::text)
+            .map_err(|error| error.to_string()),
+        AblyFormat::MsgPack => rmp_serde::to_vec_named(message)
+            .map(Message::binary)
+            .map_err(|error| error.to_string()),
+    }
+}
+
+fn decode_ably_protocol_message(
+    body: &[u8],
+    format: AblyFormat,
+) -> Result<AblyProtocolMessage, String> {
+    match format {
+        AblyFormat::Json => sonic_rs::from_slice(body).map_err(|error| error.to_string()),
+        AblyFormat::MsgPack => {
+            let value = rmp_serde::from_slice::<serde_json::Value>(body)
+                .map_err(|error| error.to_string())?;
+            ably_protocol_message_from_json_value(value).map_err(|error| error.to_string())
+        }
+    }
+}
+
+fn ably_protocol_message_from_json_value(
+    value: serde_json::Value,
+) -> Result<AblyProtocolMessage, AppError> {
+    let serde_json::Value::Object(object) = value else {
+        return Err(AppError::InvalidInput(
+            "Ably ProtocolMessage must be an object".to_string(),
+        ));
+    };
+    let action = json_u8_field(&object, "action").ok_or_else(|| {
+        AppError::InvalidInput("Ably ProtocolMessage.action is required".to_string())
+    })?;
+
+    Ok(AblyProtocolMessage {
+        action,
+        id: json_string_field(&object, "id"),
+        flags: json_u64_field(&object, "flags"),
+        timestamp: json_i64_field(&object, "timestamp"),
+        count: json_u64_field(&object, "count"),
+        error: None,
+        connection_id: json_string_field(&object, "connectionId"),
+        channel: json_string_field(&object, "channel"),
+        channel_serial: json_string_field(&object, "channelSerial"),
+        msg_serial: json_u64_field(&object, "msgSerial"),
+        messages: object
+            .get("messages")
+            .map(ably_messages_from_json_value)
+            .transpose()?,
+        presence: object
+            .get("presence")
+            .map(ably_presence_from_json_value)
+            .transpose()?,
+        auth: object
+            .get("auth")
+            .cloned()
+            .map(json_value_to_sonic_value)
+            .transpose()?,
+        connection_details: None,
+        params: object
+            .get("params")
+            .map(json_string_map_from_json_value)
+            .transpose()?,
+        res: object
+            .get("res")
+            .cloned()
+            .map(json_value_to_sonic_value)
+            .transpose()?,
+    })
+}
+
+fn ably_messages_from_json_value(value: &serde_json::Value) -> Result<Vec<AblyMessage>, AppError> {
+    match value {
+        serde_json::Value::Null => Ok(Vec::new()),
+        serde_json::Value::Array(items) => items
+            .iter()
+            .cloned()
+            .map(ably_message_from_json_value)
+            .collect::<Result<Vec<_>, _>>(),
+        _ => Err(AppError::InvalidInput(
+            "Ably ProtocolMessage.messages must be an array".to_string(),
+        )),
+    }
+}
+
+fn ably_presence_from_json_value(
+    value: &serde_json::Value,
+) -> Result<Vec<AblyPresenceMessage>, AppError> {
+    match value {
+        serde_json::Value::Null => Ok(Vec::new()),
+        serde_json::Value::Array(items) => items
+            .iter()
+            .map(ably_presence_message_from_json_value)
+            .collect::<Result<Vec<_>, _>>(),
+        _ => Err(AppError::InvalidInput(
+            "Ably ProtocolMessage.presence must be an array".to_string(),
+        )),
+    }
+}
+
+fn ably_presence_message_from_json_value(
+    value: &serde_json::Value,
+) -> Result<AblyPresenceMessage, AppError> {
+    let serde_json::Value::Object(object) = value else {
+        return Err(AppError::InvalidInput(
+            "Ably presence items must be objects".to_string(),
+        ));
+    };
+    Ok(AblyPresenceMessage {
+        id: json_string_field(object, "id"),
+        action: json_u8_field(object, "action"),
+        client_id: json_string_field(object, "clientId"),
+        connection_id: json_string_field(object, "connectionId"),
+        data: object
+            .get("data")
+            .cloned()
+            .map(json_value_to_sonic_value)
+            .transpose()?,
+        encoding: json_string_field(object, "encoding"),
+        timestamp: json_i64_field(object, "timestamp"),
+    })
+}
+
+fn json_string_map_from_json_value(
+    value: &serde_json::Value,
+) -> Result<HashMap<String, String>, AppError> {
+    let serde_json::Value::Object(object) = value else {
+        return Err(AppError::InvalidInput(
+            "Ably params must be an object".to_string(),
+        ));
+    };
+    let mut params = HashMap::with_capacity(object.len());
+    for (key, value) in object {
+        let value = value
+            .as_str()
+            .map(str::to_string)
+            .unwrap_or_else(|| value.to_string());
+        params.insert(key.clone(), value);
+    }
+    Ok(params)
+}
+
+fn decode_ably_publish_payload(
+    body: &[u8],
+    format: AblyFormat,
+) -> Result<Vec<AblyMessage>, AppError> {
+    if body.is_empty() {
+        return Err(AppError::InvalidInput(
+            "Ably REST publish body is required".to_string(),
+        ));
+    }
+
+    let value = match format {
+        AblyFormat::Json => serde_json::from_slice::<serde_json::Value>(body)
+            .map_err(|error| AppError::InvalidInput(format!("Invalid Ably JSON body: {error}")))?,
+        AblyFormat::MsgPack => {
+            rmp_serde::from_slice::<serde_json::Value>(body).map_err(|error| {
+                AppError::InvalidInput(format!("Invalid Ably MsgPack body: {error}"))
+            })?
+        }
+    };
+    ably_publish_value_to_messages(value)
+}
+
+fn ably_publish_value_to_messages(value: serde_json::Value) -> Result<Vec<AblyMessage>, AppError> {
+    match value {
+        serde_json::Value::Array(items) => items
+            .into_iter()
+            .map(ably_message_from_json_value)
+            .collect::<Result<Vec<_>, _>>(),
+        serde_json::Value::Object(_) => Ok(vec![ably_message_from_json_value(value)?]),
+        _ => Err(AppError::InvalidInput(
+            "Ably REST publish body must be a message object or array".to_string(),
+        )),
+    }
+}
+
+fn ably_message_from_json_value(value: serde_json::Value) -> Result<AblyMessage, AppError> {
+    let serde_json::Value::Object(object) = value else {
+        return Err(AppError::InvalidInput(
+            "Ably REST publish items must be message objects".to_string(),
+        ));
+    };
+
+    Ok(AblyMessage {
+        id: json_string_field(&object, "id"),
+        name: json_string_field(&object, "name"),
+        data: object
+            .get("data")
+            .cloned()
+            .map(json_value_to_sonic_value)
+            .transpose()?,
+        encoding: json_string_field(&object, "encoding"),
+        client_id: json_string_field(&object, "clientId"),
+        connection_id: json_string_field(&object, "connectionId"),
+        timestamp: json_i64_field(&object, "timestamp"),
+        extras: object
+            .get("extras")
+            .cloned()
+            .map(json_value_to_sonic_value)
+            .transpose()?,
+        serial: json_string_field(&object, "serial"),
+        action: json_action_field(&object),
+        version: object
+            .get("version")
+            .map(ably_message_version_from_json_value)
+            .transpose()?
+            .flatten(),
+    })
+}
+
+fn ably_message_version_from_json_value(
+    value: &serde_json::Value,
+) -> Result<Option<AblyMessageVersion>, AppError> {
+    if value.is_null() {
+        return Ok(None);
+    }
+    let serde_json::Value::Object(object) = value else {
+        return Err(AppError::InvalidInput(
+            "Ably message.version must be an object".to_string(),
+        ));
+    };
+    let Some(serial) = json_string_field(object, "serial") else {
+        return Ok(None);
+    };
+    Ok(Some(AblyMessageVersion {
+        serial,
+        timestamp: json_i64_field(object, "timestamp"),
+        client_id: json_string_field(object, "clientId"),
+        description: json_string_field(object, "description"),
+        metadata: object
+            .get("metadata")
+            .cloned()
+            .map(json_value_to_sonic_value)
+            .transpose()?,
+    }))
+}
+
+fn json_string_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    name: &str,
+) -> Option<String> {
+    object
+        .get(name)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
+fn json_u64_field(object: &serde_json::Map<String, serde_json::Value>, name: &str) -> Option<u64> {
+    object.get(name).and_then(serde_json::Value::as_u64)
+}
+
+fn json_u8_field(object: &serde_json::Map<String, serde_json::Value>, name: &str) -> Option<u8> {
+    json_u64_field(object, name).and_then(|raw| u8::try_from(raw).ok())
+}
+
+fn json_i64_field(object: &serde_json::Map<String, serde_json::Value>, name: &str) -> Option<i64> {
+    object.get(name).and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_u64().and_then(|raw| i64::try_from(raw).ok()))
+    })
+}
+
+fn json_action_field(object: &serde_json::Map<String, serde_json::Value>) -> Option<u8> {
+    let value = object.get("action")?;
+    if let Some(raw) = value.as_u64() {
+        return u8::try_from(raw).ok();
+    }
+    match value.as_str()? {
+        "message.create" => Some(MESSAGE_CREATE),
+        "message.update" => Some(MESSAGE_UPDATE),
+        "message.delete" => Some(MESSAGE_DELETE),
+        "message.summary" => Some(MESSAGE_SUMMARY),
+        "message.append" => Some(MESSAGE_APPEND),
+        _ => None,
+    }
+}
+
+fn json_value_to_sonic_value(value: serde_json::Value) -> Result<Value, AppError> {
+    let body =
+        serde_json::to_vec(&value).map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    sonic_rs::from_slice(&body).map_err(|error| AppError::InvalidInput(error.to_string()))
+}
+
+fn encode_ably_rest_response<T: Serialize>(
+    status: StatusCode,
+    format: AblyFormat,
+    value: &T,
+) -> Result<Response, AppError> {
+    match format {
+        AblyFormat::Json => {
+            let body = sonic_rs::to_vec(value)
+                .map_err(|error| AppError::InternalError(error.to_string()))?;
+            Ok((status, [(header::CONTENT_TYPE, "application/json")], body).into_response())
+        }
+        AblyFormat::MsgPack => {
+            let body = rmp_serde::to_vec_named(value)
+                .map_err(|error| AppError::InternalError(error.to_string()))?;
+            Ok((
+                status,
+                [(header::CONTENT_TYPE, "application/x-msgpack")],
+                body,
+            )
+                .into_response())
+        }
+    }
+}
+
+fn effective_ably_client_id(
+    authenticated_client_id: Option<&str>,
+    message: &AblyMessage,
+) -> Result<Option<String>, AppError> {
+    match (authenticated_client_id, message.client_id.as_deref()) {
+        (Some(authenticated), Some(message_client_id)) if authenticated != message_client_id => {
+            Err(AppError::InvalidInput(
+                "message.clientId must match authenticated clientId".to_string(),
+            ))
+        }
+        (Some(authenticated), _) => Ok(Some(authenticated.to_string())),
+        (None, Some(message_client_id)) => Ok(Some(message_client_id.to_string())),
+        (None, None) => Ok(None),
+    }
+}
+
 fn pusher_to_ably_message(
     message: &PusherMessage,
     projection: AblyMessageProjection,
@@ -2443,6 +2911,123 @@ mod tests {
         });
 
         let error = stamp_ai_identity(&mut extras, AI_EVENT_INPUT, "client-1").unwrap_err();
+        assert!(error.to_string().contains("authenticated clientId"));
+    }
+
+    #[test]
+    fn rest_publish_payload_decodes_json_and_msgpack_arrays() {
+        let messages = vec![AblyMessage {
+            name: Some("chat".to_string()),
+            data: Some(json!({ "ok": true })),
+            encoding: Some("json".to_string()),
+            client_id: Some("client-1".to_string()),
+            ..Default::default()
+        }];
+
+        let json_body = sonic_rs::to_vec(&messages).unwrap();
+        let decoded_json = decode_ably_publish_payload(&json_body, AblyFormat::Json).unwrap();
+        assert_eq!(decoded_json[0].name.as_deref(), Some("chat"));
+        assert_eq!(decoded_json[0].client_id.as_deref(), Some("client-1"));
+
+        let msgpack_value = serde_json::json!([
+            {
+                "name": "chat",
+                "data": { "ok": true },
+                "encoding": "json",
+                "clientId": "client-1"
+            }
+        ]);
+        let msgpack_body = rmp_serde::to_vec(&msgpack_value).unwrap();
+        let decoded_msgpack =
+            decode_ably_publish_payload(&msgpack_body, AblyFormat::MsgPack).unwrap();
+        assert_eq!(decoded_msgpack[0].name.as_deref(), Some("chat"));
+        assert_eq!(decoded_msgpack[0].client_id.as_deref(), Some("client-1"));
+    }
+
+    #[test]
+    fn rest_publish_payload_decodes_single_json_object() {
+        let message = AblyMessage {
+            name: Some("chat".to_string()),
+            data: Some(json!("hello")),
+            ..Default::default()
+        };
+        let body = sonic_rs::to_vec(&message).unwrap();
+        let decoded = decode_ably_publish_payload(&body, AblyFormat::Json).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].name.as_deref(), Some("chat"));
+    }
+
+    #[test]
+    fn rest_msgpack_response_uses_named_message_fields() {
+        let messages = vec![AblyMessage {
+            name: Some("chat".to_string()),
+            data: Some(json!("hello")),
+            ..Default::default()
+        }];
+        let body = rmp_serde::to_vec_named(&messages).unwrap();
+        let decoded: serde_json::Value = rmp_serde::from_slice(&body).unwrap();
+        assert_eq!(decoded[0]["name"], "chat");
+        assert_eq!(decoded[0]["data"], "hello");
+    }
+
+    #[test]
+    fn realtime_msgpack_protocol_message_round_trips_named_fields() {
+        let wire = serde_json::json!({
+            "action": ACTION_MESSAGE,
+            "channel": "chat",
+            "msgSerial": 7,
+            "messages": [
+                {
+                    "name": "chat-message",
+                    "data": { "ok": true },
+                    "encoding": "json"
+                }
+            ]
+        });
+        let body = rmp_serde::to_vec(&wire).unwrap();
+        let decoded = decode_ably_protocol_message(&body, AblyFormat::MsgPack).unwrap();
+        assert_eq!(decoded.action, ACTION_MESSAGE);
+        assert_eq!(decoded.channel.as_deref(), Some("chat"));
+        assert_eq!(decoded.msg_serial, Some(7));
+        assert_eq!(
+            decoded
+                .messages
+                .as_ref()
+                .and_then(|messages| messages.first())
+                .and_then(|message| message.name.as_deref()),
+            Some("chat-message")
+        );
+
+        let encoded = encode_ably_protocol_message(&decoded, AblyFormat::MsgPack).unwrap();
+        let Message::Binary(encoded_body) = encoded else {
+            panic!("expected binary websocket frame");
+        };
+        let encoded_value: serde_json::Value =
+            rmp_serde::from_slice(encoded_body.as_ref()).unwrap();
+        assert_eq!(encoded_value["action"], ACTION_MESSAGE);
+        assert_eq!(encoded_value["channel"], "chat");
+        assert_eq!(encoded_value["msgSerial"], 7);
+        assert_eq!(encoded_value["messages"][0]["name"], "chat-message");
+    }
+
+    #[test]
+    fn ably_protocol_format_defaults_to_json_and_accepts_msgpack() {
+        assert_eq!(parse_ably_format(None).unwrap(), AblyFormat::Json);
+        assert_eq!(parse_ably_format(Some("json")).unwrap(), AblyFormat::Json);
+        assert_eq!(
+            parse_ably_format(Some("msgpack")).unwrap(),
+            AblyFormat::MsgPack
+        );
+        assert!(parse_ably_format(Some("xml")).is_err());
+    }
+
+    #[test]
+    fn rest_publish_rejects_message_client_id_spoofing() {
+        let message = AblyMessage {
+            client_id: Some("other-client".to_string()),
+            ..Default::default()
+        };
+        let error = effective_ably_client_id(Some("client-1"), &message).unwrap_err();
         assert!(error.to_string().contains("authenticated clientId"));
     }
 

--- a/crates/sockudo-server/src/http_handler/mod.rs
+++ b/crates/sockudo-server/src/http_handler/mod.rs
@@ -17,8 +17,9 @@ pub(crate) mod test_support;
 
 #[cfg(feature = "ably-compat")]
 pub use ably_compat::{
-    ably_channel_history, ably_channel_message, ably_channel_message_versions, ably_channel_status,
-    ably_request_token, ably_time, global_ably_hub, handle_ably_realtime_upgrade,
+    ably_channel_history, ably_channel_message, ably_channel_message_versions,
+    ably_channel_publish, ably_channel_status, ably_request_token, ably_time, global_ably_hub,
+    handle_ably_realtime_upgrade,
 };
 pub use annotations::{channel_message_annotations, delete_annotation, publish_annotation};
 pub use channels::{

--- a/docs/ably-compat/ABLY_COMPAT_GAPS.md
+++ b/docs/ably-compat/ABLY_COMPAT_GAPS.md
@@ -13,7 +13,6 @@ the reduced Ably Pub/Sub subset needed by AI Transport tests and demos.
 | Full channel mode/capability enforcement | Not yet implemented | Sockudo app auth remains authoritative. |
 | Full Ably presence-history parity | Not yet implemented | Realtime presence frames are supported for the reduced path. |
 | Byte-for-byte Ably serial internals | Not yet implemented | Sockudo emits stable compatible serials for the tested history/recovery path. |
-| Browser SDK discovery lane | Not yet implemented | A real Chromium/Playwright runner is not wired into `make ably-protocol-discovery` yet. |
 
 ## Required Before Broader Claims
 

--- a/docs/ably-compat/ABLY_COMPAT_GAPS.md
+++ b/docs/ably-compat/ABLY_COMPAT_GAPS.md
@@ -10,12 +10,10 @@ the reduced Ably Pub/Sub subset needed by AI Transport tests and demos.
 | Full Ably platform API parity | Intentionally out of scope | Sockudo is not claiming to replace every Ably service or endpoint. |
 | Ably Push compatibility | Intentionally out of scope | Sockudo native push remains separate. |
 | LiveObjects/object modes | Intentionally out of scope | Not required for the current AI Transport target. |
-| Binary MsgPack protocol | Not yet implemented | Current harness forces JSON protocol. |
 | Full channel mode/capability enforcement | Not yet implemented | Sockudo app auth remains authoritative. |
 | Full Ably presence-history parity | Not yet implemented | Realtime presence frames are supported for the reduced path. |
 | Byte-for-byte Ably serial internals | Not yet implemented | Sockudo emits stable compatible serials for the tested history/recovery path. |
-| Stock Ably REST publish/history parity | Not yet implemented | `make ably-protocol-discovery` currently records HTTP 405 for REST publish/history. |
-| Browser SDK discovery lane | Not yet implemented | Chromium runner is not wired yet. |
+| Browser SDK discovery lane | Not yet implemented | A real Chromium/Playwright runner is not wired into `make ably-protocol-discovery` yet. |
 
 ## Required Before Broader Claims
 

--- a/docs/ably-compat/ABLY_COMPAT_GAPS.md
+++ b/docs/ably-compat/ABLY_COMPAT_GAPS.md
@@ -14,11 +14,15 @@ the reduced Ably Pub/Sub subset needed by AI Transport tests and demos.
 | Full channel mode/capability enforcement | Not yet implemented | Sockudo app auth remains authoritative. |
 | Full Ably presence-history parity | Not yet implemented | Realtime presence frames are supported for the reduced path. |
 | Byte-for-byte Ably serial internals | Not yet implemented | Sockudo emits stable compatible serials for the tested history/recovery path. |
+| Stock Ably REST publish/history parity | Not yet implemented | `make ably-protocol-discovery` currently records HTTP 405 for REST publish/history. |
+| Browser SDK discovery lane | Not yet implemented | Chromium runner is not wired yet. |
 
 ## Required Before Broader Claims
 
 - Run the current unmodified Ably AI Transport SDK test suite, or a documented equivalent subset,
   against Sockudo.
+- Run `make ably-protocol-discovery` and promote optional lanes only when they pass without
+  `ABLY_PROTOCOL_STRICT=0` carve-outs.
 - Keep the `ably-compat` feature disabled in native-only AI Transport builds.
 - Keep Pusher V1 and Sockudo V2 conformance green with and without `ably-compat`.
 - Expand docs only when supported by tests in `tests/ably-compat` or the upstream SDK suite.

--- a/docs/ably-compat/ABLY_COMPAT_SCORECARD.md
+++ b/docs/ably-compat/ABLY_COMPAT_SCORECARD.md
@@ -14,7 +14,7 @@ Sockudo V1/V2 conformance tests pass against pinned target versions.
 | Surface | Target | Evidence |
 | --- | --- | --- |
 | Ably AI Transport package | `@ably/ai-transport@0.4.0` | Smoke harness in `tests/ably-compat`. |
-| Ably Realtime JS peer | `ably@2.23.0` | Smoke harness in `tests/ably-compat`. |
+| Ably Realtime JS peer | `ably@2.23.0` | Smoke and protocol discovery harnesses in `tests/ably-compat`. |
 | Sockudo server workspace | `4.7.0` | Root Cargo workspace package version. |
 
 ## Compatibility Summary
@@ -47,9 +47,37 @@ Then run:
 
 ```bash
 make ably-compat-test
+make ably-protocol-discovery
 make ably-ai-transport-test
 make ably-ai-demo
 ```
+
+`make ably-protocol-discovery` is not a support claim by itself. It records the
+current stock `ably` SDK behavior across required and optional lanes. Required
+lanes protect the claimed AI Transport Pub/Sub subset; optional failures remain
+scorecard gaps until intentionally implemented.
+
+## Protocol Discovery Baseline
+
+Last local run: 2026-07-04 against `ably@2.23.0`, Sockudo built with
+`v2,ai-transport,ably-compat,redis,postgres,push`.
+
+Command:
+
+```bash
+ABLY_PROTOCOL_RUN_ID=codex-baseline npm run protocol:discovery
+```
+
+| Lane | Status | Notes |
+| --- | --- | --- |
+| `node-realtime-json-pubsub` | Supported | Required baseline for the current compatibility claim. |
+| `node-rest-json-time` | Supported | Stock Ably REST `time()` returned a timestamp. |
+| `node-rest-json-publish-history` | Not yet implemented | Stock Ably REST publish/history path returned HTTP 405. |
+| `node-realtime-json-presence` | Supported | Enter, get, update, and leave passed for one client. |
+| `node-auth-json-request-token` | Supported | Stock Ably token request returned a token. |
+| `node-realtime-msgpack-pubsub` | Not yet implemented | Realtime MsgPack connect timed out because Sockudo replies JSON frames. |
+| `node-rest-msgpack-time` | Supported | REST time works with the SDK's MsgPack option. |
+| `browser-chromium-json-pubsub` | Not run | Browser runner is the next discovery harness gap. |
 
 ## Compatibility Claim
 

--- a/docs/ably-compat/ABLY_COMPAT_SCORECARD.md
+++ b/docs/ably-compat/ABLY_COMPAT_SCORECARD.md
@@ -15,6 +15,7 @@ Sockudo V1/V2 conformance tests pass against pinned target versions.
 | --- | --- | --- |
 | Ably AI Transport package | `@ably/ai-transport@0.4.0` | Smoke harness in `tests/ably-compat`. |
 | Ably Realtime JS peer | `ably@2.23.0` | Smoke and protocol discovery harnesses in `tests/ably-compat`. |
+| Browser discovery runtime | Playwright Chromium | `make ably-protocol-discovery` installs and runs Chromium for the browser lane. |
 | Sockudo server workspace | `4.7.0` | Root Cargo workspace package version. |
 
 ## Compatibility Summary
@@ -65,7 +66,7 @@ Last local run: 2026-07-04 against `ably@2.23.0`, Sockudo built with
 Command:
 
 ```bash
-ABLY_PROTOCOL_RUN_ID=realtime-msgpack npm run protocol:discovery
+make ably-protocol-discovery
 ```
 
 | Lane | Status | Notes |
@@ -78,7 +79,7 @@ ABLY_PROTOCOL_RUN_ID=realtime-msgpack npm run protocol:discovery
 | `node-auth-json-request-token` | Supported | Stock Ably token request returned a token. |
 | `node-realtime-msgpack-pubsub` | Supported | Realtime Pub/Sub passes with `format=msgpack` binary ProtocolMessages. |
 | `node-rest-msgpack-time` | Supported | REST time works with the SDK's MsgPack option. |
-| `browser-chromium-json-pubsub` | Not run | Browser runner needs an explicit Playwright/browser dependency and CI setup. |
+| `browser-chromium-json-pubsub` | Supported | Stock Ably browser bundle passes Chromium connect, attach, publish, receive, history, and detach over the reduced JSON Realtime path. |
 
 ## Compatibility Claim
 

--- a/docs/ably-compat/ABLY_COMPAT_SCORECARD.md
+++ b/docs/ably-compat/ABLY_COMPAT_SCORECARD.md
@@ -1,6 +1,6 @@
 # Ably AI Transport Compatibility Scorecard
 
-Discovery date: 2026-07-03
+Discovery date: 2026-07-04
 
 Status: reduced compatibility implementation added for the Ably AI Transport SDK smoke path. When
 built with Cargo feature `ably-compat`, Sockudo exposes an additive Ably Realtime/REST facade while
@@ -24,14 +24,14 @@ Sockudo V1/V2 conformance tests pass against pinned target versions.
 | Pusher Protocol V1 compatibility | Supported | Ably compatibility is additive and must not alter V1 wire behavior. |
 | Sockudo-native AI Transport | Supported | Uses Cargo feature `ai-transport` plus runtime `[ai_transport]`; it does not require `ably-compat`. |
 | Ably facade feature gate | Supported | Root Ably WebSocket route, Ably REST routes, and Ably realtime egress tap are compiled only with `ably-compat`. |
-| Ably Realtime JSON protocol | Supported for AI Transport only | Handles the JSON ProtocolMessage flows needed by the harness. |
-| Ably REST time/token/history/message reads | Supported for AI Transport only | Provides the reduced surfaces used by stock Ably clients and AI Transport smoke tests. |
+| Ably Realtime JSON/MsgPack protocol | Supported for AI Transport only | Handles the ProtocolMessage flows needed by the harness in JSON and MsgPack WebSocket modes. |
+| Ably REST time/token/history/message reads and publish | Supported for AI Transport only | Provides the reduced surfaces used by stock Ably clients and AI Transport smoke tests in the tested JSON/MsgPack lanes. |
 | Mutable output streaming | Supported for AI Transport only | Ably mutable message calls map to Sockudo versioned messages. |
 | History and recovery | Supported for AI Transport only | Harness covers history projection and recovery of missed append fragments. |
 | Channel modes/capabilities | Not yet implemented | Attach accepts requested SDK modes; full Ably mode enforcement is not claimed. |
 | LiveObjects/object modes | Intentionally out of scope | Not part of the current compatibility target. |
 | Ably Push | Intentionally out of scope | Sockudo native push is separate from Ably Push compatibility. |
-| Binary MsgPack Ably protocol | Not yet implemented | Harness uses JSON protocol. |
+| Binary MsgPack Ably protocol | Supported for AI Transport only | Covered for Realtime Pub/Sub and REST publish/history/time discovery lanes. |
 | Full Ably platform API parity | Intentionally out of scope | The claim is limited to AI Transport compatibility. |
 
 ## Stable Commands
@@ -65,19 +65,20 @@ Last local run: 2026-07-04 against `ably@2.23.0`, Sockudo built with
 Command:
 
 ```bash
-ABLY_PROTOCOL_RUN_ID=codex-baseline npm run protocol:discovery
+ABLY_PROTOCOL_RUN_ID=realtime-msgpack npm run protocol:discovery
 ```
 
 | Lane | Status | Notes |
 | --- | --- | --- |
 | `node-realtime-json-pubsub` | Supported | Required baseline for the current compatibility claim. |
 | `node-rest-json-time` | Supported | Stock Ably REST `time()` returned a timestamp. |
-| `node-rest-json-publish-history` | Not yet implemented | Stock Ably REST publish/history path returned HTTP 405. |
+| `node-rest-json-publish-history` | Supported | Stock Ably REST publish writes through the real publish path and history returns the message. |
+| `node-rest-msgpack-publish-history` | Supported | Stock Ably REST publish/history passes with `useBinaryProtocol: true`. |
 | `node-realtime-json-presence` | Supported | Enter, get, update, and leave passed for one client. |
 | `node-auth-json-request-token` | Supported | Stock Ably token request returned a token. |
-| `node-realtime-msgpack-pubsub` | Not yet implemented | Realtime MsgPack connect timed out because Sockudo replies JSON frames. |
+| `node-realtime-msgpack-pubsub` | Supported | Realtime Pub/Sub passes with `format=msgpack` binary ProtocolMessages. |
 | `node-rest-msgpack-time` | Supported | REST time works with the SDK's MsgPack option. |
-| `browser-chromium-json-pubsub` | Not run | Browser runner is the next discovery harness gap. |
+| `browser-chromium-json-pubsub` | Not run | Browser runner needs an explicit Playwright/browser dependency and CI setup. |
 
 ## Compatibility Claim
 

--- a/docs/ably-compat/TEST_PLAN.md
+++ b/docs/ably-compat/TEST_PLAN.md
@@ -26,6 +26,8 @@ make ably-ai-demo
 The `make` targets use `tests/ably-compat`, stock `ably@2.23.0`, and
 `@ably/ai-transport@0.4.0`. The Ably facade is expected at the Sockudo root WebSocket/REST endpoint;
 existing Sockudo/Pusher clients continue to use `/app/{appKey}` and `/apps/{appId}`.
+`make ably-protocol-discovery` also installs Playwright Chromium and runs one stock browser bundle
+Pub/Sub/history lane from an allowed localhost origin.
 
 ## Required Test Cases
 

--- a/docs/ably-compat/TEST_PLAN.md
+++ b/docs/ably-compat/TEST_PLAN.md
@@ -18,6 +18,7 @@ channel prefix `private-ai-`.
 
 ```bash
 make ably-compat-test
+make ably-protocol-discovery
 make ably-ai-transport-test
 make ably-ai-demo
 ```
@@ -31,6 +32,7 @@ existing Sockudo/Pusher clients continue to use `/app/{appKey}` and `/apps/{appI
 | Case | Command |
 | --- | --- |
 | Ably Realtime connect, attach, publish, receive, history, detach | `make ably-compat-test` |
+| Broader stock `ably` SDK discovery across JSON, REST, presence, token, MsgPack, and browser lanes | `make ably-protocol-discovery` |
 | Ably mutable message create/append/update/delete/version reads | `make ably-compat-test` |
 | Ably recovery/history replay during streamed output | `make ably-compat-test` |
 | Stock `@ably/ai-transport` chat smoke | `make ably-ai-transport-test` |

--- a/docs/ably-compat/TEST_PLAN.md
+++ b/docs/ably-compat/TEST_PLAN.md
@@ -32,7 +32,7 @@ existing Sockudo/Pusher clients continue to use `/app/{appKey}` and `/apps/{appI
 | Case | Command |
 | --- | --- |
 | Ably Realtime connect, attach, publish, receive, history, detach | `make ably-compat-test` |
-| Broader stock `ably` SDK discovery across JSON, REST, presence, token, MsgPack, and browser lanes | `make ably-protocol-discovery` |
+| Broader stock `ably` SDK discovery across JSON, REST publish/history, presence, token, MsgPack, and browser lanes | `make ably-protocol-discovery` |
 | Ably mutable message create/append/update/delete/version reads | `make ably-compat-test` |
 | Ably recovery/history replay during streamed output | `make ably-compat-test` |
 | Stock `@ably/ai-transport` chat smoke | `make ably-ai-transport-test` |

--- a/docs/content/docs/server/ably-ai-transport-compatibility.mdx
+++ b/docs/content/docs/server/ably-ai-transport-compatibility.mdx
@@ -22,8 +22,8 @@ against Sockudo and the scorecard records that evidence.
 
 | Surface | Status | Scope |
 | --- | --- | --- |
-| Ably Realtime WebSocket JSON protocol | Supported for AI Transport only | Root WebSocket endpoint accepts Ably JSON `ProtocolMessage` connect, attach, detach, message, presence, auth, heartbeat, ACK, and NACK flows needed by the smoke harness. |
-| Ably REST time/token/history/message reads | Supported for AI Transport only | `/time`, `/keys/{keyName}/requestToken`, `/channels/{channel}/messages`, message lookup, and version lookup exist for the reduced SDK path. |
+| Ably Realtime WebSocket JSON/MsgPack protocol | Supported for AI Transport only | Root WebSocket endpoint accepts Ably `ProtocolMessage` connect, attach, detach, message, presence, auth, heartbeat, ACK, and NACK flows needed by the smoke harness in JSON and MsgPack modes. |
+| Ably REST time/token/history/message reads and publish | Supported for AI Transport only | `/time`, `/keys/{keyName}/requestToken`, `/channels/{channel}/messages`, message lookup, and version lookup exist for the reduced SDK path. REST publish/history is covered in JSON and MsgPack discovery lanes. |
 | Run lifecycle vocabulary | Supported | Native AI Transport docs and fixtures use `ai-run-start`, `ai-run-suspend`, `ai-run-resume`, `ai-run-end`, and `ai-cancel`. |
 | Legacy turn vocabulary | Legacy alias | `ai-turn-start`, `ai-turn-end`, `turn-id`, and `turn-reason` remain accepted for migration, but new docs and demos use run vocabulary. |
 | Mutable output streaming | Supported for AI Transport only | Ably `publish`, `appendMessage`, `updateMessage`, `deleteMessage`, `getMessage`, `getMessageVersions`, and history map to Sockudo versioned messages. |
@@ -32,7 +32,7 @@ against Sockudo and the scorecard records that evidence.
 | Channel modes/capabilities | Not yet implemented | Attach accepts requested SDK modes, but Ably mode capability enforcement is not complete. Sockudo app auth remains authoritative. |
 | LiveObjects/object modes | Intentionally out of scope | The current compatibility target does not implement Ably LiveObjects. |
 | Ably Push | Intentionally out of scope | Sockudo has native push APIs, but Ably Push compatibility is not part of this target. |
-| Binary MsgPack Ably protocol | Not yet implemented | The documented harness sets `useBinaryProtocol: false`. |
+| Binary MsgPack Ably protocol | Supported for AI Transport only | Realtime Pub/Sub and REST publish/history/time pass the stock `ably@2.23.0` discovery lanes with `useBinaryProtocol: true`. |
 | Full Ably platform API parity | Intentionally out of scope | This surface is for AI Transport compatibility, not a replacement for all Ably services. |
 
 ## Test Commands
@@ -50,6 +50,7 @@ Then run the compatibility lanes:
 
 ```bash
 make ably-compat-test
+make ably-protocol-discovery
 make ably-ai-transport-test
 make ably-ai-demo
 ```

--- a/docs/content/docs/server/ably-ai-transport-compatibility.mdx
+++ b/docs/content/docs/server/ably-ai-transport-compatibility.mdx
@@ -55,6 +55,10 @@ make ably-ai-transport-test
 make ably-ai-demo
 ```
 
+`make ably-protocol-discovery` installs Playwright Chromium and includes a real
+stock Ably browser bundle lane for JSON Pub/Sub/history. The other stable targets
+remain headless Node.js checks.
+
 The targets read these environment variables:
 
 | Variable | Default |
@@ -67,6 +71,7 @@ The targets read these environment variables:
 | `ABLY_AGENT_CLIENT_ID` | `sockudo-ably-ait-agent` |
 | `ABLY_CHANNEL` | generated per run |
 | `ABLY_DEMO_PROMPT` | `Say hello from Sockudo AI Transport.` |
+| `ABLY_BROWSER_ORIGIN_PORTS` | `4173,3001,5174` |
 
 ## Demos
 
@@ -79,7 +84,8 @@ The targets read these environment variables:
    additional fragments while offline, reconnects with an Ably recovery key, and
    verifies that only missed fragments replay and the final aggregate is intact.
 
-These are deliberately Node-based so CI can run them without a browser.
+These AI Transport demos are deliberately Node-based so CI can run them without
+a browser.
 
 ## Evidence Files
 

--- a/tests/ably-compat/README.md
+++ b/tests/ably-compat/README.md
@@ -31,6 +31,7 @@ Environment variables:
 | `ABLY_PROTOCOL_TIMEOUT_MS` | `15000` | Per-lane timeout for protocol discovery. |
 | `ABLY_PROTOCOL_OUTPUT` | unset | Optional JSON output path for protocol discovery results. |
 | `ABLY_PROTOCOL_STRICT` | `0` | Set `1` to fail when optional broader-protocol lanes fail. |
+| `ABLY_BROWSER_ORIGIN_PORTS` | `4173,3001,5174` | Allowed localhost origin ports tried by the Chromium discovery lane. |
 
 ```bash
 cd tests/ably-compat
@@ -59,8 +60,13 @@ publishes, receives the same message, reads history, and detaches.
 a machine-readable scorecard. The required lane is the JSON Realtime Pub/Sub
 baseline already covered by the compatibility claim. Optional lanes currently
 cover REST time, REST publish/history in JSON and MsgPack, Realtime presence,
-token requests, Realtime MsgPack Pub/Sub, and a browser placeholder. Optional
+token requests, Realtime MsgPack Pub/Sub, and Chromium browser Pub/Sub/history. Optional
 failures are reported as gaps unless `ABLY_PROTOCOL_STRICT=1` is set.
+
+`make ably-protocol-discovery` installs the Playwright Chromium browser before
+running the discovery script. On minimal Linux CI images, install the Playwright
+system dependencies first or run `npx playwright install --with-deps chromium`
+in the job setup.
 
 `npm run pubsub:chat` verifies plain Ably Pub/Sub chat behavior with two
 separate stock Ably Realtime clients on a normal `chat:` channel. Alice publishes,

--- a/tests/ably-compat/README.md
+++ b/tests/ably-compat/README.md
@@ -27,11 +27,16 @@ Environment variables:
 | `ABLY_AGENT_CLIENT_ID` | `sockudo-ably-ait-agent` | Agent identity for the stock AIT chat demo. |
 | `ABLY_CHANNEL` | generated | Override the test/demo channel. |
 | `ABLY_DEMO_PROMPT` | `Say hello from Sockudo AI Transport.` | Prompt text for the stock AIT chat demo. |
+| `ABLY_PROTOCOL_RUN_ID` | timestamp | Stable suffix for protocol discovery channels and client IDs. |
+| `ABLY_PROTOCOL_TIMEOUT_MS` | `15000` | Per-lane timeout for protocol discovery. |
+| `ABLY_PROTOCOL_OUTPUT` | unset | Optional JSON output path for protocol discovery results. |
+| `ABLY_PROTOCOL_STRICT` | `0` | Set `1` to fail when optional broader-protocol lanes fail. |
 
 ```bash
 cd tests/ably-compat
 npm ci
 npm run smoke
+npm run protocol:discovery
 npm run pubsub:chat
 npm run ait:mutable
 npm run ait:recovery
@@ -42,12 +47,20 @@ Repository-level commands:
 
 ```bash
 make ably-compat-test
+make ably-protocol-discovery
 make ably-ai-transport-test
 make ably-ai-demo
 ```
 
 `npm run smoke` verifies that the Ably SDK connects, attaches, subscribes,
 publishes, receives the same message, reads history, and detaches.
+
+`npm run protocol:discovery` probes a broader stock `ably` SDK surface and emits
+a machine-readable scorecard. The required lane is the JSON Realtime Pub/Sub
+baseline already covered by the compatibility claim. Optional lanes currently
+cover REST time, REST publish/history, Realtime presence, token requests,
+MsgPack, and a browser placeholder. Optional failures are reported as gaps
+unless `ABLY_PROTOCOL_STRICT=1` is set.
 
 `npm run pubsub:chat` verifies plain Ably Pub/Sub chat behavior with two
 separate stock Ably Realtime clients on a normal `chat:` channel. Alice publishes,

--- a/tests/ably-compat/README.md
+++ b/tests/ably-compat/README.md
@@ -58,9 +58,9 @@ publishes, receives the same message, reads history, and detaches.
 `npm run protocol:discovery` probes a broader stock `ably` SDK surface and emits
 a machine-readable scorecard. The required lane is the JSON Realtime Pub/Sub
 baseline already covered by the compatibility claim. Optional lanes currently
-cover REST time, REST publish/history, Realtime presence, token requests,
-MsgPack, and a browser placeholder. Optional failures are reported as gaps
-unless `ABLY_PROTOCOL_STRICT=1` is set.
+cover REST time, REST publish/history in JSON and MsgPack, Realtime presence,
+token requests, Realtime MsgPack Pub/Sub, and a browser placeholder. Optional
+failures are reported as gaps unless `ABLY_PROTOCOL_STRICT=1` is set.
 
 `npm run pubsub:chat` verifies plain Ably Pub/Sub chat behavior with two
 separate stock Ably Realtime clients on a normal `chat:` channel. Alice publishes,

--- a/tests/ably-compat/package-lock.json
+++ b/tests/ably-compat/package-lock.json
@@ -10,6 +10,9 @@
         "ably": "2.23.0",
         "ai": "^6.0.137"
       },
+      "devDependencies": {
+        "playwright": "1.61.1"
+      },
       "engines": {
         "node": ">=22.0.0"
       }
@@ -358,6 +361,21 @@
       "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
       "license": "CC0-1.0"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -484,6 +502,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pump": {

--- a/tests/ably-compat/package.json
+++ b/tests/ably-compat/package.json
@@ -21,5 +21,8 @@
   },
   "engines": {
     "node": ">=22.0.0"
+  },
+  "devDependencies": {
+    "playwright": "1.61.1"
   }
 }

--- a/tests/ably-compat/package.json
+++ b/tests/ably-compat/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "npm run smoke && npm run ait:mutable && npm run ait:recovery",
     "smoke": "node smoke.mjs",
+    "protocol:discovery": "node protocol-discovery.mjs",
     "pubsub:chat": "node pubsub-chat-smoke.mjs",
     "demo:pubsub-chat": "node pubsub-chat-server.mjs",
     "ait:mutable": "node ait-mutable.mjs",

--- a/tests/ably-compat/protocol-discovery.mjs
+++ b/tests/ably-compat/protocol-discovery.mjs
@@ -1,7 +1,9 @@
 import * as Ably from 'ably';
 import assert from 'node:assert/strict';
 import { readFile, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
 const endpoint = process.env.ABLY_ENDPOINT ?? '127.0.0.1';
 const port = Number(process.env.ABLY_PORT ?? '6001');
@@ -12,9 +14,16 @@ const runId = process.env.ABLY_PROTOCOL_RUN_ID ?? String(Date.now());
 const timeoutMs = Number(process.env.ABLY_PROTOCOL_TIMEOUT_MS ?? '15000');
 const strict = process.env.ABLY_PROTOCOL_STRICT === '1';
 const outputPath = process.env.ABLY_PROTOCOL_OUTPUT;
+const browserOriginPorts = (process.env.ABLY_BROWSER_ORIGIN_PORTS ?? '4173,3001,5174')
+  .split(',')
+  .map((value) => Number(value.trim()))
+  .filter(Number.isFinite);
 
 const ablyPackage = JSON.parse(
   await readFile(new URL('./node_modules/ably/package.json', import.meta.url), 'utf8'),
+);
+const ablyBrowserBundlePath = fileURLToPath(
+  new URL('./node_modules/ably/build/ably.min.js', import.meta.url),
 );
 
 function realtimeOptions({ clientId, binary }) {
@@ -183,6 +192,203 @@ async function authRequestToken() {
   return { clientId, tokenId: token.id ?? null };
 }
 
+async function startBrowserOriginServer() {
+  if (browserOriginPorts.length === 0) {
+    throw new Error('ABLY_BROWSER_ORIGIN_PORTS did not contain any usable ports');
+  }
+
+  const html = '<!doctype html><html><head><meta charset="utf-8"><title>Ably browser discovery</title></head><body></body></html>';
+  const errors = [];
+
+  for (const originPort of browserOriginPorts) {
+    const server = createServer((_, response) => {
+      response.writeHead(200, {
+        'content-type': 'text/html; charset=utf-8',
+        'cache-control': 'no-store',
+      });
+      response.end(html);
+    });
+
+    try {
+      await new Promise((resolve, reject) => {
+        const onError = (error) => {
+          server.off('listening', onListening);
+          reject(error);
+        };
+        const onListening = () => {
+          server.off('error', onError);
+          resolve();
+        };
+
+        server.once('error', onError);
+        server.once('listening', onListening);
+        server.listen(originPort, '127.0.0.1');
+      });
+
+      return {
+        origin: `http://127.0.0.1:${originPort}/`,
+        close: () =>
+          new Promise((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+          }),
+      };
+    } catch (error) {
+      errors.push(`${originPort}: ${error.message}`);
+      if (error.code !== 'EADDRINUSE' && error.code !== 'EACCES') {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error(
+    `unable to start browser origin on ports ${browserOriginPorts.join(', ')} (${errors.join('; ')})`,
+  );
+}
+
+async function browserChromiumPubSub() {
+  const { chromium } = await import('playwright');
+  const originServer = await startBrowserOriginServer();
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const browserErrors = [];
+
+  page.on('pageerror', (error) => browserErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      browserErrors.push(message.text());
+    }
+  });
+
+  try {
+    await page.goto(originServer.origin, { waitUntil: 'domcontentloaded' });
+    await page.addScriptTag({ path: ablyBrowserBundlePath });
+
+    const clientId = `${baseClientId}-browser-json-${runId}`;
+    const channelName = `ably-browser-json-${runId}`;
+    const details = await withTimeout(
+      page.evaluate(
+        async ({ channelName, clientId, endpoint, key, port, runId, timeoutMs, tls }) => {
+          const AblyBrowser = window.Ably;
+          if (!AblyBrowser?.Realtime) {
+            throw new Error('Ably browser bundle did not expose window.Ably.Realtime');
+          }
+
+          function withBrowserTimeout(promise, label, ms = timeoutMs) {
+            let timer;
+            return Promise.race([
+              promise,
+              new Promise((_, reject) => {
+                timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+              }),
+            ]).finally(() => clearTimeout(timer));
+          }
+
+          function onceBrowserConnection(client, state) {
+            if (client.connection.state === state) {
+              return Promise.resolve();
+            }
+            return new Promise((resolve, reject) => {
+              const onState = (change) => {
+                if (change.current === state) {
+                  client.connection.off(onState);
+                  resolve(change);
+                } else if (change.current === 'failed' || change.current === 'closed') {
+                  client.connection.off(onState);
+                  const reason = change.reason?.message ?? `connection ${change.current}`;
+                  reject(new Error(reason));
+                }
+              };
+              client.connection.on(onState);
+            });
+          }
+
+          function expectBrowserMessage(message, expectedName, expectedData) {
+            if (message.name !== expectedName) {
+              throw new Error(`expected message name ${expectedName}, got ${message.name}`);
+            }
+            if (JSON.stringify(message.data) !== JSON.stringify(expectedData)) {
+              throw new Error(
+                `expected message data ${JSON.stringify(expectedData)}, got ${JSON.stringify(message.data)}`,
+              );
+            }
+          }
+
+          const client = new AblyBrowser.Realtime({
+            key,
+            clientId,
+            endpoint,
+            port,
+            tls,
+            useBinaryProtocol: false,
+            transports: ['web_socket'],
+            autoConnect: false,
+            logLevel: 0,
+          });
+
+          try {
+            client.connect();
+            await withBrowserTimeout(onceBrowserConnection(client, 'connected'), 'browser connect');
+
+            const channel = client.channels.get(channelName);
+            await withBrowserTimeout(channel.attach(), 'browser attach');
+
+            let resolveMessage;
+            const received = new Promise((resolve) => {
+              resolveMessage = resolve;
+            });
+            await withBrowserTimeout(
+              Promise.resolve(channel.subscribe('browser-protocol-discovery', resolveMessage)),
+              'browser subscribe',
+            );
+
+            const data = { via: 'browser', runId };
+            await withBrowserTimeout(
+              channel.publish('browser-protocol-discovery', data),
+              'browser publish',
+            );
+
+            const message = await withBrowserTimeout(received, 'browser delivery');
+            expectBrowserMessage(message, 'browser-protocol-discovery', data);
+
+            const history = await withBrowserTimeout(
+              channel.history({ limit: 1, untilAttach: true }),
+              'browser history',
+            );
+            if (!history.items.length) {
+              throw new Error('expected at least one browser history item');
+            }
+            expectBrowserMessage(history.items[0], 'browser-protocol-discovery', data);
+
+            await withBrowserTimeout(channel.detach(), 'browser detach');
+            return {
+              channel: channelName,
+              clientId,
+              userAgent: navigator.userAgent,
+            };
+          } finally {
+            client.close();
+            try {
+              await withBrowserTimeout(onceBrowserConnection(client, 'closed'), 'browser close', 2000);
+            } catch {
+              // Closing is best-effort; the browser process is torn down after the lane.
+            }
+          }
+        },
+        { channelName, clientId, endpoint, key, port, runId, timeoutMs, tls },
+      ),
+      'browser chromium pubsub',
+    );
+
+    if (browserErrors.length > 0) {
+      details.browserErrors = browserErrors.slice(0, 10);
+    }
+    return { ...details, origin: originServer.origin };
+  } finally {
+    await browser.close();
+    await originServer.close();
+  }
+}
+
 function errorSummary(error) {
   const reason = error?.reason ?? error;
   return {
@@ -273,7 +479,7 @@ const scenarios = [
     runtime: 'chromium',
     area: 'realtime',
     claim: 'broader Ably protocol discovery',
-    skip: 'browser runner needs explicit Playwright/Chromium dependency and CI setup',
+    run: browserChromiumPubSub,
   },
 ];
 

--- a/tests/ably-compat/protocol-discovery.mjs
+++ b/tests/ably-compat/protocol-discovery.mjs
@@ -222,6 +222,15 @@ const scenarios = [
     run: () => restPublishHistory({ binary: false }),
   },
   {
+    id: 'node-rest-msgpack-publish-history',
+    required: false,
+    protocol: 'msgpack',
+    runtime: 'node',
+    area: 'rest',
+    claim: 'broader Ably protocol discovery',
+    run: () => restPublishHistory({ binary: true }),
+  },
+  {
     id: 'node-realtime-json-presence',
     required: false,
     protocol: 'json',
@@ -264,7 +273,7 @@ const scenarios = [
     runtime: 'chromium',
     area: 'realtime',
     claim: 'broader Ably protocol discovery',
-    skip: 'browser runner is not wired yet; add Playwright once Node gaps are stable',
+    skip: 'browser runner needs explicit Playwright/Chromium dependency and CI setup',
   },
 ];
 

--- a/tests/ably-compat/protocol-discovery.mjs
+++ b/tests/ably-compat/protocol-discovery.mjs
@@ -1,0 +1,370 @@
+import * as Ably from 'ably';
+import assert from 'node:assert/strict';
+import { readFile, writeFile } from 'node:fs/promises';
+import process from 'node:process';
+
+const endpoint = process.env.ABLY_ENDPOINT ?? '127.0.0.1';
+const port = Number(process.env.ABLY_PORT ?? '6001');
+const tls = process.env.ABLY_TLS === 'true';
+const key = process.env.ABLY_KEY ?? 'app-key:app-secret';
+const baseClientId = process.env.ABLY_CLIENT_ID ?? 'sockudo-ably-protocol';
+const runId = process.env.ABLY_PROTOCOL_RUN_ID ?? String(Date.now());
+const timeoutMs = Number(process.env.ABLY_PROTOCOL_TIMEOUT_MS ?? '15000');
+const strict = process.env.ABLY_PROTOCOL_STRICT === '1';
+const outputPath = process.env.ABLY_PROTOCOL_OUTPUT;
+
+const ablyPackage = JSON.parse(
+  await readFile(new URL('./node_modules/ably/package.json', import.meta.url), 'utf8'),
+);
+
+function realtimeOptions({ clientId, binary }) {
+  return {
+    key,
+    clientId,
+    endpoint,
+    port,
+    tls,
+    useBinaryProtocol: binary,
+    transports: ['web_socket'],
+    autoConnect: false,
+    logLevel: 0,
+  };
+}
+
+function restOptions({ clientId, binary }) {
+  return {
+    key,
+    clientId,
+    endpoint,
+    port,
+    tls,
+    useBinaryProtocol: binary,
+    logLevel: 0,
+  };
+}
+
+function withTimeout(promise, label, ms = timeoutMs) {
+  let timer;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+function onceConnection(client, state) {
+  if (client.connection.state === state) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const onState = (change) => {
+      if (change.current === state) {
+        client.connection.off(onState);
+        resolve(change);
+      } else if (change.current === 'failed' || change.current === 'closed') {
+        client.connection.off(onState);
+        reject(change.reason ?? new Error(`connection ${change.current}`));
+      }
+    };
+    client.connection.on(onState);
+  });
+}
+
+async function closeRealtime(client) {
+  if (!client) {
+    return;
+  }
+  client.close();
+  try {
+    await withTimeout(onceConnection(client, 'closed'), 'close', 2000);
+  } catch {
+    // Closing is best-effort for discovery. A failed close should not hide the
+    // actual scenario result.
+  }
+}
+
+function expectMessage(message, expectedName, expectedData) {
+  assert.equal(message.name, expectedName);
+  assert.deepEqual(message.data, expectedData);
+}
+
+async function realtimePubSub({ binary }) {
+  const clientId = `${baseClientId}-${binary ? 'msgpack' : 'json'}-${runId}`;
+  const client = new Ably.Realtime(realtimeOptions({ clientId, binary }));
+  const channelName = `ably-protocol-${binary ? 'msgpack' : 'json'}-${runId}`;
+  try {
+    client.connect();
+    await withTimeout(onceConnection(client, 'connected'), 'connect');
+
+    const channel = client.channels.get(channelName);
+    await withTimeout(channel.attach(), 'attach');
+
+    const received = withTimeout(
+      new Promise((resolve) => {
+        channel.subscribe('protocol-discovery', resolve);
+      }),
+      'subscribe delivery',
+    );
+
+    const data = { ok: true, binary, runId };
+    await withTimeout(channel.publish('protocol-discovery', data), 'publish');
+    expectMessage(await received, 'protocol-discovery', data);
+
+    const history = await withTimeout(channel.history({ limit: 1, untilAttach: true }), 'history');
+    assert.ok(history.items.length >= 1, 'expected at least one history item');
+    assert.equal(history.items[0].name, 'protocol-discovery');
+
+    await withTimeout(channel.detach(), 'detach');
+    return { channel: channelName, clientId };
+  } finally {
+    await closeRealtime(client);
+  }
+}
+
+async function restTime({ binary }) {
+  const clientId = `${baseClientId}-rest-time-${binary ? 'msgpack' : 'json'}-${runId}`;
+  const rest = new Ably.Rest(restOptions({ clientId, binary }));
+  const now = await withTimeout(rest.time(), 'rest time');
+  assert.equal(typeof now, 'number');
+  assert.ok(now > 0, 'expected positive timestamp');
+  return { timestamp: now, clientId };
+}
+
+async function restPublishHistory({ binary }) {
+  const clientId = `${baseClientId}-rest-history-${binary ? 'msgpack' : 'json'}-${runId}`;
+  const rest = new Ably.Rest(restOptions({ clientId, binary }));
+  const channelName = `ably-rest-history-${binary ? 'msgpack' : 'json'}-${runId}`;
+  const channel = rest.channels.get(channelName);
+  const data = { via: 'rest', binary, runId };
+
+  await withTimeout(channel.publish('rest-protocol-discovery', data), 'rest publish');
+  const history = await withTimeout(channel.history({ limit: 1 }), 'rest history');
+  assert.ok(history.items.length >= 1, 'expected at least one REST history item');
+  expectMessage(history.items[0], 'rest-protocol-discovery', data);
+
+  return { channel: channelName, clientId };
+}
+
+async function realtimePresence({ binary }) {
+  const clientId = `${baseClientId}-presence-${binary ? 'msgpack' : 'json'}-${runId}`;
+  const client = new Ably.Realtime(realtimeOptions({ clientId, binary }));
+  const channelName = `ably-presence-${binary ? 'msgpack' : 'json'}-${runId}`;
+  try {
+    client.connect();
+    await withTimeout(onceConnection(client, 'connected'), 'connect');
+
+    const channel = client.channels.get(channelName);
+    await withTimeout(channel.attach(), 'attach');
+    await withTimeout(channel.presence.enter({ status: 'online', runId }), 'presence enter');
+
+    const members = await withTimeout(channel.presence.get(), 'presence get');
+    assert.ok(
+      members.some((member) => member.clientId === clientId),
+      `expected ${clientId} in presence set`,
+    );
+
+    await withTimeout(channel.presence.update({ status: 'busy', runId }), 'presence update');
+    await withTimeout(channel.presence.leave({ status: 'offline', runId }), 'presence leave');
+    await withTimeout(channel.detach(), 'detach');
+
+    return { channel: channelName, clientId, members: members.length };
+  } finally {
+    await closeRealtime(client);
+  }
+}
+
+async function authRequestToken() {
+  const clientId = `${baseClientId}-token-${runId}`;
+  const rest = new Ably.Rest(restOptions({ clientId, binary: false }));
+  const token = await withTimeout(rest.auth.requestToken({ clientId }), 'request token');
+  assert.equal(typeof token.token, 'string');
+  assert.ok(token.token.length > 0, 'expected token string');
+  return { clientId, tokenId: token.id ?? null };
+}
+
+function errorSummary(error) {
+  const reason = error?.reason ?? error;
+  return {
+    name: reason?.name ?? error?.name ?? 'Error',
+    message: String(reason?.message ?? error?.message ?? error).slice(0, 500),
+    code: reason?.code ?? error?.code,
+    statusCode: reason?.statusCode ?? error?.statusCode,
+  };
+}
+
+const scenarios = [
+  {
+    id: 'node-realtime-json-pubsub',
+    required: true,
+    protocol: 'json',
+    runtime: 'node',
+    area: 'realtime',
+    claim: 'Ably Pub/Sub subset for AI Transport',
+    run: () => realtimePubSub({ binary: false }),
+  },
+  {
+    id: 'node-rest-json-time',
+    required: false,
+    protocol: 'json',
+    runtime: 'node',
+    area: 'rest',
+    claim: 'broader Ably protocol discovery',
+    run: () => restTime({ binary: false }),
+  },
+  {
+    id: 'node-rest-json-publish-history',
+    required: false,
+    protocol: 'json',
+    runtime: 'node',
+    area: 'rest',
+    claim: 'broader Ably protocol discovery',
+    run: () => restPublishHistory({ binary: false }),
+  },
+  {
+    id: 'node-realtime-json-presence',
+    required: false,
+    protocol: 'json',
+    runtime: 'node',
+    area: 'presence',
+    claim: 'broader Ably protocol discovery',
+    run: () => realtimePresence({ binary: false }),
+  },
+  {
+    id: 'node-auth-json-request-token',
+    required: false,
+    protocol: 'json',
+    runtime: 'node',
+    area: 'auth',
+    claim: 'broader Ably protocol discovery',
+    run: authRequestToken,
+  },
+  {
+    id: 'node-realtime-msgpack-pubsub',
+    required: false,
+    protocol: 'msgpack',
+    runtime: 'node',
+    area: 'realtime',
+    claim: 'broader Ably protocol discovery',
+    run: () => realtimePubSub({ binary: true }),
+  },
+  {
+    id: 'node-rest-msgpack-time',
+    required: false,
+    protocol: 'msgpack',
+    runtime: 'node',
+    area: 'rest',
+    claim: 'broader Ably protocol discovery',
+    run: () => restTime({ binary: true }),
+  },
+  {
+    id: 'browser-chromium-json-pubsub',
+    required: false,
+    protocol: 'json',
+    runtime: 'chromium',
+    area: 'realtime',
+    claim: 'broader Ably protocol discovery',
+    skip: 'browser runner is not wired yet; add Playwright once Node gaps are stable',
+  },
+];
+
+const results = [];
+
+for (const scenario of scenarios) {
+  const startedAt = Date.now();
+  if (scenario.skip) {
+    results.push({
+      id: scenario.id,
+      status: 'not-run',
+      classification: 'not-run',
+      required: scenario.required,
+      protocol: scenario.protocol,
+      runtime: scenario.runtime,
+      area: scenario.area,
+      claim: scenario.claim,
+      note: scenario.skip,
+      durationMs: 0,
+    });
+    continue;
+  }
+
+  try {
+    const details = await withTimeout(scenario.run(), scenario.id);
+    results.push({
+      id: scenario.id,
+      status: 'passed',
+      classification: 'supported',
+      required: scenario.required,
+      protocol: scenario.protocol,
+      runtime: scenario.runtime,
+      area: scenario.area,
+      claim: scenario.claim,
+      durationMs: Date.now() - startedAt,
+      details,
+    });
+  } catch (error) {
+    results.push({
+      id: scenario.id,
+      status: 'failed',
+      classification: scenario.required ? 'regression' : 'not-yet-implemented',
+      required: scenario.required,
+      protocol: scenario.protocol,
+      runtime: scenario.runtime,
+      area: scenario.area,
+      claim: scenario.claim,
+      durationMs: Date.now() - startedAt,
+      error: errorSummary(error),
+    });
+  }
+}
+
+const summary = {
+  schema: 'sockudo.ably-protocol-discovery.v1',
+  generatedAt: new Date().toISOString(),
+  sdk: {
+    name: 'ably',
+    version: ablyPackage.version,
+  },
+  target: {
+    endpoint,
+    port,
+    tls,
+    keyName: key.split(':')[0] ?? null,
+  },
+  strict,
+  counts: results.reduce(
+    (counts, result) => {
+      counts[result.status] = (counts[result.status] ?? 0) + 1;
+      return counts;
+    },
+    {},
+  ),
+  requiredFailures: results
+    .filter((result) => result.required && result.status !== 'passed')
+    .map((result) => result.id),
+  strictFailures: strict
+    ? results
+        .filter((result) => result.status !== 'passed')
+        .map((result) => result.id)
+    : [],
+  results,
+};
+
+if (outputPath) {
+  await writeFile(outputPath, `${JSON.stringify(summary, null, 2)}\n`);
+}
+
+for (const result of results) {
+  const marker = result.status.padEnd(7);
+  const requiredMarker = result.required ? 'required' : 'optional';
+  const note = result.error?.message ?? result.note ?? '';
+  console.log(`${marker} ${requiredMarker.padEnd(8)} ${result.id} ${note}`);
+}
+
+console.log(JSON.stringify(summary, null, 2));
+
+if (summary.requiredFailures.length > 0) {
+  process.exitCode = 1;
+} else if (strict && summary.strictFailures.length > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Adds a next-step Ably protocol discovery harness on top of the merged AI Transport compatibility work.

- Adds `npm run protocol:discovery` in `tests/ably-compat`.
- Adds `make ably-protocol-discovery`.
- Probes stock `ably@2.23.0` across required JSON Pub/Sub and optional REST, presence, token, MsgPack, and browser lanes.
- Keeps the support claim narrow: optional broader-protocol failures are reported as gaps unless `ABLY_PROTOCOL_STRICT=1` is set.
- Updates the Ably compatibility scorecard/test plan/gaps with the first local baseline.

## Local Verification

Started local Sockudo with:

```bash
PUSH_ALLOW_MEMORY_DRIVERS=true RUST_LOG=info cargo run -p sockudo --features "v2,ai-transport,ably-compat,redis,postgres,push" -- --config config/config.toml
```

Then ran:

```bash
npm ci --silent
node --check tests/ably-compat/protocol-discovery.mjs
git diff --check
ABLY_PROTOCOL_RUN_ID=codex-baseline-quiet npm run protocol:discovery
ABLY_PROTOCOL_RUN_ID=codex-make ABLY_PROTOCOL_TIMEOUT_MS=15000 make ably-protocol-discovery
```

Baseline result: 5 passed, 2 optional failed, 1 optional not-run. Required lane passed.

Known gaps recorded by the runner:

- `node-rest-json-publish-history`: HTTP 405.
- `node-realtime-msgpack-pubsub`: connect timeout because Sockudo replies JSON frames.
- `browser-chromium-json-pubsub`: not wired yet.
