### PR TITLE
Implement push retry and dead-letter handling

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -114,6 +114,7 @@ planner_worker_count = 1
 shard_worker_count = 1
 dispatch_worker_count = 1
 feedback_worker_count = 1
+retry_worker_count = 1
 queue_partition_count = 1
 channel_shard_count = 1
 fanout_fast_threshold = 10000
@@ -139,6 +140,7 @@ initial_backoff_ms = 1000
 max_backoff_ms = 60000
 max_elapsed_secs = 86400
 jitter = true
+jitter_ratio_percent = 20
 respect_retry_after = true
 
 [push.circuit_breaker]

--- a/crates/sockudo-core/src/options/env/features.rs
+++ b/crates/sockudo-core/src/options/env/features.rs
@@ -57,6 +57,31 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
         "PUSH_PUBLISH_STATUS_TTL_DAYS",
         options.push.publish_status_ttl_days,
     );
+    options.push.retry.max_attempts =
+        parse_env::<u32>("PUSH_RETRY_MAX_ATTEMPTS", options.push.retry.max_attempts);
+    options.push.retry.initial_backoff_ms = parse_env::<u64>(
+        "PUSH_RETRY_INITIAL_BACKOFF_MS",
+        options.push.retry.initial_backoff_ms,
+    );
+    options.push.retry.max_backoff_ms = parse_env::<u64>(
+        "PUSH_RETRY_MAX_BACKOFF_MS",
+        options.push.retry.max_backoff_ms,
+    );
+    options.push.retry.max_elapsed_secs = parse_env::<u64>(
+        "PUSH_RETRY_MAX_ELAPSED_SECS",
+        options.push.retry.max_elapsed_secs,
+    );
+    options.push.retry.jitter = parse_bool_env("PUSH_RETRY_JITTER", options.push.retry.jitter);
+    options.push.retry.jitter_ratio_percent = parse_env::<u8>(
+        "PUSH_RETRY_JITTER_RATIO_PERCENT",
+        options.push.retry.jitter_ratio_percent,
+    );
+    options.push.retry.respect_retry_after = parse_bool_env(
+        "PUSH_RETRY_RESPECT_RETRY_AFTER",
+        options.push.retry.respect_retry_after,
+    );
+    options.push.retry_worker_count =
+        parse_env::<u32>("PUSH_RETRY_WORKER_COUNT", options.push.retry_worker_count);
     options.push.circuit_breaker.failure_threshold = parse_env::<u32>(
         "PUSH_FAILURE_THRESHOLD",
         options.push.circuit_breaker.failure_threshold,

--- a/crates/sockudo-core/src/options/push.rs
+++ b/crates/sockudo-core/src/options/push.rs
@@ -88,6 +88,7 @@ pub struct PushConfig {
     pub shard_worker_count: u32,
     pub dispatch_worker_count: u32,
     pub feedback_worker_count: u32,
+    pub retry_worker_count: u32,
     pub queue_partition_count: u32,
     pub channel_shard_count: u32,
     pub fanout_fast_threshold: u64,
@@ -236,6 +237,7 @@ impl Default for PushConfig {
             shard_worker_count: 1,
             dispatch_worker_count: 1,
             feedback_worker_count: 1,
+            retry_worker_count: 1,
             queue_partition_count: 1,
             channel_shard_count: 1,
             fanout_fast_threshold: 10_000,
@@ -267,6 +269,7 @@ pub struct PushRetryConfig {
     pub max_backoff_ms: u64,
     pub max_elapsed_secs: u64,
     pub jitter: bool,
+    pub jitter_ratio_percent: u8,
     pub respect_retry_after: bool,
 }
 
@@ -278,6 +281,7 @@ impl Default for PushRetryConfig {
             max_backoff_ms: 60_000,
             max_elapsed_secs: 86_400,
             jitter: true,
+            jitter_ratio_percent: 20,
             respect_retry_after: true,
         }
     }

--- a/crates/sockudo-push/benches/push_pipeline_bench.rs
+++ b/crates/sockudo-push/benches/push_pipeline_bench.rs
@@ -12,8 +12,9 @@ use sockudo_push::{
     DevicePushDetails, DevicePushState, FanoutConfig, FormFactor, MemoryPushQueue, MemoryPushStore,
     Platform, ProviderDispatchWorker, PublishIntent, PublishTarget, PushAcceptRequest,
     PushDeviceStore, PushMetrics, PushPayload, PushPipeline, PushPlanner, PushProviderKind,
-    PushQueue, PushQueuePayload, PushQueueStage, PushRecipient, PushShardWorker,
-    PushSubscriptionStore, SecretString, any_rule_matches, render_provider_payload,
+    PushQueue, PushQueuePayload, PushQueueStage, PushRecipient, PushRetryScheduler,
+    PushShardWorker, PushSubscriptionStore, RetryScheduleEntry, SecretString, any_rule_matches,
+    render_provider_payload,
 };
 use sonic_rs::json;
 use tokio::runtime::Runtime;
@@ -290,6 +291,50 @@ fn bench_provider_dispatch(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_retry_scheduler(c: &mut Criterion) {
+    const RETRY_ENTRIES: usize = 100_000;
+    let mut group = c.benchmark_group("push_retry_scheduler");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(RETRY_ENTRIES as u64));
+    // Budget: draining 100k due retry entries through the memory queue/store
+    // should remain under 5s on a typical local development machine.
+    group.bench_function("memory_drain_100k_due_retry_entries_budget_lt_5s", |b| {
+        b.iter_batched(
+            || {
+                let runtime = Runtime::new().expect("tokio runtime");
+                let store = Arc::new(MemoryPushStore::new());
+                let queue = Arc::new(MemoryPushQueue::new());
+                runtime.block_on(seed_retry_entries(queue.clone(), RETRY_ENTRIES));
+                (runtime, store, queue)
+            },
+            |(runtime, store, queue)| {
+                runtime.block_on(async move {
+                    let scheduler = PushRetryScheduler::new(store, queue.clone(), "bench-retry")
+                        .with_max_messages_per_tick(1_024);
+                    let mut processed = 0_usize;
+                    while processed < RETRY_ENTRIES {
+                        let tick = scheduler.run_once("bench-retry").await.unwrap();
+                        if tick == 0 {
+                            break;
+                        }
+                        processed += tick;
+                    }
+                    assert_eq!(processed, RETRY_ENTRIES);
+                    black_box(
+                        queue
+                            .lag(PushQueueStage::DeliveryJobs(PushProviderKind::Fcm))
+                            .await
+                            .unwrap()
+                            .ready_depth,
+                    );
+                });
+            },
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
 fn bench_provider_rendering(c: &mut Criterion) {
     let payload = sample_payload();
     let mut group = c.benchmark_group("push_provider_rendering");
@@ -546,10 +591,58 @@ fn sample_delivery_batch(publish_id: String, jobs: usize) -> DeliveryBatch {
                 },
                 payload: Arc::clone(&payload),
                 attempt: 1,
+                first_attempt_at_ms: None,
                 not_before_ms: None,
                 expires_at_ms: None,
             })
             .collect(),
+    }
+}
+
+async fn seed_retry_entries(queue: Arc<MemoryPushQueue>, count: usize) {
+    let payload = Arc::new(sample_payload());
+    for index in 0..count {
+        let key = format!("retry:bench:{index}");
+        let job = DeliveryJob {
+            app_id: APP_ID.to_owned(),
+            publish_id: format!("retry-publish-{index}"),
+            provider: PushProviderKind::Fcm,
+            batch_id: format!("retry-batch-{index}"),
+            device_id: Some(format!("device-{index}")),
+            recipient: PushRecipient::Fcm {
+                registration_token: SecretString::new(format!("token-{index}")).unwrap(),
+            },
+            payload: Arc::clone(&payload),
+            attempt: 2,
+            first_attempt_at_ms: Some(1),
+            not_before_ms: Some(1),
+            expires_at_ms: None,
+        };
+        let entry = RetryScheduleEntry {
+            app_id: APP_ID.to_owned(),
+            publish_id: job.publish_id.clone(),
+            provider: Some(PushProviderKind::Fcm),
+            job: Some(Box::new(job)),
+            attempt: 2,
+            first_attempt_at_ms: 1,
+            next_attempt_at_ms: 1,
+            max_attempts: 5,
+            expires_at_ms: u64::MAX,
+            last_error: None,
+            retry_idempotency_key: key.clone(),
+            stage: "delivery".to_owned(),
+            key: key.clone(),
+            not_before_ms: Some(1),
+            payload: None,
+        };
+        queue
+            .produce(
+                PushQueueStage::RetrySchedule,
+                key,
+                PushQueuePayload::RetrySchedule(Box::new(entry)),
+            )
+            .await
+            .unwrap();
     }
 }
 
@@ -567,6 +660,7 @@ criterion_group!(
     bench_sharded_fanout,
     bench_queue,
     bench_provider_dispatch,
+    bench_retry_scheduler,
     bench_provider_rendering,
     bench_metrics,
     bench_device_secret_pbkdf2

--- a/crates/sockudo-push/examples/webpush_send.rs
+++ b/crates/sockudo-push/examples/webpush_send.rs
@@ -80,6 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 collapse_key: Some(collapse_key),
             }),
             attempt: 1,
+            first_attempt_at_ms: Some(now_ms),
             not_before_ms: None,
             expires_at_ms: None,
         }],

--- a/crates/sockudo-push/src/dispatch/test_support.rs
+++ b/crates/sockudo-push/src/dispatch/test_support.rs
@@ -85,6 +85,7 @@ pub(crate) fn batch(provider: PushProviderKind) -> DeliveryBatch {
                 collapse_key: Some("collapse".to_owned()),
             }),
             attempt: 1,
+            first_attempt_at_ms: None,
             not_before_ms: None,
             expires_at_ms: None,
         }],

--- a/crates/sockudo-push/src/dispatch/tests.rs
+++ b/crates/sockudo-push/src/dispatch/tests.rs
@@ -175,6 +175,37 @@ fn classifies_provider_error_classes_and_retry_after() {
 }
 
 #[test]
+fn provider_outage_responses_are_retryable() {
+    let fcm = classify_fcm_response(&ProviderHttpResponse {
+        status: 429,
+        headers: BTreeMap::from([("retry-after".to_owned(), "3".to_owned())]),
+        body: br#"{"error":{"status":"RESOURCE_EXHAUSTED"}}"#.to_vec(),
+    });
+    assert_eq!(fcm.0, DeliveryOutcome::Retryable);
+    assert_eq!(fcm.1.as_ref().unwrap().class, "quota");
+    assert!(fcm.1.as_ref().unwrap().retry_after_ms.is_some());
+
+    for status in [429, 500] {
+        let apns = classify_apns_response(&response(status, json!({"reason": "TooManyRequests"})));
+        assert_eq!(apns.0, DeliveryOutcome::Retryable, "apns {status}");
+    }
+    for status in [429, 503] {
+        let webpush = classify_webpush_response(&response(status, json!({})));
+        assert_eq!(webpush.0, DeliveryOutcome::Retryable, "webpush {status}");
+    }
+
+    let mut batch = batch(PushProviderKind::Fcm);
+    let job = batch.jobs.remove(0);
+    let timeout = classify_http_result(
+        job,
+        Err("transport timeout".to_owned()),
+        classify_fcm_response,
+    );
+    assert_eq!(timeout.outcome, DeliveryOutcome::Retryable);
+    assert_eq!(timeout.error.unwrap().class, "unavailable");
+}
+
+#[test]
 fn adaptive_rate_limiter_shrinks_and_grows_slowly() {
     let mut limiter = AdaptiveRateLimiter::default();
     assert_eq!(limiter.limit("app-1", PushProviderKind::Fcm), 100);
@@ -345,6 +376,7 @@ fn batch(provider: PushProviderKind) -> DeliveryBatch {
                 collapse_key: Some("collapse".to_owned()),
             }),
             attempt: 1,
+            first_attempt_at_ms: None,
             not_before_ms: None,
             expires_at_ms: None,
         }],

--- a/crates/sockudo-push/src/dispatch/worker.rs
+++ b/crates/sockudo-push/src/dispatch/worker.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use super::PushDispatcher;
-use crate::domain::{DeliveryOutcome, DeliveryResult, PushProviderKind, provider_key};
+use crate::domain::{
+    DeliveryFeedback, DeliveryJob, DeliveryOutcome, DeliveryResult, PushProviderKind, provider_key,
+    stable_hash,
+};
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::PushMetrics;
 use crate::pipeline::{PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage, now_ms};
@@ -110,6 +113,7 @@ impl ProviderDispatchWorker {
         };
         let batch = *batch;
         let app_id = batch.app_id.clone();
+        let retry_jobs = batch.jobs.clone();
         self.metrics
             .worker_pool(self.provider, self.max_batches_per_tick, 1);
 
@@ -142,11 +146,14 @@ impl ProviderDispatchWorker {
         }
 
         let started = Instant::now();
+        let started_ms = now_ms();
         self.metrics.dispatch_started(self.provider, &app_id);
         let results = self.dispatcher.dispatch(batch).await;
         let mut saw_retry_after = None;
         let mut failures = 0_u64;
+        let mut retry_jobs = retry_jobs.into_iter();
         for result in results {
+            let original_job = retry_jobs.next();
             if !matches!(result.outcome, DeliveryOutcome::Accepted) {
                 failures += 1;
                 tracing::warn!(
@@ -180,11 +187,12 @@ impl ProviderDispatchWorker {
             {
                 saw_retry_after = Some(retry_after_ms);
             }
+            let feedback = delivery_feedback(result, original_job, started_ms);
             self.queue
                 .produce(
                     PushQueueStage::DeliveryResults,
-                    result_key(&result),
-                    PushQueuePayload::DeliveryResult(Box::new(result)),
+                    feedback_key(&feedback),
+                    PushQueuePayload::DeliveryFeedback(Box::new(feedback)),
                 )
                 .await?;
         }
@@ -499,14 +507,57 @@ impl WeightedFairScheduler {
     }
 }
 
-fn result_key(result: &DeliveryResult) -> String {
+fn delivery_feedback(
+    result: DeliveryResult,
+    original_job: Option<DeliveryJob>,
+    started_ms: u64,
+) -> DeliveryFeedback {
+    let delivery_key = original_job
+        .as_ref()
+        .map(|job| stable_hash(job.idempotency_key().as_bytes()))
+        .unwrap_or_else(|| {
+            stable_hash(
+                format!(
+                    "{}:{}:{}:{}:{}",
+                    result.app_id,
+                    result.publish_id,
+                    provider_key(result.provider),
+                    result.batch_id,
+                    result.device_id.as_deref().unwrap_or("[provider-target]")
+                )
+                .as_bytes(),
+            )
+        });
+    let retry_job = if matches!(result.outcome, DeliveryOutcome::Retryable) {
+        original_job.map(|mut job| {
+            job.first_attempt_at_ms = Some(job.first_attempt_at_ms.unwrap_or(started_ms));
+            Box::new(job)
+        })
+    } else {
+        None
+    };
+    let first_attempt_at_ms = retry_job
+        .as_ref()
+        .and_then(|job| job.first_attempt_at_ms)
+        .or(Some(started_ms));
+    let expires_at_ms = retry_job.as_ref().and_then(|job| job.expires_at_ms);
+    DeliveryFeedback {
+        result,
+        delivery_key,
+        retry_job,
+        first_attempt_at_ms,
+        expires_at_ms,
+    }
+}
+
+fn feedback_key(feedback: &DeliveryFeedback) -> String {
     format!(
         "{}:{}:{}:{}:{}:{}",
-        result.app_id,
-        result.publish_id,
-        provider_key(result.provider),
-        result.batch_id,
-        result.device_id.as_deref().unwrap_or("[provider-target]"),
-        result.attempt
+        feedback.result.app_id,
+        feedback.result.publish_id,
+        provider_key(feedback.result.provider),
+        feedback.result.batch_id,
+        feedback.delivery_key,
+        feedback.result.attempt
     )
 }

--- a/crates/sockudo-push/src/domain.rs
+++ b/crates/sockudo-push/src/domain.rs
@@ -33,6 +33,11 @@ pub const DEFAULT_PUSH_FANOUT_SHARD_SIZE: u64 = 100_000;
 pub const DEFAULT_PUSH_FANOUT_PAGE_SIZE: usize = 1_000;
 pub const DEFAULT_PUSH_PROVIDER_BATCH_SIZE: usize = 500;
 pub const DEFAULT_PUSH_STATUS_RETENTION_DAYS: u64 = 30;
+pub const DEFAULT_PUSH_RETRY_INITIAL_BACKOFF_MS: u64 = 1_000;
+pub const DEFAULT_PUSH_RETRY_MAX_BACKOFF_MS: u64 = 60_000;
+pub const DEFAULT_PUSH_RETRY_MAX_ATTEMPTS: u32 = 5;
+pub const DEFAULT_PUSH_RETRY_MAX_AGE_MS: u64 = 86_400_000;
+pub const DEFAULT_PUSH_RETRY_JITTER_RATIO_PERCENT: u8 = 20;
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum PushDomainError {
@@ -923,6 +928,8 @@ pub enum PublishLifecycleState {
     Cancelled,
     Expired,
     Failed,
+    #[serde(rename = "dead_lettered")]
+    DeadLettered,
     Succeeded,
     PartiallySucceeded,
 }
@@ -996,6 +1003,12 @@ pub struct PublishCounters {
     pub succeeded: u64,
     pub failed: u64,
     pub expired: u64,
+    #[serde(default)]
+    pub retry_scheduled: u64,
+    #[serde(default)]
+    pub retry_attempted: u64,
+    #[serde(default)]
+    pub dead_lettered: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1052,6 +1065,8 @@ pub struct ShardJob {
     pub target: PublishTarget,
     pub payload: PushPayload,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<PushCursor>,
     pub page_size: usize,
     pub shard_size: u64,
@@ -1079,6 +1094,8 @@ pub struct DeliveryJob {
     #[serde(with = "arc_push_payload")]
     pub payload: Arc<PushPayload>,
     pub attempt: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_attempt_at_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub not_before_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1129,6 +1146,7 @@ impl fmt::Debug for DeliveryJob {
             .field("recipient", &self.recipient)
             .field("payload", &self.payload)
             .field("attempt", &self.attempt)
+            .field("first_attempt_at_ms", &self.first_attempt_at_ms)
             .field("not_before_ms", &self.not_before_ms)
             .field("expires_at_ms", &self.expires_at_ms)
             .finish()
@@ -1218,6 +1236,39 @@ pub struct DeliveryResult {
     pub attempt: u32,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeliveryFeedback {
+    pub result: DeliveryResult,
+    pub delivery_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_job: Option<Box<DeliveryJob>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_attempt_at_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at_ms: Option<u64>,
+}
+
+impl DeliveryFeedback {
+    pub fn from_result(result: DeliveryResult) -> Self {
+        let delivery_key = format!(
+            "{}:{}:{}:{}:{}",
+            result.app_id,
+            result.publish_id,
+            provider_key(result.provider),
+            result.batch_id,
+            result.device_id.as_deref().unwrap_or("[provider-target]")
+        );
+        Self {
+            result,
+            delivery_key,
+            retry_job: None,
+            first_attempt_at_ms: None,
+            expires_at_ms: None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeliveryEvent {
@@ -1239,15 +1290,67 @@ pub struct DeadLetter {
     pub occurred_at_ms: u64,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RetryScheduleEntry {
     pub app_id: String,
     pub publish_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<PushProviderKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub job: Option<Box<DeliveryJob>>,
+    #[serde(default = "default_retry_attempt")]
+    pub attempt: u32,
+    #[serde(default)]
+    pub first_attempt_at_ms: u64,
+    #[serde(default)]
+    pub next_attempt_at_ms: u64,
+    #[serde(default = "default_retry_max_attempts")]
+    pub max_attempts: u32,
+    #[serde(default)]
+    pub expires_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<ProviderError>,
+    #[serde(default)]
+    pub retry_idempotency_key: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub stage: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub key: String,
-    pub not_before_ms: u64,
-    pub payload: sonic_rs::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub not_before_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<sonic_rs::Value>,
+}
+
+impl fmt::Debug for RetryScheduleEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RetryScheduleEntry")
+            .field("app_id", &self.app_id)
+            .field("publish_id", &self.publish_id)
+            .field("provider", &self.provider)
+            .field("job", &self.job)
+            .field("attempt", &self.attempt)
+            .field("first_attempt_at_ms", &self.first_attempt_at_ms)
+            .field("next_attempt_at_ms", &self.next_attempt_at_ms)
+            .field("max_attempts", &self.max_attempts)
+            .field("expires_at_ms", &self.expires_at_ms)
+            .field("last_error", &self.last_error)
+            .field("retry_idempotency_key", &self.retry_idempotency_key)
+            .field("stage", &self.stage)
+            .field("key", &self.key)
+            .field("not_before_ms", &self.not_before_ms)
+            .field("payload", &self.payload.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
+}
+
+fn default_retry_attempt() -> u32 {
+    1
+}
+
+fn default_retry_max_attempts() -> u32 {
+    DEFAULT_PUSH_RETRY_MAX_ATTEMPTS
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/sockudo-push/src/feedback.rs
+++ b/crates/sockudo-push/src/feedback.rs
@@ -1,12 +1,13 @@
 use futures_util::StreamExt;
 
 use crate::domain::{
-    DeliveryEvent, DeliveryOutcome, DeliveryResult, DevicePushState, PublishLifecycleState,
-    RetryScheduleEntry, to_json_value,
+    DeadLetter, DeliveryEvent, DeliveryFeedback, DeliveryOutcome, DeliveryResult, DevicePushState,
+    PublishLifecycleState,
 };
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::{PushMetrics, provider_label};
 use crate::pipeline::{PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage, now_ms};
+use crate::retry::RetryPolicy;
 use crate::storage::{DynPushStore, IdempotencyRecord};
 
 #[derive(Clone)]
@@ -14,6 +15,7 @@ pub struct PushFeedbackProcessor {
     store: DynPushStore,
     queue: crate::pipeline::DynPushQueue,
     failure_threshold: u32,
+    retry_policy: RetryPolicy,
     metrics: PushMetrics,
 }
 
@@ -25,6 +27,7 @@ impl PushFeedbackProcessor {
             store,
             queue,
             failure_threshold: 3,
+            retry_policy: RetryPolicy::default(),
             metrics: PushMetrics::default(),
         }
     }
@@ -36,6 +39,11 @@ impl PushFeedbackProcessor {
 
     pub fn with_failure_threshold(mut self, failure_threshold: u32) -> Self {
         self.failure_threshold = failure_threshold.max(1);
+        self
+    }
+
+    pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
+        self.retry_policy = retry_policy.bounded();
         self
     }
 
@@ -67,21 +75,30 @@ impl PushFeedbackProcessor {
     }
 
     async fn handle_message(&self, message: QueueMessage) -> PushPipelineResult<()> {
-        let PushQueuePayload::DeliveryResult(result) = message.payload.clone() else {
-            self.queue
-                .dead_letter(message.ack, "unexpected payload for feedback".to_owned())
-                .await?;
-            return Ok(());
+        let feedback = match message.payload.clone() {
+            PushQueuePayload::DeliveryResult(result) => DeliveryFeedback::from_result(*result),
+            PushQueuePayload::DeliveryFeedback(feedback) => *feedback,
+            _ => {
+                self.queue
+                    .dead_letter(message.ack, "unexpected payload for feedback".to_owned())
+                    .await?;
+                return Ok(());
+            }
         };
-        let result = *result;
 
-        self.apply_result(result).await?;
+        self.apply_feedback(feedback).await?;
         self.queue.ack(message.ack).await?;
         Ok(())
     }
 
     pub async fn apply_result(&self, result: DeliveryResult) -> PushPipelineResult<()> {
-        let event_id = result_event_id(&result);
+        self.apply_feedback(DeliveryFeedback::from_result(result))
+            .await
+    }
+
+    pub async fn apply_feedback(&self, feedback: DeliveryFeedback) -> PushPipelineResult<()> {
+        let result = &feedback.result;
+        let event_id = result_event_id(&feedback);
         let dedupe_key = format!("delivery-result:{event_id}");
         let inserted = self
             .store
@@ -116,11 +133,11 @@ impl PushFeedbackProcessor {
         }
 
         if let Some(device_id) = result.device_id.as_deref() {
-            self.update_device_state(&result, device_id).await?;
+            self.update_device_state(result, device_id).await?;
         }
-        self.update_publish_status(&result).await?;
-        self.handle_retry_or_dlq(&result).await?;
-        emit_feedback_meta_event(&result);
+        self.update_publish_status(result).await?;
+        self.handle_retry_or_dlq(&feedback).await?;
+        emit_feedback_meta_event(result);
         Ok(())
     }
 
@@ -220,11 +237,19 @@ impl PushFeedbackProcessor {
             return Ok(());
         };
 
-        status.counters.dispatched = status.counters.dispatched.saturating_add(1);
         match result.outcome {
-            DeliveryOutcome::Accepted => status.counters.succeeded += 1,
-            DeliveryOutcome::Rejected => status.counters.failed += 1,
-            DeliveryOutcome::Expired => status.counters.expired += 1,
+            DeliveryOutcome::Accepted => {
+                status.counters.dispatched = status.counters.dispatched.saturating_add(1);
+                status.counters.succeeded = status.counters.succeeded.saturating_add(1);
+            }
+            DeliveryOutcome::Rejected => {
+                status.counters.dispatched = status.counters.dispatched.saturating_add(1);
+                status.counters.failed = status.counters.failed.saturating_add(1);
+            }
+            DeliveryOutcome::Expired => {
+                status.counters.dispatched = status.counters.dispatched.saturating_add(1);
+                status.counters.expired = status.counters.expired.saturating_add(1);
+            }
             DeliveryOutcome::Retryable | DeliveryOutcome::Cancelled => {}
         }
         if let Some(retry_after_ms) = result.error.as_ref().and_then(|error| error.retry_after_ms) {
@@ -234,6 +259,7 @@ impl PushFeedbackProcessor {
             status.counters.succeeded,
             status.counters.failed,
             status.counters.expired,
+            status.counters.dead_lettered,
             status.counters.planned,
             status.state,
         );
@@ -245,6 +271,7 @@ impl PushFeedbackProcessor {
                 | PublishLifecycleState::PartiallySucceeded
                 | PublishLifecycleState::Failed
                 | PublishLifecycleState::Expired
+                | PublishLifecycleState::DeadLettered
         ) {
             emit_push_meta_event(PushMetaEvent::completed(
                 &result.app_id,
@@ -262,36 +289,54 @@ impl PushFeedbackProcessor {
         Ok(())
     }
 
-    async fn handle_retry_or_dlq(&self, result: &DeliveryResult) -> PushPipelineResult<()> {
+    async fn handle_retry_or_dlq(&self, feedback: &DeliveryFeedback) -> PushPipelineResult<()> {
+        let result = &feedback.result;
         if matches!(result.outcome, DeliveryOutcome::Retryable) {
-            let not_before_ms = result
-                .error
-                .as_ref()
-                .and_then(|error| error.retry_after_ms)
-                .unwrap_or_else(|| now_ms().saturating_add(30_000));
-            let entry = RetryScheduleEntry {
-                app_id: result.app_id.clone(),
-                publish_id: result.publish_id.clone(),
-                stage: "delivery".to_owned(),
-                key: format!(
-                    "{}:{}:{}",
-                    result.batch_id,
-                    result.device_id.as_deref().unwrap_or("[provider-target]"),
-                    result.attempt
-                ),
-                not_before_ms,
-                payload: to_json_value(result).unwrap_or_else(|_| sonic_rs::Value::new_null()),
+            let Some(entry) = self.retry_policy.schedule_retry(feedback, now_ms()) else {
+                let dead_letter = DeadLetter {
+                    app_id: result.app_id.clone(),
+                    publish_id: result.publish_id.clone(),
+                    stage: "delivery_result".to_owned(),
+                    key: result.batch_id.clone(),
+                    reason: "retryable result missing retry context".to_owned(),
+                    occurred_at_ms: now_ms(),
+                };
+                self.queue
+                    .produce(
+                        PushQueueStage::DeadLetters,
+                        dead_letter.key.clone(),
+                        PushQueuePayload::DeadLetter(Box::new(dead_letter)),
+                    )
+                    .await?;
+                self.mark_retry_context_missing(result).await?;
+                emit_push_meta_event(PushMetaEvent::dead_letter(
+                    &result.app_id,
+                    &result.publish_id,
+                    "delivery_result",
+                    "retryable result missing retry context",
+                ));
+                return Ok(());
             };
+            let next_attempt_at_ms = entry.next_attempt_at_ms;
             self.queue
                 .retry_at(
                     PushQueueStage::RetrySchedule,
                     entry.key.clone(),
                     PushQueuePayload::RetrySchedule(Box::new(entry)),
-                    not_before_ms,
+                    next_attempt_at_ms,
                 )
                 .await?;
+            self.mark_retry_scheduled(result, next_attempt_at_ms)
+                .await?;
+            self.metrics
+                .retry_scheduled(result.provider, &result.app_id);
+            emit_push_meta_event(PushMetaEvent::scheduler_event(
+                &result.app_id,
+                &result.publish_id,
+                "retry-scheduled",
+            ));
         } else if matches!(result.outcome, DeliveryOutcome::Rejected) && !is_invalid_token(result) {
-            let dead_letter = crate::domain::DeadLetter {
+            let dead_letter = DeadLetter {
                 app_id: result.app_id.clone(),
                 publish_id: result.publish_id.clone(),
                 stage: "delivery_result".to_owned(),
@@ -323,15 +368,54 @@ impl PushFeedbackProcessor {
         }
         Ok(())
     }
+
+    async fn mark_retry_scheduled(
+        &self,
+        result: &DeliveryResult,
+        next_attempt_at_ms: u64,
+    ) -> PushPipelineResult<()> {
+        if let Some(mut status) = self
+            .store
+            .get_publish_status(&result.app_id, &result.publish_id)
+            .await?
+        {
+            status.counters.retry_scheduled = status.counters.retry_scheduled.saturating_add(1);
+            status.retry_after_ms = Some(next_attempt_at_ms);
+            self.store.put_publish_status(status).await?;
+        }
+        Ok(())
+    }
+
+    async fn mark_retry_context_missing(&self, result: &DeliveryResult) -> PushPipelineResult<()> {
+        if let Some(mut status) = self
+            .store
+            .get_publish_status(&result.app_id, &result.publish_id)
+            .await?
+        {
+            status.counters.dead_lettered = status.counters.dead_lettered.saturating_add(1);
+            status.error_reason = Some("retryable result missing retry context".to_owned());
+            status.state = terminal_state(
+                status.counters.succeeded,
+                status.counters.failed,
+                status.counters.expired,
+                status.counters.dead_lettered,
+                status.counters.planned,
+                status.state,
+            );
+            self.store.put_publish_status(status).await?;
+        }
+        Ok(())
+    }
 }
 
-fn result_event_id(result: &DeliveryResult) -> String {
+fn result_event_id(feedback: &DeliveryFeedback) -> String {
+    let result = &feedback.result;
     format!(
         "result-{}-{}-{}-{}-{}-{}",
         provider_label(result.provider),
         result.publish_id,
         result.batch_id,
-        result.device_id.as_deref().unwrap_or("provider-target"),
+        feedback.delivery_key,
         result.attempt,
         outcome_label(result.outcome)
     )
@@ -357,6 +441,7 @@ fn lifecycle_label(state: PublishLifecycleState) -> &'static str {
         PublishLifecycleState::Cancelled => "cancelled",
         PublishLifecycleState::Expired => "expired",
         PublishLifecycleState::Failed => "failed",
+        PublishLifecycleState::DeadLettered => "dead_lettered",
         PublishLifecycleState::Succeeded => "succeeded",
         PublishLifecycleState::PartiallySucceeded => "partially_succeeded",
     }
@@ -366,19 +451,23 @@ fn terminal_state(
     succeeded: u64,
     failed: u64,
     expired: u64,
+    dead_lettered: u64,
     planned: u64,
     current: PublishLifecycleState,
 ) -> PublishLifecycleState {
     let terminal = succeeded.saturating_add(failed).saturating_add(expired);
+    let terminal = terminal.saturating_add(dead_lettered);
     if planned == 0 || terminal < planned {
         return current;
     }
-    if failed == 0 && expired == 0 {
+    if failed == 0 && expired == 0 && dead_lettered == 0 {
         PublishLifecycleState::Succeeded
     } else if succeeded > 0 {
         PublishLifecycleState::PartiallySucceeded
     } else if expired > 0 {
         PublishLifecycleState::Expired
+    } else if dead_lettered > 0 {
+        PublishLifecycleState::DeadLettered
     } else {
         PublishLifecycleState::Failed
     }
@@ -415,13 +504,17 @@ fn emit_feedback_meta_event(result: &DeliveryResult) {
 mod tests {
     use std::sync::Arc;
 
+    use sonic_rs::json;
+
     use crate::domain::{
-        DeliveryOutcome, DeliveryResult, PublishCounters, PublishLifecycleState, PublishStatus,
-        PushProviderKind,
+        DeliveryFeedback, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError,
+        PublishCounters, PublishLifecycleState, PublishStatus, PushPayload, PushProviderKind,
+        PushRecipient, SecretString,
     };
     use crate::memory::MemoryPushStore;
     use crate::metrics::PushMetrics;
-    use crate::pipeline::MemoryPushQueue;
+    use crate::pipeline::{MemoryPushQueue, PushQueue};
+    use crate::retry::RetryPolicy;
     use crate::storage::PushPublishStatusStore;
 
     use super::*;
@@ -441,6 +534,9 @@ mod tests {
                     succeeded: 0,
                     failed: 0,
                     expired: 0,
+                    retry_scheduled: 0,
+                    retry_attempted: 0,
+                    dead_lettered: 0,
                 },
                 fanout_regime: None,
                 retry_after_ms: None,
@@ -493,6 +589,9 @@ mod tests {
                         succeeded: 0,
                         failed: 0,
                         expired: 0,
+                        retry_scheduled: 0,
+                        retry_attempted: 0,
+                        dead_lettered: 0,
                     },
                     fanout_regime: None,
                     retry_after_ms: None,
@@ -533,5 +632,147 @@ mod tests {
             assert_eq!(status.state, PublishLifecycleState::Succeeded);
         }
         assert_eq!(metrics.get("sockudo_push_duplicate_suppressed_total"), 0);
+    }
+
+    #[tokio::test]
+    async fn retryable_feedback_enqueues_retry_with_original_job_context() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.put_publish_status(status()).await.unwrap();
+        let metrics = PushMetrics::default();
+        let processor = PushFeedbackProcessor::new(store.clone(), queue.clone())
+            .with_metrics(metrics.clone())
+            .with_retry_policy(RetryPolicy {
+                initial_backoff_ms: 1,
+                max_backoff_ms: 1,
+                jitter_ratio_percent: 0,
+                ..RetryPolicy::default()
+            });
+
+        processor
+            .apply_feedback(retryable_feedback())
+            .await
+            .unwrap();
+
+        let mut messages = queue
+            .consume(PushQueueStage::RetrySchedule, "retry-test", 1, 30_000)
+            .await
+            .unwrap();
+        assert_eq!(messages.len(), 1);
+        let PushQueuePayload::RetrySchedule(entry) = messages.pop().unwrap().payload else {
+            panic!("expected retry schedule payload");
+        };
+        assert_eq!(entry.app_id, "app-1");
+        assert_eq!(entry.publish_id, "publish-1");
+        assert_eq!(entry.provider, Some(PushProviderKind::Fcm));
+        assert_eq!(entry.attempt, 2);
+        assert_eq!(entry.max_attempts, 5);
+        let job = entry.job.unwrap();
+        assert_eq!(job.device_id.as_deref(), Some("device-1"));
+        assert_eq!(job.attempt, 2);
+        assert_eq!(job.first_attempt_at_ms, Some(1_000));
+        assert!(!entry.retry_idempotency_key.is_empty());
+
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.counters.dispatched, 0);
+        assert_eq!(status.counters.retry_scheduled, 1);
+        assert_eq!(status.state, PublishLifecycleState::Dispatching);
+        assert_eq!(metrics.get("sockudo_push_retry_scheduled_total"), 1);
+    }
+
+    #[tokio::test]
+    async fn duplicate_retryable_feedback_is_suppressed() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.put_publish_status(status()).await.unwrap();
+        let metrics = PushMetrics::default();
+        let processor =
+            PushFeedbackProcessor::new(store.clone(), queue.clone()).with_metrics(metrics.clone());
+        let feedback = retryable_feedback();
+
+        processor.apply_feedback(feedback.clone()).await.unwrap();
+        processor.apply_feedback(feedback).await.unwrap();
+
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.counters.retry_scheduled, 1);
+        assert_eq!(status.counters.dead_lettered, 0);
+        assert_eq!(metrics.get("sockudo_push_duplicate_suppressed_total"), 1);
+        let lag = queue.lag(PushQueueStage::RetrySchedule).await.unwrap();
+        assert_eq!(lag.ready_depth + lag.delayed_depth, 1);
+    }
+
+    fn status() -> PublishStatus {
+        PublishStatus {
+            app_id: "app-1".to_owned(),
+            publish_id: "publish-1".to_owned(),
+            state: PublishLifecycleState::Dispatching,
+            counters: PublishCounters {
+                planned: 1,
+                dispatched: 0,
+                succeeded: 0,
+                failed: 0,
+                expired: 0,
+                retry_scheduled: 0,
+                retry_attempted: 0,
+                dead_lettered: 0,
+            },
+            fanout_regime: None,
+            retry_after_ms: None,
+            error_reason: None,
+        }
+    }
+
+    fn retryable_feedback() -> DeliveryFeedback {
+        DeliveryFeedback {
+            result: DeliveryResult {
+                app_id: "app-1".to_owned(),
+                publish_id: "publish-1".to_owned(),
+                provider: PushProviderKind::Fcm,
+                batch_id: "batch-1".to_owned(),
+                device_id: Some("device-1".to_owned()),
+                outcome: DeliveryOutcome::Retryable,
+                provider_message_id: None,
+                error: Some(ProviderError {
+                    class: "unavailable".to_owned(),
+                    reason: Some("provider unavailable".to_owned()),
+                    retry_after_ms: Some(now_ms()),
+                }),
+                attempt: 1,
+            },
+            delivery_key: "delivery-key-1".to_owned(),
+            retry_job: Some(Box::new(DeliveryJob {
+                app_id: "app-1".to_owned(),
+                publish_id: "publish-1".to_owned(),
+                provider: PushProviderKind::Fcm,
+                batch_id: "batch-1".to_owned(),
+                device_id: Some("device-1".to_owned()),
+                recipient: PushRecipient::Fcm {
+                    registration_token: SecretString::new("token-1").unwrap(),
+                },
+                payload: Arc::new(PushPayload {
+                    template_id: None,
+                    template_data: json!({}),
+                    title: Some("hello".to_owned()),
+                    body: Some("body".to_owned()),
+                    icon: None,
+                    sound: None,
+                    collapse_key: None,
+                }),
+                attempt: 1,
+                first_attempt_at_ms: Some(1_000),
+                not_before_ms: None,
+                expires_at_ms: None,
+            })),
+            first_attempt_at_ms: Some(1_000),
+            expires_at_ms: None,
+        }
     }
 }

--- a/crates/sockudo-push/src/lib.rs
+++ b/crates/sockudo-push/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pipeline;
 pub mod planner;
 pub mod ratelimit;
 pub mod registry;
+pub mod retry;
 pub mod rules;
 pub mod scheduler;
 #[cfg(any(feature = "postgres", feature = "mysql"))]
@@ -55,19 +56,21 @@ pub use dispatch::{
 pub use domain::{
     ChannelSubscription, DEFAULT_PUSH_FANOUT_FAST_THRESHOLD, DEFAULT_PUSH_FANOUT_PAGE_SIZE,
     DEFAULT_PUSH_FANOUT_SHARD_SIZE, DEFAULT_PUSH_PROVIDER_BATCH_SIZE,
-    DEFAULT_PUSH_STATUS_RETENTION_DAYS, DEVICE_IDENTITY_TOKEN_BYTES,
-    DEVICE_SECRET_PBKDF2_ITERATIONS, DeadLetter, DeleteDeviceOutcome, DeliveryBatch, DeliveryEvent,
-    DeliveryJob, DeliveryOutcome, DeliveryResult, DeviceDetails, DevicePushDetails,
-    DevicePushState, EncryptedSecret, FanoutConfig, FanoutRegime, FormFactor, MAX_APP_ID_BYTES,
-    MAX_CURSOR_BYTES, MAX_METADATA_BYTES, MAX_PROVIDER_OVERRIDE_BYTES, MAX_PUSH_BODY_BYTES,
-    MAX_PUSH_ICON_BYTES, MAX_PUSH_TARGETS, MAX_PUSH_TITLE_BYTES, MAX_RENDERED_TEMPLATE_BYTES,
-    MAX_TEMPLATE_DATA_BYTES, NotificationTemplate, Platform, ProviderCredential,
-    ProviderCredentialMaterial, ProviderError, ProviderOverridePayload, PublishCounters,
-    PublishIntent, PublishLifecycleState, PublishLogEvent, PublishStatus, PublishTarget,
-    PushCursor, PushCursorKind, PushDomainError, PushPayload, PushProviderKind, PushRecipient,
-    RetryScheduleEntry, SecretString, ShardJob, ShardJobStatus, TemplateContent, TokenBucketPolicy,
-    generate_device_identity_token, hash_device_identity_token, is_hashed_device_secret,
-    stable_hash, verify_device_identity_token,
+    DEFAULT_PUSH_RETRY_INITIAL_BACKOFF_MS, DEFAULT_PUSH_RETRY_JITTER_RATIO_PERCENT,
+    DEFAULT_PUSH_RETRY_MAX_AGE_MS, DEFAULT_PUSH_RETRY_MAX_ATTEMPTS,
+    DEFAULT_PUSH_RETRY_MAX_BACKOFF_MS, DEFAULT_PUSH_STATUS_RETENTION_DAYS,
+    DEVICE_IDENTITY_TOKEN_BYTES, DEVICE_SECRET_PBKDF2_ITERATIONS, DeadLetter, DeleteDeviceOutcome,
+    DeliveryBatch, DeliveryEvent, DeliveryFeedback, DeliveryJob, DeliveryOutcome, DeliveryResult,
+    DeviceDetails, DevicePushDetails, DevicePushState, EncryptedSecret, FanoutConfig, FanoutRegime,
+    FormFactor, MAX_APP_ID_BYTES, MAX_CURSOR_BYTES, MAX_METADATA_BYTES,
+    MAX_PROVIDER_OVERRIDE_BYTES, MAX_PUSH_BODY_BYTES, MAX_PUSH_ICON_BYTES, MAX_PUSH_TARGETS,
+    MAX_PUSH_TITLE_BYTES, MAX_RENDERED_TEMPLATE_BYTES, MAX_TEMPLATE_DATA_BYTES,
+    NotificationTemplate, Platform, ProviderCredential, ProviderCredentialMaterial, ProviderError,
+    ProviderOverridePayload, PublishCounters, PublishIntent, PublishLifecycleState,
+    PublishLogEvent, PublishStatus, PublishTarget, PushCursor, PushCursorKind, PushDomainError,
+    PushPayload, PushProviderKind, PushRecipient, RetryScheduleEntry, SecretString, ShardJob,
+    ShardJobStatus, TemplateContent, TokenBucketPolicy, generate_device_identity_token,
+    hash_device_identity_token, is_hashed_device_secret, stable_hash, verify_device_identity_token,
 };
 pub use feedback::{PushFeedbackProcessor, device_is_terminally_failed};
 pub use memory::MemoryPushStore;
@@ -93,6 +96,7 @@ pub use pipeline::{
     publish_uid_key,
 };
 pub use planner::{PushPlanner, PushShardWorker};
+pub use retry::{PushRetryScheduler, RetryPolicy};
 pub use rules::{
     ChannelPushRule, PushRuleError, PushRulePayloadMapping, any_rule_matches, matching_rule_indices,
 };

--- a/crates/sockudo-push/src/metrics.rs
+++ b/crates/sockudo-push/src/metrics.rs
@@ -79,6 +79,22 @@ pub const PUSH_METRIC_SPECS: &[PushMetricSpec] = &[
     PushMetricSpec::counter("sockudo_push_delivery_status_total", &["status", "app"]),
     PushMetricSpec::counter("sockudo_push_wfq_dispatched_total", &["provider", "app"]),
     PushMetricSpec::gauge("sockudo_push_wfq_starvation_seconds", &["provider", "app"]),
+    PushMetricSpec::counter("sockudo_push_retry_scheduled_total", &["provider", "app"]),
+    PushMetricSpec::counter("sockudo_push_retry_attempted_total", &["provider", "app"]),
+    PushMetricSpec::counter("sockudo_push_retry_deferred_total", &["provider", "app"]),
+    PushMetricSpec::gauge(
+        "sockudo_push_retry_deferred_delay_seconds",
+        &["provider", "app"],
+    ),
+    PushMetricSpec::counter("sockudo_push_retry_expired_total", &["provider", "app"]),
+    PushMetricSpec::counter(
+        "sockudo_push_retry_dead_lettered_total",
+        &["provider", "app"],
+    ),
+    PushMetricSpec::counter(
+        "sockudo_push_retry_malformed_total",
+        &["provider", "reason"],
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -465,6 +481,59 @@ impl PushMetrics {
         );
     }
 
+    pub fn retry_scheduled(&self, provider: PushProviderKind, app_id: &str) {
+        self.counter(
+            "sockudo_push_retry_scheduled_total",
+            &[("provider", provider_label(provider)), ("app", app_id)],
+            1,
+        );
+    }
+
+    pub fn retry_attempted(&self, provider: PushProviderKind, app_id: &str) {
+        self.counter(
+            "sockudo_push_retry_attempted_total",
+            &[("provider", provider_label(provider)), ("app", app_id)],
+            1,
+        );
+    }
+
+    pub fn retry_deferred(&self, provider: &str, app_id: &str, delay_ms: u64) {
+        self.counter(
+            "sockudo_push_retry_deferred_total",
+            &[("provider", provider), ("app", app_id)],
+            1,
+        );
+        self.gauge(
+            "sockudo_push_retry_deferred_delay_seconds",
+            &[("provider", provider), ("app", app_id)],
+            delay_ms as f64 / 1000.0,
+        );
+    }
+
+    pub fn retry_expired(&self, provider: &str, app_id: &str) {
+        self.counter(
+            "sockudo_push_retry_expired_total",
+            &[("provider", provider), ("app", app_id)],
+            1,
+        );
+    }
+
+    pub fn retry_dead_lettered(&self, provider: &str, app_id: &str) {
+        self.counter(
+            "sockudo_push_retry_dead_lettered_total",
+            &[("provider", provider), ("app", app_id)],
+            1,
+        );
+    }
+
+    pub fn retry_malformed(&self, provider: &str, reason: &str) {
+        self.counter(
+            "sockudo_push_retry_malformed_total",
+            &[("provider", provider), ("reason", reason)],
+            1,
+        );
+    }
+
     pub fn delivery_result(&self, provider: PushProviderKind, app_id: &str, outcome: &str) {
         self.counter(
             "sockudo_push_dispatched_total",
@@ -622,6 +691,13 @@ mod tests {
             "sockudo_push_delivery_status_total",
             "sockudo_push_wfq_dispatched_total",
             "sockudo_push_wfq_starvation_seconds",
+            "sockudo_push_retry_scheduled_total",
+            "sockudo_push_retry_attempted_total",
+            "sockudo_push_retry_deferred_total",
+            "sockudo_push_retry_deferred_delay_seconds",
+            "sockudo_push_retry_expired_total",
+            "sockudo_push_retry_dead_lettered_total",
+            "sockudo_push_retry_malformed_total",
         ];
 
         for name in required {

--- a/crates/sockudo-push/src/pipeline.rs
+++ b/crates/sockudo-push/src/pipeline.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::domain::{
-    DeadLetter, DeliveryBatch, DeliveryResult, FanoutConfig, FanoutRegime, PublishCounters,
-    PublishIntent, PublishLifecycleState, PublishLogEvent, PublishStatus, PushDomainError,
-    RetryScheduleEntry, provider_key, stable_hash,
+    DeadLetter, DeliveryBatch, DeliveryFeedback, DeliveryResult, FanoutConfig, FanoutRegime,
+    PublishCounters, PublishIntent, PublishLifecycleState, PublishLogEvent, PublishStatus,
+    PushDomainError, RetryScheduleEntry, provider_key, stable_hash,
 };
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::PushMetrics;
@@ -38,6 +38,7 @@ pub enum PushQueuePayload {
     ShardJob(Box<crate::domain::ShardJob>),
     DeliveryBatch(Box<DeliveryBatch>),
     DeliveryResult(Box<DeliveryResult>),
+    DeliveryFeedback(Box<DeliveryFeedback>),
     DeadLetter(Box<DeadLetter>),
     RetrySchedule(Box<RetryScheduleEntry>),
 }
@@ -214,6 +215,9 @@ fn partition_key_for_payload(stage: PushQueueStage, payload: &PushQueuePayload) 
         (PushQueueStage::DeliveryResults, PushQueuePayload::DeliveryResult(result)) => {
             result.app_id.clone()
         }
+        (PushQueueStage::DeliveryResults, PushQueuePayload::DeliveryFeedback(feedback)) => {
+            feedback.result.app_id.clone()
+        }
         (PushQueueStage::RetrySchedule, PushQueuePayload::RetrySchedule(entry)) => {
             entry.app_id.clone()
         }
@@ -230,6 +234,7 @@ fn payload_app_id(payload: &PushQueuePayload) -> Option<String> {
         PushQueuePayload::ShardJob(job) => Some(job.app_id.clone()),
         PushQueuePayload::DeliveryBatch(batch) => Some(batch.app_id.clone()),
         PushQueuePayload::DeliveryResult(result) => Some(result.app_id.clone()),
+        PushQueuePayload::DeliveryFeedback(feedback) => Some(feedback.result.app_id.clone()),
         PushQueuePayload::DeadLetter(dead_letter) => Some(dead_letter.app_id.clone()),
         PushQueuePayload::RetrySchedule(entry) => Some(entry.app_id.clone()),
     }
@@ -603,6 +608,10 @@ fn dead_letter_from_message(
         PushQueuePayload::DeliveryResult(result) => {
             (result.app_id.clone(), result.publish_id.clone())
         }
+        PushQueuePayload::DeliveryFeedback(feedback) => (
+            feedback.result.app_id.clone(),
+            feedback.result.publish_id.clone(),
+        ),
         PushQueuePayload::DeadLetter(dead_letter) => {
             (dead_letter.app_id.clone(), dead_letter.publish_id.clone())
         }
@@ -755,6 +764,9 @@ impl PushPipeline {
                 succeeded: 0,
                 failed: 0,
                 expired: 0,
+                retry_scheduled: 0,
+                retry_attempted: 0,
+                dead_lettered: 0,
             },
             fanout_regime: Some(fanout_regime),
             retry_after_ms: None,
@@ -956,7 +968,7 @@ mod tests {
 
     use sonic_rs::json;
 
-    use crate::dispatch::{AcceptAllDispatcher, ProviderDispatchWorker};
+    use crate::dispatch::{AcceptAllDispatcher, ProviderDispatchWorker, RetryAfterDispatcher};
     use crate::domain::{
         ChannelSubscription, DeviceDetails, DevicePushDetails, DevicePushState, FanoutConfig,
         FormFactor, Platform, PublishIntent, PublishLifecycleState, PublishTarget, PushPayload,
@@ -965,6 +977,7 @@ mod tests {
     use crate::feedback::PushFeedbackProcessor;
     use crate::memory::MemoryPushStore;
     use crate::planner::{PushPlanner, PushShardWorker};
+    use crate::retry::{PushRetryScheduler, RetryPolicy};
     use crate::storage::{PushDeviceStore, PushPublishStatusStore, PushSubscriptionStore};
 
     use super::*;
@@ -1279,6 +1292,183 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(device.push.state, DevicePushState::Active);
+    }
+
+    #[tokio::test]
+    async fn retryable_once_then_accepted_completes_publish() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store
+            .upsert_device(sample_device("device-1"))
+            .await
+            .unwrap();
+        let pipeline = PushPipeline::new(store.clone(), queue.clone(), FanoutConfig::default());
+        pipeline
+            .accept_publish(
+                PushAcceptRequest {
+                    intent: sample_intent(vec![PublishTarget::Device {
+                        device_id: "device-1".to_owned(),
+                    }]),
+                    expected_recipients: 1,
+                },
+                10,
+            )
+            .await
+            .unwrap();
+        PushPlanner::new(store.clone(), queue.clone(), FanoutConfig::default())
+            .run_once("planner")
+            .await
+            .unwrap();
+
+        let retry_dispatcher = Arc::new(RetryAfterDispatcher::new(PushProviderKind::Fcm, now_ms()));
+        let mut retry_worker =
+            ProviderDispatchWorker::new(PushProviderKind::Fcm, queue.clone(), retry_dispatcher);
+        assert_eq!(retry_worker.run_once("fcm").await.unwrap(), 1);
+        let feedback = PushFeedbackProcessor::new(store.clone(), queue.clone()).with_retry_policy(
+            RetryPolicy {
+                jitter_ratio_percent: 0,
+                ..RetryPolicy::default()
+            },
+        );
+        assert_eq!(feedback.run_once("feedback").await.unwrap(), 1);
+        assert_eq!(
+            store
+                .get_publish_status("app-1", "publish-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            PublishLifecycleState::Dispatching
+        );
+
+        let retry_scheduler = PushRetryScheduler::new(store.clone(), queue.clone(), "node-a");
+        assert_eq!(retry_scheduler.run_once("retry").await.unwrap(), 1);
+        let accept_dispatcher = Arc::new(AcceptAllDispatcher::new(PushProviderKind::Fcm));
+        let mut accept_worker =
+            ProviderDispatchWorker::new(PushProviderKind::Fcm, queue.clone(), accept_dispatcher);
+        assert_eq!(accept_worker.run_once("fcm").await.unwrap(), 1);
+        assert_eq!(feedback.run_once("feedback").await.unwrap(), 1);
+
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.counters.dispatched, 1);
+        assert_eq!(status.counters.retry_scheduled, 1);
+        assert_eq!(status.counters.retry_attempted, 1);
+        assert_eq!(status.counters.succeeded, 1);
+        assert_eq!(status.state, PublishLifecycleState::Succeeded);
+    }
+
+    #[tokio::test]
+    async fn retryable_until_attempts_exhausted_dead_letters_publish() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store
+            .upsert_device(sample_device("device-1"))
+            .await
+            .unwrap();
+        let pipeline = PushPipeline::new(store.clone(), queue.clone(), FanoutConfig::default());
+        pipeline
+            .accept_publish(
+                PushAcceptRequest {
+                    intent: sample_intent(vec![PublishTarget::Device {
+                        device_id: "device-1".to_owned(),
+                    }]),
+                    expected_recipients: 1,
+                },
+                10,
+            )
+            .await
+            .unwrap();
+        PushPlanner::new(store.clone(), queue.clone(), FanoutConfig::default())
+            .run_once("planner")
+            .await
+            .unwrap();
+
+        let policy = RetryPolicy {
+            max_attempts: 2,
+            jitter_ratio_percent: 0,
+            ..RetryPolicy::default()
+        };
+        let feedback = PushFeedbackProcessor::new(store.clone(), queue.clone())
+            .with_retry_policy(policy.clone());
+        let dispatcher = Arc::new(RetryAfterDispatcher::new(PushProviderKind::Fcm, now_ms()));
+        let mut worker =
+            ProviderDispatchWorker::new(PushProviderKind::Fcm, queue.clone(), dispatcher);
+        assert_eq!(worker.run_once("fcm").await.unwrap(), 1);
+        assert_eq!(feedback.run_once("feedback").await.unwrap(), 1);
+
+        let retry_scheduler = PushRetryScheduler::new(store.clone(), queue.clone(), "node-a");
+        assert_eq!(retry_scheduler.run_once("retry").await.unwrap(), 1);
+        let dispatcher = Arc::new(RetryAfterDispatcher::new(PushProviderKind::Fcm, now_ms()));
+        let mut worker =
+            ProviderDispatchWorker::new(PushProviderKind::Fcm, queue.clone(), dispatcher);
+        assert_eq!(worker.run_once("fcm").await.unwrap(), 1);
+        assert_eq!(feedback.run_once("feedback").await.unwrap(), 1);
+        assert_eq!(retry_scheduler.run_once("retry").await.unwrap(), 1);
+
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.counters.dead_lettered, 1);
+        assert_eq!(status.state, PublishLifecycleState::DeadLettered);
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::DeadLetters)
+                .await
+                .unwrap()
+                .ready_depth,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_expiry_before_retry_marks_publish_expired() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store
+            .upsert_device(sample_device("device-1"))
+            .await
+            .unwrap();
+        let pipeline = PushPipeline::new(store.clone(), queue.clone(), FanoutConfig::default());
+        let mut intent = sample_intent(vec![PublishTarget::Device {
+            device_id: "device-1".to_owned(),
+        }]);
+        intent.expires_at_ms = Some(11);
+        pipeline
+            .accept_publish(
+                PushAcceptRequest {
+                    intent,
+                    expected_recipients: 1,
+                },
+                10,
+            )
+            .await
+            .unwrap();
+        PushPlanner::new(store.clone(), queue.clone(), FanoutConfig::default())
+            .run_once("planner")
+            .await
+            .unwrap();
+        let dispatcher = Arc::new(RetryAfterDispatcher::new(PushProviderKind::Fcm, now_ms()));
+        let mut worker =
+            ProviderDispatchWorker::new(PushProviderKind::Fcm, queue.clone(), dispatcher);
+        assert_eq!(worker.run_once("fcm").await.unwrap(), 1);
+        let feedback = PushFeedbackProcessor::new(store.clone(), queue.clone());
+        assert_eq!(feedback.run_once("feedback").await.unwrap(), 1);
+
+        let retry_scheduler = PushRetryScheduler::new(store.clone(), queue.clone(), "node-a");
+        assert_eq!(retry_scheduler.run_once("retry").await.unwrap(), 1);
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.counters.expired, 1);
+        assert_eq!(status.state, PublishLifecycleState::Expired);
     }
 
     fn sample_intent(targets: Vec<PublishTarget>) -> PublishIntent {

--- a/crates/sockudo-push/src/planner.rs
+++ b/crates/sockudo-push/src/planner.rs
@@ -96,6 +96,7 @@ impl PushPlanner {
             event.publish_id.clone(),
             "fast".to_owned(),
             self.config.provider_batch_size,
+            event.intent.expires_at_ms,
             self.metrics.clone(),
         );
         let payload = Arc::new(event.intent.payload.clone());
@@ -122,6 +123,7 @@ impl PushPlanner {
                         shard_id: dedupe_key(format!("shard-{index}"), &mut ids),
                         target: target.clone(),
                         payload: event.intent.payload.clone(),
+                        expires_at_ms: event.intent.expires_at_ms,
                         cursor: None,
                         page_size: self.config.page_size,
                         shard_size: self.config.shard_size,
@@ -144,6 +146,7 @@ impl PushPlanner {
                         event.publish_id.clone(),
                         format!("direct-{index}"),
                         self.config.provider_batch_size,
+                        event.intent.expires_at_ms,
                         self.metrics.clone(),
                     );
                     self.stream_target(
@@ -252,8 +255,9 @@ impl PushPlanner {
                             recipient: recipient.clone(),
                             payload: Arc::clone(&payload),
                             attempt: 1,
+                            first_attempt_at_ms: None,
                             not_before_ms: None,
-                            expires_at_ms: None,
+                            expires_at_ms: batcher.expires_at_ms,
                         },
                         &self.queue,
                     )
@@ -329,6 +333,7 @@ impl PushShardWorker {
             shard.publish_id.clone(),
             shard.shard_id.clone(),
             self.config.provider_batch_size,
+            shard.expires_at_ms,
             self.metrics.clone(),
         );
         let next_cursor = self.stream_shard(&shard, &mut batcher).await?;
@@ -434,6 +439,7 @@ struct ProviderBatcher {
     publish_id: String,
     batch_prefix: String,
     max_batch_size: usize,
+    expires_at_ms: Option<u64>,
     batches: BTreeMap<PushProviderKind, Vec<DeliveryJob>>,
     batch_indexes: BTreeMap<PushProviderKind, u64>,
     emitted_recipients: u64,
@@ -447,6 +453,7 @@ impl ProviderBatcher {
         publish_id: String,
         batch_prefix: String,
         max_batch_size: usize,
+        expires_at_ms: Option<u64>,
         metrics: PushMetrics,
     ) -> Self {
         Self {
@@ -454,6 +461,7 @@ impl ProviderBatcher {
             publish_id,
             batch_prefix,
             max_batch_size,
+            expires_at_ms,
             batches: BTreeMap::new(),
             batch_indexes: BTreeMap::new(),
             emitted_recipients: 0,
@@ -480,8 +488,9 @@ impl ProviderBatcher {
                 recipient: device.push.recipient,
                 payload,
                 attempt: 1,
+                first_attempt_at_ms: None,
                 not_before_ms: None,
-                expires_at_ms: None,
+                expires_at_ms: self.expires_at_ms,
             },
             queue,
         )

--- a/crates/sockudo-push/src/retry.rs
+++ b/crates/sockudo-push/src/retry.rs
@@ -1,0 +1,1035 @@
+use crate::domain::{
+    DEFAULT_PUSH_RETRY_INITIAL_BACKOFF_MS, DEFAULT_PUSH_RETRY_JITTER_RATIO_PERCENT,
+    DEFAULT_PUSH_RETRY_MAX_AGE_MS, DEFAULT_PUSH_RETRY_MAX_ATTEMPTS,
+    DEFAULT_PUSH_RETRY_MAX_BACKOFF_MS, DeadLetter, DeliveryBatch, DeliveryFeedback, DeliveryJob,
+    DeliveryOutcome, ProviderError, PublishLifecycleState, PublishStatus, PushProviderKind,
+    RetryScheduleEntry, provider_key, stable_hash,
+};
+use crate::meta::{PushMetaEvent, emit_push_meta_event};
+use crate::metrics::PushMetrics;
+use crate::pipeline::{PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage, now_ms};
+use crate::storage::{DynPushStore, IdempotencyRecord, SchedulerLock};
+
+const MAX_RETRY_ATTEMPTS: u32 = 100;
+const MAX_RETRY_BACKOFF_MS: u64 = 24 * 60 * 60 * 1000;
+const MAX_RETRY_AGE_MS: u64 = 30 * 24 * 60 * 60 * 1000;
+const RETRY_IDEMPOTENCY_TTL_MS: u64 = 7 * 24 * 60 * 60 * 1000;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RetryPolicy {
+    pub initial_backoff_ms: u64,
+    pub max_backoff_ms: u64,
+    pub max_attempts: u32,
+    pub max_retry_age_ms: u64,
+    pub jitter_ratio_percent: u8,
+    pub respect_retry_after: bool,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            initial_backoff_ms: DEFAULT_PUSH_RETRY_INITIAL_BACKOFF_MS,
+            max_backoff_ms: DEFAULT_PUSH_RETRY_MAX_BACKOFF_MS,
+            max_attempts: DEFAULT_PUSH_RETRY_MAX_ATTEMPTS,
+            max_retry_age_ms: DEFAULT_PUSH_RETRY_MAX_AGE_MS,
+            jitter_ratio_percent: DEFAULT_PUSH_RETRY_JITTER_RATIO_PERCENT,
+            respect_retry_after: true,
+        }
+    }
+}
+
+impl RetryPolicy {
+    pub fn bounded(mut self) -> Self {
+        self.max_attempts = self.max_attempts.clamp(1, MAX_RETRY_ATTEMPTS);
+        self.initial_backoff_ms = self.initial_backoff_ms.clamp(1, MAX_RETRY_BACKOFF_MS);
+        self.max_backoff_ms = self
+            .max_backoff_ms
+            .clamp(self.initial_backoff_ms, MAX_RETRY_BACKOFF_MS);
+        self.max_retry_age_ms = self.max_retry_age_ms.clamp(1, MAX_RETRY_AGE_MS);
+        self.jitter_ratio_percent = self.jitter_ratio_percent.min(100);
+        self
+    }
+
+    pub fn schedule_retry(
+        &self,
+        feedback: &DeliveryFeedback,
+        now_ms: u64,
+    ) -> Option<RetryScheduleEntry> {
+        if !matches!(feedback.result.outcome, DeliveryOutcome::Retryable) {
+            return None;
+        }
+        let policy = self.clone().bounded();
+        let mut job = feedback.retry_job.as_deref()?.clone();
+        let next_attempt = feedback.result.attempt.saturating_add(1);
+        let first_attempt_at_ms = feedback
+            .first_attempt_at_ms
+            .or(job.first_attempt_at_ms)
+            .unwrap_or(now_ms);
+        let retry_age_deadline = first_attempt_at_ms.saturating_add(policy.max_retry_age_ms);
+        let delivery_deadline = job.expires_at_ms.unwrap_or(u64::MAX);
+        let expires_at_ms = retry_age_deadline.min(delivery_deadline);
+        let retry_idempotency_key =
+            retry_idempotency_key(&feedback.result, &feedback.delivery_key, next_attempt);
+        let next_attempt_at_ms = if next_attempt > policy.max_attempts {
+            now_ms
+        } else {
+            policy.next_attempt_at_ms(
+                feedback.result.attempt,
+                feedback
+                    .result
+                    .error
+                    .as_ref()
+                    .and_then(|error| error.retry_after_ms),
+                now_ms,
+                &retry_idempotency_key,
+            )
+        }
+        .min(expires_at_ms);
+
+        job.attempt = next_attempt;
+        job.first_attempt_at_ms = Some(first_attempt_at_ms);
+        job.not_before_ms = Some(next_attempt_at_ms);
+
+        Some(RetryScheduleEntry {
+            app_id: feedback.result.app_id.clone(),
+            publish_id: feedback.result.publish_id.clone(),
+            provider: Some(feedback.result.provider),
+            job: Some(Box::new(job)),
+            attempt: next_attempt,
+            first_attempt_at_ms,
+            next_attempt_at_ms,
+            max_attempts: policy.max_attempts,
+            expires_at_ms,
+            last_error: feedback.result.error.clone(),
+            retry_idempotency_key: retry_idempotency_key.clone(),
+            stage: "delivery".to_owned(),
+            key: retry_idempotency_key,
+            not_before_ms: Some(next_attempt_at_ms),
+            payload: None,
+        })
+    }
+
+    pub fn next_attempt_at_ms(
+        &self,
+        current_attempt: u32,
+        provider_retry_after_ms: Option<u64>,
+        now_ms: u64,
+        jitter_seed: &str,
+    ) -> u64 {
+        let policy = self.clone().bounded();
+        if policy.respect_retry_after
+            && let Some(retry_after_ms) = provider_retry_after_ms
+        {
+            return retry_after_ms.max(now_ms);
+        }
+
+        let exponent = current_attempt.saturating_sub(1).min(31);
+        let multiplier = 1_u64.checked_shl(exponent).unwrap_or(u64::MAX);
+        let delay = policy
+            .initial_backoff_ms
+            .saturating_mul(multiplier)
+            .min(policy.max_backoff_ms);
+        let jittered =
+            apply_deterministic_jitter(delay, policy.jitter_ratio_percent, jitter_seed.as_bytes())
+                .min(policy.max_backoff_ms);
+        now_ms.saturating_add(jittered)
+    }
+}
+
+#[derive(Clone)]
+pub struct PushRetryScheduler {
+    store: DynPushStore,
+    queue: crate::pipeline::DynPushQueue,
+    owner_id: String,
+    lock_ttl_ms: u64,
+    max_messages_per_tick: usize,
+    metrics: PushMetrics,
+}
+
+impl PushRetryScheduler {
+    pub fn new(
+        store: DynPushStore,
+        queue: crate::pipeline::DynPushQueue,
+        owner_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            store,
+            queue,
+            owner_id: owner_id.into(),
+            lock_ttl_ms: 30_000,
+            max_messages_per_tick: 64,
+            metrics: PushMetrics::default(),
+        }
+    }
+
+    pub fn with_metrics(mut self, metrics: PushMetrics) -> Self {
+        self.metrics = metrics;
+        self
+    }
+
+    pub fn with_lock_ttl_ms(mut self, lock_ttl_ms: u64) -> Self {
+        self.lock_ttl_ms = lock_ttl_ms.max(1);
+        self
+    }
+
+    pub fn with_max_messages_per_tick(mut self, max_messages_per_tick: usize) -> Self {
+        self.max_messages_per_tick = max_messages_per_tick.max(1);
+        self
+    }
+
+    pub async fn run_once(&self, consumer_group: &str) -> PushPipelineResult<usize> {
+        let messages = self
+            .queue
+            .consume(
+                PushQueueStage::RetrySchedule,
+                consumer_group,
+                self.max_messages_per_tick,
+                30_000,
+            )
+            .await?;
+        let mut processed = 0;
+        for message in messages {
+            if self.handle_message(message).await? {
+                processed += 1;
+            }
+        }
+        Ok(processed)
+    }
+
+    async fn handle_message(&self, message: QueueMessage) -> PushPipelineResult<bool> {
+        let PushQueuePayload::RetrySchedule(entry) = message.payload.clone() else {
+            self.queue
+                .dead_letter(
+                    message.ack,
+                    "unexpected payload for retry scheduler".to_owned(),
+                )
+                .await?;
+            self.metrics
+                .retry_malformed("unknown", "unexpected_payload");
+            return Ok(false);
+        };
+        let mut entry = *entry;
+        normalize_retry_entry(&mut entry);
+        let now = now_ms();
+        let Some(provider) = entry.provider else {
+            return self
+                .dead_letter_malformed(message, &entry, "missing retry provider")
+                .await
+                .map(|_| false);
+        };
+        let Some(job) = entry.job.as_deref().cloned() else {
+            return self
+                .dead_letter_malformed(message, &entry, "missing retry job")
+                .await
+                .map(|_| false);
+        };
+        if entry.retry_idempotency_key.trim().is_empty() {
+            return self
+                .dead_letter_malformed(message, &entry, "missing retry idempotency key")
+                .await
+                .map(|_| false);
+        }
+        if entry.next_attempt_at_ms > now {
+            self.metrics.retry_deferred(
+                provider_for_metrics(entry.provider),
+                &entry.app_id,
+                entry.next_attempt_at_ms.saturating_sub(now),
+            );
+            self.queue
+                .nack(message.ack, Some(entry.next_attempt_at_ms))
+                .await?;
+            return Ok(false);
+        }
+
+        if self.retry_already_completed(&entry).await? {
+            self.queue.ack(message.ack).await?;
+            return Ok(false);
+        }
+
+        let lock_key = retry_lock_key(&entry.retry_idempotency_key);
+        let lock_acquired = self
+            .store
+            .acquire_scheduler_lock(
+                SchedulerLock {
+                    app_id: entry.app_id.clone(),
+                    publish_id: lock_key.clone(),
+                    owner_id: self.owner_id.clone(),
+                    expires_at_ms: now.saturating_add(self.lock_ttl_ms),
+                },
+                now,
+            )
+            .await?;
+        if !lock_acquired {
+            self.queue
+                .nack(message.ack, Some(now.saturating_add(1_000)))
+                .await?;
+            return Ok(false);
+        }
+
+        let app_id = entry.app_id.clone();
+        let result = self
+            .handle_locked_retry(message, entry, provider, job, now)
+            .await;
+        let release = self
+            .store
+            .release_scheduler_lock(&app_id, &lock_key, &self.owner_id)
+            .await;
+        result?;
+        release?;
+        Ok(true)
+    }
+
+    async fn handle_locked_retry(
+        &self,
+        message: QueueMessage,
+        entry: RetryScheduleEntry,
+        provider: PushProviderKind,
+        job: DeliveryJob,
+        now: u64,
+    ) -> PushPipelineResult<()> {
+        if job
+            .expires_at_ms
+            .is_some_and(|expires_at_ms| expires_at_ms <= now)
+        {
+            self.complete_terminal_retry(
+                message,
+                &entry,
+                RetryTerminalKind::Expired,
+                "delivery expired before retry",
+            )
+            .await?;
+            return Ok(());
+        }
+        if entry.attempt > entry.max_attempts || entry.max_attempts == 0 {
+            self.complete_terminal_retry(
+                message,
+                &entry,
+                RetryTerminalKind::DeadLettered,
+                "retry attempts exhausted",
+            )
+            .await?;
+            return Ok(());
+        }
+        if entry.expires_at_ms <= now {
+            self.complete_terminal_retry(
+                message,
+                &entry,
+                RetryTerminalKind::DeadLettered,
+                "retry age expired",
+            )
+            .await?;
+            return Ok(());
+        }
+
+        let mut retry_job = job;
+        retry_job.app_id = entry.app_id.clone();
+        retry_job.publish_id = entry.publish_id.clone();
+        retry_job.provider = provider;
+        retry_job.attempt = entry.attempt;
+        retry_job.first_attempt_at_ms = Some(entry.first_attempt_at_ms);
+        retry_job.not_before_ms = Some(entry.next_attempt_at_ms);
+        retry_job.batch_id = format!("{}-retry-{}", retry_job.batch_id, entry.attempt);
+        let batch = DeliveryBatch {
+            app_id: entry.app_id.clone(),
+            publish_id: entry.publish_id.clone(),
+            provider,
+            batch_id: retry_job.batch_id.clone(),
+            jobs: vec![retry_job],
+        };
+        self.queue
+            .produce(
+                PushQueueStage::DeliveryJobs(provider),
+                batch.queue_key(),
+                PushQueuePayload::DeliveryBatch(Box::new(batch)),
+            )
+            .await?;
+        self.mark_retry_attempted(&entry).await?;
+        self.put_retry_idempotency(&entry).await?;
+        self.metrics.retry_attempted(provider, &entry.app_id);
+        emit_push_meta_event(PushMetaEvent::scheduler_event(
+            &entry.app_id,
+            &entry.publish_id,
+            "retry-dispatched",
+        ));
+        self.queue.ack(message.ack).await?;
+        Ok(())
+    }
+
+    async fn dead_letter_malformed(
+        &self,
+        message: QueueMessage,
+        entry: &RetryScheduleEntry,
+        reason: &'static str,
+    ) -> PushPipelineResult<()> {
+        self.metrics
+            .retry_malformed(provider_for_metrics(entry.provider), reason);
+        self.mark_terminal_status(entry, RetryTerminalKind::DeadLettered, reason)
+            .await?;
+        self.queue
+            .dead_letter(message.ack, reason.to_owned())
+            .await?;
+        emit_push_meta_event(PushMetaEvent::dead_letter(
+            &entry.app_id,
+            &entry.publish_id,
+            "retry_schedule",
+            reason,
+        ));
+        Ok(())
+    }
+
+    async fn complete_terminal_retry(
+        &self,
+        message: QueueMessage,
+        entry: &RetryScheduleEntry,
+        kind: RetryTerminalKind,
+        reason: &'static str,
+    ) -> PushPipelineResult<()> {
+        self.mark_terminal_status(entry, kind, reason).await?;
+        let dead_letter = DeadLetter {
+            app_id: entry.app_id.clone(),
+            publish_id: entry.publish_id.clone(),
+            stage: "retry_schedule".to_owned(),
+            key: entry.retry_idempotency_key.clone(),
+            reason: reason.to_owned(),
+            occurred_at_ms: now_ms(),
+        };
+        self.queue
+            .produce(
+                PushQueueStage::DeadLetters,
+                dead_letter.key.clone(),
+                PushQueuePayload::DeadLetter(Box::new(dead_letter)),
+            )
+            .await?;
+        self.put_retry_idempotency(entry).await?;
+        match kind {
+            RetryTerminalKind::Expired => {
+                self.metrics
+                    .retry_expired(provider_for_metrics(entry.provider), &entry.app_id);
+            }
+            RetryTerminalKind::DeadLettered => {
+                self.metrics
+                    .retry_dead_lettered(provider_for_metrics(entry.provider), &entry.app_id);
+            }
+        }
+        emit_push_meta_event(PushMetaEvent::dead_letter(
+            &entry.app_id,
+            &entry.publish_id,
+            "retry_schedule",
+            reason,
+        ));
+        self.queue.ack(message.ack).await?;
+        Ok(())
+    }
+
+    async fn mark_retry_attempted(&self, entry: &RetryScheduleEntry) -> PushPipelineResult<()> {
+        if let Some(mut status) = self
+            .store
+            .get_publish_status(&entry.app_id, &entry.publish_id)
+            .await?
+        {
+            status.counters.retry_attempted = status.counters.retry_attempted.saturating_add(1);
+            status.state = PublishLifecycleState::Dispatching;
+            status.retry_after_ms = None;
+            self.store.put_publish_status(status).await?;
+        }
+        Ok(())
+    }
+
+    async fn mark_terminal_status(
+        &self,
+        entry: &RetryScheduleEntry,
+        kind: RetryTerminalKind,
+        reason: &str,
+    ) -> PushPipelineResult<()> {
+        let Some(mut status) = self
+            .store
+            .get_publish_status(&entry.app_id, &entry.publish_id)
+            .await?
+        else {
+            return Ok(());
+        };
+
+        match kind {
+            RetryTerminalKind::Expired => {
+                status.counters.expired = status.counters.expired.saturating_add(1);
+            }
+            RetryTerminalKind::DeadLettered => {
+                status.counters.dead_lettered = status.counters.dead_lettered.saturating_add(1);
+            }
+        }
+        status.error_reason = Some(redact_retry_reason(reason, entry.last_error.as_ref()));
+        status.state = retry_terminal_state(&status);
+        self.store.put_publish_status(status).await?;
+        Ok(())
+    }
+
+    async fn retry_already_completed(
+        &self,
+        entry: &RetryScheduleEntry,
+    ) -> PushPipelineResult<bool> {
+        Ok(self
+            .store
+            .get_idempotency_record(&entry.app_id, &entry.retry_idempotency_key)
+            .await?
+            .is_some())
+    }
+
+    async fn put_retry_idempotency(&self, entry: &RetryScheduleEntry) -> PushPipelineResult<()> {
+        self.store
+            .put_idempotency_record_if_absent(IdempotencyRecord {
+                app_id: entry.app_id.clone(),
+                key: entry.retry_idempotency_key.clone(),
+                publish_id: entry.publish_id.clone(),
+                expires_at_ms: now_ms().saturating_add(RETRY_IDEMPOTENCY_TTL_MS),
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RetryTerminalKind {
+    Expired,
+    DeadLettered,
+}
+
+fn retry_terminal_state(status: &PublishStatus) -> PublishLifecycleState {
+    let terminal = status
+        .counters
+        .succeeded
+        .saturating_add(status.counters.failed)
+        .saturating_add(status.counters.expired)
+        .saturating_add(status.counters.dead_lettered);
+    if status.counters.planned == 0 || terminal < status.counters.planned {
+        return status.state;
+    }
+    if status.counters.failed == 0
+        && status.counters.expired == 0
+        && status.counters.dead_lettered == 0
+    {
+        PublishLifecycleState::Succeeded
+    } else if status.counters.succeeded > 0 {
+        PublishLifecycleState::PartiallySucceeded
+    } else if status.counters.expired > 0 {
+        PublishLifecycleState::Expired
+    } else if status.counters.dead_lettered > 0 {
+        PublishLifecycleState::DeadLettered
+    } else {
+        PublishLifecycleState::Failed
+    }
+}
+
+fn normalize_retry_entry(entry: &mut RetryScheduleEntry) {
+    if entry.next_attempt_at_ms == 0 {
+        entry.next_attempt_at_ms = entry.not_before_ms.unwrap_or_else(now_ms);
+    }
+    if entry.retry_idempotency_key.trim().is_empty() && !entry.key.trim().is_empty() {
+        entry.retry_idempotency_key = entry.key.clone();
+    }
+    if entry.expires_at_ms == 0 {
+        entry.expires_at_ms = entry
+            .job
+            .as_ref()
+            .and_then(|job| job.expires_at_ms)
+            .unwrap_or(u64::MAX);
+    }
+    if entry.first_attempt_at_ms == 0 {
+        entry.first_attempt_at_ms = entry
+            .job
+            .as_ref()
+            .and_then(|job| job.first_attempt_at_ms)
+            .unwrap_or_else(now_ms);
+    }
+    if entry.max_attempts == 0 {
+        entry.max_attempts = DEFAULT_PUSH_RETRY_MAX_ATTEMPTS;
+    }
+}
+
+fn retry_idempotency_key(
+    result: &crate::domain::DeliveryResult,
+    delivery_key: &str,
+    next_attempt: u32,
+) -> String {
+    format!(
+        "retry:{}",
+        stable_hash(
+            format!(
+                "{}:{}:{}:{}:{}:{}",
+                result.app_id,
+                result.publish_id,
+                provider_key(result.provider),
+                result.batch_id,
+                delivery_key,
+                next_attempt
+            )
+            .as_bytes()
+        )
+    )
+}
+
+fn retry_lock_key(retry_idempotency_key: &str) -> String {
+    format!("retry-lock:{retry_idempotency_key}")
+}
+
+fn apply_deterministic_jitter(delay_ms: u64, ratio_percent: u8, seed: &[u8]) -> u64 {
+    if delay_ms == 0 || ratio_percent == 0 {
+        return delay_ms;
+    }
+    let spread = delay_ms.saturating_mul(u64::from(ratio_percent)) / 100;
+    if spread == 0 {
+        return delay_ms;
+    }
+    let hash = stable_hash(seed);
+    let prefix = hash.get(..16).unwrap_or(&hash);
+    let raw = u64::from_str_radix(prefix, 16).unwrap_or(0);
+    let range = spread.saturating_mul(2).saturating_add(1);
+    delay_ms.saturating_sub(spread).saturating_add(raw % range)
+}
+
+fn provider_for_metrics(provider: Option<PushProviderKind>) -> &'static str {
+    provider.map(provider_key).unwrap_or("unknown")
+}
+
+fn redact_retry_reason(reason: &str, last_error: Option<&ProviderError>) -> String {
+    last_error
+        .map(|error| format!("{reason}: {}", error.class))
+        .unwrap_or_else(|| reason.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use sonic_rs::json;
+
+    use crate::domain::{
+        DeliveryOutcome, DeliveryResult, PushPayload, PushProviderKind, PushRecipient, SecretString,
+    };
+    use crate::memory::MemoryPushStore;
+    use crate::pipeline::{MemoryPushQueue, PushQueue, PushQueueError, QueueAckToken};
+    use crate::storage::PushPublishStatusStore;
+
+    use super::*;
+
+    #[test]
+    fn retry_after_wins_over_exponential_backoff() {
+        let policy = RetryPolicy::default();
+        assert_eq!(
+            policy.next_attempt_at_ms(1, Some(10_000), 1_000, "seed"),
+            10_000
+        );
+    }
+
+    #[test]
+    fn deterministic_jitter_stays_inside_ratio() {
+        let policy = RetryPolicy {
+            jitter_ratio_percent: 20,
+            ..RetryPolicy::default()
+        };
+        let next = policy.next_attempt_at_ms(1, None, 1_000, "seed");
+        assert!((1_800..=2_000).contains(&next));
+    }
+
+    #[test]
+    fn max_backoff_clamps_exponential_growth() {
+        let policy = RetryPolicy {
+            initial_backoff_ms: 1_000,
+            max_backoff_ms: 5_000,
+            jitter_ratio_percent: 0,
+            ..RetryPolicy::default()
+        };
+        assert_eq!(policy.next_attempt_at_ms(10, None, 1_000, "seed"), 6_000);
+    }
+
+    #[test]
+    fn overflow_safe_timestamp_math_saturates() {
+        let policy = RetryPolicy {
+            initial_backoff_ms: u64::MAX / 2,
+            max_backoff_ms: u64::MAX,
+            jitter_ratio_percent: 0,
+            ..RetryPolicy::default()
+        };
+        assert_eq!(
+            policy.next_attempt_at_ms(32, None, u64::MAX - 10, "seed"),
+            u64::MAX
+        );
+    }
+
+    #[test]
+    fn expiry_prevents_retry_schedule_from_passing_deadline() {
+        let feedback = retryable_feedback(Some(1_500));
+        let entry = RetryPolicy {
+            initial_backoff_ms: 10_000,
+            jitter_ratio_percent: 0,
+            ..RetryPolicy::default()
+        }
+        .schedule_retry(&feedback, 1_000)
+        .unwrap();
+
+        assert_eq!(entry.next_attempt_at_ms, 1_500);
+        assert_eq!(entry.expires_at_ms, 1_500);
+    }
+
+    #[tokio::test]
+    async fn retry_scheduler_defers_future_entries() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        let mut entry = retry_entry(2, 60_000);
+        entry.next_attempt_at_ms = now_ms().saturating_add(60_000);
+        queue
+            .retry_at(
+                PushQueueStage::RetrySchedule,
+                entry.key.clone(),
+                PushQueuePayload::RetrySchedule(Box::new(entry)),
+                now_ms(),
+            )
+            .await
+            .unwrap();
+
+        let scheduler = PushRetryScheduler::new(store, queue.clone(), "node-a");
+        assert_eq!(scheduler.run_once("retry").await.unwrap(), 0);
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::RetrySchedule)
+                .await
+                .unwrap()
+                .delayed_depth,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_scheduler_emits_due_delivery_batch() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        let entry = retry_entry(2, now_ms());
+        queue
+            .produce(
+                PushQueueStage::RetrySchedule,
+                entry.key.clone(),
+                PushQueuePayload::RetrySchedule(Box::new(entry)),
+            )
+            .await
+            .unwrap();
+
+        let scheduler = PushRetryScheduler::new(store, queue.clone(), "node-a");
+        assert_eq!(scheduler.run_once("retry").await.unwrap(), 1);
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::DeliveryJobs(PushProviderKind::Fcm))
+                .await
+                .unwrap()
+                .ready_depth,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_scheduler_dead_letters_expired_entries() {
+        let store = Arc::new(MemoryPushStore::new());
+        store.put_publish_status(status()).await.unwrap();
+        let queue = Arc::new(MemoryPushQueue::new());
+        let mut entry = retry_entry(2, now_ms());
+        entry.expires_at_ms = now_ms().saturating_sub(1);
+        if let Some(job) = entry.job.as_mut() {
+            job.expires_at_ms = Some(now_ms().saturating_sub(1));
+        }
+        queue
+            .produce(
+                PushQueueStage::RetrySchedule,
+                entry.key.clone(),
+                PushQueuePayload::RetrySchedule(Box::new(entry)),
+            )
+            .await
+            .unwrap();
+
+        let scheduler = PushRetryScheduler::new(store.clone(), queue.clone(), "node-a");
+        assert_eq!(scheduler.run_once("retry").await.unwrap(), 1);
+        assert_eq!(
+            store
+                .get_publish_status("app-1", "publish-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            PublishLifecycleState::Expired
+        );
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::DeadLetters)
+                .await
+                .unwrap()
+                .ready_depth,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_scheduler_dead_letters_attempt_exhaustion() {
+        let store = Arc::new(MemoryPushStore::new());
+        store.put_publish_status(status()).await.unwrap();
+        let queue = Arc::new(MemoryPushQueue::new());
+        let mut entry = retry_entry(6, now_ms());
+        entry.max_attempts = 5;
+        queue
+            .produce(
+                PushQueueStage::RetrySchedule,
+                entry.key.clone(),
+                PushQueuePayload::RetrySchedule(Box::new(entry)),
+            )
+            .await
+            .unwrap();
+
+        let scheduler = PushRetryScheduler::new(store.clone(), queue.clone(), "node-a");
+        assert_eq!(scheduler.run_once("retry").await.unwrap(), 1);
+        assert_eq!(
+            store
+                .get_publish_status("app-1", "publish-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .state,
+            PublishLifecycleState::DeadLettered
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_scheduler_dead_letters_malformed_payload() {
+        let store = Arc::new(MemoryPushStore::new());
+        store.put_publish_status(status()).await.unwrap();
+        let queue = Arc::new(MemoryPushQueue::new());
+        let mut entry = retry_entry(2, now_ms());
+        entry.job = None;
+        queue
+            .produce(
+                PushQueueStage::RetrySchedule,
+                entry.key.clone(),
+                PushQueuePayload::RetrySchedule(Box::new(entry)),
+            )
+            .await
+            .unwrap();
+
+        let scheduler = PushRetryScheduler::new(store, queue.clone(), "node-a");
+        assert_eq!(scheduler.run_once("retry").await.unwrap(), 0);
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::DeadLetters)
+                .await
+                .unwrap()
+                .ready_depth,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_scheduler_does_not_ack_when_successor_produce_fails() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(FailingProduceQueue::default());
+        let entry = retry_entry(2, now_ms());
+        queue.seed_retry(entry).await;
+
+        let scheduler = PushRetryScheduler::new(store, queue.clone(), "node-a");
+        assert!(scheduler.run_once("retry").await.is_err());
+        assert!(!queue.acked().await);
+    }
+
+    fn retryable_feedback(expires_at_ms: Option<u64>) -> DeliveryFeedback {
+        let mut job = sample_job();
+        job.expires_at_ms = expires_at_ms;
+        DeliveryFeedback {
+            result: DeliveryResult {
+                app_id: "app-1".to_owned(),
+                publish_id: "publish-1".to_owned(),
+                provider: PushProviderKind::Fcm,
+                batch_id: "batch-1".to_owned(),
+                device_id: Some("device-1".to_owned()),
+                outcome: DeliveryOutcome::Retryable,
+                provider_message_id: None,
+                error: Some(ProviderError {
+                    class: "unavailable".to_owned(),
+                    reason: None,
+                    retry_after_ms: None,
+                }),
+                attempt: 1,
+            },
+            delivery_key: stable_hash(b"delivery-1"),
+            retry_job: Some(Box::new(job)),
+            first_attempt_at_ms: Some(1_000),
+            expires_at_ms,
+        }
+    }
+
+    fn retry_entry(attempt: u32, next_attempt_at_ms: u64) -> RetryScheduleEntry {
+        let feedback = retryable_feedback(None);
+        let mut entry = RetryPolicy {
+            jitter_ratio_percent: 0,
+            ..RetryPolicy::default()
+        }
+        .schedule_retry(&feedback, now_ms())
+        .unwrap();
+        entry.attempt = attempt;
+        entry.next_attempt_at_ms = next_attempt_at_ms;
+        entry.not_before_ms = Some(next_attempt_at_ms);
+        entry.expires_at_ms = now_ms().saturating_add(60_000);
+        entry
+    }
+
+    fn sample_job() -> DeliveryJob {
+        DeliveryJob {
+            app_id: "app-1".to_owned(),
+            publish_id: "publish-1".to_owned(),
+            provider: PushProviderKind::Fcm,
+            batch_id: "batch-1".to_owned(),
+            device_id: Some("device-1".to_owned()),
+            recipient: PushRecipient::Fcm {
+                registration_token: SecretString::new("token-1").unwrap(),
+            },
+            payload: Arc::new(PushPayload {
+                template_id: None,
+                template_data: json!({}),
+                title: Some("hello".to_owned()),
+                body: Some("body".to_owned()),
+                icon: None,
+                sound: None,
+                collapse_key: None,
+            }),
+            attempt: 1,
+            first_attempt_at_ms: Some(1_000),
+            not_before_ms: None,
+            expires_at_ms: None,
+        }
+    }
+
+    fn status() -> PublishStatus {
+        PublishStatus {
+            app_id: "app-1".to_owned(),
+            publish_id: "publish-1".to_owned(),
+            state: PublishLifecycleState::Dispatching,
+            counters: crate::domain::PublishCounters {
+                planned: 1,
+                dispatched: 0,
+                succeeded: 0,
+                failed: 0,
+                expired: 0,
+                retry_scheduled: 0,
+                retry_attempted: 0,
+                dead_lettered: 0,
+            },
+            fanout_regime: None,
+            retry_after_ms: None,
+            error_reason: None,
+        }
+    }
+
+    #[derive(Default)]
+    struct FailingProduceQueue {
+        inner: tokio::sync::Mutex<FailingProduceState>,
+    }
+
+    #[derive(Default)]
+    struct FailingProduceState {
+        message: Option<QueueMessage>,
+        acked: bool,
+    }
+
+    impl FailingProduceQueue {
+        async fn seed_retry(&self, entry: RetryScheduleEntry) {
+            let payload = PushQueuePayload::RetrySchedule(Box::new(entry.clone()));
+            self.inner.lock().await.message = Some(QueueMessage {
+                message_id: "retry-1".to_owned(),
+                stage: PushQueueStage::RetrySchedule,
+                key: entry.key,
+                partition_key: "app-1".to_owned(),
+                partition: 0,
+                payload,
+                attempt: 1,
+                not_before_ms: None,
+                lease_deadline_ms: u64::MAX,
+                ack: QueueAckToken {
+                    stage: PushQueueStage::RetrySchedule,
+                    message_id: "retry-1".to_owned(),
+                },
+            });
+        }
+
+        async fn acked(&self) -> bool {
+            self.inner.lock().await.acked
+        }
+    }
+
+    #[async_trait]
+    impl crate::pipeline::PushQueue for FailingProduceQueue {
+        fn backend(&self) -> crate::pipeline::PushQueueBackendKind {
+            crate::pipeline::PushQueueBackendKind::Memory
+        }
+
+        async fn produce(
+            &self,
+            stage: PushQueueStage,
+            _key: String,
+            _payload: PushQueuePayload,
+        ) -> crate::pipeline::PushQueueResult<String> {
+            if matches!(stage, PushQueueStage::DeliveryJobs(_)) {
+                return Err(PushQueueError::Backend("produce failed".to_owned()));
+            }
+            Ok("ok".to_owned())
+        }
+
+        async fn retry_at(
+            &self,
+            stage: PushQueueStage,
+            key: String,
+            payload: PushQueuePayload,
+            _not_before_ms: u64,
+        ) -> crate::pipeline::PushQueueResult<String> {
+            self.produce(stage, key, payload).await
+        }
+
+        async fn consume(
+            &self,
+            _stage: PushQueueStage,
+            _consumer_group: &str,
+            _max_messages: usize,
+            _lease_timeout_ms: u64,
+        ) -> crate::pipeline::PushQueueResult<Vec<QueueMessage>> {
+            Ok(self.inner.lock().await.message.take().into_iter().collect())
+        }
+
+        async fn ack(&self, _token: QueueAckToken) -> crate::pipeline::PushQueueResult<()> {
+            self.inner.lock().await.acked = true;
+            Ok(())
+        }
+
+        async fn nack(
+            &self,
+            _token: QueueAckToken,
+            _retry_at_ms: Option<u64>,
+        ) -> crate::pipeline::PushQueueResult<()> {
+            Ok(())
+        }
+
+        async fn dead_letter(
+            &self,
+            _token: QueueAckToken,
+            _reason: String,
+        ) -> crate::pipeline::PushQueueResult<()> {
+            Ok(())
+        }
+
+        async fn health(&self) -> crate::pipeline::PushQueueResult<crate::pipeline::QueueHealth> {
+            Ok(crate::pipeline::QueueHealth {
+                backend: crate::pipeline::PushQueueBackendKind::Memory,
+                healthy: true,
+                details: "test".to_owned(),
+            })
+        }
+
+        async fn lag(
+            &self,
+            _stage: PushQueueStage,
+        ) -> crate::pipeline::PushQueueResult<crate::pipeline::QueueLagMetrics> {
+            Ok(crate::pipeline::QueueLagMetrics::default())
+        }
+    }
+}

--- a/crates/sockudo-server/src/bootstrap/push/queue.rs
+++ b/crates/sockudo-server/src/bootstrap/push/queue.rs
@@ -412,6 +412,9 @@ fn push_queue_payload_app_id(payload: &sockudo_push::PushQueuePayload) -> String
         sockudo_push::PushQueuePayload::ShardJob(job) => job.app_id.clone(),
         sockudo_push::PushQueuePayload::DeliveryBatch(batch) => batch.app_id.clone(),
         sockudo_push::PushQueuePayload::DeliveryResult(result) => result.app_id.clone(),
+        sockudo_push::PushQueuePayload::DeliveryFeedback(feedback) => {
+            feedback.result.app_id.clone()
+        }
         sockudo_push::PushQueuePayload::DeadLetter(dead_letter) => dead_letter.app_id.clone(),
         sockudo_push::PushQueuePayload::RetrySchedule(entry) => entry.app_id.clone(),
     }
@@ -424,6 +427,9 @@ fn push_queue_payload_publish_id(payload: &sockudo_push::PushQueuePayload) -> St
         sockudo_push::PushQueuePayload::ShardJob(job) => job.publish_id.clone(),
         sockudo_push::PushQueuePayload::DeliveryBatch(batch) => batch.publish_id.clone(),
         sockudo_push::PushQueuePayload::DeliveryResult(result) => result.publish_id.clone(),
+        sockudo_push::PushQueuePayload::DeliveryFeedback(feedback) => {
+            feedback.result.publish_id.clone()
+        }
         sockudo_push::PushQueuePayload::DeadLetter(dead_letter) => dead_letter.publish_id.clone(),
         sockudo_push::PushQueuePayload::RetrySchedule(entry) => entry.publish_id.clone(),
     }

--- a/crates/sockudo-server/src/bootstrap/push/workers.rs
+++ b/crates/sockudo-server/src/bootstrap/push/workers.rs
@@ -21,12 +21,30 @@ fn push_fanout_config(config: &ServerOptions) -> sockudo_push::FanoutConfig {
 }
 
 #[cfg(all(feature = "push", feature = "monolith"))]
+fn push_retry_policy(config: &ServerOptions) -> sockudo_push::RetryPolicy {
+    sockudo_push::RetryPolicy {
+        initial_backoff_ms: config.push.retry.initial_backoff_ms,
+        max_backoff_ms: config.push.retry.max_backoff_ms,
+        max_attempts: config.push.retry.max_attempts,
+        max_retry_age_ms: config.push.retry.max_elapsed_secs.saturating_mul(1_000),
+        jitter_ratio_percent: if config.push.retry.jitter {
+            config.push.retry.jitter_ratio_percent
+        } else {
+            0
+        },
+        respect_retry_after: config.push.retry.respect_retry_after,
+    }
+    .bounded()
+}
+
+#[cfg(all(feature = "push", feature = "monolith"))]
 pub(crate) fn start_push_monolith_workers(
     config: &ServerOptions,
     store: sockudo_push::DynPushStore,
     queue: sockudo_push::DynPushQueue,
 ) {
     let fanout_config = push_fanout_config(config);
+    let retry_policy = push_retry_policy(config);
 
     for worker_index in 0..config.push.planner_worker_count {
         let planner =
@@ -71,7 +89,8 @@ pub(crate) fn start_push_monolith_workers(
     }
 
     for worker_index in 0..config.push.feedback_worker_count {
-        let processor = sockudo_push::PushFeedbackProcessor::new(store.clone(), queue.clone());
+        let processor = sockudo_push::PushFeedbackProcessor::new(store.clone(), queue.clone())
+            .with_retry_policy(retry_policy.clone());
         tokio::spawn(async move {
             let group = format!("sockudo-monolith-feedback-{worker_index}");
             warn!(worker = %group, "push feedback worker started");
@@ -83,6 +102,30 @@ pub(crate) fn start_push_monolith_workers(
                     Ok(_) => {}
                     Err(error) => {
                         warn!(worker = %group, error = %error, "push feedback worker tick failed");
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+        });
+    }
+
+    for worker_index in 0..config.push.retry_worker_count {
+        let scheduler = sockudo_push::PushRetryScheduler::new(
+            store.clone(),
+            queue.clone(),
+            format!("sockudo-monolith-retry-{worker_index}"),
+        );
+        tokio::spawn(async move {
+            let group = format!("sockudo-monolith-retry-{worker_index}");
+            warn!(worker = %group, "push retry scheduler worker started");
+            loop {
+                match scheduler.run_once(&group).await {
+                    Ok(processed) if processed > 0 => {
+                        warn!(worker = %group, processed, "push retry scheduler worker processed messages");
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        warn!(worker = %group, error = %error, "push retry scheduler worker tick failed");
                     }
                 }
                 tokio::time::sleep(Duration::from_millis(200)).await;

--- a/crates/sockudo-server/src/push_http.rs
+++ b/crates/sockudo-server/src/push_http.rs
@@ -130,6 +130,7 @@ fn publish_state_label(state: PublishLifecycleState) -> &'static str {
         PublishLifecycleState::Failed => "failed",
         PublishLifecycleState::QuotaExceeded => "quota_exceeded",
         PublishLifecycleState::Expired => "expired",
+        PublishLifecycleState::DeadLettered => "dead_lettered",
     }
 }
 
@@ -1043,6 +1044,9 @@ async fn accept_publish_inner(
                 succeeded: 0,
                 failed: 0,
                 expired: 0,
+                retry_scheduled: 0,
+                retry_attempted: 0,
+                dead_lettered: 0,
             },
             fanout_regime: Some(fanout_regime),
             retry_after_ms: None,

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -187,6 +187,7 @@ planner_worker_count = 1
 shard_worker_count = 1
 dispatch_worker_count = 1
 feedback_worker_count = 1
+retry_worker_count = 1
 queue_partition_count = 1
 channel_shard_count = 1
 fanout_fast_threshold = 10000
@@ -206,6 +207,7 @@ initial_backoff_ms = 1000
 max_backoff_ms = 60000
 max_elapsed_secs = 86400
 jitter = true
+jitter_ratio_percent = 20
 respect_retry_after = true
 
 [push.circuit_breaker]

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -388,6 +388,14 @@ This page lists every runtime environment variable referenced by the server, cor
 | `PUSH_PUBLISH_LOG_MAX_LAG` | Maximum publish-log lag tolerated before push backpressure. |
 | `PUSH_CRITICAL_QUEUE_MAX_LAG` | Maximum lag tolerated for shard, delivery result, retry, dead-letter, and active provider delivery stages. |
 | `PUSH_PUBLISH_STATUS_TTL_DAYS` | Retention for push publish status records. |
+| `PUSH_RETRY_WORKER_COUNT` | Number of monolith retry scheduler workers consuming `push.retry.v1`. |
+| `PUSH_RETRY_MAX_ATTEMPTS` | Maximum provider delivery attempts before retry work is dead-lettered. |
+| `PUSH_RETRY_INITIAL_BACKOFF_MS` | Initial retry backoff when the provider does not send `Retry-After`. |
+| `PUSH_RETRY_MAX_BACKOFF_MS` | Maximum exponential retry backoff. |
+| `PUSH_RETRY_MAX_ELAPSED_SECS` | Maximum retry age from first provider attempt. |
+| `PUSH_RETRY_JITTER` | Enables deterministic retry jitter. |
+| `PUSH_RETRY_JITTER_RATIO_PERCENT` | Retry jitter spread as a percentage of the selected backoff. |
+| `PUSH_RETRY_RESPECT_RETRY_AFTER` | Uses provider `Retry-After` deadlines when present. |
 | `PUSH_FAILURE_THRESHOLD` | Push circuit-breaker failure threshold. |
 | `PUSH_SCHEDULER_INTERVAL_SECS` | Scheduled push scan interval. |
 | `PUSH_STALE_DEVICE_MAX_AGE_DAYS` | Stale device age threshold. |

--- a/docs/content/docs/server/push-notifications.mdx
+++ b/docs/content/docs/server/push-notifications.mdx
@@ -66,6 +66,33 @@ Readiness failures return `503`. Queue pressure returns `429` with `Retry-After`
 persists a terminal `quota_exceeded` publish status and idempotency record without appending publish
 log work or enqueueing the pipeline.
 
+## Retry and dead letters
+
+Provider throttling, 5xx responses, and transport failures are classified as retryable. Feedback
+workers schedule retry entries on `push.retry.v1` with the original delivery job context, a
+deterministic retry idempotency key, the next attempt number, the first-attempt timestamp, retry
+deadline, and the provider error class. Retry scheduler workers consume only due entries, respect
+provider `Retry-After` deadlines when configured, and otherwise use bounded exponential backoff with
+deterministic jitter.
+
+Retries stop at the earliest of `max_attempts`, `max_elapsed_secs`, or the publish/job
+`expires_at_ms`. Exhausted retry work is emitted to `push.deadletters.v1` and the publish status
+moves to `dead_lettered` unless some deliveries already succeeded, in which case it becomes
+`partially_succeeded`. If the publish expiry passes before a retry can run, the publish moves to
+`expired`. Pending retry work increments `retryScheduled`; retry dispatch increments
+`retryAttempted`; `dispatched` counts terminal provider outcomes so retry attempts do not inflate
+completion accounting.
+
+Operators inspect aggregate status with `GET /apps/{appId}/push/publish/{publishId}/status`, retry
+and dead-letter queue lag through the health/backpressure surfaces, and metrics such as
+`sockudo_push_retry_scheduled_total`, `sockudo_push_retry_attempted_total`,
+`sockudo_push_retry_dead_lettered_total`, and `sockudo_push_retry_malformed_total`.
+
+Upgrade note: provider workers now enqueue internal `deliveryFeedback` payloads on
+`push.results.v1` so feedback workers can schedule retries with replayable job context. Older
+`deliveryResult` payloads are still accepted, but retryable legacy results without job context are
+dead-lettered instead of being retried blindly.
+
 ## Configure providers
 
 ```toml
@@ -259,6 +286,10 @@ node scripts/push-benchmark.mjs \
 
 Track accepted publishes, queue depth, provider dispatch latency, provider error classes, and status write latency.
 
+The Criterion benchmark `push_retry_scheduler/memory_drain_100k_due_retry_entries_budget_lt_5s`
+seeds and drains 100k due retry entries through the memory queue/store path as a regression guard
+for retry scheduling overhead.
+
 ## Troubleshooting
 
 | Symptom | Check |
@@ -271,5 +302,7 @@ Track accepted publishes, queue depth, provider dispatch latency, provider error
 | Large push is rejected | Check platform payload limits and remove nonessential data. |
 | Push publish returns `503` | Check push queue health, memory-driver production guard, provider feature flags, provider credentials, and dispatch worker count. |
 | Push publish returns `429` | Check publish-log, shard, delivery result, retry, dead-letter, and active provider delivery queue lag. |
+| Publish remains `dispatching` | Check retry scheduler workers, `push.retry.v1` lag, dead-letter lag, and provider retry-after deadlines. |
+| Publish becomes `dead_lettered` | Inspect the dead-letter queue reason, retry metrics, provider outage history, and `max_attempts`/`max_elapsed_secs`. |
 
 Push payloads should wake the app and include stable IDs. Fetch authoritative application state after the user opens the notification.

--- a/ops/dashboards/push.json
+++ b/ops/dashboards/push.json
@@ -324,6 +324,65 @@
     {
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 45 },
+      "id": 106,
+      "panels": [],
+      "title": "Retries And Dead Letters",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 46 },
+      "id": 15,
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (provider,app) (rate(sockudo_push_retry_scheduled_total{provider=~\"$provider\",app=~\"$app\"}[5m]))",
+          "legendFormat": "{{provider}} {{app}} scheduled",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (provider,app) (rate(sockudo_push_retry_attempted_total{provider=~\"$provider\",app=~\"$app\"}[5m]))",
+          "legendFormat": "{{provider}} {{app}} attempted",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (provider,app) (rate(sockudo_push_retry_deferred_total{provider=~\"$provider\",app=~\"$app\"}[5m]))",
+          "legendFormat": "{{provider}} {{app}} deferred",
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (provider,app) (rate(sockudo_push_retry_expired_total{provider=~\"$provider\",app=~\"$app\"}[5m]))",
+          "legendFormat": "{{provider}} {{app}} expired",
+          "refId": "D"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (provider,app) (rate(sockudo_push_retry_dead_lettered_total{provider=~\"$provider\",app=~\"$app\"}[5m]))",
+          "legendFormat": "{{provider}} {{app}} dead-lettered",
+          "refId": "E"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (provider,reason) (rate(sockudo_push_retry_malformed_total{provider=~\"$provider\"}[5m]))",
+          "legendFormat": "{{provider}} {{reason}} malformed",
+          "refId": "F"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max by (provider,app) (sockudo_push_retry_deferred_delay_seconds{provider=~\"$provider\",app=~\"$app\"})",
+          "legendFormat": "{{provider}} {{app}} defer seconds",
+          "refId": "G"
+        }
+      ],
+      "title": "Retry Outcomes",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 54 },
       "id": 105,
       "panels": [],
       "title": "Scheduling And Provider Capacity",
@@ -331,7 +390,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 55 },
       "id": 13,
       "targets": [
         {
@@ -364,7 +423,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 46 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 55 },
       "id": 14,
       "targets": [
         {


### PR DESCRIPTION
## Disaster scenario made safe

Provider outages, transient credential/provider failures, and retry queue pressure no longer leave accepted push publishes stuck in `dispatching` forever. Retryable provider outcomes now have replayable context, bounded retry policy, deterministic scheduling, and terminal dead-letter behavior when retries are malformed, exhausted, or expired.

## Behavior changed

- Added a durable retry scheduler for `retrySchedule` entries that emits due `deliveryBatch` jobs and defers future work without scanning historic jobs.
- Provider workers now emit internal `deliveryFeedback` with replayable job context so retryable outcomes can be retried for real.
- Retryable feedback no longer counts as a terminal dispatched outcome before retry completion.
- Malformed, expired, or attempt-exhausted retry entries are dead-lettered and reflected in publish status.
- Publish status now tracks `retryScheduled`, `retryAttempted`, and `deadLettered` counters plus a `dead_lettered` lifecycle state.
- Monolith push bootstrap starts bounded retry scheduler workers and exposes retry policy/configuration.
- Metrics, dashboard panels, config docs, and push docs now include retry/dead-letter observability and knobs.

## Behavior intentionally not changed

- Protocol V1/Pusher wire compatibility is unchanged.
- Existing provider classification contracts are preserved; this PR consumes retryable classifications rather than redefining provider semantics.
- Legacy `deliveryResult` feedback remains accepted for compatibility, but retryable legacy entries that lack replayable job context are dead-lettered instead of guessed.
- Queue backends, provider credentials, registration APIs, and public push HTTP response shapes are not otherwise redesigned.

## Verification

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p sockudo-push`
- `cargo test -p sockudo --features "push,monolith" push`
- `cargo check -p sockudo-push --benches --examples`
- `python3 -m json.tool ops/dashboards/push.json >/dev/null`
- `npm run types:check` in `docs`
- `npm run build` in `docs` (passes; Next.js reports the existing multiple-lockfile workspace-root warning)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Deferred disaster modes

- Provider-specific multi-region failover and credential rotation workflows remain for later PRs.
- Cross-backend retry queue operational tuning beyond the shared queue contract remains for later chaos/load work.
- Operator APIs for manually replaying or draining dead letters are not added in this PR.
