### PR TITLE
Classify push provider failures safely

### DIFF
--- a/crates/sockudo-push/src/dispatch/apns.rs
+++ b/crates/sockudo-push/src/dispatch/apns.rs
@@ -11,12 +11,13 @@ use super::http::{
     ProviderEndpointConfig, ProviderHttpClient, ProviderHttpRequest, ProviderHttpResponse,
 };
 use super::outcome::{
-    ProviderClassification, classify_http_result, json_request, recipient_token, rejected,
-    render_payload_json, result_from_error, retryable,
+    ProviderClassification, classify_http_result, json_field, json_request, recipient_token,
+    rejected, render_payload_json, result_from_error, retryable,
 };
 use super::{HealthStatus, PushDispatcher};
 use crate::domain::{
-    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError, PushProviderKind,
+    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError,
+    ProviderFailureClass, PushProviderKind,
 };
 use crate::pipeline::now_ms;
 
@@ -81,6 +82,7 @@ impl ApnsDispatcher {
         };
         let device_token = recipient_token(&job.recipient).ok_or_else(|| ProviderError {
             class: "invalid_token".to_owned(),
+            failure_class: ProviderFailureClass::DeviceTerminal,
             reason: Some("apns device token is missing".to_owned()),
             retry_after_ms: None,
         })?;
@@ -169,16 +171,73 @@ pub(super) fn classify_apns_response(response: &ProviderHttpResponse) -> Provide
             response.headers.get("apns-id").cloned(),
         );
     }
+    let reason = apns_reason(response);
     match response.status {
-        400 => rejected("invalid_payload", response, None),
-        403 if is_apns_expired_provider_token_response(response) => {
-            retryable("auth_failure", response)
+        400 if apns_reason_matches(reason.as_deref(), &["BadDeviceToken"]) => rejected(
+            "invalid_token",
+            ProviderFailureClass::DeviceTerminal,
+            response,
+            reason.as_deref(),
+        ),
+        400 if apns_reason_matches(
+            reason.as_deref(),
+            &[
+                "BadCertificateEnvironment",
+                "BadTopic",
+                "DeviceTokenNotForTopic",
+                "TopicDisallowed",
+            ],
+        ) =>
+        {
+            rejected(
+                "apns_topic_mismatch",
+                ProviderFailureClass::CredentialAuth,
+                response,
+                reason.as_deref(),
+            )
         }
-        403 => rejected("auth_failure", response, None),
-        410 => rejected("invalid_token", response, Some("unregistered")),
-        429 => retryable("quota", response),
-        500 | 503 => retryable("unavailable", response),
-        _ => rejected("provider_rejected", response, None),
+        400 => rejected(
+            "invalid_payload",
+            ProviderFailureClass::CallerPayload,
+            response,
+            reason.as_deref(),
+        ),
+        403 if is_apns_expired_provider_token_response(response) => retryable(
+            "auth_failure",
+            ProviderFailureClass::CredentialAuth,
+            response,
+        ),
+        403 if apns_reason_matches(reason.as_deref(), &["TooManyProviderTokenUpdates"]) => {
+            retryable(
+                "auth_failure",
+                ProviderFailureClass::CredentialAuth,
+                response,
+            )
+        }
+        403 => rejected(
+            "auth_failure",
+            ProviderFailureClass::CredentialAuth,
+            response,
+            reason.as_deref(),
+        ),
+        410 => rejected(
+            "invalid_token",
+            ProviderFailureClass::DeviceTerminal,
+            response,
+            Some("unregistered"),
+        ),
+        429 => retryable("quota", ProviderFailureClass::ProviderQuota, response),
+        500 | 503 => retryable(
+            "unavailable",
+            ProviderFailureClass::ProviderTransient,
+            response,
+        ),
+        _ => rejected(
+            "provider_rejected",
+            ProviderFailureClass::Unknown,
+            response,
+            reason.as_deref(),
+        ),
     }
 }
 
@@ -196,4 +255,17 @@ fn is_apns_expired_provider_token_response(response: &ProviderHttpResponse) -> b
         && String::from_utf8_lossy(&response.body)
             .to_ascii_lowercase()
             .contains("expiredprovidertoken")
+}
+
+fn apns_reason(response: &ProviderHttpResponse) -> Option<String> {
+    json_field(&response.body, &["reason"]).or_else(|| json_field(&response.body, &["error"]))
+}
+
+fn apns_reason_matches(reason: Option<&str>, values: &[&str]) -> bool {
+    let Some(reason) = reason else {
+        return false;
+    };
+    values
+        .iter()
+        .any(|value| reason.eq_ignore_ascii_case(value))
 }

--- a/crates/sockudo-push/src/dispatch/auth.rs
+++ b/crates/sockudo-push/src/dispatch/auth.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::domain::{ProviderError, SecretString};
+use crate::domain::{ProviderError, ProviderFailureClass, SecretString};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProviderAccessToken {
@@ -136,6 +136,7 @@ pub struct ProviderAuthError {
 pub(super) fn auth_error(error: ProviderAuthError) -> ProviderError {
     ProviderError {
         class: error.class.to_owned(),
+        failure_class: ProviderFailureClass::CredentialAuth,
         reason: Some(error.reason),
         retry_after_ms: None,
     }

--- a/crates/sockudo-push/src/dispatch/fcm.rs
+++ b/crates/sockudo-push/src/dispatch/fcm.rs
@@ -25,7 +25,8 @@ use super::{HealthStatus, PushDispatcher};
 #[cfg(feature = "push-fcm")]
 use crate::domain::SecretString;
 use crate::domain::{
-    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError, PushProviderKind,
+    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError,
+    ProviderFailureClass, PushProviderKind,
 };
 use crate::pipeline::now_ms;
 
@@ -319,24 +320,67 @@ pub(super) fn classify_fcm_response(response: &ProviderHttpResponse) -> Provider
         );
     }
     let body = String::from_utf8_lossy(&response.body).to_ascii_uppercase();
-    if matches!(response.status, 404 | 410)
-        || body.contains("UNREGISTERED")
-        || body.contains("NOT_FOUND")
-    {
-        rejected("invalid_token", response, None)
-    } else if matches!(response.status, 400 | 413) {
-        rejected("invalid_payload", response, None)
+    if is_fcm_terminal_token_failure(&body) {
+        rejected(
+            "invalid_token",
+            ProviderFailureClass::DeviceTerminal,
+            response,
+            None,
+        )
     } else if response.status == 403 && body.contains("SENDER_ID_MISMATCH") {
-        rejected("invalid_token", response, Some("sender_id_mismatch"))
+        rejected(
+            "project_mismatch",
+            ProviderFailureClass::CredentialAuth,
+            response,
+            Some("sender_id_mismatch"),
+        )
+    } else if matches!(response.status, 400 | 413) {
+        rejected(
+            "invalid_payload",
+            ProviderFailureClass::CallerPayload,
+            response,
+            None,
+        )
+    } else if response.status == 404 || body.contains("NOT_FOUND") {
+        rejected(
+            "project_mismatch",
+            ProviderFailureClass::CredentialAuth,
+            response,
+            None,
+        )
     } else if matches!(response.status, 401 | 403) {
-        rejected("auth_failure", response, None)
+        rejected(
+            "auth_failure",
+            ProviderFailureClass::CredentialAuth,
+            response,
+            None,
+        )
     } else if response.status == 429 {
-        retryable("quota", response)
+        retryable("quota", ProviderFailureClass::ProviderQuota, response)
     } else if matches!(response.status, 500 | 502 | 503 | 504) {
-        retryable("unavailable", response)
+        retryable(
+            "unavailable",
+            ProviderFailureClass::ProviderTransient,
+            response,
+        )
     } else {
-        rejected("provider_rejected", response, None)
+        rejected(
+            "provider_rejected",
+            ProviderFailureClass::Unknown,
+            response,
+            None,
+        )
     }
+}
+
+fn is_fcm_terminal_token_failure(body: &str) -> bool {
+    body.contains("UNREGISTERED")
+        || body.contains("REGISTRATION-TOKEN-NOT-REGISTERED")
+        || (body.contains("INVALID_ARGUMENT")
+            && body.contains("REGISTRATION TOKEN")
+            && (body.contains("NOT A VALID")
+                || body.contains("INVALID")
+                || body.contains("MALFORMED")))
 }
 
 fn is_fcm_auth_failure_response(response: &ProviderHttpResponse) -> bool {

--- a/crates/sockudo-push/src/dispatch/hms.rs
+++ b/crates/sockudo-push/src/dispatch/hms.rs
@@ -15,7 +15,8 @@ use super::outcome::{
 };
 use super::{HealthStatus, PushDispatcher};
 use crate::domain::{
-    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError, PushProviderKind,
+    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError,
+    ProviderFailureClass, PushProviderKind,
 };
 use crate::pipeline::now_ms;
 
@@ -113,16 +114,40 @@ pub(super) fn classify_hms_response(response: &ProviderHttpResponse) -> Provider
     if matches!(response.status, 404 | 410)
         || (body.contains("token") && (body.contains("invalid") || body.contains("not exist")))
     {
-        rejected("invalid_token", response, None)
+        rejected(
+            "invalid_token",
+            ProviderFailureClass::DeviceTerminal,
+            response,
+            None,
+        )
     } else if response.status == 413 {
-        rejected("invalid_payload", response, Some("payload_too_large"))
+        rejected(
+            "invalid_payload",
+            ProviderFailureClass::CallerPayload,
+            response,
+            Some("payload_too_large"),
+        )
     } else if response.status == 429 || body.contains("quota") {
-        retryable("quota", response)
+        retryable("quota", ProviderFailureClass::ProviderQuota, response)
     } else if matches!(response.status, 401 | 403) {
-        rejected("auth_failure", response, None)
+        rejected(
+            "auth_failure",
+            ProviderFailureClass::CredentialAuth,
+            response,
+            None,
+        )
     } else if response.status >= 500 {
-        retryable("unavailable", response)
+        retryable(
+            "unavailable",
+            ProviderFailureClass::ProviderTransient,
+            response,
+        )
     } else {
-        rejected("provider_rejected", response, None)
+        rejected(
+            "provider_rejected",
+            ProviderFailureClass::Unknown,
+            response,
+            None,
+        )
     }
 }

--- a/crates/sockudo-push/src/dispatch/http.rs
+++ b/crates/sockudo-push/src/dispatch/http.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use url::{Host, Url};
 
-use crate::domain::{ProviderError, SecretString};
+use crate::domain::{ProviderError, ProviderFailureClass, SecretString};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProviderHttpMethod {
@@ -208,6 +208,7 @@ impl ProviderEndpointConfig {
 pub(super) fn validate_webpush_target(endpoint: &str) -> Result<(), ProviderError> {
     let parsed = Url::parse(endpoint).map_err(|_| ProviderError {
         class: "invalid_token".to_owned(),
+        failure_class: ProviderFailureClass::DeviceTerminal,
         reason: Some("web push endpoint must be a URL".to_owned()),
         retry_after_ms: None,
     })?;
@@ -218,6 +219,7 @@ pub(super) fn validate_webpush_target(endpoint: &str) -> Result<(), ProviderErro
     {
         return Err(ProviderError {
             class: "invalid_token".to_owned(),
+            failure_class: ProviderFailureClass::DeviceTerminal,
             reason: Some("web push endpoint host is not allowed".to_owned()),
             retry_after_ms: None,
         });
@@ -303,6 +305,7 @@ fn validate_parsed_https_url(parsed: &Url, class: &str) -> Result<(), ProviderEr
     if parsed.scheme() != "https" {
         return Err(ProviderError {
             class: class.to_owned(),
+            failure_class: ProviderFailureClass::from_legacy_url_class(class),
             reason: Some("provider URL must use https".to_owned()),
             retry_after_ms: None,
         });
@@ -310,6 +313,7 @@ fn validate_parsed_https_url(parsed: &Url, class: &str) -> Result<(), ProviderEr
     if !parsed.username().is_empty() || parsed.password().is_some() {
         return Err(ProviderError {
             class: class.to_owned(),
+            failure_class: ProviderFailureClass::from_legacy_url_class(class),
             reason: Some("provider URL must not include userinfo".to_owned()),
             retry_after_ms: None,
         });

--- a/crates/sockudo-push/src/dispatch/mod.rs
+++ b/crates/sockudo-push/src/dispatch/mod.rs
@@ -61,7 +61,8 @@ use sonic_rs::prelude::*;
 use sonic_rs::{Value, json};
 
 use crate::domain::{
-    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError, PushProviderKind,
+    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError,
+    ProviderFailureClass, PushProviderKind,
 };
 use crate::pipeline::now_ms;
 
@@ -184,6 +185,7 @@ impl WnsDispatcher {
     ) -> Result<ProviderHttpRequest, ProviderError> {
         let channel_uri = recipient_token(&job.recipient).ok_or_else(|| ProviderError {
             class: "invalid_token".to_owned(),
+            failure_class: ProviderFailureClass::DeviceTerminal,
             reason: Some("wns channel URI is missing".to_owned()),
             retry_after_ms: None,
         })?;
@@ -253,17 +255,41 @@ fn classify_hms_response(response: &ProviderHttpResponse) -> ProviderClassificat
     if matches!(response.status, 404 | 410)
         || (body.contains("token") && (body.contains("invalid") || body.contains("not exist")))
     {
-        rejected("invalid_token", response, None)
+        rejected(
+            "invalid_token",
+            ProviderFailureClass::DeviceTerminal,
+            response,
+            None,
+        )
     } else if response.status == 413 {
-        rejected("invalid_payload", response, Some("payload_too_large"))
+        rejected(
+            "invalid_payload",
+            ProviderFailureClass::CallerPayload,
+            response,
+            Some("payload_too_large"),
+        )
     } else if response.status == 429 || body.contains("quota") {
-        retryable("quota", response)
+        retryable("quota", ProviderFailureClass::ProviderQuota, response)
     } else if matches!(response.status, 401 | 403) {
-        rejected("auth_failure", response, None)
+        rejected(
+            "auth_failure",
+            ProviderFailureClass::CredentialAuth,
+            response,
+            None,
+        )
     } else if response.status >= 500 {
-        retryable("unavailable", response)
+        retryable(
+            "unavailable",
+            ProviderFailureClass::ProviderTransient,
+            response,
+        )
     } else {
-        rejected("provider_rejected", response, None)
+        rejected(
+            "provider_rejected",
+            ProviderFailureClass::Unknown,
+            response,
+            None,
+        )
     }
 }
 
@@ -276,12 +302,36 @@ fn classify_wns_response(response: &ProviderHttpResponse) -> ProviderClassificat
         );
     }
     match response.status {
-        404 | 410 => rejected("invalid_token", response, None),
-        401 | 403 => rejected("auth_failure", response, None),
-        413 => rejected("invalid_payload", response, Some("payload_too_large")),
-        429 => retryable("quota", response),
-        500..=599 => retryable("unavailable", response),
-        _ => rejected("provider_rejected", response, None),
+        404 | 410 => rejected(
+            "invalid_token",
+            ProviderFailureClass::DeviceTerminal,
+            response,
+            None,
+        ),
+        401 | 403 => rejected(
+            "auth_failure",
+            ProviderFailureClass::CredentialAuth,
+            response,
+            None,
+        ),
+        413 => rejected(
+            "invalid_payload",
+            ProviderFailureClass::CallerPayload,
+            response,
+            Some("payload_too_large"),
+        ),
+        429 => retryable("quota", ProviderFailureClass::ProviderQuota, response),
+        500..=599 => retryable(
+            "unavailable",
+            ProviderFailureClass::ProviderTransient,
+            response,
+        ),
+        _ => rejected(
+            "provider_rejected",
+            ProviderFailureClass::Unknown,
+            response,
+            None,
+        ),
     }
 }
 
@@ -293,6 +343,7 @@ fn validate_wns_payload(payload: &Value) -> Result<(), ProviderError> {
     if !matches!(kind, "toast" | "tile" | "raw") {
         return Err(ProviderError {
             class: "invalid_payload".to_owned(),
+            failure_class: ProviderFailureClass::CallerPayload,
             reason: Some("invalid WNS notification type".to_owned()),
             retry_after_ms: None,
         });

--- a/crates/sockudo-push/src/dispatch/outcome.rs
+++ b/crates/sockudo-push/src/dispatch/outcome.rs
@@ -5,8 +5,8 @@ use sonic_rs::prelude::*;
 
 use super::http::{ProviderHttpMethod, ProviderHttpRequest, ProviderHttpResponse};
 use crate::domain::{
-    DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError, PushProviderKind, PushRecipient,
-    SecretString,
+    DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError, ProviderFailureClass,
+    PushProviderKind, PushRecipient, SecretString,
 };
 use crate::pipeline::now_ms;
 use crate::transform::render_provider_payload;
@@ -22,6 +22,7 @@ pub(super) fn render_payload_json(
         if rendered.provider != provider {
             return Err(ProviderError {
                 class: "invalid_payload".to_owned(),
+                failure_class: ProviderFailureClass::CallerPayload,
                 reason: Some("cached provider payload does not match dispatcher".to_owned()),
                 retry_after_ms: None,
             });
@@ -32,6 +33,7 @@ pub(super) fn render_payload_json(
         .map(|rendered| rendered.payload)
         .map_err(|error| ProviderError {
             class: "invalid_payload".to_owned(),
+            failure_class: ProviderFailureClass::CallerPayload,
             reason: Some(error.to_string()),
             retry_after_ms: None,
         })
@@ -58,6 +60,7 @@ pub(super) fn json_request_with_content_type(
         .or_insert_with(|| content_type.unwrap_or("application/json").to_owned());
     let body = sonic_rs::to_vec(&payload).map_err(|_| ProviderError {
         class: "invalid_payload".to_owned(),
+        failure_class: ProviderFailureClass::CallerPayload,
         reason: Some("provider payload serialization failed".to_owned()),
         retry_after_ms: None,
     })?;
@@ -101,12 +104,13 @@ pub(super) fn classify_http_result(
                 attempt: job.attempt,
             }
         }
-        Err(error) => result_from_error(
+        Err(_) => result_from_error(
             job,
             DeliveryOutcome::Retryable,
             ProviderError {
-                class: "unavailable".to_owned(),
-                reason: Some(error),
+                class: "network_transport".to_owned(),
+                failure_class: ProviderFailureClass::NetworkTransport,
+                reason: Some("provider transport failure".to_owned()),
                 retry_after_ms: None,
             },
         ),
@@ -115,21 +119,27 @@ pub(super) fn classify_http_result(
 
 pub(super) fn rejected(
     class: &str,
+    failure_class: ProviderFailureClass,
     response: &ProviderHttpResponse,
     reason: Option<&str>,
 ) -> ProviderClassification {
     (
         DeliveryOutcome::Rejected,
-        Some(provider_error(class, response, reason, None)),
+        Some(provider_error(class, failure_class, response, reason, None)),
         None,
     )
 }
 
-pub(super) fn retryable(class: &str, response: &ProviderHttpResponse) -> ProviderClassification {
+pub(super) fn retryable(
+    class: &str,
+    failure_class: ProviderFailureClass,
+    response: &ProviderHttpResponse,
+) -> ProviderClassification {
     (
         DeliveryOutcome::Retryable,
         Some(provider_error(
             class,
+            failure_class,
             response,
             None,
             retry_after_ms(&response.headers),
@@ -140,12 +150,14 @@ pub(super) fn retryable(class: &str, response: &ProviderHttpResponse) -> Provide
 
 fn provider_error(
     class: &str,
+    failure_class: ProviderFailureClass,
     response: &ProviderHttpResponse,
     reason: Option<&str>,
     retry_after_ms: Option<u64>,
 ) -> ProviderError {
     ProviderError {
         class: class.to_owned(),
+        failure_class,
         reason: reason
             .map(str::to_owned)
             .or_else(|| json_field(&response.body, &["error", "status"]))

--- a/crates/sockudo-push/src/dispatch/stubs.rs
+++ b/crates/sockudo-push/src/dispatch/stubs.rs
@@ -2,7 +2,8 @@ use async_trait::async_trait;
 
 use super::{HealthStatus, PushDispatcher};
 use crate::domain::{
-    DeliveryBatch, DeliveryOutcome, DeliveryResult, ProviderError, PushProviderKind,
+    DeliveryBatch, DeliveryOutcome, DeliveryResult, ProviderError, ProviderFailureClass,
+    PushProviderKind,
 };
 
 pub struct AcceptAllDispatcher {
@@ -82,6 +83,7 @@ impl PushDispatcher for RetryAfterDispatcher {
                 provider_message_id: None,
                 error: Some(ProviderError {
                     class: "quota".to_owned(),
+                    failure_class: ProviderFailureClass::ProviderQuota,
                     reason: Some("retry-after".to_owned()),
                     retry_after_ms: Some(self.retry_after_ms),
                 }),

--- a/crates/sockudo-push/src/dispatch/tests.rs
+++ b/crates/sockudo-push/src/dispatch/tests.rs
@@ -281,6 +281,17 @@ fn classifies_provider_error_classes_and_retry_after() {
     .retry_after_ms
     .unwrap();
     assert!(retry_at > now_ms());
+    assert_eq!(
+        classify_fcm_response(&ProviderHttpResponse {
+            status: 429,
+            headers: BTreeMap::from([("retry-after".to_owned(), "7".to_owned())]),
+            body: br#"{"error":{"status":"RESOURCE_EXHAUSTED"}}"#.to_vec(),
+        })
+        .1
+        .unwrap()
+        .resolved_failure_class(),
+        ProviderFailureClass::ProviderQuota
+    );
 
     for (provider, status, class) in [
         (PushProviderKind::Fcm, 400, "invalid_payload"),
@@ -298,6 +309,155 @@ fn classifies_provider_error_classes_and_retry_after() {
         }
         .unwrap();
         assert_eq!(error.class, class);
+    }
+}
+
+#[test]
+fn fcm_failure_classification_preserves_devices_for_project_auth_quota_and_payload_errors() {
+    let unregistered = classify_fcm_response(&ProviderHttpResponse {
+        status: 404,
+        headers: BTreeMap::new(),
+        body: br#"{"error":{"status":"NOT_FOUND","details":[{"errorCode":"UNREGISTERED"}]}}"#
+            .to_vec(),
+    });
+    assert_eq!(unregistered.0, DeliveryOutcome::Rejected);
+    assert_eq!(
+        unregistered.1.unwrap().resolved_failure_class(),
+        ProviderFailureClass::DeviceTerminal
+    );
+
+    let invalid_token_argument = classify_fcm_response(&ProviderHttpResponse {
+        status: 400,
+        headers: BTreeMap::new(),
+        body: br#"{"error":{"status":"INVALID_ARGUMENT","message":"The registration token is not a valid FCM registration token"}}"#.to_vec(),
+    });
+    assert_eq!(
+        invalid_token_argument.1.unwrap().resolved_failure_class(),
+        ProviderFailureClass::DeviceTerminal
+    );
+
+    for (status, body, failure_class) in [
+        (
+            403,
+            json!({"error":{"status":"PERMISSION_DENIED","details":[{"errorCode":"SENDER_ID_MISMATCH"}]}}),
+            ProviderFailureClass::CredentialAuth,
+        ),
+        (
+            401,
+            json!({"error":{"status":"UNAUTHENTICATED"}}),
+            ProviderFailureClass::CredentialAuth,
+        ),
+        (
+            400,
+            json!({"error":{"status":"INVALID_ARGUMENT","message":"invalid payload field"}}),
+            ProviderFailureClass::CallerPayload,
+        ),
+    ] {
+        let classification = classify_fcm_response(&response(status, body));
+        assert_eq!(classification.0, DeliveryOutcome::Rejected);
+        assert_eq!(
+            classification.1.unwrap().resolved_failure_class(),
+            failure_class
+        );
+    }
+
+    for (status, failure_class) in [
+        (429, ProviderFailureClass::ProviderQuota),
+        (503, ProviderFailureClass::ProviderTransient),
+    ] {
+        let classification = classify_fcm_response(&response(status, json!({})));
+        assert_eq!(classification.0, DeliveryOutcome::Retryable);
+        assert_eq!(
+            classification.1.unwrap().resolved_failure_class(),
+            failure_class
+        );
+    }
+}
+
+#[test]
+fn apns_failure_classification_keeps_topic_auth_and_quota_off_device_health() {
+    for reason in ["BadDeviceToken", "Unregistered"] {
+        let status = if reason == "Unregistered" { 410 } else { 400 };
+        let classification = classify_apns_response(&response(status, json!({"reason": reason})));
+        assert_eq!(classification.0, DeliveryOutcome::Rejected);
+        assert_eq!(
+            classification.1.unwrap().resolved_failure_class(),
+            ProviderFailureClass::DeviceTerminal,
+            "{reason}"
+        );
+    }
+
+    for reason in ["BadTopic", "DeviceTokenNotForTopic"] {
+        let classification = classify_apns_response(&response(400, json!({"reason": reason})));
+        assert_eq!(
+            classification.1.unwrap().resolved_failure_class(),
+            ProviderFailureClass::CredentialAuth,
+            "{reason}"
+        );
+    }
+
+    let expired_provider_token =
+        classify_apns_response(&response(403, json!({"reason": "ExpiredProviderToken"})));
+    assert_eq!(expired_provider_token.0, DeliveryOutcome::Retryable);
+    assert_eq!(
+        expired_provider_token.1.unwrap().resolved_failure_class(),
+        ProviderFailureClass::CredentialAuth
+    );
+
+    for (status, failure_class) in [
+        (429, ProviderFailureClass::ProviderQuota),
+        (500, ProviderFailureClass::ProviderTransient),
+    ] {
+        let classification = classify_apns_response(&response(status, json!({})));
+        assert_eq!(classification.0, DeliveryOutcome::Retryable);
+        assert_eq!(
+            classification.1.unwrap().resolved_failure_class(),
+            failure_class
+        );
+    }
+}
+
+#[test]
+fn webpush_failure_classification_separates_subscription_auth_quota_and_provider_errors() {
+    for status in [404, 410] {
+        let classification = classify_webpush_response(&response(status, json!({})));
+        assert_eq!(classification.0, DeliveryOutcome::Rejected);
+        assert_eq!(
+            classification.1.unwrap().resolved_failure_class(),
+            ProviderFailureClass::DeviceTerminal,
+            "{status}"
+        );
+    }
+
+    for (status, outcome, failure_class) in [
+        (
+            401,
+            DeliveryOutcome::Rejected,
+            ProviderFailureClass::CredentialAuth,
+        ),
+        (
+            403,
+            DeliveryOutcome::Rejected,
+            ProviderFailureClass::CredentialAuth,
+        ),
+        (
+            429,
+            DeliveryOutcome::Retryable,
+            ProviderFailureClass::ProviderQuota,
+        ),
+        (
+            503,
+            DeliveryOutcome::Retryable,
+            ProviderFailureClass::ProviderTransient,
+        ),
+    ] {
+        let classification = classify_webpush_response(&response(status, json!({})));
+        assert_eq!(classification.0, outcome);
+        assert_eq!(
+            classification.1.unwrap().resolved_failure_class(),
+            failure_class,
+            "{status}"
+        );
     }
 }
 
@@ -329,7 +489,12 @@ fn provider_outage_responses_are_retryable() {
         classify_fcm_response,
     );
     assert_eq!(timeout.outcome, DeliveryOutcome::Retryable);
-    assert_eq!(timeout.error.unwrap().class, "unavailable");
+    let error = timeout.error.unwrap();
+    assert_eq!(error.class, "network_transport");
+    assert_eq!(
+        error.resolved_failure_class(),
+        ProviderFailureClass::NetworkTransport
+    );
 }
 
 #[test]
@@ -579,9 +744,19 @@ async fn native_web_push_crypto_encrypts_and_signs_request() {
 #[test]
 fn invalid_token_classes_are_cleanup_signals() {
     let (_, error, _) = classify_webpush_response(&response(410, json!({})));
-    assert_eq!(error.unwrap().class, "invalid_token");
+    let error = error.unwrap();
+    assert_eq!(error.class, "invalid_token");
+    assert_eq!(
+        error.resolved_failure_class(),
+        ProviderFailureClass::DeviceTerminal
+    );
     let (_, error, _) = classify_apns_response(&response(410, json!({})));
-    assert_eq!(error.unwrap().class, "invalid_token");
+    let error = error.unwrap();
+    assert_eq!(error.class, "invalid_token");
+    assert_eq!(
+        error.resolved_failure_class(),
+        ProviderFailureClass::DeviceTerminal
+    );
 }
 
 fn cached_static_token(raw: &str, expires_at_ms: u64) -> CachedTokenProvider {

--- a/crates/sockudo-push/src/dispatch/webpush.rs
+++ b/crates/sockudo-push/src/dispatch/webpush.rs
@@ -25,8 +25,8 @@ use super::outcome::{
 };
 use super::{HealthStatus, PushDispatcher};
 use crate::domain::{
-    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError, PushProviderKind,
-    PushRecipient, SecretString,
+    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError,
+    ProviderFailureClass, PushProviderKind, PushRecipient, SecretString,
 };
 use crate::pipeline::now_ms;
 
@@ -141,17 +141,20 @@ impl NativeWebPushCrypto {
         let vapid_key = self.vapid_key.as_ref().map_err(|error| match error {
             NativeWebPushKeyError::Encoding => ProviderError {
                 class: "auth_failure".to_owned(),
+                failure_class: ProviderFailureClass::CredentialAuth,
                 reason: Some("invalid VAPID private key encoding".to_owned()),
                 retry_after_ms: None,
             },
             NativeWebPushKeyError::Key => ProviderError {
                 class: "auth_failure".to_owned(),
+                failure_class: ProviderFailureClass::CredentialAuth,
                 reason: Some("invalid VAPID private key".to_owned()),
                 retry_after_ms: None,
             },
         })?;
         let endpoint_uri = Url::parse(endpoint).map_err(|_| ProviderError {
             class: "invalid_token".to_owned(),
+            failure_class: ProviderFailureClass::DeviceTerminal,
             reason: Some("invalid Web Push endpoint".to_owned()),
             retry_after_ms: None,
         })?;
@@ -159,12 +162,14 @@ impl NativeWebPushCrypto {
         if scheme.is_empty() {
             return Err(ProviderError {
                 class: "invalid_token".to_owned(),
+                failure_class: ProviderFailureClass::DeviceTerminal,
                 reason: Some("invalid Web Push endpoint scheme".to_owned()),
                 retry_after_ms: None,
             });
         }
         let host = endpoint_uri.host_str().ok_or_else(|| ProviderError {
             class: "invalid_token".to_owned(),
+            failure_class: ProviderFailureClass::DeviceTerminal,
             reason: Some("invalid Web Push endpoint host".to_owned()),
             retry_after_ms: None,
         })?;
@@ -172,6 +177,7 @@ impl NativeWebPushCrypto {
             .duration_since(UNIX_EPOCH)
             .map_err(|_| ProviderError {
                 class: "auth_failure".to_owned(),
+                failure_class: ProviderFailureClass::CredentialAuth,
                 reason: Some("system clock before Unix epoch".to_owned()),
                 retry_after_ms: None,
             })?
@@ -186,6 +192,7 @@ impl NativeWebPushCrypto {
             }))
             .map_err(|_| ProviderError {
                 class: "auth_failure".to_owned(),
+                failure_class: ProviderFailureClass::CredentialAuth,
                 reason: Some("failed to serialize VAPID claims".to_owned()),
                 retry_after_ms: None,
             })?,
@@ -199,6 +206,7 @@ impl NativeWebPushCrypto {
         SecretString::new(format!("vapid t={token}, k={}", vapid_key.public_key)).map_err(|_| {
             ProviderError {
                 class: "auth_failure".to_owned(),
+                failure_class: ProviderFailureClass::CredentialAuth,
                 reason: Some("invalid VAPID authorization header".to_owned()),
                 retry_after_ms: None,
             }
@@ -223,6 +231,7 @@ impl WebPushCrypto for NativeWebPushCrypto {
             .decode(p256dh.expose_secret().as_bytes())
             .map_err(|_| ProviderError {
                 class: "invalid_token".to_owned(),
+                failure_class: ProviderFailureClass::DeviceTerminal,
                 reason: Some("invalid Web Push p256dh encoding".to_owned()),
                 retry_after_ms: None,
             })?;
@@ -230,12 +239,14 @@ impl WebPushCrypto for NativeWebPushCrypto {
             .decode(auth.expose_secret().as_bytes())
             .map_err(|_| ProviderError {
                 class: "invalid_token".to_owned(),
+                failure_class: ProviderFailureClass::DeviceTerminal,
                 reason: Some("invalid Web Push auth encoding".to_owned()),
                 retry_after_ms: None,
             })?;
         if auth_bytes.len() != 16 {
             return Err(ProviderError {
                 class: "invalid_token".to_owned(),
+                failure_class: ProviderFailureClass::DeviceTerminal,
                 reason: Some("invalid Web Push auth length".to_owned()),
                 retry_after_ms: None,
             });
@@ -244,11 +255,13 @@ impl WebPushCrypto for NativeWebPushCrypto {
         let request = WebPushBuilder::new(
             endpoint.parse().map_err(|_| ProviderError {
                 class: "invalid_token".to_owned(),
+                failure_class: ProviderFailureClass::DeviceTerminal,
                 reason: Some("invalid Web Push endpoint".to_owned()),
                 retry_after_ms: None,
             })?,
             PublicKey::from_sec1_bytes(&p256dh_bytes).map_err(|_| ProviderError {
                 class: "invalid_token".to_owned(),
+                failure_class: ProviderFailureClass::DeviceTerminal,
                 reason: Some("invalid Web Push p256dh key".to_owned()),
                 retry_after_ms: None,
             })?,
@@ -258,6 +271,7 @@ impl WebPushCrypto for NativeWebPushCrypto {
         .build(payload.to_vec())
         .map_err(|error| ProviderError {
             class: "invalid_payload".to_owned(),
+            failure_class: ProviderFailureClass::CallerPayload,
             reason: Some(format!("web push encryption failed: {error}")),
             retry_after_ms: None,
         })?;
@@ -307,6 +321,7 @@ impl WebPushDispatcher {
         else {
             return Err(ProviderError {
                 class: "invalid_token".to_owned(),
+                failure_class: ProviderFailureClass::DeviceTerminal,
                 reason: Some("web push recipient is missing subscription material".to_owned()),
                 retry_after_ms: None,
             });
@@ -321,6 +336,7 @@ impl WebPushDispatcher {
         let rendered = render_payload_json(PushProviderKind::WebPush, job)?;
         let body = sonic_rs::to_vec(&rendered).map_err(|_| ProviderError {
             class: "invalid_payload".to_owned(),
+            failure_class: ProviderFailureClass::CallerPayload,
             reason: Some("web push payload serialization failed".to_owned()),
             retry_after_ms: None,
         })?;
@@ -383,6 +399,7 @@ fn web_push_headers(rendered: &Value) -> Result<BTreeMap<String, String>, Provid
             .or_else(|| ttl.as_str().map(str::to_owned))
             .ok_or_else(|| ProviderError {
                 class: "invalid_payload".to_owned(),
+                failure_class: ProviderFailureClass::CallerPayload,
                 reason: Some("web push ttl must be a positive integer".to_owned()),
                 retry_after_ms: None,
             })?;
@@ -392,6 +409,7 @@ fn web_push_headers(rendered: &Value) -> Result<BTreeMap<String, String>, Provid
         if let Some(value) = rendered_headers.get(&name) {
             let value = value.as_str().ok_or_else(|| ProviderError {
                 class: "invalid_payload".to_owned(),
+                failure_class: ProviderFailureClass::CallerPayload,
                 reason: Some(format!("web push {name} must be a string")),
                 retry_after_ms: None,
             })?;
@@ -410,12 +428,36 @@ pub(super) fn classify_webpush_response(response: &ProviderHttpResponse) -> Prov
         );
     }
     match response.status {
-        404 | 410 => rejected("invalid_token", response, None),
-        413 => rejected("invalid_payload", response, Some("payload_too_large")),
-        429 => retryable("quota", response),
-        500..=599 => retryable("unavailable", response),
-        401 | 403 => rejected("auth_failure", response, None),
-        _ => rejected("provider_rejected", response, None),
+        404 | 410 => rejected(
+            "invalid_token",
+            ProviderFailureClass::DeviceTerminal,
+            response,
+            None,
+        ),
+        413 => rejected(
+            "invalid_payload",
+            ProviderFailureClass::CallerPayload,
+            response,
+            Some("payload_too_large"),
+        ),
+        429 => retryable("quota", ProviderFailureClass::ProviderQuota, response),
+        500..=599 => retryable(
+            "unavailable",
+            ProviderFailureClass::ProviderTransient,
+            response,
+        ),
+        401 | 403 => rejected(
+            "auth_failure",
+            ProviderFailureClass::CredentialAuth,
+            response,
+            None,
+        ),
+        _ => rejected(
+            "provider_rejected",
+            ProviderFailureClass::Unknown,
+            response,
+            None,
+        ),
     }
 }
 

--- a/crates/sockudo-push/src/dispatch/wns.rs
+++ b/crates/sockudo-push/src/dispatch/wns.rs
@@ -15,7 +15,8 @@ use super::outcome::{
 };
 use super::{HealthStatus, PushDispatcher};
 use crate::domain::{
-    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError, PushProviderKind,
+    DeliveryBatch, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError,
+    ProviderFailureClass, PushProviderKind,
 };
 use crate::pipeline::now_ms;
 
@@ -42,6 +43,7 @@ impl WnsDispatcher {
     ) -> Result<ProviderHttpRequest, ProviderError> {
         let channel_uri = recipient_token(&job.recipient).ok_or_else(|| ProviderError {
             class: "invalid_token".to_owned(),
+            failure_class: ProviderFailureClass::DeviceTerminal,
             reason: Some("wns channel URI is missing".to_owned()),
             retry_after_ms: None,
         })?;
@@ -105,12 +107,36 @@ pub(super) fn classify_wns_response(response: &ProviderHttpResponse) -> Provider
         );
     }
     match response.status {
-        404 | 410 => rejected("invalid_token", response, None),
-        401 | 403 => rejected("auth_failure", response, None),
-        413 => rejected("invalid_payload", response, Some("payload_too_large")),
-        429 => retryable("quota", response),
-        500..=599 => retryable("unavailable", response),
-        _ => rejected("provider_rejected", response, None),
+        404 | 410 => rejected(
+            "invalid_token",
+            ProviderFailureClass::DeviceTerminal,
+            response,
+            None,
+        ),
+        401 | 403 => rejected(
+            "auth_failure",
+            ProviderFailureClass::CredentialAuth,
+            response,
+            None,
+        ),
+        413 => rejected(
+            "invalid_payload",
+            ProviderFailureClass::CallerPayload,
+            response,
+            Some("payload_too_large"),
+        ),
+        429 => retryable("quota", ProviderFailureClass::ProviderQuota, response),
+        500..=599 => retryable(
+            "unavailable",
+            ProviderFailureClass::ProviderTransient,
+            response,
+        ),
+        _ => rejected(
+            "provider_rejected",
+            ProviderFailureClass::Unknown,
+            response,
+            None,
+        ),
     }
 }
 
@@ -122,6 +148,7 @@ fn validate_wns_payload(payload: &Value) -> Result<(), ProviderError> {
     if !matches!(kind, "toast" | "tile" | "raw") {
         return Err(ProviderError {
             class: "invalid_payload".to_owned(),
+            failure_class: ProviderFailureClass::CallerPayload,
             reason: Some("invalid WNS notification type".to_owned()),
             retry_after_ms: None,
         });

--- a/crates/sockudo-push/src/dispatch/worker.rs
+++ b/crates/sockudo-push/src/dispatch/worker.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use super::PushDispatcher;
 use crate::domain::{
     DeliveryBatch, DeliveryFeedback, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError,
-    PushProviderKind, provider_key, stable_hash,
+    ProviderFailureClass, PushProviderKind, provider_key, stable_hash,
 };
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::PushMetrics;
@@ -166,7 +166,10 @@ impl ProviderDispatchWorker {
                     batch_id = %result.batch_id,
                     outcome = ?result.outcome,
                     error_class = result.error.as_ref().map(|error| error.class.as_str()),
-                    error_reason = result.error.as_ref().and_then(|error| error.reason.as_deref()),
+                    failure_class = result
+                        .error
+                        .as_ref()
+                        .map(|error| error.resolved_failure_class().label()),
                     retry_after_ms = result.error.as_ref().and_then(|error| error.retry_after_ms),
                     "push dispatch failure"
                 );
@@ -355,6 +358,7 @@ impl ProviderDispatchWorker {
             provider_message_id: None,
             error: Some(ProviderError {
                 class: "expired".to_owned(),
+                failure_class: ProviderFailureClass::Unknown,
                 reason: Some("delivery expired before provider dispatch".to_owned()),
                 retry_after_ms: None,
             }),

--- a/crates/sockudo-push/src/domain.rs
+++ b/crates/sockudo-push/src/domain.rs
@@ -1262,20 +1262,103 @@ pub enum DeliveryOutcome {
     Cancelled,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderFailureClass {
+    DeviceTerminal,
+    DeviceTransient,
+    ProviderTransient,
+    ProviderQuota,
+    CredentialAuth,
+    CallerPayload,
+    NetworkTransport,
+    #[default]
+    Unknown,
+}
+
+impl ProviderFailureClass {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::DeviceTerminal => "device_terminal",
+            Self::DeviceTransient => "device_transient",
+            Self::ProviderTransient => "provider_transient",
+            Self::ProviderQuota => "provider_quota",
+            Self::CredentialAuth => "credential_auth",
+            Self::CallerPayload => "caller_payload",
+            Self::NetworkTransport => "network_transport",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub fn is_device_terminal(self) -> bool {
+        matches!(self, Self::DeviceTerminal)
+    }
+
+    pub fn is_device_transient(self) -> bool {
+        matches!(self, Self::DeviceTransient)
+    }
+
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown)
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderError {
     pub class: String,
+    #[serde(default, skip_serializing_if = "ProviderFailureClass::is_unknown")]
+    pub failure_class: ProviderFailureClass,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_after_ms: Option<u64>,
 }
 
+impl ProviderError {
+    pub fn resolved_failure_class(&self) -> ProviderFailureClass {
+        if !self.failure_class.is_unknown() {
+            return self.failure_class;
+        }
+        ProviderFailureClass::from_legacy_error(&self.class, self.reason.as_deref())
+    }
+}
+
+impl ProviderFailureClass {
+    fn from_legacy_error(class: &str, reason: Option<&str>) -> Self {
+        match class {
+            "invalid_token" | "unregistered" | "not_registered" | "expired_channel" => {
+                if reason.is_some_and(|reason| reason.eq_ignore_ascii_case("sender_id_mismatch")) {
+                    Self::CredentialAuth
+                } else {
+                    Self::DeviceTerminal
+                }
+            }
+            "device_transient" => Self::DeviceTransient,
+            "quota" => Self::ProviderQuota,
+            "unavailable" => Self::ProviderTransient,
+            "auth_failure" => Self::CredentialAuth,
+            "invalid_payload" => Self::CallerPayload,
+            "network_transport" => Self::NetworkTransport,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub(crate) fn from_legacy_url_class(class: &str) -> Self {
+        match class {
+            "invalid_token" => Self::DeviceTerminal,
+            "invalid_payload" => Self::CallerPayload,
+            "auth_failure" => Self::CredentialAuth,
+            _ => Self::Unknown,
+        }
+    }
+}
+
 impl fmt::Debug for ProviderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProviderError")
             .field("class", &self.class)
+            .field("failure_class", &self.resolved_failure_class())
             .field("reason", &self.reason.as_ref().map(|_| "[REDACTED]"))
             .field("retry_after_ms", &self.retry_after_ms)
             .finish()
@@ -1890,6 +1973,7 @@ mod tests {
 
         let provider_error = ProviderError {
             class: "invalid-token".to_owned(),
+            failure_class: ProviderFailureClass::DeviceTerminal,
             reason: Some("token fcm-token-secret rejected".to_owned()),
             retry_after_ms: None,
         };

--- a/crates/sockudo-push/src/feedback.rs
+++ b/crates/sockudo-push/src/feedback.rs
@@ -2,13 +2,16 @@ use futures_util::StreamExt;
 
 use crate::domain::{
     DeadLetter, DeliveryEvent, DeliveryFeedback, DeliveryOutcome, DeliveryResult, DevicePushState,
-    PublishLifecycleState,
+    ProviderError, ProviderFailureClass, PublishLifecycleState, PublishStatus,
 };
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::{PushMetrics, provider_label};
 use crate::pipeline::{PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage, now_ms};
 use crate::retry::RetryPolicy;
 use crate::storage::{DynPushStore, IdempotencyRecord};
+
+const INVALIDATION_GUARD_MIN_SAMPLES: u64 = 10;
+const INVALIDATION_GUARD_RATIO_PERCENT: u64 = 20;
 
 #[derive(Clone)]
 pub struct PushFeedbackProcessor {
@@ -123,19 +126,31 @@ impl PushFeedbackProcessor {
         };
         self.store.append_delivery_event(event).await?;
         if !matches!(result.outcome, DeliveryOutcome::Accepted) {
+            let failure_class = result_failure_class(result);
             emit_push_meta_event(PushMetaEvent::provider_rejected(
                 &result.app_id,
                 &result.publish_id,
                 result.provider,
                 result.outcome,
                 result.error.as_ref().map(|error| error.class.as_str()),
+                Some(failure_class),
             ));
+            self.metrics.provider_failure_class(
+                result.provider,
+                &result.app_id,
+                failure_class.label(),
+            );
         }
 
         if let Some(device_id) = result.device_id.as_deref() {
             self.update_device_state(result, device_id).await?;
         }
-        self.update_publish_status(result).await?;
+        let status = self.update_publish_status(result).await?;
+        if is_device_terminal_failure(result)
+            && let Some(status) = status.as_ref()
+        {
+            self.emit_invalidation_guard_if_needed(result, status);
+        }
         self.handle_retry_or_dlq(&feedback).await?;
         emit_feedback_meta_event(result);
         Ok(())
@@ -168,7 +183,7 @@ impl PushFeedbackProcessor {
                     self.store.upsert_device(device).await?;
                 }
             }
-            DeliveryOutcome::Rejected if is_invalid_token(result) => {
+            DeliveryOutcome::Rejected if is_device_terminal_failure(result) => {
                 self.store.delete_device(&result.app_id, device_id).await?;
                 self.metrics
                     .token_invalidated(result.provider, &result.app_id);
@@ -178,7 +193,9 @@ impl PushFeedbackProcessor {
                     result.provider,
                 ));
             }
-            DeliveryOutcome::Rejected | DeliveryOutcome::Retryable => {
+            DeliveryOutcome::Rejected | DeliveryOutcome::Retryable
+                if is_device_transient_failure(result) =>
+            {
                 if let Some(mut device) = self.store.get_device(&result.app_id, device_id).await? {
                     let previous = device.push.state;
                     if device.push.failure_count == 0 {
@@ -223,18 +240,22 @@ impl PushFeedbackProcessor {
                     self.store.upsert_device(device).await?;
                 }
             }
+            DeliveryOutcome::Rejected | DeliveryOutcome::Retryable => {}
             DeliveryOutcome::Expired | DeliveryOutcome::Cancelled => {}
         }
         Ok(())
     }
 
-    async fn update_publish_status(&self, result: &DeliveryResult) -> PushPipelineResult<()> {
+    async fn update_publish_status(
+        &self,
+        result: &DeliveryResult,
+    ) -> PushPipelineResult<Option<PublishStatus>> {
         let Some(mut status) = self
             .store
             .get_publish_status(&result.app_id, &result.publish_id)
             .await?
         else {
-            return Ok(());
+            return Ok(None);
         };
 
         match result.outcome {
@@ -285,8 +306,33 @@ impl PushFeedbackProcessor {
                 "push publish completed"
             );
         }
-        self.store.put_publish_status(status).await?;
-        Ok(())
+        self.store.put_publish_status(status.clone()).await?;
+        Ok(Some(status))
+    }
+
+    fn emit_invalidation_guard_if_needed(&self, result: &DeliveryResult, status: &PublishStatus) {
+        if !invalidation_guard_threshold_crossed(status) {
+            return;
+        }
+        self.metrics
+            .token_invalidation_guard(result.provider, &result.app_id);
+        emit_push_meta_event(PushMetaEvent::token_invalidation_guard(
+            &result.app_id,
+            &result.publish_id,
+            result.provider,
+            status.counters.planned,
+            status.counters.failed,
+            INVALIDATION_GUARD_RATIO_PERCENT,
+        ));
+        tracing::warn!(
+            app_id = %result.app_id,
+            publish_id = %result.publish_id,
+            provider = ?result.provider,
+            planned = status.counters.planned,
+            failed = status.counters.failed,
+            threshold_percent = INVALIDATION_GUARD_RATIO_PERCENT,
+            "push token invalidation guard threshold crossed"
+        );
     }
 
     async fn handle_retry_or_dlq(&self, feedback: &DeliveryFeedback) -> PushPipelineResult<()> {
@@ -335,7 +381,9 @@ impl PushFeedbackProcessor {
                 &result.publish_id,
                 "retry-scheduled",
             ));
-        } else if matches!(result.outcome, DeliveryOutcome::Rejected) && !is_invalid_token(result) {
+        } else if matches!(result.outcome, DeliveryOutcome::Rejected)
+            && !is_device_terminal_failure(result)
+        {
             let dead_letter = DeadLetter {
                 app_id: result.app_id.clone(),
                 publish_id: result.publish_id.clone(),
@@ -473,13 +521,34 @@ fn terminal_state(
     }
 }
 
-fn is_invalid_token(result: &DeliveryResult) -> bool {
-    result.error.as_ref().is_some_and(|error| {
-        matches!(
-            error.class.as_str(),
-            "invalid_token" | "unregistered" | "not_registered" | "expired_channel"
-        )
-    })
+fn result_failure_class(result: &DeliveryResult) -> ProviderFailureClass {
+    result
+        .error
+        .as_ref()
+        .map(ProviderError::resolved_failure_class)
+        .unwrap_or(ProviderFailureClass::Unknown)
+}
+
+fn is_device_terminal_failure(result: &DeliveryResult) -> bool {
+    result_failure_class(result).is_device_terminal()
+}
+
+fn is_device_transient_failure(result: &DeliveryResult) -> bool {
+    result_failure_class(result).is_device_transient()
+}
+
+fn invalidation_guard_threshold_crossed(status: &PublishStatus) -> bool {
+    let planned = status.counters.planned;
+    if planned == 0 || status.counters.failed < INVALIDATION_GUARD_MIN_SAMPLES {
+        return false;
+    }
+    let threshold = planned
+        .saturating_mul(INVALIDATION_GUARD_RATIO_PERCENT)
+        .saturating_add(99)
+        / 100;
+    let threshold = threshold.max(INVALIDATION_GUARD_MIN_SAMPLES);
+    let previous_failed = status.counters.failed.saturating_sub(1);
+    status.counters.failed >= threshold && previous_failed < threshold
 }
 
 pub fn device_is_terminally_failed(state: DevicePushState) -> bool {
@@ -495,7 +564,8 @@ fn emit_feedback_meta_event(result: &DeliveryResult) {
         batch_id = %result.batch_id,
         device_id = result.device_id.as_deref().unwrap_or("[provider-target]"),
         outcome = outcome_label(result.outcome),
-        invalid_token = is_invalid_token(result),
+        failure_class = result_failure_class(result).label(),
+        device_terminal = is_device_terminal_failure(result),
         "push provider feedback processed"
     );
 }
@@ -507,15 +577,16 @@ mod tests {
     use sonic_rs::json;
 
     use crate::domain::{
-        DeliveryFeedback, DeliveryJob, DeliveryOutcome, DeliveryResult, ProviderError,
+        DeliveryFeedback, DeliveryJob, DeliveryOutcome, DeliveryResult, DeviceDetails,
+        DevicePushDetails, FormFactor, Platform, ProviderError, ProviderFailureClass,
         PublishCounters, PublishLifecycleState, PublishStatus, PushPayload, PushProviderKind,
-        PushRecipient, SecretString,
+        PushRecipient, SecretString, generate_device_identity_token, hash_device_identity_token,
     };
     use crate::memory::MemoryPushStore;
     use crate::metrics::PushMetrics;
     use crate::pipeline::{MemoryPushQueue, PushQueue};
     use crate::retry::RetryPolicy;
-    use crate::storage::PushPublishStatusStore;
+    use crate::storage::{PushDeviceStore, PushPublishStatusStore};
 
     use super::*;
 
@@ -709,13 +780,164 @@ mod tests {
         assert_eq!(lag.ready_depth + lag.delayed_depth, 1);
     }
 
+    #[tokio::test]
+    async fn feedback_provider_transient_does_not_increment_device_failure_count() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.put_publish_status(status()).await.unwrap();
+        store.upsert_device(device("device-1")).await.unwrap();
+        let metrics = PushMetrics::default();
+        let processor = PushFeedbackProcessor::new(store.clone(), queue)
+            .with_metrics(metrics.clone())
+            .with_retry_policy(RetryPolicy {
+                initial_backoff_ms: 1,
+                max_backoff_ms: 1,
+                jitter_ratio_percent: 0,
+                ..RetryPolicy::default()
+            });
+
+        processor
+            .apply_feedback(retryable_feedback())
+            .await
+            .unwrap();
+
+        let device = store
+            .get_device("app-1", "device-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(device.push.state, DevicePushState::Active);
+        assert_eq!(device.push.failure_count, 0);
+        assert_eq!(metrics.get("sockudo_push_provider_failures_total"), 1);
+    }
+
+    #[tokio::test]
+    async fn feedback_device_transient_increments_only_that_device_failure_count() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.put_publish_status(status()).await.unwrap();
+        store.upsert_device(device("device-1")).await.unwrap();
+        store.upsert_device(device("device-2")).await.unwrap();
+        let processor = PushFeedbackProcessor::new(store.clone(), queue);
+
+        processor
+            .apply_result(rejected_result(
+                "publish-1",
+                "device-1",
+                "device_transient",
+                ProviderFailureClass::DeviceTransient,
+            ))
+            .await
+            .unwrap();
+
+        let device_1 = store
+            .get_device("app-1", "device-1")
+            .await
+            .unwrap()
+            .unwrap();
+        let device_2 = store
+            .get_device("app-1", "device-2")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(device_1.push.state, DevicePushState::Failing);
+        assert_eq!(device_1.push.failure_count, 1);
+        assert_eq!(device_2.push.state, DevicePushState::Active);
+        assert_eq!(device_2.push.failure_count, 0);
+    }
+
+    #[tokio::test]
+    async fn feedback_device_terminal_deletes_only_target_and_is_idempotent() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.put_publish_status(status()).await.unwrap();
+        store.upsert_device(device("device-1")).await.unwrap();
+        store.upsert_device(device("device-2")).await.unwrap();
+        let metrics = PushMetrics::default();
+        let processor =
+            PushFeedbackProcessor::new(store.clone(), queue).with_metrics(metrics.clone());
+        let result = rejected_result(
+            "publish-1",
+            "device-1",
+            "invalid_token",
+            ProviderFailureClass::DeviceTerminal,
+        );
+
+        processor.apply_result(result.clone()).await.unwrap();
+        processor.apply_result(result).await.unwrap();
+
+        assert!(
+            store
+                .get_device("app-1", "device-1")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            store
+                .get_device("app-1", "device-2")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(metrics.get("sockudo_push_token_invalidations_total"), 1);
+        assert_eq!(metrics.get("sockudo_push_duplicate_suppressed_total"), 1);
+    }
+
+    #[tokio::test]
+    async fn feedback_mass_provider_auth_outage_preserves_device_registry() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store
+            .put_publish_status(status_with_planned("publish-auth", 3))
+            .await
+            .unwrap();
+        for device_id in ["device-1", "device-2", "device-3"] {
+            store.upsert_device(device(device_id)).await.unwrap();
+        }
+        let metrics = PushMetrics::default();
+        let processor =
+            PushFeedbackProcessor::new(store.clone(), queue).with_metrics(metrics.clone());
+
+        for device_id in ["device-1", "device-2", "device-3"] {
+            processor
+                .apply_result(rejected_result(
+                    "publish-auth",
+                    device_id,
+                    "auth_failure",
+                    ProviderFailureClass::CredentialAuth,
+                ))
+                .await
+                .unwrap();
+        }
+
+        for device_id in ["device-1", "device-2", "device-3"] {
+            let device = store.get_device("app-1", device_id).await.unwrap().unwrap();
+            assert_eq!(device.push.state, DevicePushState::Active);
+            assert_eq!(device.push.failure_count, 0);
+        }
+        let status = store
+            .get_publish_status("app-1", "publish-auth")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.counters.failed, 3);
+        assert_eq!(status.state, PublishLifecycleState::Failed);
+        assert_eq!(metrics.get("sockudo_push_provider_failures_total"), 3);
+        assert_eq!(metrics.get("sockudo_push_token_invalidations_total"), 0);
+    }
+
     fn status() -> PublishStatus {
+        status_with_planned("publish-1", 1)
+    }
+
+    fn status_with_planned(publish_id: &str, planned: u64) -> PublishStatus {
         PublishStatus {
             app_id: "app-1".to_owned(),
-            publish_id: "publish-1".to_owned(),
+            publish_id: publish_id.to_owned(),
             state: PublishLifecycleState::Dispatching,
             counters: PublishCounters {
-                planned: 1,
+                planned,
                 dispatched: 0,
                 succeeded: 0,
                 failed: 0,
@@ -727,6 +949,55 @@ mod tests {
             fanout_regime: None,
             retry_after_ms: None,
             error_reason: None,
+        }
+    }
+
+    fn rejected_result(
+        publish_id: &str,
+        device_id: &str,
+        class: &str,
+        failure_class: ProviderFailureClass,
+    ) -> DeliveryResult {
+        DeliveryResult {
+            app_id: "app-1".to_owned(),
+            publish_id: publish_id.to_owned(),
+            provider: PushProviderKind::Fcm,
+            batch_id: format!("batch-{device_id}"),
+            device_id: Some(device_id.to_owned()),
+            outcome: DeliveryOutcome::Rejected,
+            provider_message_id: None,
+            error: Some(ProviderError {
+                class: class.to_owned(),
+                failure_class,
+                reason: Some(class.to_owned()),
+                retry_after_ms: None,
+            }),
+            attempt: 1,
+        }
+    }
+
+    fn device(device_id: &str) -> DeviceDetails {
+        let identity_token = generate_device_identity_token();
+        DeviceDetails {
+            app_id: "app-1".to_owned(),
+            id: device_id.to_owned(),
+            client_id: None,
+            form_factor: FormFactor::Phone,
+            platform: Platform::Android,
+            metadata: json!({}),
+            device_secret: hash_device_identity_token(&identity_token),
+            timezone: "UTC".to_owned(),
+            locale: "en-US".to_owned(),
+            last_active_at_ms: 1,
+            push: DevicePushDetails {
+                recipient: PushRecipient::Fcm {
+                    registration_token: SecretString::new(format!("token-{device_id}")).unwrap(),
+                },
+                state: DevicePushState::Active,
+                failure_count: 0,
+                error_reason: None,
+            },
+            push_rate_policy: None,
         }
     }
 
@@ -742,6 +1013,7 @@ mod tests {
                 provider_message_id: None,
                 error: Some(ProviderError {
                     class: "unavailable".to_owned(),
+                    failure_class: ProviderFailureClass::ProviderTransient,
                     reason: Some("provider unavailable".to_owned()),
                     retry_after_ms: Some(now_ms()),
                 }),

--- a/crates/sockudo-push/src/meta.rs
+++ b/crates/sockudo-push/src/meta.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use sonic_rs::prelude::*;
 use sonic_rs::{Value, json};
 
-use crate::domain::{DeliveryOutcome, DevicePushState, PushProviderKind};
+use crate::domain::{DeliveryOutcome, DevicePushState, ProviderFailureClass, PushProviderKind};
 use crate::metrics::{delivery_outcome_label, device_state_label, provider_label};
 
 pub const PUSH_META_LOG_TARGET: &str = "[meta]log:push";
@@ -31,6 +31,7 @@ pub enum PushMetaEventKind {
     DeviceStateChanged,
     ProviderRejected,
     TokenInvalidated,
+    TokenInvalidationGuard,
     QuotaEvent,
     SchedulerEvent,
     CircuitBreakerEvent,
@@ -82,6 +83,7 @@ impl PushMetaEvent {
         provider: PushProviderKind,
         outcome: DeliveryOutcome,
         class: Option<&str>,
+        failure_class: Option<ProviderFailureClass>,
     ) -> Self {
         Self {
             event: PushMetaEventKind::ProviderRejected,
@@ -90,18 +92,43 @@ impl PushMetaEvent {
             provider: Some(Cow::Borrowed(provider_label(provider))),
             detail: json!({
                 "outcome": delivery_outcome_label(outcome),
-                "class": class
+                "class": class,
+                "failureClass": failure_class
+                    .unwrap_or(ProviderFailureClass::Unknown)
+                    .label()
             }),
         }
     }
 
     pub fn token_invalidated(app_id: &str, publish_id: &str, provider: PushProviderKind) -> Self {
         Self {
-            event: PushMetaEventKind::TokenInvalidated,
+            event: PushMetaEventKind::TokenInvalidationGuard,
             app_id: app_id.to_owned(),
             publish_id: Some(publish_id.to_owned()),
             provider: Some(Cow::Borrowed(provider_label(provider))),
             detail: Value::new_null(),
+        }
+    }
+
+    pub fn token_invalidation_guard(
+        app_id: &str,
+        publish_id: &str,
+        provider: PushProviderKind,
+        planned: u64,
+        failed: u64,
+        threshold_percent: u64,
+    ) -> Self {
+        Self {
+            event: PushMetaEventKind::TokenInvalidated,
+            app_id: app_id.to_owned(),
+            publish_id: Some(publish_id.to_owned()),
+            provider: Some(Cow::Borrowed(provider_label(provider))),
+            detail: json!({
+                "action": "invalidation-spike-guard",
+                "planned": planned,
+                "failed": failed,
+                "thresholdPercent": threshold_percent
+            }),
         }
     }
 
@@ -175,6 +202,7 @@ mod tests {
             PushProviderKind::Fcm,
             DeliveryOutcome::Rejected,
             Some("invalid_token"),
+            Some(ProviderFailureClass::DeviceTerminal),
         );
         let serialized = sonic_rs::to_string(&event).unwrap();
 

--- a/crates/sockudo-push/src/metrics.rs
+++ b/crates/sockudo-push/src/metrics.rs
@@ -62,6 +62,14 @@ pub const PUSH_METRIC_SPECS: &[PushMetricSpec] = &[
         "sockudo_push_token_invalidations_total",
         &["provider", "app"],
     ),
+    PushMetricSpec::counter(
+        "sockudo_push_provider_failures_total",
+        &["provider", "failure_class", "app"],
+    ),
+    PushMetricSpec::counter(
+        "sockudo_push_token_invalidation_guard_total",
+        &["provider", "app"],
+    ),
     PushMetricSpec::counter("sockudo_push_quota_acceptance_rejections_total", &["app"]),
     PushMetricSpec::counter("sockudo_push_quota_delivery_rejections_total", &["app"]),
     PushMetricSpec::gauge("sockudo_push_quota_consumed_acceptance", &["app"]),
@@ -396,6 +404,31 @@ impl PushMetrics {
         );
     }
 
+    pub fn provider_failure_class(
+        &self,
+        provider: PushProviderKind,
+        app_id: &str,
+        failure_class: &str,
+    ) {
+        self.counter(
+            "sockudo_push_provider_failures_total",
+            &[
+                ("provider", provider_label(provider)),
+                ("failure_class", failure_class),
+                ("app", app_id),
+            ],
+            1,
+        );
+    }
+
+    pub fn token_invalidation_guard(&self, provider: PushProviderKind, app_id: &str) {
+        self.counter(
+            "sockudo_push_token_invalidation_guard_total",
+            &[("provider", provider_label(provider)), ("app", app_id)],
+            1,
+        );
+    }
+
     pub fn quota_acceptance_rejected(&self, app_id: &str) {
         self.counter(
             "sockudo_push_quota_acceptance_rejections_total",
@@ -678,6 +711,8 @@ mod tests {
             "sockudo_push_devices_total",
             "sockudo_push_device_state_transitions_total",
             "sockudo_push_token_invalidations_total",
+            "sockudo_push_provider_failures_total",
+            "sockudo_push_token_invalidation_guard_total",
             "sockudo_push_quota_acceptance_rejections_total",
             "sockudo_push_quota_delivery_rejections_total",
             "sockudo_push_quota_consumed_acceptance",

--- a/crates/sockudo-push/src/retry.rs
+++ b/crates/sockudo-push/src/retry.rs
@@ -604,7 +604,8 @@ mod tests {
     use sonic_rs::json;
 
     use crate::domain::{
-        DeliveryOutcome, DeliveryResult, PushPayload, PushProviderKind, PushRecipient, SecretString,
+        DeliveryOutcome, DeliveryResult, ProviderFailureClass, PushPayload, PushProviderKind,
+        PushRecipient, SecretString,
     };
     use crate::memory::MemoryPushStore;
     use crate::pipeline::{MemoryPushQueue, PushQueue, PushQueueError, QueueAckToken};
@@ -848,6 +849,7 @@ mod tests {
                 provider_message_id: None,
                 error: Some(ProviderError {
                     class: "unavailable".to_owned(),
+                    failure_class: ProviderFailureClass::ProviderTransient,
                     reason: None,
                     retry_after_ms: None,
                 }),

--- a/docs/content/docs/server/push-notifications.mdx
+++ b/docs/content/docs/server/push-notifications.mdx
@@ -68,12 +68,12 @@ log work or enqueueing the pipeline.
 
 ## Retry and dead letters
 
-Provider throttling, 5xx responses, and transport failures are classified as retryable. Feedback
-workers schedule retry entries on `push.retry.v1` with the original delivery job context, a
-deterministic retry idempotency key, the next attempt number, the first-attempt timestamp, retry
-deadline, and the provider error class. Retry scheduler workers consume only due entries, respect
-provider `Retry-After` deadlines when configured, and otherwise use bounded exponential backoff with
-deterministic jitter.
+Provider throttling, 5xx responses, and transport failures are classified as retryable provider,
+quota, or network failures. Feedback workers schedule retry entries on `push.retry.v1` with the
+original delivery job context, a deterministic retry idempotency key, the next attempt number, the
+first-attempt timestamp, retry deadline, and the provider error class. Retry scheduler workers
+consume only due entries, respect provider `Retry-After` deadlines when configured, and otherwise
+use bounded exponential backoff with deterministic jitter.
 
 Retries stop at the earliest of `max_attempts`, `max_elapsed_secs`, or the publish/job
 `expires_at_ms`. Exhausted retry work is emitted to `push.deadletters.v1` and the publish status
@@ -91,12 +91,37 @@ Retry scheduling preserves the original timing window and does not run past publ
 Operators inspect aggregate status with `GET /apps/{appId}/push/publish/{publishId}/status`, retry
 and dead-letter queue lag through the health/backpressure surfaces, and metrics such as
 `sockudo_push_retry_scheduled_total`, `sockudo_push_retry_attempted_total`,
-`sockudo_push_retry_dead_lettered_total`, and `sockudo_push_retry_malformed_total`.
+`sockudo_push_retry_dead_lettered_total`, `sockudo_push_retry_malformed_total`, and
+`sockudo_push_provider_failures_total{failure_class=...}`.
 
 Upgrade note: provider workers now enqueue internal `deliveryFeedback` payloads on
 `push.results.v1` so feedback workers can schedule retries with replayable job context. Older
 `deliveryResult` payloads are still accepted, but retryable legacy results without job context are
 dead-lettered instead of being retried blindly.
+
+## Device invalidation safety
+
+Sockudo deletes or terminally invalidates a device only for device-specific terminal failures:
+
+- FCM `UNREGISTERED`, `registration-token-not-registered`, or an `INVALID_ARGUMENT` response that
+  specifically identifies the registration token as invalid.
+- APNs `BadDeviceToken` or `Unregistered`.
+- Web Push, HMS, and WNS expired subscription/channel responses such as `404` or `410`.
+
+Provider-wide failures do not increment device failure counts and do not delete devices. This
+includes FCM `SENDER_ID_MISMATCH` or project mismatch, APNs topic/environment/auth failures, Web
+Push VAPID/auth failures, provider `429` quota responses, provider `5xx` responses, DNS/TLS/network
+transport failures, and caller payload errors. These outcomes still update publish status, schedule
+retry or dead-letter work according to the retry policy, and emit classified metrics.
+
+Operators should treat `credential_auth` and project/topic mismatch failures as credential or
+configuration incidents: rotate or fix the provider credential, project id, APNs topic/environment,
+or VAPID configuration, then replay or republish as appropriate. Do not purge device registries for
+these classes. The `sockudo_push_provider_failures_total{failure_class=...}` metric separates
+`device_terminal`, `provider_transient`, `provider_quota`, `credential_auth`, `caller_payload`,
+`network_transport`, and `unknown` failures. The `sockudo_push_token_invalidation_guard_total`
+metric and `token-invalidation-guard` meta event fire when a publish crosses the built-in
+invalidation spike threshold.
 
 ## Configure providers
 

--- a/ops/dashboards/push.json
+++ b/ops/dashboards/push.json
@@ -316,6 +316,18 @@
           "expr": "sum by (app) (rate(sockudo_push_stale_devices_removed_total{app=~\"$app\"}[5m]))",
           "legendFormat": "{{app}} stale removed",
           "refId": "D"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (provider,failure_class) (rate(sockudo_push_provider_failures_total{provider=~\"$provider\",app=~\"$app\"}[5m]))",
+          "legendFormat": "{{provider}} {{failure_class}}",
+          "refId": "E"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (provider) (rate(sockudo_push_token_invalidation_guard_total{provider=~\"$provider\",app=~\"$app\"}[5m]))",
+          "legendFormat": "{{provider}} invalidation guard",
+          "refId": "F"
         }
       ],
       "title": "Feedback And Cleanup",


### PR DESCRIPTION
## Disaster scenario made safe

A provider-wide outage or credential/configuration failure can no longer poison device state. Bad FCM project credentials, APNs topic/environment/auth failures, Web Push VAPID/auth failures, provider quota/outage responses, and network transport failures update publish/retry/dead-letter state without incrementing per-device failure counts or deleting healthy devices.

## Behavior changed

- Added a `ProviderFailureClass` taxonomy carried on provider errors while preserving existing `DeliveryOutcome` mapping.
- Classified FCM, APNs, Web Push, HMS, and WNS failures into device-terminal, device-transient, provider-transient, provider-quota, credential/auth, caller-payload, network-transport, and unknown classes.
- Made feedback mutate device state only for `device_terminal` and `device_transient` classes.
- Treated FCM `SENDER_ID_MISMATCH`/project mismatch and auth failures as credential/auth failures, not invalid tokens.
- Added classified provider failure metrics, an invalidation spike guard metric/meta event, and dashboard coverage.
- Sanitized transport failure reasons and dispatch logs so raw provider/network text is not emitted.

## Behavior intentionally not changed

- Existing public `DeliveryOutcome` values and retry/dead-letter flow remain in place.
- The retry scheduler and provider credential storage were not redesigned.
- Genuine terminal token/subscription failures still clean up only the affected device and remain idempotent.
- Protocol V1/Pusher wire behavior is unchanged.

## Tests and commands passed

- `cargo fmt --all`
- `cargo test -p sockudo-push fcm`
- `cargo test -p sockudo-push apns`
- `cargo test -p sockudo-push webpush`
- `cargo test -p sockudo-push feedback`
- `cargo test -p sockudo-push`
- `cargo test -p sockudo` (server package)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cd docs && npm run types:check && npm run build`

## Remaining disaster modes deferred

- Provider credential rotation and refresh orchestration beyond classification.
- Retry scheduler redesign or provider-specific retry policy tuning.
- Cross-node/global invalidation-rate circuit state beyond the bounded per-publish guard metric/event added here.
- Further HMS/WNS credential-refresh semantics for static-token-only deployments.
