### PR TITLE
Harden push cluster queue resilience

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -113,6 +113,10 @@ accept_worker_count = 1
 planner_worker_count = 1
 shard_worker_count = 1
 dispatch_worker_count = 1
+# Maximum outbound provider requests each dispatch worker hands to a provider
+# dispatcher at once. Batches larger than this are split without changing
+# delivery idempotency keys.
+dispatch_max_outbound_requests = 32
 feedback_worker_count = 1
 retry_worker_count = 1
 queue_partition_count = 1

--- a/crates/sockudo-core/src/options/env/features.rs
+++ b/crates/sockudo-core/src/options/env/features.rs
@@ -82,6 +82,10 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
     );
     options.push.retry_worker_count =
         parse_env::<u32>("PUSH_RETRY_WORKER_COUNT", options.push.retry_worker_count);
+    options.push.dispatch_max_outbound_requests = parse_env::<usize>(
+        "PUSH_DISPATCH_MAX_OUTBOUND_REQUESTS",
+        options.push.dispatch_max_outbound_requests,
+    );
     options.push.circuit_breaker.failure_threshold = parse_env::<u32>(
         "PUSH_FAILURE_THRESHOLD",
         options.push.circuit_breaker.failure_threshold,

--- a/crates/sockudo-core/src/options/push.rs
+++ b/crates/sockudo-core/src/options/push.rs
@@ -87,6 +87,7 @@ pub struct PushConfig {
     pub planner_worker_count: u32,
     pub shard_worker_count: u32,
     pub dispatch_worker_count: u32,
+    pub dispatch_max_outbound_requests: usize,
     pub feedback_worker_count: u32,
     pub retry_worker_count: u32,
     pub queue_partition_count: u32,
@@ -236,6 +237,7 @@ impl Default for PushConfig {
             planner_worker_count: 1,
             shard_worker_count: 1,
             dispatch_worker_count: 1,
+            dispatch_max_outbound_requests: 32,
             feedback_worker_count: 1,
             retry_worker_count: 1,
             queue_partition_count: 1,
@@ -445,6 +447,7 @@ mod tests {
             "PUSH_FANOUT_SYNC_THRESHOLD",
             "PUSH_BACKPRESSURE_LAG_THRESHOLD_SECS",
             "PUSH_PUBLISH_STATUS_TTL_DAYS",
+            "PUSH_DISPATCH_MAX_OUTBOUND_REQUESTS",
             "PUSH_FAILURE_THRESHOLD",
             "PUSH_SCHEDULER_INTERVAL_SECS",
             "PUSH_STALE_DEVICE_MAX_AGE_DAYS",
@@ -474,6 +477,7 @@ mod tests {
             std::env::set_var("PUSH_FANOUT_SYNC_THRESHOLD", "250");
             std::env::set_var("PUSH_BACKPRESSURE_LAG_THRESHOLD_SECS", "42");
             std::env::set_var("PUSH_PUBLISH_STATUS_TTL_DAYS", "14");
+            std::env::set_var("PUSH_DISPATCH_MAX_OUTBOUND_REQUESTS", "17");
             std::env::set_var("PUSH_FAILURE_THRESHOLD", "9");
             std::env::set_var("PUSH_SCHEDULER_INTERVAL_SECS", "11");
             std::env::set_var("PUSH_STALE_DEVICE_MAX_AGE_DAYS", "120");
@@ -514,6 +518,7 @@ mod tests {
         assert_eq!(options.push.fanout_sync_threshold, 250);
         assert_eq!(options.push.backpressure_lag_threshold_secs, 42);
         assert_eq!(options.push.publish_status_ttl_days, 14);
+        assert_eq!(options.push.dispatch_max_outbound_requests, 17);
         assert_eq!(options.push.circuit_breaker.failure_threshold, 9);
         assert_eq!(options.push.scheduler_interval_secs, 11);
         assert_eq!(options.push.stale_device_max_age_days, 120);

--- a/crates/sockudo-push/src/dispatch/tests.rs
+++ b/crates/sockudo-push/src/dispatch/tests.rs
@@ -3,7 +3,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tokio::sync::Mutex;
 
-use crate::domain::{ProviderOverridePayload, PushPayload, PushRecipient, SecretString};
+use crate::domain::{
+    DeliveryJob, ProviderOverridePayload, PushPayload, PushRecipient, SecretString,
+};
 use crate::pipeline::{MemoryPushQueue, PushQueue, PushQueuePayload, PushQueueStage, QueueMessage};
 use crate::transform::render_provider_payload;
 
@@ -674,6 +676,64 @@ async fn provider_worker_dispatches_due_jobs_and_requeues_future_jobs() {
             .unwrap()
             .ready_depth,
         1
+    );
+}
+
+#[tokio::test]
+async fn provider_worker_bounds_outbound_dispatch_batch_size() {
+    let queue = Arc::new(MemoryPushQueue::new());
+    let dispatcher = Arc::new(RecordingDispatcher::default());
+    let mut batch = batch(PushProviderKind::Fcm);
+    let template = batch.jobs[0].clone();
+    batch.jobs = (0..5)
+        .map(|index| {
+            let mut job = template.clone();
+            job.device_id = Some(format!("device-{index}"));
+            job.recipient = PushRecipient::Fcm {
+                registration_token: SecretString::new(format!("fcm-token-{index}")).unwrap(),
+            };
+            job
+        })
+        .collect();
+    let original_keys = batch
+        .jobs
+        .iter()
+        .map(DeliveryJob::idempotency_key)
+        .collect::<Vec<_>>();
+    queue
+        .produce(
+            PushQueueStage::DeliveryJobs(PushProviderKind::Fcm),
+            batch.queue_key(),
+            PushQueuePayload::DeliveryBatch(Box::new(batch)),
+        )
+        .await
+        .unwrap();
+
+    let mut worker =
+        ProviderDispatchWorker::new(PushProviderKind::Fcm, queue.clone(), dispatcher.clone())
+            .with_max_outbound_requests(2);
+    assert_eq!(worker.run_once("fcm").await.unwrap(), 1);
+
+    let batches = dispatcher.batches().await;
+    assert_eq!(
+        batches
+            .iter()
+            .map(|batch| batch.jobs.len())
+            .collect::<Vec<_>>(),
+        vec![2, 2, 1]
+    );
+    let redelivered_keys = batches
+        .iter()
+        .flat_map(|batch| batch.jobs.iter().map(DeliveryJob::idempotency_key))
+        .collect::<Vec<_>>();
+    assert_eq!(redelivered_keys, original_keys);
+    assert_eq!(
+        queue
+            .lag(PushQueueStage::DeliveryResults)
+            .await
+            .unwrap()
+            .ready_depth,
+        5
     );
 }
 

--- a/crates/sockudo-push/src/dispatch/worker.rs
+++ b/crates/sockudo-push/src/dispatch/worker.rs
@@ -20,6 +20,7 @@ pub struct ProviderDispatchWorker {
     rate_limiter: AdaptiveRateLimiter,
     metrics: PushMetrics,
     max_batches_per_tick: usize,
+    max_outbound_requests: usize,
     over_quota_tenants: BTreeSet<String>,
     tenant_inflight_cap: usize,
 }
@@ -38,6 +39,7 @@ impl ProviderDispatchWorker {
             rate_limiter: AdaptiveRateLimiter::default(),
             metrics: PushMetrics::default(),
             max_batches_per_tick: 32,
+            max_outbound_requests: 32,
             over_quota_tenants: BTreeSet::new(),
             tenant_inflight_cap: 8,
         }
@@ -60,6 +62,11 @@ impl ProviderDispatchWorker {
 
     pub fn with_over_quota_tenants(mut self, tenants: impl IntoIterator<Item = String>) -> Self {
         self.over_quota_tenants = tenants.into_iter().collect();
+        self
+    }
+
+    pub fn with_max_outbound_requests(mut self, limit: usize) -> Self {
+        self.max_outbound_requests = limit.max(1);
         self
     }
 
@@ -116,9 +123,8 @@ impl ProviderDispatchWorker {
             return Ok(());
         };
         let app_id = batch.app_id.clone();
-        let retry_jobs = batch.jobs.clone();
         self.metrics
-            .worker_pool(self.provider, self.max_batches_per_tick, 1);
+            .worker_pool(self.provider, self.max_outbound_requests, 0);
 
         if self.circuit_breaker.is_open(now_ms()) {
             self.metrics.counter(
@@ -151,56 +157,77 @@ impl ProviderDispatchWorker {
         let started = Instant::now();
         let started_ms = now_ms();
         self.metrics.dispatch_started(self.provider, &app_id);
-        let results = self.dispatcher.dispatch(batch).await;
         let mut saw_retry_after = None;
         let mut failures = 0_u64;
-        let mut retry_jobs = retry_jobs.into_iter();
-        for result in results {
-            let original_job = retry_jobs.next();
-            if !matches!(result.outcome, DeliveryOutcome::Accepted) {
-                failures += 1;
-                tracing::warn!(
-                    app_id = %result.app_id,
-                    publish_id = %result.publish_id,
-                    provider = ?result.provider,
-                    batch_id = %result.batch_id,
-                    outcome = ?result.outcome,
-                    error_class = result.error.as_ref().map(|error| error.class.as_str()),
-                    failure_class = result
-                        .error
-                        .as_ref()
-                        .map(|error| error.resolved_failure_class().label()),
-                    retry_after_ms = result.error.as_ref().and_then(|error| error.retry_after_ms),
-                    "push dispatch failure"
+        let DeliveryBatch {
+            app_id,
+            publish_id,
+            provider,
+            batch_id,
+            jobs,
+        } = batch;
+        for chunk in jobs.chunks(self.max_outbound_requests) {
+            let chunk_jobs = chunk.to_vec();
+            self.metrics
+                .worker_pool(self.provider, self.max_outbound_requests, chunk_jobs.len());
+            let mut original_jobs = chunk_jobs.clone().into_iter();
+            let results = self
+                .dispatcher
+                .dispatch(DeliveryBatch {
+                    app_id: app_id.clone(),
+                    publish_id: publish_id.clone(),
+                    provider,
+                    batch_id: batch_id.clone(),
+                    jobs: chunk_jobs,
+                })
+                .await;
+            for result in results {
+                let original_job = original_jobs.next();
+                if !matches!(result.outcome, DeliveryOutcome::Accepted) {
+                    failures += 1;
+                    tracing::warn!(
+                        app_id = %result.app_id,
+                        publish_id = %result.publish_id,
+                        provider = ?result.provider,
+                        batch_id = %result.batch_id,
+                        outcome = ?result.outcome,
+                        error_class = result.error.as_ref().map(|error| error.class.as_str()),
+                        failure_class = result
+                            .error
+                            .as_ref()
+                            .map(|error| error.resolved_failure_class().label()),
+                        retry_after_ms = result.error.as_ref().and_then(|error| error.retry_after_ms),
+                        "push dispatch failure"
+                    );
+                } else {
+                    tracing::info!(
+                        app_id = %result.app_id,
+                        publish_id = %result.publish_id,
+                        provider = ?result.provider,
+                        batch_id = %result.batch_id,
+                        "push dispatch success"
+                    );
+                }
+                self.metrics.dispatch_finished(
+                    result.provider,
+                    &result.app_id,
+                    result.outcome,
+                    started.elapsed(),
                 );
-            } else {
-                tracing::info!(
-                    app_id = %result.app_id,
-                    publish_id = %result.publish_id,
-                    provider = ?result.provider,
-                    batch_id = %result.batch_id,
-                    "push dispatch success"
-                );
+                if let Some(retry_after_ms) =
+                    result.error.as_ref().and_then(|error| error.retry_after_ms)
+                {
+                    saw_retry_after = Some(retry_after_ms);
+                }
+                let feedback = delivery_feedback(result, original_job, started_ms);
+                self.queue
+                    .produce(
+                        PushQueueStage::DeliveryResults,
+                        feedback_key(&feedback),
+                        PushQueuePayload::DeliveryFeedback(Box::new(feedback)),
+                    )
+                    .await?;
             }
-            self.metrics.dispatch_finished(
-                result.provider,
-                &result.app_id,
-                result.outcome,
-                started.elapsed(),
-            );
-            if let Some(retry_after_ms) =
-                result.error.as_ref().and_then(|error| error.retry_after_ms)
-            {
-                saw_retry_after = Some(retry_after_ms);
-            }
-            let feedback = delivery_feedback(result, original_job, started_ms);
-            self.queue
-                .produce(
-                    PushQueueStage::DeliveryResults,
-                    feedback_key(&feedback),
-                    PushQueuePayload::DeliveryFeedback(Box::new(feedback)),
-                )
-                .await?;
         }
 
         if let Some(retry_after_ms) = saw_retry_after {
@@ -209,7 +236,7 @@ impl ProviderDispatchWorker {
             self.circuit_breaker.defer_until(retry_after_ms);
             self.metrics
                 .circuit_breaker_state(self.provider, &app_id, true);
-            self.emit_circuit_event("open_retry_after", retry_after_ms);
+            self.emit_circuit_event(&app_id, "open_retry_after", retry_after_ms);
         } else if failures == 0 {
             self.rate_limiter
                 .record_success_window(&app_id, self.provider, now_ms());
@@ -220,13 +247,17 @@ impl ProviderDispatchWorker {
             if self.circuit_breaker.record_failure(now_ms()) {
                 self.metrics
                     .circuit_breaker_state(self.provider, &app_id, true);
-                self.emit_circuit_event("open_failure_rate", self.circuit_breaker.open_until_ms);
+                self.emit_circuit_event(
+                    &app_id,
+                    "open_failure_rate",
+                    self.circuit_breaker.open_until_ms,
+                );
             }
         }
 
         self.rate_limiter.release(&app_id, self.provider);
         self.metrics
-            .worker_pool(self.provider, self.max_batches_per_tick, 0);
+            .worker_pool(self.provider, self.max_outbound_requests, 0);
         self.queue.ack(message.ack).await?;
         Ok(())
     }
@@ -375,9 +406,9 @@ impl ProviderDispatchWorker {
         Ok(())
     }
 
-    fn emit_circuit_event(&self, action: &'static str, retry_at_ms: u64) {
+    fn emit_circuit_event(&self, app_id: &str, action: &'static str, retry_at_ms: u64) {
         emit_push_meta_event(PushMetaEvent::circuit_breaker_event(
-            "unknown",
+            app_id,
             self.provider,
             action,
             retry_at_ms,

--- a/crates/sockudo-push/src/feedback.rs
+++ b/crates/sockudo-push/src/feedback.rs
@@ -584,7 +584,7 @@ mod tests {
     };
     use crate::memory::MemoryPushStore;
     use crate::metrics::PushMetrics;
-    use crate::pipeline::{MemoryPushQueue, PushQueue};
+    use crate::pipeline::{MemoryPushQueue, PushQueue, PushQueuePayload, PushQueueStage};
     use crate::retry::RetryPolicy;
     use crate::storage::{PushDeviceStore, PushPublishStatusStore};
 
@@ -642,6 +642,46 @@ mod tests {
         assert_eq!(status.counters.succeeded, 1);
         assert_eq!(status.state, PublishLifecycleState::Succeeded);
         assert_eq!(metrics.get("sockudo_push_duplicate_suppressed_total"), 1);
+    }
+
+    #[tokio::test]
+    async fn redelivered_feedback_message_does_not_double_count_status() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.put_publish_status(status()).await.unwrap();
+        let processor = PushFeedbackProcessor::new(store.clone(), queue.clone());
+        let feedback = DeliveryFeedback::from_result(DeliveryResult {
+            app_id: "app-1".to_owned(),
+            publish_id: "publish-1".to_owned(),
+            provider: PushProviderKind::Fcm,
+            batch_id: "batch-1".to_owned(),
+            device_id: Some("device-1".to_owned()),
+            outcome: DeliveryOutcome::Accepted,
+            provider_message_id: Some("provider-1".to_owned()),
+            error: None,
+            attempt: 1,
+        });
+
+        for key in ["result-before-ack", "result-redelivered"] {
+            queue
+                .produce(
+                    PushQueueStage::DeliveryResults,
+                    key.to_owned(),
+                    PushQueuePayload::DeliveryFeedback(Box::new(feedback.clone())),
+                )
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(processor.run_once("feedback").await.unwrap(), 2);
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.counters.dispatched, 1);
+        assert_eq!(status.counters.succeeded, 1);
+        assert_eq!(status.state, PublishLifecycleState::Succeeded);
     }
 
     #[tokio::test]

--- a/crates/sockudo-push/src/metrics.rs
+++ b/crates/sockudo-push/src/metrics.rs
@@ -103,6 +103,14 @@ pub const PUSH_METRIC_SPECS: &[PushMetricSpec] = &[
         "sockudo_push_retry_malformed_total",
         &["provider", "reason"],
     ),
+    PushMetricSpec::counter(
+        "sockudo_push_worker_exits_total",
+        &["kind", "worker", "reason"],
+    ),
+    PushMetricSpec::counter(
+        "sockudo_push_queue_local_requeued_total",
+        &["stage", "reason"],
+    ),
 ];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -563,6 +571,22 @@ impl PushMetrics {
         self.counter(
             "sockudo_push_retry_malformed_total",
             &[("provider", provider), ("reason", reason)],
+            1,
+        );
+    }
+
+    pub fn worker_exit(&self, kind: &str, worker: &str, reason: &str) {
+        self.counter(
+            "sockudo_push_worker_exits_total",
+            &[("kind", kind), ("worker", worker), ("reason", reason)],
+            1,
+        );
+    }
+
+    pub fn queue_local_requeued(&self, stage: &str, reason: &str) {
+        self.counter(
+            "sockudo_push_queue_local_requeued_total",
+            &[("stage", stage), ("reason", reason)],
             1,
         );
     }

--- a/crates/sockudo-server/src/bootstrap/mod.rs
+++ b/crates/sockudo-server/src/bootstrap/mod.rs
@@ -73,6 +73,8 @@ struct ServerState {
     push_queue: sockudo_push::DynPushQueue,
     #[cfg(feature = "push")]
     push_admission: Arc<push::PushAdmissionSnapshot>,
+    #[cfg(all(feature = "push", feature = "monolith"))]
+    push_worker_handles: Vec<tokio::task::JoinHandle<()>>,
 }
 
 /// Main server struct

--- a/crates/sockudo-server/src/bootstrap/push/mod.rs
+++ b/crates/sockudo-server/src/bootstrap/push/mod.rs
@@ -54,6 +54,7 @@ pub(crate) async fn create_push_store(
 pub(crate) fn create_push_queue(
     config: &ServerOptions,
     queue_manager: Option<Arc<QueueManager>>,
+    admission: &PushAdmissionSnapshot,
 ) -> Result<sockudo_push::DynPushQueue> {
     let backend = match config.push.queue_driver {
         PushQueueDriver::Memory => sockudo_push::PushQueueBackendKind::Memory,
@@ -86,7 +87,11 @@ pub(crate) fn create_push_queue(
             backend
         ))
     })?;
-    Ok(Arc::new(QueueManagerPushQueue::new(backend, queue_manager)))
+    Ok(Arc::new(QueueManagerPushQueue::new(
+        backend,
+        queue_manager,
+        queue::QueueManagerPushQueueStageOwnership::from_config(config, admission),
+    )))
 }
 
 #[cfg(test)]
@@ -110,8 +115,8 @@ mod tests {
         assert!(error.to_string().contains("memory is unsafe in production"));
     }
 
-    #[test]
-    fn production_memory_push_queue_requires_explicit_allow() {
+    #[tokio::test]
+    async fn production_memory_push_queue_requires_explicit_allow() {
         let mut config = ServerOptions {
             mode: "production".to_owned(),
             ..Default::default()
@@ -119,7 +124,9 @@ mod tests {
         config.push.queue_driver = PushQueueDriver::Memory;
         config.push.allow_memory_drivers = false;
 
-        let error = match create_push_queue(&config, None) {
+        let store: sockudo_push::DynPushStore = Arc::new(sockudo_push::MemoryPushStore::new());
+        let admission = PushAdmissionSnapshot::from_config(&config, &store).await;
+        let error = match create_push_queue(&config, None, &admission) {
             Ok(_) => panic!("memory push queue should be rejected in production"),
             Err(error) => error,
         };
@@ -137,7 +144,8 @@ mod tests {
         config.push.queue_driver = PushQueueDriver::Memory;
         config.push.allow_memory_drivers = true;
 
-        create_push_store(&config).await.unwrap();
-        create_push_queue(&config, None).unwrap();
+        let store = create_push_store(&config).await.unwrap();
+        let admission = PushAdmissionSnapshot::from_config(&config, &store).await;
+        create_push_queue(&config, None, &admission).unwrap();
     }
 }

--- a/crates/sockudo-server/src/bootstrap/push/queue.rs
+++ b/crates/sockudo-server/src/bootstrap/push/queue.rs
@@ -653,7 +653,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(queue.state.lock().await.started.get(&stage).is_none());
+        assert!(!queue.state.lock().await.started.contains(&stage));
     }
 
     #[tokio::test]

--- a/crates/sockudo-server/src/bootstrap/push/queue.rs
+++ b/crates/sockudo-server/src/bootstrap/push/queue.rs
@@ -1,15 +1,71 @@
 use sockudo_core::error::Error;
 use sockudo_webhook::integration::QueueManager;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
+
+#[cfg(feature = "push")]
+const LOCAL_READY_CAP_PER_STAGE: usize = 4_096;
+#[cfg(feature = "push")]
+const LOCAL_PENDING_CAP_PER_STAGE: usize = 8_192;
+#[cfg(feature = "push")]
+const LOCAL_LEASE_TIMEOUT_MS: u64 = 30_000;
 
 #[cfg(feature = "push")]
 #[derive(Clone)]
 pub(crate) struct QueueManagerPushQueue {
     backend: sockudo_push::PushQueueBackendKind,
     manager: Arc<QueueManager>,
+    ownership: QueueManagerPushQueueStageOwnership,
     state: Arc<tokio::sync::Mutex<QueueManagerPushQueueState>>,
     notify: Arc<tokio::sync::Notify>,
+    metrics: sockudo_push::PushMetrics,
+}
+
+#[cfg(feature = "push")]
+#[derive(Clone, Debug)]
+pub(crate) struct QueueManagerPushQueueStageOwnership {
+    stages: Arc<BTreeSet<sockudo_push::PushQueueStage>>,
+}
+
+#[cfg(feature = "push")]
+impl QueueManagerPushQueueStageOwnership {
+    pub(crate) fn from_config(
+        config: &sockudo_core::options::ServerOptions,
+        admission: &super::capability::PushAdmissionSnapshot,
+    ) -> Self {
+        let mut stages = BTreeSet::new();
+        if config.push.planner_worker_count > 0 {
+            stages.insert(sockudo_push::PushQueueStage::PublishLog);
+        }
+        if config.push.shard_worker_count > 0 {
+            stages.insert(sockudo_push::PushQueueStage::ShardJobs);
+        }
+        if config.push.feedback_worker_count > 0 {
+            stages.insert(sockudo_push::PushQueueStage::DeliveryResults);
+        }
+        if config.push.retry_worker_count > 0 {
+            stages.insert(sockudo_push::PushQueueStage::RetrySchedule);
+        }
+        stages.insert(sockudo_push::PushQueueStage::DeadLetters);
+        for provider in admission.active_providers() {
+            stages.insert(sockudo_push::PushQueueStage::DeliveryJobs(provider));
+        }
+        Self {
+            stages: Arc::new(stages),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn testing(stages: impl IntoIterator<Item = sockudo_push::PushQueueStage>) -> Self {
+        Self {
+            stages: Arc::new(stages.into_iter().collect()),
+        }
+    }
+
+    fn can_process(&self, stage: sockudo_push::PushQueueStage) -> bool {
+        self.stages.contains(&stage)
+    }
 }
 
 #[cfg(feature = "push")]
@@ -63,14 +119,17 @@ impl QueueManagerPushQueue {
     pub(crate) fn new(
         backend: sockudo_push::PushQueueBackendKind,
         manager: Arc<QueueManager>,
+        ownership: QueueManagerPushQueueStageOwnership,
     ) -> Self {
         Self {
             backend,
             manager,
+            ownership,
             state: Arc::new(tokio::sync::Mutex::new(
                 QueueManagerPushQueueState::default(),
             )),
             notify: Arc::new(tokio::sync::Notify::new()),
+            metrics: sockudo_push::PushMetrics::default(),
         }
     }
 
@@ -97,6 +156,12 @@ impl QueueManagerPushQueue {
         &self,
         stage: sockudo_push::PushQueueStage,
     ) -> sockudo_push::PushQueueResult<()> {
+        if !self.ownership.can_process(stage) {
+            return Err(sockudo_push::PushQueueError::UnsupportedBackend {
+                backend: "queue-manager",
+                reason: "this node is not configured to process the requested push queue stage",
+            });
+        }
         {
             let mut state = self.state.lock().await;
             if !state.started.insert(stage) {
@@ -106,7 +171,8 @@ impl QueueManagerPushQueue {
 
         let queue_name = stage.logical_topic();
         let queue = self.clone();
-        self.manager
+        match self
+            .manager
             .process_queue(
                 &queue_name,
                 Box::new(move |job| {
@@ -120,7 +186,13 @@ impl QueueManagerPushQueue {
                 }),
             )
             .await
-            .map_err(push_queue_manager_error)
+        {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.state.lock().await.started.remove(&stage);
+                Err(push_queue_manager_error(error))
+            }
+        }
     }
 
     async fn handle_queue_job(
@@ -137,6 +209,26 @@ impl QueueManagerPushQueue {
 
         let route =
             sockudo_push::QueueRoute::for_message(envelope.stage, &envelope.key, &envelope.payload);
+        let now = push_queue_now_ms();
+        let should_requeue = {
+            let state = self.state.lock().await;
+            let ready_depth = state
+                .ready
+                .get(&envelope.stage)
+                .map_or(0, std::collections::VecDeque::len);
+            let pending_depth = state
+                .pending
+                .keys()
+                .filter(|(pending_stage, _)| pending_stage == &envelope.stage)
+                .count();
+            ready_depth >= LOCAL_READY_CAP_PER_STAGE || pending_depth >= LOCAL_PENDING_CAP_PER_STAGE
+        };
+        if should_requeue {
+            self.requeue_envelope(envelope, Some(now.saturating_add(1_000)), "local_capacity")
+                .await?;
+            return Ok(());
+        }
+
         let token = sockudo_push::QueueAckToken {
             stage: envelope.stage,
             message_id: envelope.message_id.clone(),
@@ -150,7 +242,7 @@ impl QueueManagerPushQueue {
             payload: envelope.payload.clone(),
             attempt: envelope.attempt,
             not_before_ms: envelope.not_before_ms,
-            lease_deadline_ms: push_queue_now_ms().saturating_add(30_000),
+            lease_deadline_ms: now.saturating_add(LOCAL_LEASE_TIMEOUT_MS),
             ack: token.clone(),
         };
         let (tx, rx) = tokio::sync::oneshot::channel();
@@ -167,13 +259,22 @@ impl QueueManagerPushQueue {
         }
         self.notify.notify_waiters();
 
-        match rx.await.unwrap_or(PushQueueAction::Ack) {
+        let action = match tokio::time::timeout(Duration::from_millis(LOCAL_LEASE_TIMEOUT_MS), rx)
+            .await
+        {
+            Ok(Ok(action)) => action,
+            Ok(Err(_)) => PushQueueAction::Nack(Some(push_queue_now_ms().saturating_add(1_000))),
+            Err(_) => PushQueueAction::Nack(Some(push_queue_now_ms().saturating_add(1_000))),
+        };
+
+        self.remove_pending_and_ready(envelope.stage, &envelope.message_id)
+            .await;
+
+        match action {
             PushQueueAction::Ack => Ok(()),
             PushQueueAction::Nack(retry_at_ms) => {
-                let mut retry = envelope;
-                retry.attempt = retry.attempt.saturating_add(1);
-                retry.not_before_ms = retry_at_ms;
-                self.enqueue_envelope(retry).await
+                self.requeue_envelope(envelope, retry_at_ms, "nack_or_lease_timeout")
+                    .await
             }
             PushQueueAction::DeadLetter(reason) => {
                 let dead_letter = sockudo_push::DeadLetter {
@@ -194,6 +295,35 @@ impl QueueManagerPushQueue {
                 };
                 self.enqueue_envelope(dlq).await
             }
+        }
+    }
+
+    async fn requeue_envelope(
+        &self,
+        mut envelope: PushQueueEnvelope,
+        retry_at_ms: Option<u64>,
+        reason: &'static str,
+    ) -> sockudo_push::PushQueueResult<()> {
+        envelope.attempt = envelope.attempt.saturating_add(1);
+        envelope.not_before_ms = retry_at_ms;
+        self.metrics
+            .queue_local_requeued(&push_queue_stage_label(envelope.stage), reason);
+        self.enqueue_envelope(envelope).await
+    }
+
+    async fn remove_pending_and_ready(
+        &self,
+        stage: sockudo_push::PushQueueStage,
+        message_id: &str,
+    ) {
+        let mut state = self.state.lock().await;
+        state.pending.remove(&(stage, message_id.to_owned()));
+        if let Some(ready) = state.ready.get_mut(&stage)
+            && let Some(index) = ready
+                .iter()
+                .position(|message| message.message_id == message_id)
+        {
+            ready.remove(index);
         }
     }
 
@@ -228,7 +358,6 @@ impl sockudo_push::PushQueue for QueueManagerPushQueue {
         key: String,
         payload: sockudo_push::PushQueuePayload,
     ) -> sockudo_push::PushQueueResult<String> {
-        self.ensure_stage_processor(stage).await?;
         let message_id = self.next_message_id().await;
         self.enqueue_envelope(PushQueueEnvelope {
             message_id: message_id.clone(),
@@ -249,7 +378,6 @@ impl sockudo_push::PushQueue for QueueManagerPushQueue {
         payload: sockudo_push::PushQueuePayload,
         not_before_ms: u64,
     ) -> sockudo_push::PushQueueResult<String> {
-        self.ensure_stage_processor(stage).await?;
         let message_id = self.next_message_id().await;
         self.enqueue_envelope(PushQueueEnvelope {
             message_id: message_id.clone(),
@@ -284,12 +412,17 @@ impl sockudo_push::PushQueue for QueueManagerPushQueue {
 
         let now = push_queue_now_ms();
         let mut state = self.state.lock().await;
-        let queue = state.ready.entry(stage).or_default();
         let mut messages = Vec::new();
         for _ in 0..max_messages.max(1) {
-            let Some(mut message) = queue.pop_front() else {
+            let Some(mut message) = state.ready.entry(stage).or_default().pop_front() else {
                 break;
             };
+            if !state
+                .pending
+                .contains_key(&(stage, message.message_id.clone()))
+            {
+                continue;
+            }
             message.lease_deadline_ms = now.saturating_add(lease_timeout_ms);
             messages.push(message);
         }
@@ -326,7 +459,7 @@ impl sockudo_push::PushQueue for QueueManagerPushQueue {
         Ok(sockudo_push::QueueHealth {
             backend: self.backend,
             healthy: true,
-            details: "push queue is backed by the configured Sockudo queue manager".to_owned(),
+            details: "push queue is backed by the configured Sockudo queue manager; lag reports this node's local pull-ahead ready/pending depth, not broker-wide backlog".to_owned(),
         })
     }
 
@@ -436,9 +569,203 @@ fn push_queue_payload_publish_id(payload: &sockudo_push::PushQueuePayload) -> St
 }
 
 #[cfg(feature = "push")]
+fn push_queue_stage_label(stage: sockudo_push::PushQueueStage) -> String {
+    match stage {
+        sockudo_push::PushQueueStage::PublishLog => "publish_log".to_owned(),
+        sockudo_push::PushQueueStage::ShardJobs => "shard_jobs".to_owned(),
+        sockudo_push::PushQueueStage::DeliveryJobs(provider) => {
+            format!("delivery_jobs_{}", sockudo_push::provider_label(provider))
+        }
+        sockudo_push::PushQueueStage::DeliveryResults => "delivery_results".to_owned(),
+        sockudo_push::PushQueueStage::DeadLetters => "dead_letters".to_owned(),
+        sockudo_push::PushQueueStage::RetrySchedule => "retry_schedule".to_owned(),
+    }
+}
+
+#[cfg(feature = "push")]
 pub(crate) fn push_queue_now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_millis().try_into().unwrap_or(u64::MAX))
         .unwrap_or(0)
+}
+
+#[cfg(all(test, feature = "push"))]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use sockudo_push::{
+        DeliveryBatch, DeliveryJob, PushPayload, PushProviderKind, PushQueue, PushQueuePayload,
+        PushQueueStage, PushRecipient, SecretString,
+    };
+    use sonic_rs::json;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn node_without_provider_worker_does_not_consume_provider_stage() {
+        let queue = test_queue(QueueManagerPushQueueStageOwnership::testing([
+            PushQueueStage::PublishLog,
+        ]));
+        let stage = PushQueueStage::DeliveryJobs(PushProviderKind::Fcm);
+        queue
+            .produce(
+                stage,
+                "delivery".to_owned(),
+                PushQueuePayload::DeliveryBatch(Box::new(sample_batch())),
+            )
+            .await
+            .unwrap();
+
+        let error = queue.consume(stage, "node-without-fcm", 1, 30_000).await;
+        assert!(matches!(
+            error,
+            Err(sockudo_push::PushQueueError::UnsupportedBackend { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn node_with_provider_worker_consumes_provider_stage() {
+        let stage = PushQueueStage::DeliveryJobs(PushProviderKind::Fcm);
+        let queue = test_queue(QueueManagerPushQueueStageOwnership::testing([stage]));
+        insert_local_message(&queue, stage).await;
+
+        let message = next_message(&queue, stage).await;
+        assert_eq!(message.stage, stage);
+        let PushQueuePayload::DeliveryBatch(batch) = &message.payload else {
+            panic!("expected delivery batch");
+        };
+        assert_eq!(batch.provider, PushProviderKind::Fcm);
+        queue.ack(message.ack).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn produce_does_not_start_provider_stage_processor() {
+        let stage = PushQueueStage::DeliveryJobs(PushProviderKind::Fcm);
+        let queue = test_queue(QueueManagerPushQueueStageOwnership::testing([stage]));
+        queue
+            .produce(
+                stage,
+                "delivery".to_owned(),
+                PushQueuePayload::DeliveryBatch(Box::new(sample_batch())),
+            )
+            .await
+            .unwrap();
+
+        assert!(queue.state.lock().await.started.get(&stage).is_none());
+    }
+
+    #[tokio::test]
+    async fn non_provider_stages_are_consumable_when_owned() {
+        let stages = [
+            PushQueueStage::PublishLog,
+            PushQueueStage::ShardJobs,
+            PushQueueStage::DeliveryResults,
+            PushQueueStage::RetrySchedule,
+            PushQueueStage::DeadLetters,
+        ];
+        let queue = test_queue(QueueManagerPushQueueStageOwnership::testing(stages));
+
+        for stage in stages {
+            assert!(
+                queue
+                    .consume(stage, "pipeline-worker", 1, 30_000)
+                    .await
+                    .unwrap()
+                    .is_empty(),
+                "{stage:?}"
+            );
+        }
+    }
+
+    fn test_queue(ownership: QueueManagerPushQueueStageOwnership) -> QueueManagerPushQueue {
+        let driver = sockudo_queue::MemoryQueueManager::new();
+        driver.start_processing();
+        let manager = Arc::new(QueueManager::new(Box::new(driver)));
+        QueueManagerPushQueue::new(
+            sockudo_push::PushQueueBackendKind::Redis,
+            manager,
+            ownership,
+        )
+    }
+
+    async fn next_message(
+        queue: &QueueManagerPushQueue,
+        stage: PushQueueStage,
+    ) -> sockudo_push::QueueMessage {
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                let mut messages = queue.consume(stage, "worker", 1, 30_000).await.unwrap();
+                if let Some(message) = messages.pop() {
+                    return message;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .unwrap()
+    }
+
+    async fn insert_local_message(queue: &QueueManagerPushQueue, stage: PushQueueStage) {
+        let payload = PushQueuePayload::DeliveryBatch(Box::new(sample_batch()));
+        let route = sockudo_push::QueueRoute::for_message(stage, "delivery", &payload);
+        let message_id = "external-1".to_owned();
+        let token = sockudo_push::QueueAckToken {
+            stage,
+            message_id: message_id.clone(),
+        };
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+        let mut state = queue.state.lock().await;
+        state.pending.insert((stage, message_id.clone()), tx);
+        state
+            .ready
+            .entry(stage)
+            .or_default()
+            .push_back(sockudo_push::QueueMessage {
+                message_id,
+                stage,
+                key: "delivery".to_owned(),
+                partition_key: route.partition_key,
+                partition: route.partition,
+                payload,
+                attempt: 1,
+                not_before_ms: None,
+                lease_deadline_ms: 0,
+                ack: token,
+            });
+    }
+
+    fn sample_batch() -> DeliveryBatch {
+        DeliveryBatch {
+            app_id: "app-1".to_owned(),
+            publish_id: "publish-1".to_owned(),
+            provider: PushProviderKind::Fcm,
+            batch_id: "batch-1".to_owned(),
+            jobs: vec![DeliveryJob {
+                app_id: "app-1".to_owned(),
+                publish_id: "publish-1".to_owned(),
+                provider: PushProviderKind::Fcm,
+                batch_id: "batch-1".to_owned(),
+                device_id: Some("device-1".to_owned()),
+                recipient: PushRecipient::Fcm {
+                    registration_token: SecretString::new("fcm-token").unwrap(),
+                },
+                payload: Arc::new(PushPayload {
+                    template_id: None,
+                    template_data: json!({}),
+                    title: Some("hello".to_owned()),
+                    body: Some("body".to_owned()),
+                    icon: None,
+                    sound: None,
+                    collapse_key: Some("collapse".to_owned()),
+                }),
+                rendered_payload: None,
+                attempt: 1,
+                first_attempt_at_ms: None,
+                not_before_ms: None,
+                expires_at_ms: None,
+            }],
+        }
+    }
 }

--- a/crates/sockudo-server/src/bootstrap/push/workers.rs
+++ b/crates/sockudo-server/src/bootstrap/push/workers.rs
@@ -1,6 +1,10 @@
 use super::queue::push_queue_now_ms;
+use futures_util::FutureExt;
 use sockudo_core::options::ServerOptions;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use tracing::warn;
 
 mod providers;
@@ -37,20 +41,56 @@ fn push_retry_policy(config: &ServerOptions) -> sockudo_push::RetryPolicy {
     .bounded()
 }
 
+const PUSH_WORKER_RESTART_BACKOFF: Duration = Duration::from_secs(1);
+
+pub(super) fn spawn_supervised_worker<F, Fut>(
+    kind: &'static str,
+    group: String,
+    mut build: F,
+) -> JoinHandle<()>
+where
+    F: FnMut(String) -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let metrics = sockudo_push::PushMetrics::default();
+        loop {
+            let worker = group.clone();
+            let reason = match AssertUnwindSafe(build(worker.clone())).catch_unwind().await {
+                Ok(()) => "returned",
+                Err(_) => "panic",
+            };
+            metrics.worker_exit(kind, &worker, reason);
+            warn!(
+                worker = %worker,
+                kind,
+                reason,
+                "push worker exited; restarting after backoff"
+            );
+            tokio::time::sleep(PUSH_WORKER_RESTART_BACKOFF).await;
+        }
+    })
+}
+
 #[cfg(all(feature = "push", feature = "monolith"))]
 pub(crate) fn start_push_monolith_workers(
     config: &ServerOptions,
     store: sockudo_push::DynPushStore,
     queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<JoinHandle<()>> {
     let fanout_config = push_fanout_config(config);
     let retry_policy = push_retry_policy(config);
+    let mut handles = Vec::new();
 
     for worker_index in 0..config.push.planner_worker_count {
         let planner =
             sockudo_push::PushPlanner::new(store.clone(), queue.clone(), fanout_config.clone());
-        tokio::spawn(async move {
-            let group = format!("sockudo-monolith-planner-{worker_index}");
+        handles.push(spawn_supervised_worker(
+            "planner",
+            format!("sockudo-monolith-planner-{worker_index}"),
+            move |group| {
+                let planner = planner.clone();
+                async move {
             warn!(worker = %group, "push planner worker started");
             loop {
                 match planner.run_once(&group).await {
@@ -64,14 +104,20 @@ pub(crate) fn start_push_monolith_workers(
                 }
                 tokio::time::sleep(Duration::from_millis(200)).await;
             }
-        });
+                }
+            },
+        ));
     }
 
     for worker_index in 0..config.push.shard_worker_count {
         let worker =
             sockudo_push::PushShardWorker::new(store.clone(), queue.clone(), fanout_config.clone());
-        tokio::spawn(async move {
-            let group = format!("sockudo-monolith-shard-{worker_index}");
+        handles.push(spawn_supervised_worker(
+            "shard",
+            format!("sockudo-monolith-shard-{worker_index}"),
+            move |group| {
+                let worker = worker.clone();
+                async move {
             warn!(worker = %group, "push shard worker started");
             loop {
                 match worker.run_once(&group).await {
@@ -85,14 +131,20 @@ pub(crate) fn start_push_monolith_workers(
                 }
                 tokio::time::sleep(Duration::from_millis(200)).await;
             }
-        });
+                }
+            },
+        ));
     }
 
     for worker_index in 0..config.push.feedback_worker_count {
         let processor = sockudo_push::PushFeedbackProcessor::new(store.clone(), queue.clone())
             .with_retry_policy(retry_policy.clone());
-        tokio::spawn(async move {
-            let group = format!("sockudo-monolith-feedback-{worker_index}");
+        handles.push(spawn_supervised_worker(
+            "feedback",
+            format!("sockudo-monolith-feedback-{worker_index}"),
+            move |group| {
+                let processor = processor.clone();
+                async move {
             warn!(worker = %group, "push feedback worker started");
             loop {
                 match processor.run_once(&group).await {
@@ -106,7 +158,9 @@ pub(crate) fn start_push_monolith_workers(
                 }
                 tokio::time::sleep(Duration::from_millis(200)).await;
             }
-        });
+                }
+            },
+        ));
     }
 
     for worker_index in 0..config.push.retry_worker_count {
@@ -115,8 +169,12 @@ pub(crate) fn start_push_monolith_workers(
             queue.clone(),
             format!("sockudo-monolith-retry-{worker_index}"),
         );
-        tokio::spawn(async move {
-            let group = format!("sockudo-monolith-retry-{worker_index}");
+        handles.push(spawn_supervised_worker(
+            "retry",
+            format!("sockudo-monolith-retry-{worker_index}"),
+            move |group| {
+                let scheduler = scheduler.clone();
+                async move {
             warn!(worker = %group, "push retry scheduler worker started");
             loop {
                 match scheduler.run_once(&group).await {
@@ -130,7 +188,9 @@ pub(crate) fn start_push_monolith_workers(
                 }
                 tokio::time::sleep(Duration::from_millis(200)).await;
             }
-        });
+                }
+            },
+        ));
     }
 
     {
@@ -141,8 +201,13 @@ pub(crate) fn start_push_monolith_workers(
             fanout_config.clone(),
         );
         let store = store.clone();
-        tokio::spawn(async move {
-            let group = "sockudo-monolith-scheduler";
+        handles.push(spawn_supervised_worker(
+            "scheduler",
+            "sockudo-monolith-scheduler".to_owned(),
+            move |group| {
+                let scheduler = scheduler.clone();
+                let store = store.clone();
+                async move {
             warn!(worker = %group, "push scheduler worker started");
             loop {
                 let now = push_queue_now_ms();
@@ -167,10 +232,13 @@ pub(crate) fn start_push_monolith_workers(
                 }
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }
-        });
+                }
+            },
+        ));
     }
 
-    start_push_provider_workers(config, store, queue);
+    handles.extend(start_push_provider_workers(config, store, queue));
+    handles
 }
 
 #[cfg(all(feature = "push", feature = "monolith"))]
@@ -178,24 +246,34 @@ fn start_push_provider_workers(
     config: &ServerOptions,
     store: sockudo_push::DynPushStore,
     queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<JoinHandle<()>> {
+    let mut handles = Vec::new();
     if config.push.webpush_enabled {
-        start_webpush_provider_workers(config, queue.clone());
+        handles.extend(start_webpush_provider_workers(config, queue.clone()));
     }
 
     if config.push.apns_enabled {
-        start_apns_provider_workers(config, store.clone(), queue.clone());
+        handles.extend(start_apns_provider_workers(
+            config,
+            store.clone(),
+            queue.clone(),
+        ));
     }
 
     if config.push.fcm_enabled {
-        start_fcm_provider_workers(config, store.clone(), queue.clone());
+        handles.extend(start_fcm_provider_workers(
+            config,
+            store.clone(),
+            queue.clone(),
+        ));
     }
 
     if config.push.hms_enabled {
-        start_hms_provider_workers(config, queue.clone());
+        handles.extend(start_hms_provider_workers(config, queue.clone()));
     }
 
     if config.push.wns_enabled {
-        start_wns_provider_workers(config, queue);
+        handles.extend(start_wns_provider_workers(config, queue));
     }
+    handles
 }

--- a/crates/sockudo-server/src/bootstrap/push/workers/providers/apns.rs
+++ b/crates/sockudo-server/src/bootstrap/push/workers/providers/apns.rs
@@ -1,3 +1,4 @@
+use super::super::spawn_supervised_worker;
 use crate::push_http::decrypt_credential_secret;
 use base64::{
     Engine as _,
@@ -6,7 +7,7 @@ use base64::{
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use sockudo_core::error::{Error, Result};
 use sockudo_core::options::ServerOptions;
-use std::{env, fs, sync::Arc, time::Duration};
+use std::{env, fs, sync::Arc};
 use tracing::warn;
 
 #[cfg(all(feature = "push", feature = "monolith", feature = "push-apns"))]
@@ -14,17 +15,17 @@ pub(in crate::bootstrap::push::workers) fn start_apns_provider_workers(
     config: &ServerOptions,
     store: sockudo_push::DynPushStore,
     queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<tokio::task::JoinHandle<()>> {
     let topic = env::var("APNS_TOPIC").or_else(|_| env::var("PUSH_APNS_TOPIC"));
     let Ok(topic) = topic else {
         warn!(
             "push.apns_enabled is true but APNS_TOPIC/PUSH_APNS_TOPIC is not set; APNs dispatch worker not started"
         );
-        return;
+        return Vec::new();
     };
     if topic.trim().is_empty() {
         warn!("APNS_TOPIC/PUSH_APNS_TOPIC is empty; APNs dispatch worker not started");
-        return;
+        return Vec::new();
     }
 
     let endpoint = env::var("APNS_ENDPOINT")
@@ -38,8 +39,10 @@ pub(in crate::bootstrap::push::workers) fn start_apns_provider_workers(
     if let Ok(stored_app_id) = stored_app_id {
         if stored_app_id.trim().is_empty() {
             warn!("APNS_APP_ID/PUSH_APNS_APP_ID is empty; APNs dispatch worker not started");
-            return;
+            return Vec::new();
         }
+        let mut handles = Vec::new();
+        let max_outbound = config.push.dispatch_max_outbound_requests;
         for worker_index in 0..config.push.dispatch_worker_count {
             let store = store.clone();
             let queue = queue.clone();
@@ -47,54 +50,68 @@ pub(in crate::bootstrap::push::workers) fn start_apns_provider_workers(
             let endpoint = endpoint.clone();
             let app_id = stored_app_id.clone();
             let credential_id = stored_credential_id.clone();
-            tokio::spawn(async move {
-                let dispatcher = match create_stored_apns_dispatcher(
-                    &store,
-                    &app_id,
-                    &credential_id,
-                    &topic,
-                    &endpoint,
-                )
-                .await
-                {
-                    Ok(dispatcher) => dispatcher,
-                    Err(error) => {
-                        warn!(worker = worker_index, app_id = %app_id, credential_id = %credential_id, error = %error, "APNs dispatch worker not started");
-                        return;
-                    }
-                };
-                let mut worker = sockudo_push::ProviderDispatchWorker::new(
-                    sockudo_push::PushProviderKind::Apns,
-                    queue,
-                    Arc::new(dispatcher),
-                );
-                let group = format!("sockudo-monolith-apns-{worker_index}");
-                warn!(worker = %group, app_id = %app_id, credential_id = %credential_id, "APNs dispatch worker started with stored credential");
-                loop {
-                    match worker.run_once(&group).await {
-                        Ok(processed) if processed > 0 => {
-                            warn!(worker = %group, processed, "APNs dispatch worker processed messages");
+            handles.push(spawn_supervised_worker(
+                "provider",
+                format!("sockudo-monolith-apns-{worker_index}"),
+                move |group| {
+                    let store = store.clone();
+                    let queue = queue.clone();
+                    let topic = topic.clone();
+                    let endpoint = endpoint.clone();
+                    let app_id = app_id.clone();
+                    let credential_id = credential_id.clone();
+                    async move {
+                        let dispatcher = match create_stored_apns_dispatcher(
+                            &store,
+                            &app_id,
+                            &credential_id,
+                            &topic,
+                            &endpoint,
+                        )
+                        .await
+                        {
+                            Ok(dispatcher) => dispatcher,
+                            Err(error) => {
+                                warn!(worker = %group, app_id = %app_id, credential_id = %credential_id, error = %error, "APNs dispatch worker not started");
+                                return;
+                            }
+                        };
+                        let mut worker = sockudo_push::ProviderDispatchWorker::new(
+                            sockudo_push::PushProviderKind::Apns,
+                            queue,
+                            Arc::new(dispatcher),
+                        )
+                        .with_max_outbound_requests(max_outbound);
+                        warn!(worker = %group, app_id = %app_id, credential_id = %credential_id, "APNs dispatch worker started with stored credential");
+                        loop {
+                            match worker.run_once(&group).await {
+                                Ok(processed) if processed > 0 => {
+                                    warn!(worker = %group, processed, "APNs dispatch worker processed messages");
+                                }
+                                Ok(_) => {}
+                                Err(error) => {
+                                    warn!(worker = %group, error = %error, "APNs dispatch worker tick failed");
+                                }
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                         }
-                        Ok(_) => {}
-                        Err(error) => {
-                            warn!(worker = %group, error = %error, "APNs dispatch worker tick failed");
-                        }
                     }
-                    tokio::time::sleep(Duration::from_millis(200)).await;
-                }
-            });
+                },
+            ));
         }
-        return;
+        return handles;
     }
 
     let token_provider = match create_apns_token_provider() {
         Ok(provider) => provider,
         Err(error) => {
             warn!(error = %error, "APNs dispatch worker not started");
-            return;
+            return Vec::new();
         }
     };
 
+    let mut handles = Vec::new();
+    let max_outbound = config.push.dispatch_max_outbound_requests;
     for worker_index in 0..config.push.dispatch_worker_count {
         let http = match sockudo_push::ReqwestProviderHttpClient::new() {
             Ok(http) => Arc::new(http),
@@ -106,28 +123,40 @@ pub(in crate::bootstrap::push::workers) fn start_apns_provider_workers(
         let dispatcher =
             sockudo_push::ApnsDispatcher::new(topic.clone(), token_provider.clone(), http)
                 .with_base_url(endpoint.clone());
-        let mut worker = sockudo_push::ProviderDispatchWorker::new(
-            sockudo_push::PushProviderKind::Apns,
-            queue.clone(),
-            Arc::new(dispatcher),
-        );
-        tokio::spawn(async move {
-            let group = format!("sockudo-monolith-apns-{worker_index}");
-            warn!(worker = %group, "APNs dispatch worker started");
-            loop {
-                match worker.run_once(&group).await {
-                    Ok(processed) if processed > 0 => {
-                        warn!(worker = %group, processed, "APNs dispatch worker processed messages");
-                    }
-                    Ok(_) => {}
-                    Err(error) => {
-                        warn!(worker = %group, error = %error, "APNs dispatch worker tick failed");
+        handles.push(spawn_supervised_worker(
+            "provider",
+            format!("sockudo-monolith-apns-{worker_index}"),
+            {
+                let queue = queue.clone();
+                move |group| {
+                    let queue = queue.clone();
+                    let dispatcher = dispatcher.clone();
+                    async move {
+                        let mut worker = sockudo_push::ProviderDispatchWorker::new(
+                            sockudo_push::PushProviderKind::Apns,
+                            queue,
+                            Arc::new(dispatcher),
+                        )
+                        .with_max_outbound_requests(max_outbound);
+                        warn!(worker = %group, "APNs dispatch worker started");
+                        loop {
+                            match worker.run_once(&group).await {
+                                Ok(processed) if processed > 0 => {
+                                    warn!(worker = %group, processed, "APNs dispatch worker processed messages");
+                                }
+                                Ok(_) => {}
+                                Err(error) => {
+                                    warn!(worker = %group, error = %error, "APNs dispatch worker tick failed");
+                                }
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                        }
                     }
                 }
-                tokio::time::sleep(Duration::from_millis(200)).await;
-            }
-        });
+            },
+        ));
     }
+    handles
 }
 
 #[cfg(all(feature = "push", feature = "monolith", feature = "push-apns"))]

--- a/crates/sockudo-server/src/bootstrap/push/workers/providers/fcm.rs
+++ b/crates/sockudo-server/src/bootstrap/push/workers/providers/fcm.rs
@@ -1,8 +1,9 @@
+use super::super::spawn_supervised_worker;
 use super::static_push_token_provider;
 use crate::push_http::decrypt_credential_secret;
 use sockudo_core::error::{Error, Result};
 use sockudo_core::options::ServerOptions;
-use std::{env, fs, sync::Arc, time::Duration};
+use std::{env, fs, sync::Arc};
 use tracing::warn;
 
 #[cfg(all(feature = "push", feature = "monolith", feature = "push-fcm"))]
@@ -10,12 +11,12 @@ pub(in crate::bootstrap::push::workers) fn start_fcm_provider_workers(
     config: &ServerOptions,
     store: sockudo_push::DynPushStore,
     queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<tokio::task::JoinHandle<()>> {
     let configured_project_id = match optional_env("FCM_PROJECT_ID", "PUSH_FCM_PROJECT_ID") {
         Ok(value) => value,
         Err(error) => {
             warn!(error = %error, "FCM dispatch worker not started");
-            return;
+            return Vec::new();
         }
     };
     let endpoint = env::var("FCM_ENDPOINT")
@@ -29,8 +30,10 @@ pub(in crate::bootstrap::push::workers) fn start_fcm_provider_workers(
     if let Ok(stored_app_id) = stored_app_id {
         if stored_app_id.trim().is_empty() {
             warn!("FCM_APP_ID/PUSH_FCM_APP_ID is empty; FCM dispatch worker not started");
-            return;
+            return Vec::new();
         }
+        let mut handles = Vec::new();
+        let max_outbound = config.push.dispatch_max_outbound_requests;
         for worker_index in 0..config.push.dispatch_worker_count {
             let store = store.clone();
             let queue = queue.clone();
@@ -38,51 +41,63 @@ pub(in crate::bootstrap::push::workers) fn start_fcm_provider_workers(
             let app_id = stored_app_id.clone();
             let credential_id = stored_credential_id.clone();
             let configured_project_id = configured_project_id.clone();
-            tokio::spawn(async move {
-                let dispatcher = match create_stored_fcm_dispatcher(
-                    &store,
-                    &app_id,
-                    &credential_id,
-                    configured_project_id.as_deref(),
-                    endpoint.as_deref(),
-                )
-                .await
-                {
-                    Ok(dispatcher) => dispatcher,
-                    Err(error) => {
-                        warn!(worker = worker_index, app_id = %app_id, credential_id = %credential_id, error = %error, "FCM dispatch worker not started");
-                        return;
-                    }
-                };
-                let mut worker = sockudo_push::ProviderDispatchWorker::new(
-                    sockudo_push::PushProviderKind::Fcm,
-                    queue,
-                    Arc::new(dispatcher),
-                );
-                let group = format!("sockudo-monolith-fcm-{worker_index}");
-                warn!(worker = %group, app_id = %app_id, credential_id = %credential_id, "FCM dispatch worker started with stored credential");
-                loop {
-                    match worker.run_once(&group).await {
-                        Ok(processed) if processed > 0 => {
-                            warn!(worker = %group, processed, "FCM dispatch worker processed messages");
+            handles.push(spawn_supervised_worker(
+                "provider",
+                format!("sockudo-monolith-fcm-{worker_index}"),
+                move |group| {
+                    let store = store.clone();
+                    let queue = queue.clone();
+                    let endpoint = endpoint.clone();
+                    let app_id = app_id.clone();
+                    let credential_id = credential_id.clone();
+                    let configured_project_id = configured_project_id.clone();
+                    async move {
+                        let dispatcher = match create_stored_fcm_dispatcher(
+                            &store,
+                            &app_id,
+                            &credential_id,
+                            configured_project_id.as_deref(),
+                            endpoint.as_deref(),
+                        )
+                        .await
+                        {
+                            Ok(dispatcher) => dispatcher,
+                            Err(error) => {
+                                warn!(worker = %group, app_id = %app_id, credential_id = %credential_id, error = %error, "FCM dispatch worker not started");
+                                return;
+                            }
+                        };
+                        let mut worker = sockudo_push::ProviderDispatchWorker::new(
+                            sockudo_push::PushProviderKind::Fcm,
+                            queue,
+                            Arc::new(dispatcher),
+                        )
+                        .with_max_outbound_requests(max_outbound);
+                        warn!(worker = %group, app_id = %app_id, credential_id = %credential_id, "FCM dispatch worker started with stored credential");
+                        loop {
+                            match worker.run_once(&group).await {
+                                Ok(processed) if processed > 0 => {
+                                    warn!(worker = %group, processed, "FCM dispatch worker processed messages");
+                                }
+                                Ok(_) => {}
+                                Err(error) => {
+                                    warn!(worker = %group, error = %error, "FCM dispatch worker tick failed");
+                                }
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                         }
-                        Ok(_) => {}
-                        Err(error) => {
-                            warn!(worker = %group, error = %error, "FCM dispatch worker tick failed");
-                        }
                     }
-                    tokio::time::sleep(Duration::from_millis(200)).await;
-                }
-            });
+                },
+            ));
         }
-        return;
+        return handles;
     }
 
     let (token_provider, service_account_project_id) = match create_fcm_token_provider() {
         Ok(provider) => provider,
         Err(error) => {
             warn!(error = %error, "FCM dispatch worker not started");
-            return;
+            return Vec::new();
         }
     };
     let project_id = match configured_project_id.or(service_account_project_id) {
@@ -91,10 +106,12 @@ pub(in crate::bootstrap::push::workers) fn start_fcm_provider_workers(
             warn!(
                 "FCM dispatch requires FCM_PROJECT_ID/PUSH_FCM_PROJECT_ID or project_id in the FCM service account JSON; FCM dispatch worker not started"
             );
-            return;
+            return Vec::new();
         }
     };
 
+    let mut handles = Vec::new();
+    let max_outbound = config.push.dispatch_max_outbound_requests;
     for worker_index in 0..config.push.dispatch_worker_count {
         let http = match sockudo_push::ReqwestProviderHttpClient::new() {
             Ok(http) => Arc::new(http),
@@ -108,28 +125,40 @@ pub(in crate::bootstrap::push::workers) fn start_fcm_provider_workers(
         if let Some(endpoint) = endpoint.clone() {
             dispatcher = dispatcher.with_base_url(endpoint);
         }
-        let mut worker = sockudo_push::ProviderDispatchWorker::new(
-            sockudo_push::PushProviderKind::Fcm,
-            queue.clone(),
-            Arc::new(dispatcher),
-        );
-        tokio::spawn(async move {
-            let group = format!("sockudo-monolith-fcm-{worker_index}");
-            warn!(worker = %group, "FCM dispatch worker started");
-            loop {
-                match worker.run_once(&group).await {
-                    Ok(processed) if processed > 0 => {
-                        warn!(worker = %group, processed, "FCM dispatch worker processed messages");
-                    }
-                    Ok(_) => {}
-                    Err(error) => {
-                        warn!(worker = %group, error = %error, "FCM dispatch worker tick failed");
+        handles.push(spawn_supervised_worker(
+            "provider",
+            format!("sockudo-monolith-fcm-{worker_index}"),
+            {
+                let queue = queue.clone();
+                move |group| {
+                    let queue = queue.clone();
+                    let dispatcher = dispatcher.clone();
+                    async move {
+                        let mut worker = sockudo_push::ProviderDispatchWorker::new(
+                            sockudo_push::PushProviderKind::Fcm,
+                            queue,
+                            Arc::new(dispatcher),
+                        )
+                        .with_max_outbound_requests(max_outbound);
+                        warn!(worker = %group, "FCM dispatch worker started");
+                        loop {
+                            match worker.run_once(&group).await {
+                                Ok(processed) if processed > 0 => {
+                                    warn!(worker = %group, processed, "FCM dispatch worker processed messages");
+                                }
+                                Ok(_) => {}
+                                Err(error) => {
+                                    warn!(worker = %group, error = %error, "FCM dispatch worker tick failed");
+                                }
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                        }
                     }
                 }
-                tokio::time::sleep(Duration::from_millis(200)).await;
-            }
-        });
+            },
+        ));
     }
+    handles
 }
 
 #[cfg(all(feature = "push", feature = "monolith", feature = "push-fcm"))]

--- a/crates/sockudo-server/src/bootstrap/push/workers/providers/hms.rs
+++ b/crates/sockudo-server/src/bootstrap/push/workers/providers/hms.rs
@@ -1,23 +1,24 @@
+use super::super::spawn_supervised_worker;
 use super::static_push_token_provider;
 use sockudo_core::options::ServerOptions;
-use std::{env, sync::Arc, time::Duration};
+use std::{env, sync::Arc};
 use tracing::warn;
 
 #[cfg(all(feature = "push", feature = "monolith", feature = "push-hms"))]
 pub(in crate::bootstrap::push::workers) fn start_hms_provider_workers(
     config: &ServerOptions,
     queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<tokio::task::JoinHandle<()>> {
     let app_id = env::var("HMS_APP_ID").or_else(|_| env::var("PUSH_HMS_APP_ID"));
     let Ok(app_id) = app_id else {
         warn!(
             "push.hms_enabled is true but HMS_APP_ID/PUSH_HMS_APP_ID is not set; HMS dispatch worker not started"
         );
-        return;
+        return Vec::new();
     };
     if app_id.trim().is_empty() {
         warn!("HMS_APP_ID/PUSH_HMS_APP_ID is empty; HMS dispatch worker not started");
-        return;
+        return Vec::new();
     }
 
     let token_provider =
@@ -26,13 +27,15 @@ pub(in crate::bootstrap::push::workers) fn start_hms_provider_workers(
             Ok(provider) => provider,
             Err(error) => {
                 warn!(error = %error, "HMS dispatch worker not started");
-                return;
+                return Vec::new();
             }
         };
     let endpoint = env::var("HMS_ENDPOINT")
         .or_else(|_| env::var("PUSH_HMS_ENDPOINT"))
         .ok();
 
+    let mut handles = Vec::new();
+    let max_outbound = config.push.dispatch_max_outbound_requests;
     for worker_index in 0..config.push.dispatch_worker_count {
         let http = match sockudo_push::ReqwestProviderHttpClient::new() {
             Ok(http) => Arc::new(http),
@@ -46,26 +49,38 @@ pub(in crate::bootstrap::push::workers) fn start_hms_provider_workers(
         if let Some(endpoint) = endpoint.clone() {
             dispatcher = dispatcher.with_base_url(endpoint);
         }
-        let mut worker = sockudo_push::ProviderDispatchWorker::new(
-            sockudo_push::PushProviderKind::Hms,
-            queue.clone(),
-            Arc::new(dispatcher),
-        );
-        tokio::spawn(async move {
-            let group = format!("sockudo-monolith-hms-{worker_index}");
-            warn!(worker = %group, "HMS dispatch worker started");
-            loop {
-                match worker.run_once(&group).await {
-                    Ok(processed) if processed > 0 => {
-                        warn!(worker = %group, processed, "HMS dispatch worker processed messages");
-                    }
-                    Ok(_) => {}
-                    Err(error) => {
-                        warn!(worker = %group, error = %error, "HMS dispatch worker tick failed");
+        handles.push(spawn_supervised_worker(
+            "provider",
+            format!("sockudo-monolith-hms-{worker_index}"),
+            {
+                let queue = queue.clone();
+                move |group| {
+                    let queue = queue.clone();
+                    let dispatcher = dispatcher.clone();
+                    async move {
+                        let mut worker = sockudo_push::ProviderDispatchWorker::new(
+                            sockudo_push::PushProviderKind::Hms,
+                            queue,
+                            Arc::new(dispatcher),
+                        )
+                        .with_max_outbound_requests(max_outbound);
+                        warn!(worker = %group, "HMS dispatch worker started");
+                        loop {
+                            match worker.run_once(&group).await {
+                                Ok(processed) if processed > 0 => {
+                                    warn!(worker = %group, processed, "HMS dispatch worker processed messages");
+                                }
+                                Ok(_) => {}
+                                Err(error) => {
+                                    warn!(worker = %group, error = %error, "HMS dispatch worker tick failed");
+                                }
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                        }
                     }
                 }
-                tokio::time::sleep(Duration::from_millis(200)).await;
-            }
-        });
+            },
+        ));
     }
+    handles
 }

--- a/crates/sockudo-server/src/bootstrap/push/workers/providers/mod.rs
+++ b/crates/sockudo-server/src/bootstrap/push/workers/providers/mod.rs
@@ -38,10 +38,11 @@ pub(super) fn start_apns_provider_workers(
     _config: &sockudo_core::options::ServerOptions,
     _store: sockudo_push::DynPushStore,
     _queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<tokio::task::JoinHandle<()>> {
     tracing::warn!(
         "push.apns_enabled is true but the binary was not compiled with the push-apns feature"
     );
+    Vec::new()
 }
 
 #[cfg(all(feature = "push", feature = "monolith", not(feature = "push-fcm")))]
@@ -49,40 +50,44 @@ pub(super) fn start_fcm_provider_workers(
     _config: &sockudo_core::options::ServerOptions,
     _store: sockudo_push::DynPushStore,
     _queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<tokio::task::JoinHandle<()>> {
     tracing::warn!(
         "push.fcm_enabled is true but the binary was not compiled with the push-fcm feature"
     );
+    Vec::new()
 }
 
 #[cfg(all(feature = "push", feature = "monolith", not(feature = "push-hms")))]
 pub(super) fn start_hms_provider_workers(
     _config: &sockudo_core::options::ServerOptions,
     _queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<tokio::task::JoinHandle<()>> {
     tracing::warn!(
         "push.hms_enabled is true but the binary was not compiled with the push-hms feature"
     );
+    Vec::new()
 }
 
 #[cfg(all(feature = "push", feature = "monolith", not(feature = "push-webpush")))]
 pub(super) fn start_webpush_provider_workers(
     _config: &sockudo_core::options::ServerOptions,
     _queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<tokio::task::JoinHandle<()>> {
     tracing::warn!(
         "push.webpush_enabled is true but the binary was not compiled with the push-webpush feature"
     );
+    Vec::new()
 }
 
 #[cfg(all(feature = "push", feature = "monolith", not(feature = "push-wns")))]
 pub(super) fn start_wns_provider_workers(
     _config: &sockudo_core::options::ServerOptions,
     _queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<tokio::task::JoinHandle<()>> {
     tracing::warn!(
         "push.wns_enabled is true but the binary was not compiled with the push-wns feature"
     );
+    Vec::new()
 }
 
 #[cfg(any(

--- a/crates/sockudo-server/src/bootstrap/push/workers/providers/webpush.rs
+++ b/crates/sockudo-server/src/bootstrap/push/workers/providers/webpush.rs
@@ -1,24 +1,27 @@
+use super::super::spawn_supervised_worker;
 use sockudo_core::options::ServerOptions;
-use std::{env, sync::Arc, time::Duration};
+use std::{env, sync::Arc};
 use tracing::warn;
 
 #[cfg(all(feature = "push", feature = "monolith", feature = "push-webpush"))]
 pub(in crate::bootstrap::push::workers) fn start_webpush_provider_workers(
     config: &ServerOptions,
     queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<tokio::task::JoinHandle<()>> {
     let vapid_private_key =
         env::var("VAPID_PRIVATE_KEY").or_else(|_| env::var("PUSH_WEBPUSH_VAPID_PRIVATE_KEY"));
     let Ok(vapid_private_key) = vapid_private_key else {
         warn!(
             "push.webpush_enabled is true but VAPID_PRIVATE_KEY/PUSH_WEBPUSH_VAPID_PRIVATE_KEY is not set; Web Push dispatch worker not started"
         );
-        return;
+        return Vec::new();
     };
     let vapid_contact = env::var("VAPID_CONTACT")
         .or_else(|_| env::var("PUSH_WEBPUSH_VAPID_CONTACT"))
         .unwrap_or_else(|_| "mailto:sockudo-webpush@example.com".to_owned());
 
+    let mut handles = Vec::new();
+    let max_outbound = config.push.dispatch_max_outbound_requests;
     for worker_index in 0..config.push.dispatch_worker_count {
         let http = match sockudo_push::ReqwestProviderHttpClient::new() {
             Ok(http) => Arc::new(http),
@@ -40,26 +43,38 @@ pub(in crate::bootstrap::push::workers) fn start_webpush_provider_workers(
             )),
             http,
         );
-        let mut worker = sockudo_push::ProviderDispatchWorker::new(
-            sockudo_push::PushProviderKind::WebPush,
-            queue.clone(),
-            Arc::new(dispatcher),
-        );
-        tokio::spawn(async move {
-            let group = format!("sockudo-monolith-webpush-{worker_index}");
-            warn!(worker = %group, "Web Push dispatch worker started");
-            loop {
-                match worker.run_once(&group).await {
-                    Ok(processed) if processed > 0 => {
-                        warn!(worker = %group, processed, "Web Push dispatch worker processed messages");
-                    }
-                    Ok(_) => {}
-                    Err(error) => {
-                        warn!(worker = %group, error = %error, "Web Push dispatch worker tick failed");
+        handles.push(spawn_supervised_worker(
+            "provider",
+            format!("sockudo-monolith-webpush-{worker_index}"),
+            {
+                let queue = queue.clone();
+                move |group| {
+                    let queue = queue.clone();
+                    let dispatcher = dispatcher.clone();
+                    async move {
+                        let mut worker = sockudo_push::ProviderDispatchWorker::new(
+                            sockudo_push::PushProviderKind::WebPush,
+                            queue,
+                            Arc::new(dispatcher),
+                        )
+                        .with_max_outbound_requests(max_outbound);
+                        warn!(worker = %group, "Web Push dispatch worker started");
+                        loop {
+                            match worker.run_once(&group).await {
+                                Ok(processed) if processed > 0 => {
+                                    warn!(worker = %group, processed, "Web Push dispatch worker processed messages");
+                                }
+                                Ok(_) => {}
+                                Err(error) => {
+                                    warn!(worker = %group, error = %error, "Web Push dispatch worker tick failed");
+                                }
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                        }
                     }
                 }
-                tokio::time::sleep(Duration::from_millis(200)).await;
-            }
-        });
+            },
+        ));
     }
+    handles
 }

--- a/crates/sockudo-server/src/bootstrap/push/workers/providers/wns.rs
+++ b/crates/sockudo-server/src/bootstrap/push/workers/providers/wns.rs
@@ -1,23 +1,26 @@
+use super::super::spawn_supervised_worker;
 use super::static_push_token_provider;
 use sockudo_core::options::ServerOptions;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 use tracing::warn;
 
 #[cfg(all(feature = "push", feature = "monolith", feature = "push-wns"))]
 pub(in crate::bootstrap::push::workers) fn start_wns_provider_workers(
     config: &ServerOptions,
     queue: sockudo_push::DynPushQueue,
-) {
+) -> Vec<tokio::task::JoinHandle<()>> {
     let token_provider =
         match static_push_token_provider("WNS", &["WNS_PROVIDER_TOKEN", "PUSH_WNS_PROVIDER_TOKEN"])
         {
             Ok(provider) => provider,
             Err(error) => {
                 warn!(error = %error, "WNS dispatch worker not started");
-                return;
+                return Vec::new();
             }
         };
 
+    let mut handles = Vec::new();
+    let max_outbound = config.push.dispatch_max_outbound_requests;
     for worker_index in 0..config.push.dispatch_worker_count {
         let http = match sockudo_push::ReqwestProviderHttpClient::new() {
             Ok(http) => Arc::new(http),
@@ -27,26 +30,38 @@ pub(in crate::bootstrap::push::workers) fn start_wns_provider_workers(
             }
         };
         let dispatcher = sockudo_push::WnsDispatcher::new(token_provider.clone(), http);
-        let mut worker = sockudo_push::ProviderDispatchWorker::new(
-            sockudo_push::PushProviderKind::Wns,
-            queue.clone(),
-            Arc::new(dispatcher),
-        );
-        tokio::spawn(async move {
-            let group = format!("sockudo-monolith-wns-{worker_index}");
-            warn!(worker = %group, "WNS dispatch worker started");
-            loop {
-                match worker.run_once(&group).await {
-                    Ok(processed) if processed > 0 => {
-                        warn!(worker = %group, processed, "WNS dispatch worker processed messages");
-                    }
-                    Ok(_) => {}
-                    Err(error) => {
-                        warn!(worker = %group, error = %error, "WNS dispatch worker tick failed");
+        handles.push(spawn_supervised_worker(
+            "provider",
+            format!("sockudo-monolith-wns-{worker_index}"),
+            {
+                let queue = queue.clone();
+                move |group| {
+                    let queue = queue.clone();
+                    let dispatcher = dispatcher.clone();
+                    async move {
+                        let mut worker = sockudo_push::ProviderDispatchWorker::new(
+                            sockudo_push::PushProviderKind::Wns,
+                            queue,
+                            Arc::new(dispatcher),
+                        )
+                        .with_max_outbound_requests(max_outbound);
+                        warn!(worker = %group, "WNS dispatch worker started");
+                        loop {
+                            match worker.run_once(&group).await {
+                                Ok(processed) if processed > 0 => {
+                                    warn!(worker = %group, processed, "WNS dispatch worker processed messages");
+                                }
+                                Ok(_) => {}
+                                Err(error) => {
+                                    warn!(worker = %group, error = %error, "WNS dispatch worker tick failed");
+                                }
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                        }
                     }
                 }
-                tokio::time::sleep(Duration::from_millis(200)).await;
-            }
-        });
+            },
+        ));
     }
+    handles
 }

--- a/crates/sockudo-server/src/bootstrap/runtime.rs
+++ b/crates/sockudo-server/src/bootstrap/runtime.rs
@@ -548,6 +548,17 @@ impl SockudoServer {
             info!("Cleanup system will shutdown when server process ends");
         }
 
+        #[cfg(all(feature = "push", feature = "monolith"))]
+        {
+            for handle in &self.state.push_worker_handles {
+                handle.abort();
+            }
+            info!(
+                "Aborted {} push worker supervisor tasks",
+                self.state.push_worker_handles.len()
+            );
+        }
+
         // Stop delta compression cleanup task gracefully
         #[cfg(feature = "delta")]
         self.state.delta_compression.stop_cleanup_task().await;

--- a/crates/sockudo-server/src/bootstrap/server.rs
+++ b/crates/sockudo-server/src/bootstrap/server.rs
@@ -692,10 +692,13 @@ impl SockudoServer {
         #[cfg(feature = "push")]
         let push_store = create_push_store(&config).await?;
         #[cfg(feature = "push")]
-        let push_queue = create_push_queue(&config, queue_manager_opt.clone())?;
-        #[cfg(feature = "push")]
         let push_admission =
             Arc::new(PushAdmissionSnapshot::from_config(&config, &push_store).await);
+        #[cfg(feature = "push")]
+        let push_queue = create_push_queue(&config, queue_manager_opt.clone(), &push_admission)?;
+        #[cfg(all(feature = "push", feature = "monolith"))]
+        let push_worker_handles =
+            start_push_monolith_workers(&config, push_store.clone(), push_queue.clone());
 
         let state = ServerState {
             app_manager: app_manager.clone(),
@@ -724,10 +727,9 @@ impl SockudoServer {
             push_queue,
             #[cfg(feature = "push")]
             push_admission,
+            #[cfg(all(feature = "push", feature = "monolith"))]
+            push_worker_handles,
         };
-
-        #[cfg(all(feature = "push", feature = "monolith"))]
-        start_push_monolith_workers(&config, state.push_store.clone(), state.push_queue.clone());
 
         let mut builder = ConnectionHandler::builder(
             state.app_manager.clone(),

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -186,6 +186,7 @@ accept_worker_count = 1
 planner_worker_count = 1
 shard_worker_count = 1
 dispatch_worker_count = 1
+dispatch_max_outbound_requests = 32
 feedback_worker_count = 1
 retry_worker_count = 1
 queue_partition_count = 1

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -388,6 +388,7 @@ This page lists every runtime environment variable referenced by the server, cor
 | `PUSH_PUBLISH_LOG_MAX_LAG` | Maximum publish-log lag tolerated before push backpressure. |
 | `PUSH_CRITICAL_QUEUE_MAX_LAG` | Maximum lag tolerated for shard, delivery result, retry, dead-letter, and active provider delivery stages. |
 | `PUSH_PUBLISH_STATUS_TTL_DAYS` | Retention for push publish status records. |
+| `PUSH_DISPATCH_MAX_OUTBOUND_REQUESTS` | Maximum outbound provider requests each dispatch worker hands to a provider dispatcher at once. |
 | `PUSH_RETRY_WORKER_COUNT` | Number of monolith retry scheduler workers consuming `push.retry.v1`. |
 | `PUSH_RETRY_MAX_ATTEMPTS` | Maximum provider delivery attempts before retry work is dead-lettered. |
 | `PUSH_RETRY_INITIAL_BACKOFF_MS` | Initial retry backoff when the provider does not send `Retry-After`. |

--- a/docs/content/docs/server/push-notifications.mdx
+++ b/docs/content/docs/server/push-notifications.mdx
@@ -66,6 +66,29 @@ Readiness failures return `503`. Queue pressure returns `429` with `Retry-After`
 persists a terminal `quota_exceeded` publish status and idempotency record without appending publish
 log work or enqueueing the pipeline.
 
+## Cluster queue delivery guarantees
+
+Push queue delivery is at-least-once. Accepted publish work is durable before the API returns, and
+every delivery result is idempotently applied by feedback workers. A provider send can still be
+duplicated if a worker crashes after the provider accepts the request but before `push.results.v1`
+is produced or before the original delivery batch is acknowledged. Sockudo keeps the duplicate
+window bounded with stable delivery idempotency keys, deterministic retry context, and duplicate
+feedback suppression, but it does not claim exactly-once provider delivery.
+
+In monolith deployments, each node consumes only stages it can process. Planner, shard, feedback,
+retry, and dead-letter stages are consumed only by nodes with the matching local worker enabled.
+Provider delivery stages such as `push.delivery.fcm.v1` are consumed only by nodes whose provider
+worker is active and credential-ready at boot. Changing provider capability or credentials requires
+worker restart; stored credentials are reloaded when a supervised provider worker restarts.
+
+External queue adapters pull broker messages into a bounded node-local ready/pending handoff before
+Sockudo workers ack, nack, or dead-letter them. If the local worker does not finish before the local
+lease timeout, the adapter requeues the envelope with backoff. Broker-wide visibility timeout and
+dead-node redelivery still depend on the configured `[queue]` backend. Queue health and lag reported
+by the generic queue manager adapter distinguish this node's local pull-ahead depth from
+broker-wide backlog, so operators should watch both provider/stage lag and backend-native queue
+metrics where the backend exposes them.
+
 ## Retry and dead letters
 
 Provider throttling, 5xx responses, and transport failures are classified as retryable provider,


### PR DESCRIPTION
## Disaster scenario made safe

This hardens the push pipeline for clustered monolith deployments where workers, provider dispatchers, or the local handoff loop die while work is already durable in the configured queue backend. The generic queue-manager adapter now avoids producer-side accidental stage consumption, only consumes stages this node is capable of processing, bounds node-local pull-ahead, and requeues local handoff work on nack or lease timeout. Monolith push workers are supervised and restarted after return or panic, with stored FCM/APNs credentials reloaded on provider worker restart.

## Behavior changed

- Queue-manager backed push stages are consumed only by nodes that own the stage based on local worker counts and active provider capability.
- Producing push work no longer starts an external queue processor on the producer node.
- Queue-manager local ready/pending handoff is capped and lease timed; failed local handoff is requeued with metrics.
- Push worker supervisors record exit reasons and restart pipeline/provider workers instead of letting them disappear silently.
- Provider dispatch workers bound each outbound dispatch chunk with `push.dispatch_max_outbound_requests` / `PUSH_DISPATCH_MAX_OUTBOUND_REQUESTS` while preserving delivery job identity/idempotency keys.
- Feedback redelivery remains idempotent and no longer double-counts publish status counters.

## Behavior intentionally not changed

- Push remains at-least-once, not exactly-once, for provider delivery. A provider accept followed by worker death before result enqueue/ack can still duplicate a provider send.
- Existing Pusher Protocol V1 behavior and non-push realtime paths are not changed.
- Backend-native queue visibility, dead-node redelivery, and broker-wide backlog semantics remain owned by the configured queue backend.
- Static env-based provider configuration still requires process restart; stored credential provider workers reload credentials when their supervised worker restarts.

## Tests / verification

- `cargo fmt --all --check`
- `cargo test -p sockudo-push`
- `cargo test -p sockudo-core push`
- `cargo test -p sockudo --features "push,monolith" push`
- `cargo test -p sockudo --features "push,monolith" bootstrap`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cd docs && npm run types:check && npm run build`

Docs build passed with the existing Next.js workspace-root warning about multiple lockfiles.

## Remaining disaster modes deferred

- Full broker-level lease/ack semantics for every generic queue adapter would require queue-driver API changes beyond this PR.
- Provider-side duplicate suppression still depends on provider behavior plus Sockudo's stable delivery idempotency context; Sockudo does not guarantee provider exactly-once send.
- Operators should still monitor backend-native queue metrics for broker-wide backlog because queue-manager adapter lag is node-local pull-ahead depth.
