### PR TITLE
chore: set mirror tag git identity

### DIFF
--- a/.github/workflows/mirror-php-sdk.yml
+++ b/.github/workflows/mirror-php-sdk.yml
@@ -89,6 +89,8 @@ jobs:
 
           git remote set-url mirror \
             "https://x-access-token:${MIRROR_TOKEN}@github.com/${MIRROR_REPOSITORY}.git"
+          git config user.name "sockudo-mirror[bot]"
+          git config user.email "sockudo-mirror[bot]@users.noreply.github.com"
 
           if [ -n "${mirror_tag}" ]; then
             if [[ ! "${mirror_tag}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+ ]]; then

--- a/.github/workflows/mirror-swift-sdks.yml
+++ b/.github/workflows/mirror-swift-sdks.yml
@@ -137,6 +137,8 @@ jobs:
             "${MIRROR_BRANCH}:refs/remotes/mirror/${MIRROR_BRANCH}" || true
           git remote set-url mirror \
             "https://x-access-token:${MIRROR_TOKEN}@github.com/${MIRROR_REPOSITORY}.git"
+          git config user.name "sockudo-mirror[bot]"
+          git config user.email "sockudo-mirror[bot]@users.noreply.github.com"
 
           mirror_tag="${MANUAL_MIRROR_TAG}"
           if [ "${EVENT_NAME}" = "push" ] && [ "${REF_TYPE}" = "tag" ]; then


### PR DESCRIPTION
## What changed

- Configures a bot git identity inside both mirror workflows before creating annotated mirror tags.

## Why

The manual Swift mirror seed reached `git tag --annotate v2.1.0`, but failed because the filtered clone had no committer identity:

```text
Committer identity unknown
fatal: empty ident name ... not allowed
```

The PHP mirror workflow uses the same annotated tag path, so this fixes both mirror tag flows.

## Verification

- `yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable}}" .github/workflows/mirror-swift-sdks.yml .github/workflows/mirror-php-sdk.yml`
