### PR TITLE
Push delivery correctness

### DIFF
--- a/crates/sockudo-push/src/conformance.rs
+++ b/crates/sockudo-push/src/conformance.rs
@@ -247,6 +247,33 @@ impl PushStoreConformance {
             store.get_idempotency_record("app-1", "idem-1").await?,
             Some(idempotency)
         );
+        let expired_idempotency = IdempotencyRecord {
+            app_id: "app-1".to_owned(),
+            key: "idem-expired".to_owned(),
+            publish_id: "publish-old".to_owned(),
+            expires_at_ms: crate::pipeline::now_ms().saturating_sub(1),
+        };
+        assert!(
+            store
+                .put_idempotency_record_if_absent(expired_idempotency)
+                .await?
+        );
+        assert_eq!(
+            store
+                .get_idempotency_record("app-1", "idem-expired")
+                .await?,
+            None
+        );
+        assert!(
+            store
+                .put_idempotency_record_if_absent(IdempotencyRecord {
+                    app_id: "app-1".to_owned(),
+                    key: "idem-expired".to_owned(),
+                    publish_id: "publish-new".to_owned(),
+                    expires_at_ms: crate::pipeline::now_ms().saturating_add(60_000),
+                })
+                .await?
+        );
         Ok(())
     }
 

--- a/crates/sockudo-push/src/dispatch/tests.rs
+++ b/crates/sockudo-push/src/dispatch/tests.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::Mutex;
 
 use crate::domain::{PushPayload, PushRecipient, SecretString};
-use crate::pipeline::{PushQueuePayload, PushQueueStage, QueueMessage};
+use crate::pipeline::{MemoryPushQueue, PushQueue, PushQueuePayload, PushQueueStage, QueueMessage};
 
 use super::apns::classify_apns_response;
 use super::fcm::classify_fcm_response;
@@ -56,6 +56,51 @@ impl ProviderTokenSource for CountingTokenSource {
             token: SecretString::new(format!("token-{count}")).unwrap(),
             expires_at_ms: self.first_expiry,
         })
+    }
+}
+
+#[derive(Default)]
+struct RecordingDispatcher {
+    batches: Mutex<Vec<DeliveryBatch>>,
+}
+
+impl RecordingDispatcher {
+    async fn batches(&self) -> Vec<DeliveryBatch> {
+        self.batches.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl PushDispatcher for RecordingDispatcher {
+    fn provider(&self) -> PushProviderKind {
+        PushProviderKind::Fcm
+    }
+
+    async fn dispatch(&self, batch: DeliveryBatch) -> Vec<DeliveryResult> {
+        self.batches.lock().await.push(batch.clone());
+        batch
+            .jobs
+            .into_iter()
+            .map(|job| DeliveryResult {
+                app_id: job.app_id,
+                publish_id: job.publish_id,
+                provider: job.provider,
+                batch_id: job.batch_id,
+                device_id: job.device_id,
+                outcome: DeliveryOutcome::Accepted,
+                provider_message_id: Some("recorded".to_owned()),
+                error: None,
+                attempt: job.attempt,
+            })
+            .collect()
+    }
+
+    async fn health_check(&self) -> HealthStatus {
+        HealthStatus {
+            provider: PushProviderKind::Fcm,
+            healthy: true,
+            details: "recording dispatcher".to_owned(),
+        }
     }
 }
 
@@ -272,6 +317,117 @@ fn weighted_scheduler_downgrades_over_quota_tenants_and_caps_each_lane() {
         3
     );
     assert_ne!(order.first().map(String::as_str), Some("noisy"));
+}
+
+#[tokio::test]
+async fn provider_worker_defers_future_batch_without_dispatching() {
+    let queue = Arc::new(MemoryPushQueue::new());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let mut batch = batch(PushProviderKind::Fcm);
+    let not_before_ms = now_ms().saturating_add(60_000);
+    batch.jobs[0].not_before_ms = Some(not_before_ms);
+    queue
+        .produce(
+            PushQueueStage::DeliveryJobs(PushProviderKind::Fcm),
+            batch.queue_key(),
+            PushQueuePayload::DeliveryBatch(Box::new(batch)),
+        )
+        .await
+        .unwrap();
+
+    let mut worker =
+        ProviderDispatchWorker::new(PushProviderKind::Fcm, queue.clone(), dispatcher.clone());
+    assert_eq!(worker.run_once("fcm").await.unwrap(), 1);
+
+    assert!(dispatcher.batches().await.is_empty());
+    let lag = queue
+        .lag(PushQueueStage::DeliveryJobs(PushProviderKind::Fcm))
+        .await
+        .unwrap();
+    assert_eq!(lag.ready_depth, 0);
+    assert_eq!(lag.delayed_depth, 1);
+    assert_eq!(
+        queue
+            .lag(PushQueueStage::DeliveryResults)
+            .await
+            .unwrap()
+            .ready_depth,
+        0
+    );
+}
+
+#[tokio::test]
+async fn provider_worker_expires_batch_without_dispatching() {
+    let queue = Arc::new(MemoryPushQueue::new());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let mut batch = batch(PushProviderKind::Fcm);
+    batch.jobs[0].expires_at_ms = Some(now_ms().saturating_sub(1));
+    queue
+        .produce(
+            PushQueueStage::DeliveryJobs(PushProviderKind::Fcm),
+            batch.queue_key(),
+            PushQueuePayload::DeliveryBatch(Box::new(batch)),
+        )
+        .await
+        .unwrap();
+
+    let mut worker =
+        ProviderDispatchWorker::new(PushProviderKind::Fcm, queue.clone(), dispatcher.clone());
+    assert_eq!(worker.run_once("fcm").await.unwrap(), 1);
+
+    assert!(dispatcher.batches().await.is_empty());
+    let message = queue
+        .consume(PushQueueStage::DeliveryResults, "feedback", 1, 30_000)
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    let PushQueuePayload::DeliveryFeedback(feedback) = message.payload else {
+        panic!("expected delivery feedback");
+    };
+    assert_eq!(feedback.result.outcome, DeliveryOutcome::Expired);
+}
+
+#[tokio::test]
+async fn provider_worker_dispatches_due_jobs_and_requeues_future_jobs() {
+    let queue = Arc::new(MemoryPushQueue::new());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let mut batch = batch(PushProviderKind::Fcm);
+    let mut future = batch.jobs[0].clone();
+    future.device_id = Some("device-2".to_owned());
+    future.not_before_ms = Some(now_ms().saturating_add(60_000));
+    batch.jobs.push(future);
+    queue
+        .produce(
+            PushQueueStage::DeliveryJobs(PushProviderKind::Fcm),
+            batch.queue_key(),
+            PushQueuePayload::DeliveryBatch(Box::new(batch)),
+        )
+        .await
+        .unwrap();
+
+    let mut worker =
+        ProviderDispatchWorker::new(PushProviderKind::Fcm, queue.clone(), dispatcher.clone());
+    assert_eq!(worker.run_once("fcm").await.unwrap(), 1);
+
+    let batches = dispatcher.batches().await;
+    assert_eq!(batches.len(), 1);
+    assert_eq!(batches[0].jobs.len(), 1);
+    assert_eq!(batches[0].jobs[0].device_id.as_deref(), Some("device-1"));
+    let delivery_lag = queue
+        .lag(PushQueueStage::DeliveryJobs(PushProviderKind::Fcm))
+        .await
+        .unwrap();
+    assert_eq!(delivery_lag.ready_depth, 0);
+    assert_eq!(delivery_lag.delayed_depth, 1);
+    assert_eq!(
+        queue
+            .lag(PushQueueStage::DeliveryResults)
+            .await
+            .unwrap()
+            .ready_depth,
+        1
+    );
 }
 
 #[test]

--- a/crates/sockudo-push/src/dispatch/worker.rs
+++ b/crates/sockudo-push/src/dispatch/worker.rs
@@ -4,8 +4,8 @@ use std::time::Instant;
 
 use super::PushDispatcher;
 use crate::domain::{
-    DeliveryFeedback, DeliveryJob, DeliveryOutcome, DeliveryResult, PushProviderKind, provider_key,
-    stable_hash,
+    DeliveryBatch, DeliveryFeedback, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError,
+    PushProviderKind, provider_key, stable_hash,
 };
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::PushMetrics;
@@ -112,6 +112,9 @@ impl ProviderDispatchWorker {
             return Ok(());
         };
         let batch = *batch;
+        let Some(batch) = self.preflight_batch(message.ack.clone(), batch).await? else {
+            return Ok(());
+        };
         let app_id = batch.app_id.clone();
         let retry_jobs = batch.jobs.clone();
         self.metrics
@@ -222,6 +225,149 @@ impl ProviderDispatchWorker {
         self.metrics
             .worker_pool(self.provider, self.max_batches_per_tick, 0);
         self.queue.ack(message.ack).await?;
+        Ok(())
+    }
+
+    async fn preflight_batch(
+        &self,
+        ack: crate::pipeline::QueueAckToken,
+        batch: DeliveryBatch,
+    ) -> PushPipelineResult<Option<DeliveryBatch>> {
+        let now = now_ms();
+        let DeliveryBatch {
+            app_id,
+            publish_id,
+            provider,
+            batch_id,
+            jobs,
+        } = batch;
+        let mut ready = Vec::with_capacity(jobs.len());
+        let mut future = Vec::new();
+        let mut expired = Vec::new();
+
+        for job in jobs {
+            if is_expired_before_dispatch(&job, now) {
+                expired.push(job);
+            } else if job.not_before_ms.is_some_and(|not_before| not_before > now) {
+                future.push(job);
+            } else {
+                ready.push(job);
+            }
+        }
+
+        let emitted_expired = !expired.is_empty();
+        for job in expired {
+            self.emit_expired_feedback(job, now).await?;
+        }
+
+        let next_not_before_ms = future.iter().filter_map(|job| job.not_before_ms).min();
+        if ready.is_empty() {
+            if let Some(not_before_ms) = next_not_before_ms {
+                if future.is_empty() {
+                    self.queue.ack(ack).await?;
+                } else if emitted_expired {
+                    self.defer_future_jobs(
+                        &app_id,
+                        &publish_id,
+                        provider,
+                        &batch_id,
+                        future,
+                        not_before_ms,
+                    )
+                    .await?;
+                    self.queue.ack(ack).await?;
+                } else {
+                    self.queue.nack(ack, Some(not_before_ms)).await?;
+                }
+            } else {
+                self.queue.ack(ack).await?;
+            }
+            return Ok(None);
+        }
+
+        if let Some(not_before_ms) = next_not_before_ms {
+            self.defer_future_jobs(
+                &app_id,
+                &publish_id,
+                provider,
+                &batch_id,
+                future,
+                not_before_ms,
+            )
+            .await?;
+        }
+
+        Ok(Some(DeliveryBatch {
+            app_id,
+            publish_id,
+            provider,
+            batch_id,
+            jobs: ready,
+        }))
+    }
+
+    async fn defer_future_jobs(
+        &self,
+        app_id: &str,
+        publish_id: &str,
+        provider: PushProviderKind,
+        original_batch_id: &str,
+        mut jobs: Vec<DeliveryJob>,
+        not_before_ms: u64,
+    ) -> PushPipelineResult<()> {
+        if jobs.is_empty() {
+            return Ok(());
+        }
+        let batch_id = format!("{original_batch_id}-deferred-{not_before_ms}");
+        for job in &mut jobs {
+            job.batch_id = batch_id.clone();
+        }
+        let batch = DeliveryBatch {
+            app_id: app_id.to_owned(),
+            publish_id: publish_id.to_owned(),
+            provider,
+            batch_id,
+            jobs,
+        };
+        self.queue
+            .retry_at(
+                PushQueueStage::DeliveryJobs(provider),
+                batch.queue_key(),
+                PushQueuePayload::DeliveryBatch(Box::new(batch)),
+                not_before_ms,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn emit_expired_feedback(
+        &self,
+        job: DeliveryJob,
+        occurred_at_ms: u64,
+    ) -> PushPipelineResult<()> {
+        let result = DeliveryResult {
+            app_id: job.app_id.clone(),
+            publish_id: job.publish_id.clone(),
+            provider: job.provider,
+            batch_id: job.batch_id.clone(),
+            device_id: job.device_id.clone(),
+            outcome: DeliveryOutcome::Expired,
+            provider_message_id: None,
+            error: Some(ProviderError {
+                class: "expired".to_owned(),
+                reason: Some("delivery expired before provider dispatch".to_owned()),
+                retry_after_ms: None,
+            }),
+            attempt: job.attempt,
+        };
+        let feedback = delivery_feedback(result, Some(job), occurred_at_ms);
+        self.queue
+            .produce(
+                PushQueueStage::DeliveryResults,
+                feedback_key(&feedback),
+                PushQueuePayload::DeliveryFeedback(Box::new(feedback)),
+            )
+            .await?;
         Ok(())
     }
 
@@ -560,4 +706,13 @@ fn feedback_key(feedback: &DeliveryFeedback) -> String {
         feedback.delivery_key,
         feedback.result.attempt
     )
+}
+
+fn is_expired_before_dispatch(job: &DeliveryJob, now_ms: u64) -> bool {
+    job.expires_at_ms.is_some_and(|expires_at_ms| {
+        expires_at_ms <= now_ms
+            || job
+                .not_before_ms
+                .is_some_and(|not_before_ms| expires_at_ms <= not_before_ms)
+    })
 }

--- a/crates/sockudo-push/src/domain.rs
+++ b/crates/sockudo-push/src/domain.rs
@@ -1065,6 +1065,8 @@ pub struct ShardJob {
     pub target: PublishTarget,
     pub payload: PushPayload,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub not_before_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<PushCursor>,

--- a/crates/sockudo-push/src/nosql/coordination.rs
+++ b/crates/sockudo-push/src/nosql/coordination.rs
@@ -24,6 +24,20 @@ where
         &self,
         record: IdempotencyRecord,
     ) -> PushStorageResult<bool> {
+        if let Some(existing) = self
+            .get_json::<IdempotencyRecord>(
+                FAMILY_IDEMPOTENCY,
+                &record.app_id,
+                &record.key,
+                DEFAULT_SK,
+            )
+            .await?
+            && idempotency_record_expired(&existing, crate::pipeline::now_ms())
+        {
+            self.backend
+                .delete(FAMILY_IDEMPOTENCY, &record.app_id, &record.key, DEFAULT_SK)
+                .await?;
+        }
         self.backend
             .put_if_absent(
                 FAMILY_IDEMPOTENCY,
@@ -40,9 +54,24 @@ where
         app_id: &str,
         key: &str,
     ) -> PushStorageResult<Option<IdempotencyRecord>> {
-        self.get_json(FAMILY_IDEMPOTENCY, app_id, key, DEFAULT_SK)
-            .await
+        let Some(record) = self
+            .get_json::<IdempotencyRecord>(FAMILY_IDEMPOTENCY, app_id, key, DEFAULT_SK)
+            .await?
+        else {
+            return Ok(None);
+        };
+        if idempotency_record_expired(&record, crate::pipeline::now_ms()) {
+            self.backend
+                .delete(FAMILY_IDEMPOTENCY, app_id, key, DEFAULT_SK)
+                .await?;
+            return Ok(None);
+        }
+        Ok(Some(record))
     }
+}
+
+fn idempotency_record_expired(record: &IdempotencyRecord, now_ms: u64) -> bool {
+    record.expires_at_ms >= 1_000_000_000_000 && record.expires_at_ms <= now_ms
 }
 
 #[async_trait]

--- a/crates/sockudo-push/src/pipeline.rs
+++ b/crates/sockudo-push/src/pipeline.rs
@@ -978,7 +978,9 @@ mod tests {
     use crate::memory::MemoryPushStore;
     use crate::planner::{PushPlanner, PushShardWorker};
     use crate::retry::{PushRetryScheduler, RetryPolicy};
-    use crate::storage::{PushDeviceStore, PushPublishStatusStore, PushSubscriptionStore};
+    use crate::storage::{
+        PushDeviceStore, PushFanoutShardStore, PushPublishStatusStore, PushSubscriptionStore,
+    };
 
     use super::*;
 
@@ -1170,6 +1172,124 @@ mod tests {
                 .unwrap()
                 .ready_depth,
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn planner_fast_path_copies_delivery_timing_fields() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store
+            .upsert_device(sample_device("device-1"))
+            .await
+            .unwrap();
+        let mut intent = sample_intent(vec![PublishTarget::Device {
+            device_id: "device-1".to_owned(),
+        }]);
+        intent.not_before_ms = Some(0);
+        intent.expires_at_ms = Some(123_456);
+        let pipeline = PushPipeline::new(store.clone(), queue.clone(), FanoutConfig::default());
+        pipeline
+            .accept_publish(
+                PushAcceptRequest {
+                    intent,
+                    expected_recipients: 1,
+                },
+                10,
+            )
+            .await
+            .unwrap();
+
+        let planner = PushPlanner::new(store, queue.clone(), FanoutConfig::default());
+        assert_eq!(planner.run_once("planner").await.unwrap(), 1);
+        let message = queue
+            .consume(
+                PushQueueStage::DeliveryJobs(PushProviderKind::Fcm),
+                "delivery",
+                1,
+                30_000,
+            )
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert_eq!(message.not_before_ms, Some(0));
+        let PushQueuePayload::DeliveryBatch(batch) = message.payload else {
+            panic!("expected delivery batch");
+        };
+        assert_eq!(batch.jobs[0].not_before_ms, Some(0));
+        assert_eq!(batch.jobs[0].expires_at_ms, Some(123_456));
+    }
+
+    #[tokio::test]
+    async fn shard_path_copies_timing_into_shard_and_delivery_jobs() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        for index in 0..2 {
+            let device = sample_device(&format!("device-{index}"));
+            store.upsert_device(device.clone()).await.unwrap();
+            store
+                .upsert_subscription(ChannelSubscription::from_device("room", &device))
+                .await
+                .unwrap();
+        }
+        let config = FanoutConfig {
+            fast_threshold: 1,
+            shard_size: 10,
+            page_size: 10,
+            provider_batch_size: 10,
+            status_retention_days: 30,
+        };
+        let mut intent = sample_intent(vec![PublishTarget::Channel {
+            channel: "room".to_owned(),
+        }]);
+        intent.not_before_ms = Some(0);
+        intent.expires_at_ms = Some(123_456);
+        let pipeline = PushPipeline::new(store.clone(), queue.clone(), config.clone());
+        pipeline
+            .accept_publish(
+                PushAcceptRequest {
+                    intent,
+                    expected_recipients: 2,
+                },
+                10,
+            )
+            .await
+            .unwrap();
+
+        let planner = PushPlanner::new(store.clone(), queue.clone(), config.clone());
+        assert_eq!(planner.run_once("planner").await.unwrap(), 1);
+        let shard = store
+            .get_fanout_shard("app-1", "publish-1", "shard-0")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(shard.not_before_ms, Some(0));
+        assert_eq!(shard.expires_at_ms, Some(123_456));
+
+        let worker = PushShardWorker::new(store, queue.clone(), config);
+        assert_eq!(worker.run_once("shards").await.unwrap(), 1);
+        let message = queue
+            .consume(
+                PushQueueStage::DeliveryJobs(PushProviderKind::Fcm),
+                "delivery",
+                1,
+                30_000,
+            )
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+        let PushQueuePayload::DeliveryBatch(batch) = message.payload else {
+            panic!("expected delivery batch");
+        };
+        assert_eq!(batch.jobs.len(), 2);
+        assert!(batch.jobs.iter().all(|job| job.not_before_ms == Some(0)));
+        assert!(
+            batch
+                .jobs
+                .iter()
+                .all(|job| job.expires_at_ms == Some(123_456))
         );
     }
 
@@ -1427,7 +1547,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn publish_expiry_before_retry_marks_publish_expired() {
+    async fn publish_expiry_before_dispatch_marks_publish_expired() {
         let store = Arc::new(MemoryPushStore::new());
         let queue = Arc::new(MemoryPushQueue::new());
         store
@@ -1460,8 +1580,14 @@ mod tests {
         let feedback = PushFeedbackProcessor::new(store.clone(), queue.clone());
         assert_eq!(feedback.run_once("feedback").await.unwrap(), 1);
 
-        let retry_scheduler = PushRetryScheduler::new(store.clone(), queue.clone(), "node-a");
-        assert_eq!(retry_scheduler.run_once("retry").await.unwrap(), 1);
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::RetrySchedule)
+                .await
+                .unwrap()
+                .ready_depth,
+            0
+        );
         let status = store
             .get_publish_status("app-1", "publish-1")
             .await

--- a/crates/sockudo-push/src/planner.rs
+++ b/crates/sockudo-push/src/planner.rs
@@ -85,6 +85,12 @@ impl PushPlanner {
             .await?
         {
             status.state = state;
+            if state == PublishLifecycleState::Dispatching {
+                status.retry_after_ms = event
+                    .intent
+                    .not_before_ms
+                    .filter(|not_before_ms| *not_before_ms > crate::pipeline::now_ms());
+            }
             self.store.put_publish_status(status).await?;
         }
         Ok(())
@@ -96,6 +102,7 @@ impl PushPlanner {
             event.publish_id.clone(),
             "fast".to_owned(),
             self.config.provider_batch_size,
+            event.intent.not_before_ms,
             event.intent.expires_at_ms,
             self.metrics.clone(),
         );
@@ -123,6 +130,7 @@ impl PushPlanner {
                         shard_id: dedupe_key(format!("shard-{index}"), &mut ids),
                         target: target.clone(),
                         payload: event.intent.payload.clone(),
+                        not_before_ms: event.intent.not_before_ms,
                         expires_at_ms: event.intent.expires_at_ms,
                         cursor: None,
                         page_size: self.config.page_size,
@@ -146,6 +154,7 @@ impl PushPlanner {
                         event.publish_id.clone(),
                         format!("direct-{index}"),
                         self.config.provider_batch_size,
+                        event.intent.not_before_ms,
                         event.intent.expires_at_ms,
                         self.metrics.clone(),
                     );
@@ -256,7 +265,7 @@ impl PushPlanner {
                             payload: Arc::clone(&payload),
                             attempt: 1,
                             first_attempt_at_ms: None,
-                            not_before_ms: None,
+                            not_before_ms: batcher.not_before_ms,
                             expires_at_ms: batcher.expires_at_ms,
                         },
                         &self.queue,
@@ -333,6 +342,7 @@ impl PushShardWorker {
             shard.publish_id.clone(),
             shard.shard_id.clone(),
             self.config.provider_batch_size,
+            shard.not_before_ms,
             shard.expires_at_ms,
             self.metrics.clone(),
         );
@@ -439,6 +449,7 @@ struct ProviderBatcher {
     publish_id: String,
     batch_prefix: String,
     max_batch_size: usize,
+    not_before_ms: Option<u64>,
     expires_at_ms: Option<u64>,
     batches: BTreeMap<PushProviderKind, Vec<DeliveryJob>>,
     batch_indexes: BTreeMap<PushProviderKind, u64>,
@@ -453,6 +464,7 @@ impl ProviderBatcher {
         publish_id: String,
         batch_prefix: String,
         max_batch_size: usize,
+        not_before_ms: Option<u64>,
         expires_at_ms: Option<u64>,
         metrics: PushMetrics,
     ) -> Self {
@@ -461,6 +473,7 @@ impl ProviderBatcher {
             publish_id,
             batch_prefix,
             max_batch_size,
+            not_before_ms,
             expires_at_ms,
             batches: BTreeMap::new(),
             batch_indexes: BTreeMap::new(),
@@ -489,7 +502,7 @@ impl ProviderBatcher {
                 payload,
                 attempt: 1,
                 first_attempt_at_ms: None,
-                not_before_ms: None,
+                not_before_ms: self.not_before_ms,
                 expires_at_ms: self.expires_at_ms,
             },
             queue,
@@ -553,13 +566,22 @@ impl ProviderBatcher {
             batch_id,
             jobs,
         };
-        queue
-            .produce(
-                PushQueueStage::DeliveryJobs(provider),
-                batch.queue_key(),
-                PushQueuePayload::DeliveryBatch(Box::new(batch)),
-            )
-            .await?;
+        let key = batch.queue_key();
+        let payload = PushQueuePayload::DeliveryBatch(Box::new(batch));
+        if let Some(not_before_ms) = self.not_before_ms {
+            queue
+                .retry_at(
+                    PushQueueStage::DeliveryJobs(provider),
+                    key,
+                    payload,
+                    not_before_ms,
+                )
+                .await?;
+        } else {
+            queue
+                .produce(PushQueueStage::DeliveryJobs(provider), key, payload)
+                .await?;
+        }
         self.metrics
             .delivery_jobs_emitted(provider, &self.app_id, jobs_len as u64);
         self.emitted_batches += 1;

--- a/crates/sockudo-push/src/sql/common_traits.rs
+++ b/crates/sockudo-push/src/sql/common_traits.rs
@@ -380,6 +380,17 @@ macro_rules! impl_common_sql_traits {
         #[async_trait]
         impl PushIdempotencyStore for $store {
             async fn put_idempotency_record_if_absent(&self, record: IdempotencyRecord) -> PushStorageResult<bool> {
+                let prune = sql_query(format!(
+                    "DELETE FROM push_idempotency WHERE app_id = {0} AND idempotency_key = {0} AND expires_at_ms >= 1000000000000 AND expires_at_ms <= {0}",
+                    $bind
+                ), $postgres);
+                sqlx::query(sqlx::AssertSqlSafe(prune.as_str()))
+                    .bind(&record.app_id)
+                    .bind(&record.key)
+                    .bind(now_ms_i64())
+                    .execute(&self.$pool)
+                    .await
+                    .map_err(sql_error)?;
                 let q = sql_query(format!(
                     "INSERT INTO push_idempotency (app_id, idempotency_key, publish_id, expires_at_ms, created_at_ms) VALUES ({0}, {0}, {0}, {0}, {0}) {1}",
                     $bind, ignore_conflict_clause($postgres)
@@ -397,10 +408,11 @@ macro_rules! impl_common_sql_traits {
             }
 
             async fn get_idempotency_record(&self, app_id: &str, key: &str) -> PushStorageResult<Option<IdempotencyRecord>> {
-                let q = sql_query(format!("SELECT app_id, idempotency_key, publish_id, expires_at_ms FROM push_idempotency WHERE app_id = {0} AND idempotency_key = {0}", $bind), $postgres);
+                let q = sql_query(format!("SELECT app_id, idempotency_key, publish_id, expires_at_ms FROM push_idempotency WHERE app_id = {0} AND idempotency_key = {0} AND (expires_at_ms < 1000000000000 OR expires_at_ms > {0})", $bind), $postgres);
                 sqlx::query(sqlx::AssertSqlSafe(q.as_str()))
                     .bind(app_id)
                     .bind(key)
+                    .bind(now_ms_i64())
                     .fetch_optional(&self.$pool)
                     .await
                     .map_err(sql_error)?

--- a/docs/content/docs/reference/http-endpoints.mdx
+++ b/docs/content/docs/reference/http-endpoints.mdx
@@ -178,6 +178,11 @@ Push notifications are a core Sockudo API surface. Push endpoints are available 
 | `DELETE` | `/apps/{appId}/push/scheduled/{jobId}` | Signed app API, push admin | Cancel a scheduled publish before dispatch when possible. |
 | `POST` | `/apps/{appId}/push/deliveryStatus` | Signed app API, push admin | Ingest worker or provider delivery feedback. |
 
+Push publish bodies accept `notBeforeMs` to delay provider dispatch and `expiresAtMs` to stop late
+delivery and retry. The public API does not expose `POST /push/scheduled`; delayed delivery is
+created through `/push/publish`, while `DELETE /push/scheduled/{jobId}` only cancels jobs already
+persisted by scheduler/store integrations.
+
 Push headers:
 
 | Header | Values | Meaning |

--- a/docs/content/docs/server/push-notifications.mdx
+++ b/docs/content/docs/server/push-notifications.mdx
@@ -83,6 +83,11 @@ moves to `dead_lettered` unless some deliveries already succeeded, in which case
 `retryAttempted`; `dispatched` counts terminal provider outcomes so retry attempts do not inflate
 completion accounting.
 
+Publish timing is enforced at delivery time. `notBeforeMs` delays provider dispatch; provider
+workers split mixed due/future batches so due jobs are not blocked behind future jobs. `expiresAtMs`
+prevents late sends; expired delivery jobs are recorded as `expired` and are not sent to providers.
+Retry scheduling preserves the original timing window and does not run past publish or job expiry.
+
 Operators inspect aggregate status with `GET /apps/{appId}/push/publish/{publishId}/status`, retry
 and dead-letter queue lag through the health/backpressure surfaces, and metrics such as
 `sockudo_push_retry_scheduled_total`, `sockudo_push_retry_attempted_total`,
@@ -210,17 +215,21 @@ console.log(response.publish_id);
 Use `sync: false` for most production traffic. Async admission returns quickly, then workers fan out
 to providers and update publish status records.
 
-## Schedule and cancel
+## Delayed delivery and cancellation
 
 ```ts
-const scheduled = await sockudo.schedulePush({
-  run_at: "2026-05-19T18:00:00Z",
+const delayed = await sockudo.publishPush({
+  notBeforeMs: Date.parse("2026-05-19T18:00:00Z"),
+  expiresAtMs: Date.parse("2026-05-19T18:10:00Z"),
   recipients: [{ type: "client", client_id: "user-42" }],
   payload: { title: "Reminder", body: "Your room starts soon" },
 });
-
-await sockudo.cancelScheduledPush(scheduled.publish_id);
 ```
+
+The public HTTP API does not expose a separate schedule-create endpoint. Use
+`POST /apps/{appId}/push/publish` with `notBeforeMs` for delayed delivery. Persisted scheduled jobs
+created by internal scheduler/store integrations can be cancelled before emission with
+`DELETE /apps/{appId}/push/scheduled/{jobId}`.
 
 ## Channel-triggered push rule
 


### PR DESCRIPTION
## What disaster scenario this PR makes safe

This PR makes delayed and expiring push deliveries deterministic under queue pressure, mixed batches, retry scheduling, and provider-worker lag. A publish accepted with `notBeforeMs`/`expiresAtMs` now reaches an explicit terminal or retry-visible state instead of being dispatched too early, sent after expiry, or left misleadingly dispatching when the delivery window has already closed.

It also makes expired idempotency records reusable across SQL and document stores so a buyer rotating retry/idempotency keys over long retention windows is not blocked by stale records.

## What behavior changed

- Propagates `not_before_ms` through publish planning, shard jobs, and provider delivery jobs.
- Enqueues delayed delivery batches with queue-level `retry_at` timing instead of immediately-visible delivery queue entries.
- Preflights provider batches before provider dispatch:
  - expired jobs emit `DeliveryOutcome::Expired` feedback without calling the provider;
  - future-only batches are delayed until the earliest `not_before_ms`;
  - mixed ready/future batches dispatch ready jobs and requeue future jobs separately.
- Marks delayed dispatch state with `retry_after_ms` so the delay is observable while the publish is dispatching.
- Treats expired idempotency records as absent in SQL and document stores, allowing replacement after expiry.
- Updates push docs/reference text to document the existing `/push/publish` timing contract and clarify that no separate public scheduled-push creation endpoint exists.

## What behavior intentionally did not change

- Protocol V1 Pusher-compatible wire behavior is unchanged.
- Provider payload mapping, provider credentials, retry classification, and feedback response shapes are unchanged.
- No new public `POST /push/scheduled` endpoint was added; the existing `notBeforeMs`/`expiresAtMs` publish contract remains the public scheduling surface.
- Broader queue ownership, node-death recovery, and live provider integration behavior are left for later PRs.

## Tests and commands passed

- `cargo fmt --all`
- `cargo test -p sockudo-push planner`
- `cargo test -p sockudo-push dispatch`
- `cargo test -p sockudo-push retry`
- `cargo test -p sockudo-push shard_path_copies_timing_into_shard_and_delivery_jobs`
- `cargo test -p sockudo-push scheduler`
- `cargo test -p sockudo-push`
- `cargo test -p sockudo push`
- `cargo test -p sockudo`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cd docs && npm run types:check`
- `cd docs && npm run build`

Note: `cargo test -p sockudo-server push` is not a valid package target in this workspace; the server package is `sockudo`, so the equivalent server commands above were run.

## Remaining disaster modes deferred

- Distributed queue ownership and dead-node recovery semantics for in-flight provider work.
- Live APNs/FCM/Web Push integration coverage against real provider outages.
- Provider payload override/template work from later push disaster-proofing PRs.
- Additional end-to-end operator visibility for duplicate risk under at-least-once queue redelivery.
