### PR TITLE
fix: remove push memory-driver validation that crashes non-push builds

### DIFF
--- a/crates/sockudo-core/src/options/push.rs
+++ b/crates/sockudo-core/src/options/push.rs
@@ -519,32 +519,4 @@ mod tests {
         assert_eq!(options.push.default_quotas.fanout_max, 9_000);
         assert_eq!(options.push.default_quotas.inflight_max, 1_000);
     }
-
-    #[test]
-    fn production_memory_push_drivers_require_explicit_allow() {
-        let mut options = ServerOptions {
-            mode: "production".to_owned(),
-            ..Default::default()
-        };
-        options.push.storage_driver = PushStorageDriver::Memory;
-        options.push.queue_driver = PushQueueDriver::Memory;
-        options.push.allow_memory_drivers = false;
-
-        let error = options.validate().unwrap_err();
-
-        assert!(error.contains("push.storage_driver=memory"));
-    }
-
-    #[test]
-    fn production_memory_push_drivers_validate_with_explicit_allow() {
-        let mut options = ServerOptions {
-            mode: "production".to_owned(),
-            ..Default::default()
-        };
-        options.push.storage_driver = PushStorageDriver::Memory;
-        options.push.queue_driver = PushQueueDriver::Memory;
-        options.push.allow_memory_drivers = true;
-
-        assert!(options.validate().is_ok());
-    }
 }

--- a/crates/sockudo-core/src/options/server.rs
+++ b/crates/sockudo-core/src/options/server.rs
@@ -239,21 +239,6 @@ impl ServerOptions {
         for (index, rule) in self.push_rules.iter().enumerate() {
             rule.validate(index)?;
         }
-        if self.mode.eq_ignore_ascii_case("production") && !self.push.allow_memory_drivers {
-            if self.push.storage_driver == PushStorageDriver::Memory {
-                return Err(
-                    "push.storage_driver=memory is unsafe in production; set push.allow_memory_drivers=true only for local/dev acknowledgment"
-                        .to_string(),
-                );
-            }
-            if self.push.queue_driver == PushQueueDriver::Memory {
-                return Err(
-                    "push.queue_driver=memory is unsafe in production; set push.allow_memory_drivers=true only for local/dev acknowledgment"
-                        .to_string(),
-                );
-            }
-        }
-
         if self.adapter.nats.presence_sync_chunk_size == Some(0) {
             return Err("nats.presence_sync_chunk_size must be > 0 when set".to_string());
         }


### PR DESCRIPTION
Production pods crash on startup when push is not enabled because a recently added config validation rejects the default memory drivers unconditionally, regardless of whether push is actually in use.

The same safety check already exists in the push bootstrap layer, properly gated behind the push feature flag. The ungated duplicate in core config validation is both redundant and harmful.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
