### PR TITLE
Run simulator push durability through real APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "as-slice"
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "1.130.0"
+version = "1.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33489208bd2568aa0189cdb640343d56d6bc7fd5ba01b9e1e34d4c2a4a2bda6d"
+checksum = "2548b20e9e2116b1325b1b8623787d265a2a513f35843dc579f9afa090a06be5"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1505,21 +1505,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -2090,18 +2084,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2109,27 +2103,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossfire"
@@ -2364,9 +2358,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -2374,12 +2368,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2505,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "376186e025eb294c22f06236b23417608f1867def159c3a61a5c57788a3e889e"
+checksum = "421c6cf955c6cb1451d36c8a3740ab2a22880265d0fa93d8ea22cbc425c90479"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2525,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b70289db1b66826fa1ef2b4113bf2f9d0dedc8df983b2b804c38dc1e519e15e"
+checksum = "7cdf7d491910fbff13338e07460c9197a3c172268cfd4d8f8e69e5cec5a256d9"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2542,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62c9d81aad6e3df6a026b1bb693dbbcfbee5ea93d9e7a5ff15c31576263bc29"
+checksum = "de1643bbece645f03527ef120bc7dd5e4e40557980dbe52ee51129adfb58a851"
 dependencies = [
  "cfg-if",
  "diskann-wide",
@@ -2553,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fcacef8ea9274969f98499456718f3dcaa5d3d7392b3171079653370fa0b20"
+checksum = "421f02c42e57a2153dc65b66b4b95fe2be56e14bf9f95253b663abcac8521166"
 dependencies = [
  "cfg-if",
  "half",
@@ -2713,21 +2706,15 @@ dependencies = [
 
 [[package]]
 name = "embed-collections"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49c327886cdc0e7eda24cd0827f195db19a5f941425914bc6db76c79c64bc21"
+checksum = "9be5eeb1388bef284c44bf61743bc1ec0173c67d2a7d68426bdf758a72c0f13d"
 
 [[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "endian-type"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "enumset"
@@ -2903,13 +2890,13 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash 0.2.0",
  "libm",
- "rand 0.9.4",
+ "portable-atomic",
  "siphasher",
 ]
 
@@ -2940,7 +2927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113"
 dependencies = [
  "bytes",
- "rkyv 0.8.16",
+ "rkyv 0.8.17",
  "serde",
  "simdutf8",
 ]
@@ -3078,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
@@ -3247,7 +3234,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -3361,9 +3348,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3417,7 +3406,7 @@ dependencies = [
  "google-cloud-wkt",
  "http 1.4.2",
  "pin-project",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3779,8 +3768,8 @@ dependencies = [
  "hickory-proto",
  "idna",
  "ipnet",
- "jni 0.22.4",
- "rand 0.10.1",
+ "jni",
+ "rand 0.10.2",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -3797,10 +3786,10 @@ dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "once_cell",
  "prefix-trie",
- "rand 0.10.1",
+ "rand 0.10.2",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -3820,12 +3809,12 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "moka",
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.1",
+ "rand 0.10.2",
  "resolv-conf",
  "smallvec",
  "system-configuration",
@@ -3955,9 +3944,9 @@ checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
@@ -4474,22 +4463,6 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -4497,7 +4470,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -4516,15 +4489,6 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -4548,11 +4512,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -4908,7 +4872,7 @@ dependencies = [
  "metrics",
  "ordered-float 5.3.0",
  "quanta",
- "radix_trie 0.2.1",
+ "radix_trie",
  "rand 0.9.4",
  "rand_xoshiro",
  "rapidhash",
@@ -5215,9 +5179,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -5544,7 +5508,7 @@ dependencies = [
  "hmac 0.12.1",
  "pkcs12",
  "pkcs5",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rc2",
  "sha1 0.10.6",
  "sha2 0.10.9",
@@ -6028,28 +5992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6283,21 +6225,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -6307,16 +6250,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6352,26 +6295,15 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
 dependencies = [
- "endian-type 0.1.2",
+ "endian-type",
  "nibble_vec",
-]
-
-[[package]]
-name = "radix_trie"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
-dependencies = [
- "endian-type 0.2.0",
- "nibble_vec",
- "serde",
 ]
 
 [[package]]
 name = "rancor"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
 dependencies = [
  "ptr_meta 0.3.1",
 ]
@@ -6399,9 +6331,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -6472,6 +6404,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6482,9 +6423,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.2"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
  "rustversion",
 ]
@@ -6605,7 +6546,7 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rustls",
  "rustls-native-certs",
  "ryu",
@@ -6696,9 +6637,9 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
 
 [[package]]
 name = "reqwest"
@@ -6766,7 +6707,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6848,14 +6789,14 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
 dependencies = [
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
 name = "revision"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e735a8c2864f0b0fd48a55d0a71c081c7cbef8c8958a4665d8de423f20f2d0cf"
+checksum = "13b48b66c1cd4bf814516ea48f727d4b3697e3fa8841be99a7d9cbb8c9ac1666"
 dependencies = [
  "bytes",
  "chrono",
@@ -6869,9 +6810,9 @@ dependencies = [
 
 [[package]]
 name = "revision-derive"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f446f8c55ba240992330b09f69fe9e5ec8a2e1ba266843cb9f59d7bc6037c821"
+checksum = "3d266d798eaaa2921e14188dfe998bb7cc0528ec26e894b4be0e35fe2b19c89d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6922,9 +6863,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytes",
  "hashbrown 0.17.1",
@@ -6932,8 +6873,8 @@ dependencies = [
  "munge",
  "ptr_meta 0.3.1",
  "rancor",
- "rend 0.5.3",
- "rkyv_derive 0.8.16",
+ "rend 0.5.4",
+ "rkyv_derive 0.8.17",
  "tinyvec",
  "uuid",
 ]
@@ -6951,9 +6892,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7106,9 +7047,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -7168,7 +7109,7 @@ dependencies = [
  "log",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier",
  "rustls-webpki",
 ]
 
@@ -7196,34 +7137,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni 0.21.1",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.22.4",
+ "jni",
  "log",
  "once_cell",
  "rustls",
@@ -7256,9 +7176,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -7292,9 +7212,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "3.8.3"
+version = "3.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5581cd5dd2cb79cbe9d8137071d67f62f0db926e83a07b4d14561c5b7d423776"
+checksum = "7800bc2c7e91b26aeae70c2ab6eaa653efc133104b7756e674c99304adff3fdb"
 dependencies = [
  "saa",
  "sdd",
@@ -7372,7 +7292,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "itertools 0.14.0",
  "rand 0.9.4",
- "rand_pcg",
+ "rand_pcg 0.9.0",
  "rustls",
  "scylla-cql",
  "scylla-cql-core",
@@ -7434,9 +7354,9 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "4.8.6"
+version = "4.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f0e40a01b94e35d1dacbcfbe5bfd3d31e37d9590b2e6d86a82b0e87bd4f551"
+checksum = "1836bad8bdc9c6d665b63202da3d9c6d60ed1e597cae63620e21ebf89a3595a9"
 dependencies = [
  "saa",
 ]
@@ -8496,7 +8416,7 @@ dependencies = [
  "log",
  "md-5 0.11.0",
  "memchr",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -8636,9 +8556,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ee3110fe3ab8172eb8c135c96ed2d57c7470cdf1ad732d176db95a92c9faab"
+checksum = "74c21f360e9c3705555e5894271e4db622cf055d0faad4169f1ef52d08958705"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -8674,9 +8594,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-collections"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069e0c90dad71cf8f17475f75118a56ad3047f2f46fac24643e562b415b3f11a"
+checksum = "fe5b7ce7c31b54e9b8029179c395f78549679beecd48763fa55bc17059d8b3ff"
 dependencies = [
  "revision",
  "storekey",
@@ -8684,9 +8604,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9780c2f3dd6a3cb1cce8ca7c866b5e82ac4377b826a09bf718ca441bfd2bd747"
+checksum = "9ad0e632d0ba78dede6e1432ef902b3dac4d9ce7999dc413b6d12e942db57f57"
 dependencies = [
  "addr",
  "ahash 0.8.12",
@@ -8736,7 +8656,6 @@ dependencies = [
  "phf",
  "pin-project-lite",
  "quick_cache",
- "radix_trie 0.3.0",
  "rand 0.9.4",
  "rand_core 0.6.4",
  "rayon",
@@ -8801,9 +8720,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-strand"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af300a172983b23c05e692cacba462ca023e3e9404812b6783d09a8af487865"
+checksum = "1a832fdd23c7cebe15b95c6940bf23e18360774307f939273e43c6a4d6722922"
 dependencies = [
  "revision",
  "serde",
@@ -8812,9 +8731,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd434d643c040c2872c9cfc88c90e9910e9a55456d2df7e68e92725225d3e20"
+checksum = "191f11ad65f53f7a7b7cc65e2f455997bf9533a70bf9cfc509d58e4e061d300a"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -8843,9 +8762,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d385184f3b727c58c4d099a877a4c54ffe879dd190396cc80b1676146b8b2b"
+checksum = "428bbf94f264212f3ed2f807304fae5ac8e6cc7fa2fd73f026632a3639bf673b"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -8980,12 +8899,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
@@ -9745,9 +9663,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+checksum = "159a7cadce548703edd50d24069bc294c5415ecab0a480e0cd1ca06d112dc94a"
 
 [[package]]
 name = "utf8_iter"
@@ -9769,7 +9687,7 @@ checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde_core",
  "wasm-bindgen",
  "zerocopy",
@@ -10190,29 +10108,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -10226,50 +10126,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -10283,27 +10151,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -10312,28 +10162,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
 name = "windows_i686_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -10342,34 +10174,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10378,46 +10186,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -10534,18 +10312,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8228,6 +8228,7 @@ dependencies = [
  "serde_json",
  "sockudo-core",
  "sockudo-protocol",
+ "sockudo-push",
  "sonic-rs",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/sockudo-simulator/Cargo.toml
+++ b/crates/sockudo-simulator/Cargo.toml
@@ -20,7 +20,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sockudo-core = { workspace = true }
 sockudo-protocol = { workspace = true }
+sockudo-push = { workspace = true }
 sonic-rs = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-

--- a/crates/sockudo-simulator/src/error.rs
+++ b/crates/sockudo-simulator/src/error.rs
@@ -15,5 +15,11 @@ pub enum SimulatorError {
     #[error(transparent)]
     Core(#[from] sockudo_core::error::Error),
     #[error(transparent)]
+    PushDomain(#[from] sockudo_push::PushDomainError),
+    #[error(transparent)]
+    PushPipeline(#[from] sockudo_push::PushPipelineError),
+    #[error(transparent)]
+    PushStorage(#[from] sockudo_push::PushStorageError),
+    #[error(transparent)]
     Json(#[from] serde_json::Error),
 }

--- a/crates/sockudo-simulator/src/lib.rs
+++ b/crates/sockudo-simulator/src/lib.rs
@@ -8,6 +8,7 @@
 mod config;
 mod error;
 mod push_lab;
+mod real_subsystems;
 mod simulator;
 mod workload;
 

--- a/crates/sockudo-simulator/src/push_lab.rs
+++ b/crates/sockudo-simulator/src/push_lab.rs
@@ -1,9 +1,11 @@
 use rand::Rng;
 use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};
+use sockudo_push::PushProviderKind;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use crate::error::{SimulatorError, SimulatorResult};
+use crate::real_subsystems::RealPushHarness;
 
 const MAX_TRACE_EVENTS: usize = 80;
 const DEFAULT_PUSH_DEVICES: usize = 32;
@@ -188,9 +190,10 @@ pub struct PushSimulationReport {
 }
 
 /// Deterministic model of Sockudo-side push durability and provider fallibility.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PushLab {
     config: PushLabConfig,
+    real: RealPushHarness,
     clients: usize,
     channels: Vec<String>,
     devices: BTreeMap<String, SimDevice>,
@@ -216,6 +219,7 @@ impl PushLab {
         config.validate()?;
         Ok(Self {
             config,
+            real: RealPushHarness::new(),
             clients,
             channels: channels.to_vec(),
             devices: BTreeMap::new(),
@@ -233,21 +237,26 @@ impl PushLab {
         })
     }
 
-    pub(crate) fn on_tick(&mut self, tick: u64, rng: &mut StdRng) {
+    pub(crate) async fn on_tick(&mut self, tick: u64, rng: &mut StdRng) -> SimulatorResult<()> {
         self.maybe_toggle_backend(tick, rng);
-        self.release_due_schedules(tick, rng);
-        self.process_queue(tick, rng);
+        self.release_due_schedules(tick, rng).await?;
+        self.process_queue(tick, rng).await?;
         if self.config.repair_every_ticks > 0 && tick.is_multiple_of(self.config.repair_every_ticks)
         {
             self.repair(tick, rng);
         }
+        Ok(())
     }
 
-    pub(crate) fn register_or_update_device(&mut self, tick: u64, rng: &mut StdRng) {
+    pub(crate) async fn register_or_update_device(
+        &mut self,
+        tick: u64,
+        rng: &mut StdRng,
+    ) -> SimulatorResult<()> {
         if self.backend_outage || self.write_fails_before_commit(tick, rng, "device_upsert") {
-            return;
+            return Ok(());
         }
-        let provider = PushProvider::random(rng);
+        let provider = random_provider(rng);
         let device_id = if self.devices.len() < self.config.devices {
             let id = format!("device-{:020}", self.next_device_id);
             self.next_device_id = self.next_device_id.saturating_add(1);
@@ -257,6 +266,9 @@ impl PushLab {
                 .unwrap_or_else(|| "device-00000000000000000001".to_string())
         };
         let client_id = format!("client-{}", rng.random_range(0..self.clients));
+        self.real
+            .upsert_device(&device_id, &client_id, provider, tick)
+            .await?;
         if !self.devices.contains_key(&device_id) {
             self.stats.registered_devices = self.stats.registered_devices.saturating_add(1);
             self.devices.insert(
@@ -279,16 +291,22 @@ impl PushLab {
         }
         self.after_commit_fault(tick, rng, "device_upsert");
         self.trace(tick, format!("push device upserted {device_id}"));
+        Ok(())
     }
 
-    pub(crate) fn delete_device(&mut self, tick: u64, rng: &mut StdRng) {
+    pub(crate) async fn delete_device(
+        &mut self,
+        tick: u64,
+        rng: &mut StdRng,
+    ) -> SimulatorResult<()> {
         let Some(device_id) = self.random_device_id(rng) else {
-            self.register_or_update_device(tick, rng);
-            return;
+            self.register_or_update_device(tick, rng).await?;
+            return Ok(());
         };
         if self.backend_outage || self.write_fails_before_commit(tick, rng, "device_delete") {
-            return;
+            return Ok(());
         }
+        self.real.delete_device(&device_id).await?;
         if let Some(device) = self.devices.get_mut(&device_id) {
             device.state = DeviceState::Deleted;
             device.subscriptions.clear();
@@ -296,31 +314,43 @@ impl PushLab {
             self.after_commit_fault(tick, rng, "device_delete");
             self.trace(tick, format!("push device deleted {device_id}"));
         }
+        Ok(())
     }
 
-    pub(crate) fn subscribe_device(&mut self, tick: u64, rng: &mut StdRng) {
-        let device_id = self.ensure_active_device(tick, rng);
+    pub(crate) async fn subscribe_device(
+        &mut self,
+        tick: u64,
+        rng: &mut StdRng,
+    ) -> SimulatorResult<()> {
+        let device_id = self.ensure_active_device(tick, rng).await?;
         let channel = self.random_channel(rng);
         if self.backend_outage || self.write_fails_before_commit(tick, rng, "subscribe") {
-            return;
+            return Ok(());
         }
         if let Some(device) = self.devices.get_mut(&device_id) {
+            self.real.upsert_subscription(&channel, &device_id).await?;
             device.state = DeviceState::Active;
             device.visible_removed_at = None;
             device.subscriptions.insert(channel.clone());
             self.after_commit_fault(tick, rng, "subscribe");
             self.trace(tick, format!("push subscribed {device_id} to {channel}"));
         }
+        Ok(())
     }
 
-    pub(crate) fn unsubscribe_device(&mut self, tick: u64, rng: &mut StdRng) {
+    pub(crate) async fn unsubscribe_device(
+        &mut self,
+        tick: u64,
+        rng: &mut StdRng,
+    ) -> SimulatorResult<()> {
         let Some(device_id) = self.random_device_id(rng) else {
-            return;
+            return Ok(());
         };
         let channel = self.random_channel(rng);
         if self.backend_outage || self.write_fails_before_commit(tick, rng, "unsubscribe") {
-            return;
+            return Ok(());
         }
+        self.real.delete_subscription(&channel, &device_id).await?;
         if let Some(device) = self.devices.get_mut(&device_id) {
             device.subscriptions.remove(&channel);
             if device.subscriptions.is_empty() {
@@ -332,22 +362,31 @@ impl PushLab {
                 format!("push unsubscribed {device_id} from {channel}"),
             );
         }
+        Ok(())
     }
 
-    pub(crate) fn publish_now(&mut self, tick: u64, rng: &mut StdRng) {
+    pub(crate) async fn publish_now(&mut self, tick: u64, rng: &mut StdRng) -> SimulatorResult<()> {
         let channel = self.random_channel(rng);
-        self.ensure_subscriber(tick, rng, &channel);
-        self.accept_publish(tick, rng, channel, None);
+        self.ensure_subscriber(tick, rng, &channel).await?;
+        self.accept_publish(tick, rng, channel, None).await
     }
 
-    pub(crate) fn schedule_publish(&mut self, tick: u64, rng: &mut StdRng) {
+    pub(crate) async fn schedule_publish(
+        &mut self,
+        tick: u64,
+        rng: &mut StdRng,
+    ) -> SimulatorResult<()> {
         let channel = self.random_channel(rng);
-        self.ensure_subscriber(tick, rng, &channel);
+        self.ensure_subscriber(tick, rng, &channel).await?;
         let delay = self.random_queue_delay(rng).saturating_add(1);
         let publish_id = self.next_publish_key();
         let idempotency_key = format!("schedule:{publish_id}");
+        let due_tick = tick.saturating_add(delay);
+        self.real
+            .put_scheduled_publish(&publish_id, &channel, due_tick)
+            .await?;
         self.schedules.push(ScheduledPush {
-            due_tick: tick.saturating_add(delay),
+            due_tick,
             channel: channel.clone(),
             publish_id,
             idempotency_key,
@@ -360,6 +399,7 @@ impl PushLab {
                 tick + delay
             ),
         );
+        Ok(())
     }
 
     pub(crate) fn duplicate_provider_feedback(&mut self, tick: u64, rng: &mut StdRng) {
@@ -402,7 +442,11 @@ impl PushLab {
         self.repair(tick, rng);
     }
 
-    pub(crate) fn quiesce(&mut self, mut tick: u64, rng: &mut StdRng) -> u64 {
+    pub(crate) async fn quiesce(
+        &mut self,
+        mut tick: u64,
+        rng: &mut StdRng,
+    ) -> SimulatorResult<u64> {
         let previous_quiescing = self.quiescing;
         self.quiescing = true;
         let max_steps = self
@@ -419,26 +463,80 @@ impl PushLab {
                 && self.outstanding_deliveries() == 0
             {
                 self.quiescing = previous_quiescing;
-                return tick;
+                return Ok(tick);
             }
             tick = tick.saturating_add(1);
             self.backend_outage = false;
-            self.release_due_schedules(tick, rng);
+            self.release_due_schedules(tick, rng).await?;
             self.repair(tick, rng);
-            self.process_queue(tick, rng);
+            self.process_queue(tick, rng).await?;
             self.prune_obsolete_queue();
         }
         self.quiescing = previous_quiescing;
-        tick
+        Ok(tick)
     }
 
-    pub(crate) fn check_oracles(&self, final_quiesce: bool) -> Result<(), String> {
+    pub(crate) async fn check_oracles(
+        &self,
+        final_quiesce: bool,
+        page_limit: usize,
+    ) -> Result<(), String> {
         for (key, publish_id) in &self.idempotency {
             if !self.publishes.contains_key(publish_id) {
                 return Err(format!(
                     "push idempotency key {key} points to missing publish {publish_id}"
                 ));
             }
+        }
+
+        let expected_devices = self
+            .devices
+            .values()
+            .filter(|device| device.state == DeviceState::Active)
+            .map(|device| device.id.clone())
+            .collect::<BTreeSet<_>>();
+        let actual_devices = self
+            .real
+            .active_device_ids(page_limit)
+            .await
+            .map_err(|error| format!("real push device scan failed: {error}"))?;
+        if actual_devices != expected_devices {
+            return Err(format!(
+                "real push devices mismatch: expected {expected_devices:?}, got {actual_devices:?}"
+            ));
+        }
+
+        let expected_subscriptions = self
+            .devices
+            .values()
+            .flat_map(|device| {
+                device
+                    .subscriptions
+                    .iter()
+                    .map(|channel| (channel.clone(), device.id.clone()))
+            })
+            .collect::<BTreeSet<_>>();
+        let actual_subscriptions = self
+            .real
+            .subscription_keys(page_limit)
+            .await
+            .map_err(|error| format!("real push subscription scan failed: {error}"))?;
+        if actual_subscriptions != expected_subscriptions {
+            return Err(format!(
+                "real push subscriptions mismatch: expected {expected_subscriptions:?}, got {actual_subscriptions:?}"
+            ));
+        }
+
+        let expected_publish_ids = self.publishes.keys().cloned().collect::<BTreeSet<_>>();
+        let actual_publish_log_ids = self
+            .real
+            .publish_log_ids(page_limit)
+            .await
+            .map_err(|error| format!("real push publish-log scan failed: {error}"))?;
+        if actual_publish_log_ids != expected_publish_ids {
+            return Err(format!(
+                "real push publish logs mismatch: expected {expected_publish_ids:?}, got {actual_publish_log_ids:?}"
+            ));
         }
 
         for publish in self.publishes.values() {
@@ -451,6 +549,36 @@ impl PushLab {
             if !publish.durable_log {
                 return Err(format!(
                     "accepted push publish {} is missing durable publish log",
+                    publish.id
+                ));
+            }
+            let status = self
+                .real
+                .publish_status(&publish.id)
+                .await
+                .map_err(|error| {
+                    format!("real push status read failed for {}: {error}", publish.id)
+                })?
+                .ok_or_else(|| format!("real push status missing for {}", publish.id))?;
+            if status.counters.planned != publish.planned {
+                return Err(format!(
+                    "real push planned count mismatch for {}: expected {}, got {}",
+                    publish.id, publish.planned, status.counters.planned
+                ));
+            }
+            let idempotency_target = self
+                .real
+                .publish_idempotency_target(&publish.id)
+                .await
+                .map_err(|error| {
+                    format!(
+                        "real push idempotency read failed for {}: {error}",
+                        publish.id
+                    )
+                })?;
+            if idempotency_target.as_deref() != Some(publish.id.as_str()) {
+                return Err(format!(
+                    "real push idempotency mismatch for {}: got {idempotency_target:?}",
                     publish.id
                 ));
             }
@@ -494,6 +622,25 @@ impl PushLab {
                     "push publish {} still has {} outstanding deliveries after quiesce",
                     publish.id,
                     publish.outstanding_deliveries()
+                ));
+            }
+        }
+
+        for schedule in &self.schedules {
+            let exists = self
+                .real
+                .scheduled_publish_exists(&schedule.publish_id)
+                .await
+                .map_err(|error| {
+                    format!(
+                        "real push schedule read failed for {}: {error}",
+                        schedule.publish_id
+                    )
+                })?;
+            if !exists {
+                return Err(format!(
+                    "real push schedule missing for pending publish {}",
+                    schedule.publish_id
                 ));
             }
         }
@@ -574,15 +721,15 @@ impl PushLab {
         self.trace.iter().cloned().collect()
     }
 
-    fn accept_publish(
+    async fn accept_publish(
         &mut self,
         tick: u64,
         rng: &mut StdRng,
         channel: String,
         requested: Option<(String, String)>,
-    ) {
+    ) -> SimulatorResult<()> {
         if self.backend_outage || self.write_fails_before_commit(tick, rng, "push_publish") {
-            return;
+            return Ok(());
         }
         let (publish_id, idempotency_key) = requested.unwrap_or_else(|| {
             let publish_id = if !self.idempotency.is_empty() && rng.random_ratio(1, 8) {
@@ -605,11 +752,23 @@ impl PushLab {
                     format!("push duplicate idempotency {idempotency_key} -> {publish_id}"),
                 );
             }
-            return;
+            return Ok(());
         }
 
         let planned_targets = self.eligible_targets(&channel);
         let planned = planned_targets.len() as u64;
+        let accepted = self
+            .real
+            .accept_channel_publish(&publish_id, &channel, planned, tick)
+            .await?;
+        if accepted.duplicate {
+            self.stats.duplicate_publishes = self.stats.duplicate_publishes.saturating_add(1);
+            self.trace(
+                tick,
+                format!("push duplicate real pipeline accept -> {publish_id}"),
+            );
+            return Ok(());
+        }
         let deliveries = planned_targets
             .into_iter()
             .enumerate()
@@ -659,29 +818,35 @@ impl PushLab {
             tick,
             format!("push publish accepted {publish_id} channel={channel} planned={planned}"),
         );
+        Ok(())
     }
 
-    fn release_due_schedules(&mut self, tick: u64, rng: &mut StdRng) {
+    async fn release_due_schedules(&mut self, tick: u64, rng: &mut StdRng) -> SimulatorResult<()> {
         let mut pending = Vec::with_capacity(self.schedules.len());
         let schedules = std::mem::take(&mut self.schedules);
         for schedule in schedules {
             if schedule.due_tick <= tick {
+                self.real
+                    .delete_scheduled_publish(&schedule.publish_id)
+                    .await?;
                 self.accept_publish(
                     tick,
                     rng,
                     schedule.channel,
                     Some((schedule.publish_id, schedule.idempotency_key)),
-                );
+                )
+                .await?;
             } else {
                 pending.push(schedule);
             }
         }
         self.schedules = pending;
+        Ok(())
     }
 
-    fn process_queue(&mut self, tick: u64, rng: &mut StdRng) {
+    async fn process_queue(&mut self, tick: u64, rng: &mut StdRng) -> SimulatorResult<()> {
         if self.backend_outage {
-            return;
+            return Ok(());
         }
 
         let mut pending = VecDeque::with_capacity(self.queue.len());
@@ -698,7 +863,7 @@ impl PushLab {
                 pending.push_back(duplicate);
                 self.stats.queue_lease_timeouts = self.stats.queue_lease_timeouts.saturating_add(1);
             }
-            self.apply_queue_item(tick, rng, item.clone());
+            self.apply_queue_item(tick, rng, item.clone()).await?;
             if !self.quiescing && self.roll(self.config.queue_ack_lost_probability, rng) {
                 let mut redelivery = item;
                 redelivery.id = self.next_queue_id();
@@ -709,9 +874,15 @@ impl PushLab {
         }
         pending.append(&mut self.queue);
         self.queue = pending;
+        Ok(())
     }
 
-    fn apply_queue_item(&mut self, tick: u64, rng: &mut StdRng, item: QueueItem) {
+    async fn apply_queue_item(
+        &mut self,
+        tick: u64,
+        rng: &mut StdRng,
+        item: QueueItem,
+    ) -> SimulatorResult<()> {
         match item.stage {
             QueueStage::PublishLog { publish_id } => {
                 let Some(delivery_ids) = self.publishes.get(&publish_id).map(|publish| {
@@ -722,7 +893,7 @@ impl PushLab {
                         .map(|delivery| delivery.id.clone())
                         .collect::<Vec<_>>()
                 }) else {
-                    return;
+                    return Ok(());
                 };
                 for delivery_id in delivery_ids {
                     self.enqueue(
@@ -745,22 +916,29 @@ impl PushLab {
             QueueStage::Delivery {
                 publish_id,
                 delivery_id,
-            } => self.dispatch_delivery(tick, rng, &publish_id, &delivery_id),
+            } => {
+                self.dispatch_delivery(tick, rng, &publish_id, &delivery_id)
+                    .await?
+            }
             QueueStage::ProviderResult {
                 publish_id,
                 delivery_id,
                 result,
-            } => self.apply_provider_result(tick, rng, &publish_id, &delivery_id, result),
+            } => {
+                self.apply_provider_result(tick, rng, &publish_id, &delivery_id, result)
+                    .await?;
+            }
         }
+        Ok(())
     }
 
-    fn dispatch_delivery(
+    async fn dispatch_delivery(
         &mut self,
         tick: u64,
         rng: &mut StdRng,
         publish_id: &str,
         delivery_id: &str,
-    ) {
+    ) -> SimulatorResult<()> {
         let Some((device_id, provider, attempts, terminal)) = self
             .publishes
             .get(publish_id)
@@ -774,18 +952,18 @@ impl PushLab {
                 )
             })
         else {
-            return;
+            return Ok(());
         };
         if terminal.is_some() {
-            return;
+            return Ok(());
         }
         if !self.device_is_eligible_for_publish(publish_id, &device_id, rng) {
             self.apply_terminal(publish_id, delivery_id, ProviderResult::Cancelled, tick);
-            return;
+            return Ok(());
         }
         if attempts >= self.config.max_retries {
             self.dead_letter(publish_id, delivery_id, tick);
-            return;
+            return Ok(());
         }
 
         if let Some(publish) = self.publishes.get_mut(publish_id)
@@ -806,8 +984,9 @@ impl PushLab {
                 publish_id,
                 delivery_id,
                 ProviderResult::Retryable,
-            );
-            return;
+            )
+            .await?;
+            return Ok(());
         }
         if self.roll(self.config.provider_delayed_result_probability, rng) {
             self.enqueue(
@@ -820,7 +999,8 @@ impl PushLab {
                 },
             );
         } else {
-            self.apply_provider_result(tick, rng, publish_id, delivery_id, result);
+            self.apply_provider_result(tick, rng, publish_id, delivery_id, result)
+                .await?;
         }
         if self.roll(self.config.provider_duplicate_result_probability, rng) {
             self.enqueue(
@@ -833,16 +1013,17 @@ impl PushLab {
                 },
             );
         }
+        Ok(())
     }
 
-    fn apply_provider_result(
+    async fn apply_provider_result(
         &mut self,
         tick: u64,
         rng: &mut StdRng,
         publish_id: &str,
         delivery_id: &str,
         result: ProviderResult,
-    ) {
+    ) -> SimulatorResult<()> {
         let Some((attempt, duplicate)) = self
             .publishes
             .get_mut(publish_id)
@@ -853,10 +1034,10 @@ impl PushLab {
                 (delivery.attempts, duplicate)
             })
         else {
-            return;
+            return Ok(());
         };
         if duplicate {
-            return;
+            return Ok(());
         }
 
         match result {
@@ -872,13 +1053,14 @@ impl PushLab {
                     .get(publish_id)
                     .and_then(|publish| publish.deliveries.get(delivery_id))
                     .map(|delivery| delivery.device_id.clone());
-                if let Some(device_id) = device_id
-                    && let Some(device) = self.devices.get_mut(&device_id)
-                {
-                    device.state = DeviceState::Invalid;
-                    device.subscriptions.clear();
-                    device.visible_removed_at = Some(tick);
-                    self.stats.invalid_tokens = self.stats.invalid_tokens.saturating_add(1);
+                if let Some(device_id) = device_id {
+                    self.real.delete_device(&device_id).await?;
+                    if let Some(device) = self.devices.get_mut(&device_id) {
+                        device.state = DeviceState::Invalid;
+                        device.subscriptions.clear();
+                        device.visible_removed_at = Some(tick);
+                        self.stats.invalid_tokens = self.stats.invalid_tokens.saturating_add(1);
+                    }
                 }
                 self.apply_terminal(publish_id, delivery_id, ProviderResult::Expired, tick);
             }
@@ -886,7 +1068,7 @@ impl PushLab {
                 self.stats.retryable_results = self.stats.retryable_results.saturating_add(1);
                 if attempt >= self.config.max_retries {
                     self.dead_letter(publish_id, delivery_id, tick);
-                    return;
+                    return Ok(());
                 }
                 if let Some(publish) = self.publishes.get_mut(publish_id)
                     && let Some(delivery) = publish.deliveries.get_mut(delivery_id)
@@ -905,6 +1087,7 @@ impl PushLab {
                 );
             }
         }
+        Ok(())
     }
 
     fn apply_terminal(
@@ -1126,7 +1309,7 @@ impl PushLab {
         }
     }
 
-    fn provider_result(&mut self, _provider: PushProvider, rng: &mut StdRng) -> ProviderResult {
+    fn provider_result(&mut self, _provider: PushProviderKind, rng: &mut StdRng) -> ProviderResult {
         if self.roll(self.config.provider_lost_response_probability, rng) {
             ProviderResult::LostResponseAfterAccepted
         } else if self.roll(self.config.provider_invalid_token_probability, rng) {
@@ -1140,29 +1323,44 @@ impl PushLab {
         }
     }
 
-    fn ensure_subscriber(&mut self, tick: u64, rng: &mut StdRng, channel: &str) {
+    async fn ensure_subscriber(
+        &mut self,
+        tick: u64,
+        rng: &mut StdRng,
+        channel: &str,
+    ) -> SimulatorResult<()> {
         if self.devices.values().any(|device| {
             device.state == DeviceState::Active && device.subscriptions.contains(channel)
         }) {
-            return;
+            return Ok(());
         }
-        let device_id = self.ensure_active_device(tick, rng);
+        let device_id = self.ensure_active_device(tick, rng).await?;
         if let Some(device) = self.devices.get_mut(&device_id) {
+            self.real.upsert_subscription(channel, &device_id).await?;
             device.subscriptions.insert(channel.to_string());
         }
+        Ok(())
     }
 
-    fn ensure_active_device(&mut self, tick: u64, rng: &mut StdRng) -> String {
+    async fn ensure_active_device(
+        &mut self,
+        tick: u64,
+        rng: &mut StdRng,
+    ) -> SimulatorResult<String> {
         if let Some(device) = self
             .devices
             .values()
             .find(|device| device.state == DeviceState::Active)
         {
-            return device.id.clone();
+            return Ok(device.id.clone());
         }
-        self.register_or_update_device(tick, rng);
-        self.random_device_id(rng)
-            .unwrap_or_else(|| "device-00000000000000000001".to_string())
+        self.register_or_update_device(tick, rng).await?;
+        Ok(self
+            .devices
+            .values()
+            .find(|device| device.state == DeviceState::Active)
+            .map(|device| device.id.clone())
+            .unwrap_or_else(|| "device-00000000000000000001".to_string()))
     }
 
     fn random_device_id(&self, rng: &mut StdRng) -> Option<String> {
@@ -1266,25 +1464,13 @@ impl PushLab {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum PushProvider {
-    Fcm,
-    Apns,
-    WebPush,
-    Hms,
-    Wns,
-}
-
-impl PushProvider {
-    fn random(rng: &mut StdRng) -> Self {
-        match rng.random_range(0..5) {
-            0 => Self::Fcm,
-            1 => Self::Apns,
-            2 => Self::WebPush,
-            3 => Self::Hms,
-            _ => Self::Wns,
-        }
+fn random_provider(rng: &mut StdRng) -> PushProviderKind {
+    match rng.random_range(0..5) {
+        0 => PushProviderKind::Fcm,
+        1 => PushProviderKind::Apns,
+        2 => PushProviderKind::WebPush,
+        3 => PushProviderKind::Hms,
+        _ => PushProviderKind::Wns,
     }
 }
 
@@ -1292,7 +1478,7 @@ impl PushProvider {
 struct SimDevice {
     id: String,
     client_id: String,
-    provider: PushProvider,
+    provider: PushProviderKind,
     state: DeviceState,
     subscriptions: BTreeSet<String>,
     visible_removed_at: Option<u64>,
@@ -1390,7 +1576,7 @@ impl PushCounters {
 struct Delivery {
     id: String,
     device_id: String,
-    provider: PushProvider,
+    provider: PushProviderKind,
     state: DeliveryState,
     attempts: u32,
     terminal: Option<ProviderResult>,
@@ -1420,7 +1606,7 @@ enum ProviderResult {
 #[derive(Debug, Clone)]
 struct PushTarget {
     device_id: String,
-    provider: PushProvider,
+    provider: PushProviderKind,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/sockudo-simulator/src/real_subsystems.rs
+++ b/crates/sockudo-simulator/src/real_subsystems.rs
@@ -1,0 +1,332 @@
+//! Simulator-facing boundary for real Sockudo subsystem APIs.
+//!
+//! The deterministic simulator keeps its shadow model and fault scheduler, but
+//! durable state changes should cross this module before the shadow advances.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use sockudo_core::history::{MemoryHistoryStore, MemoryHistoryStoreConfig};
+use sockudo_core::presence_history::{
+    MemoryPresenceHistoryStore, MemoryPresenceHistoryStoreConfig,
+};
+use sockudo_core::version_store::MemoryVersionStore;
+use sockudo_push::{
+    ChannelSubscription, DeviceDetails, DevicePushDetails, DevicePushState, FanoutConfig,
+    FormFactor, MemoryPushQueue, MemoryPushStore, Platform, PublishIntent, PublishStatus,
+    PublishTarget, PushAcceptOutcome, PushAcceptRequest, PushDeviceStore, PushIdempotencyStore,
+    PushPayload, PushPipeline, PushProviderKind, PushPublishLogStore, PushPublishStatusStore,
+    PushRecipient, PushScheduleStore, PushSubscriptionStore, ScheduledPushJob, SecretString,
+    publish_idempotency_key,
+};
+use sonic_rs::json;
+
+use crate::config::SimulatorConfig;
+use crate::error::SimulatorResult;
+
+pub(crate) const APP_ID: &str = "sim-app";
+
+pub(crate) struct RealSubsystemHarness {
+    pub(crate) history: MemoryHistoryStore,
+    pub(crate) version: MemoryVersionStore,
+    pub(crate) presence: MemoryPresenceHistoryStore,
+}
+
+impl RealSubsystemHarness {
+    pub(crate) fn new(config: &SimulatorConfig) -> Self {
+        Self {
+            history: MemoryHistoryStore::new(MemoryHistoryStoreConfig {
+                retention_window: config.retention_window(),
+                max_messages_per_channel: config.history_retention_messages,
+                max_bytes_per_channel: None,
+            }),
+            version: MemoryVersionStore::new(),
+            presence: MemoryPresenceHistoryStore::new(MemoryPresenceHistoryStoreConfig {
+                retention_window: config.retention_window(),
+                max_events_per_channel: config.presence_retention_events,
+                max_bytes_per_channel: None,
+                metrics: None,
+            }),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct RealPushHarness {
+    store: Arc<MemoryPushStore>,
+    pipeline: Arc<PushPipeline>,
+}
+
+impl RealPushHarness {
+    pub(crate) fn new() -> Self {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        let pipeline = PushPipeline::new(store.clone(), queue.clone(), FanoutConfig::default())
+            .with_max_publish_log_lag(u64::MAX);
+        Self {
+            store,
+            pipeline: Arc::new(pipeline),
+        }
+    }
+
+    pub(crate) async fn upsert_device(
+        &self,
+        device_id: &str,
+        client_id: &str,
+        provider: PushProviderKind,
+        occurred_at_ms: u64,
+    ) -> SimulatorResult<DeviceDetails> {
+        let device = self.device_details(device_id, client_id, provider, occurred_at_ms)?;
+        self.store.upsert_device(device.clone()).await?;
+        Ok(device)
+    }
+
+    pub(crate) async fn delete_device(&self, device_id: &str) -> SimulatorResult<()> {
+        self.store.delete_device(APP_ID, device_id).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn upsert_subscription(
+        &self,
+        channel: &str,
+        device_id: &str,
+    ) -> SimulatorResult<()> {
+        let Some(device) = self.store.get_device(APP_ID, device_id).await? else {
+            return Ok(());
+        };
+        self.store
+            .upsert_subscription(ChannelSubscription::from_device(channel, &device))
+            .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn delete_subscription(
+        &self,
+        channel: &str,
+        device_id: &str,
+    ) -> SimulatorResult<()> {
+        self.store
+            .delete_subscription(APP_ID, channel, device_id)
+            .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn put_scheduled_publish(
+        &self,
+        publish_id: &str,
+        channel: &str,
+        due_tick: u64,
+    ) -> SimulatorResult<()> {
+        self.store
+            .put_scheduled_job(ScheduledPushJob {
+                app_id: APP_ID.to_string(),
+                publish_id: publish_id.to_string(),
+                due_at_ms: due_tick,
+                due_minute_ms: due_tick,
+                payload_json: json!({
+                    "channel": channel,
+                    "simulator": true,
+                }),
+            })
+            .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn delete_scheduled_publish(&self, publish_id: &str) -> SimulatorResult<()> {
+        self.store.delete_scheduled_job(APP_ID, publish_id).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn accept_channel_publish(
+        &self,
+        publish_id: &str,
+        channel: &str,
+        expected_recipients: u64,
+        occurred_at_ms: u64,
+    ) -> SimulatorResult<PushAcceptOutcome> {
+        let request = PushAcceptRequest {
+            intent: PublishIntent {
+                app_id: APP_ID.to_string(),
+                publish_id: publish_id.to_string(),
+                targets: vec![PublishTarget::Channel {
+                    channel: channel.to_string(),
+                }],
+                payload: PushPayload {
+                    template_id: None,
+                    template_data: json!({
+                        "channel": channel,
+                        "publishId": publish_id,
+                        "tick": occurred_at_ms,
+                    }),
+                    title: Some("Sockudo simulator".to_string()),
+                    body: Some(format!("deterministic push {publish_id}")),
+                    icon: None,
+                    sound: None,
+                    collapse_key: None,
+                },
+                provider_overrides: vec![],
+                not_before_ms: None,
+                expires_at_ms: None,
+            },
+            expected_recipients,
+        };
+        Ok(self
+            .pipeline
+            .accept_publish(request, occurred_at_ms)
+            .await?)
+    }
+
+    pub(crate) async fn active_device_ids(
+        &self,
+        page_limit: usize,
+    ) -> SimulatorResult<BTreeSet<String>> {
+        let mut ids = BTreeSet::new();
+        let mut cursor = None;
+        loop {
+            let page = self.store.list_devices(APP_ID, page_limit, cursor).await?;
+            ids.extend(page.items.into_iter().map(|device| device.id));
+            if page.next_cursor.is_none() {
+                break;
+            }
+            cursor = page.next_cursor;
+        }
+        Ok(ids)
+    }
+
+    pub(crate) async fn subscription_keys(
+        &self,
+        page_limit: usize,
+    ) -> SimulatorResult<BTreeSet<(String, String)>> {
+        let mut keys = BTreeSet::new();
+        let mut cursor = None;
+        loop {
+            let page = self
+                .store
+                .list_subscriptions(APP_ID, page_limit, cursor)
+                .await?;
+            keys.extend(
+                page.items
+                    .into_iter()
+                    .map(|subscription| (subscription.channel, subscription.device_id)),
+            );
+            if page.next_cursor.is_none() {
+                break;
+            }
+            cursor = page.next_cursor;
+        }
+        Ok(keys)
+    }
+
+    pub(crate) async fn publish_log_ids(
+        &self,
+        page_limit: usize,
+    ) -> SimulatorResult<BTreeSet<String>> {
+        let mut ids = BTreeSet::new();
+        let mut cursor = None;
+        loop {
+            let page = self
+                .store
+                .list_publish_log_events(APP_ID, page_limit, cursor)
+                .await?;
+            ids.extend(page.items.into_iter().map(|event| event.publish_id));
+            if page.next_cursor.is_none() {
+                break;
+            }
+            cursor = page.next_cursor;
+        }
+        Ok(ids)
+    }
+
+    pub(crate) async fn publish_status(
+        &self,
+        publish_id: &str,
+    ) -> SimulatorResult<Option<PublishStatus>> {
+        Ok(self.store.get_publish_status(APP_ID, publish_id).await?)
+    }
+
+    pub(crate) async fn publish_idempotency_target(
+        &self,
+        publish_id: &str,
+    ) -> SimulatorResult<Option<String>> {
+        Ok(self
+            .store
+            .get_idempotency_record(APP_ID, &publish_idempotency_key(APP_ID, publish_id))
+            .await?
+            .map(|record| record.publish_id))
+    }
+
+    pub(crate) async fn scheduled_publish_exists(&self, publish_id: &str) -> SimulatorResult<bool> {
+        Ok(self
+            .store
+            .get_scheduled_job(APP_ID, publish_id)
+            .await?
+            .is_some())
+    }
+
+    fn device_details(
+        &self,
+        device_id: &str,
+        client_id: &str,
+        provider: PushProviderKind,
+        occurred_at_ms: u64,
+    ) -> SimulatorResult<DeviceDetails> {
+        Ok(DeviceDetails {
+            app_id: APP_ID.to_string(),
+            id: device_id.to_string(),
+            client_id: Some(client_id.to_string()),
+            form_factor: FormFactor::Phone,
+            platform: platform_for_provider(provider),
+            metadata: json!({
+                "source": "sockudo-simulator",
+            }),
+            device_secret: SecretString::new(format!(
+                "pbkdf2-sha256$120000$simulator${device_id}"
+            ))?,
+            timezone: "UTC".to_string(),
+            locale: "en".to_string(),
+            last_active_at_ms: occurred_at_ms,
+            push: DevicePushDetails {
+                recipient: recipient_for_provider(provider, device_id)?,
+                state: DevicePushState::Active,
+                failure_count: 0,
+                error_reason: None,
+            },
+            push_rate_policy: None,
+        })
+    }
+}
+
+fn platform_for_provider(provider: PushProviderKind) -> Platform {
+    match provider {
+        PushProviderKind::Fcm | PushProviderKind::Hms => Platform::Android,
+        PushProviderKind::Apns => Platform::Ios,
+        PushProviderKind::WebPush => Platform::Browser,
+        PushProviderKind::Wns => Platform::Windows,
+    }
+}
+
+fn recipient_for_provider(
+    provider: PushProviderKind,
+    device_id: &str,
+) -> SimulatorResult<PushRecipient> {
+    let token = |prefix: &str| SecretString::new(format!("{prefix}-{device_id}"));
+    Ok(match provider {
+        PushProviderKind::Fcm => PushRecipient::Fcm {
+            registration_token: token("fcm")?,
+        },
+        PushProviderKind::Apns => PushRecipient::Apns {
+            device_token: token("apns")?,
+        },
+        PushProviderKind::WebPush => PushRecipient::Web {
+            endpoint: SecretString::new(format!("https://push.example.com/{device_id}"))?,
+            p256dh: token("p256dh")?,
+            auth: token("auth")?,
+        },
+        PushProviderKind::Hms => PushRecipient::Hms {
+            registration_token: token("hms")?,
+        },
+        PushProviderKind::Wns => PushRecipient::Wns {
+            channel_uri: SecretString::new(format!("https://wns.example.com/{device_id}"))?,
+        },
+    })
+}

--- a/crates/sockudo-simulator/src/simulator.rs
+++ b/crates/sockudo-simulator/src/simulator.rs
@@ -5,18 +5,17 @@ use serde::Serialize;
 use sockudo_core::history::{
     HistoryAppendRecord, HistoryCursor, HistoryDirection, HistoryItem, HistoryPurgeMode,
     HistoryPurgeRequest, HistoryQueryBounds, HistoryReadRequest, HistoryRetentionPolicy,
-    HistoryStore, MemoryHistoryStore, MemoryHistoryStoreConfig,
+    HistoryStore,
 };
 use sockudo_core::presence_history::{
-    MemoryPresenceHistoryStore, MemoryPresenceHistoryStoreConfig, PresenceHistoryCursor,
-    PresenceHistoryDirection, PresenceHistoryEventCause, PresenceHistoryEventKind,
-    PresenceHistoryItem, PresenceHistoryQueryBounds, PresenceHistoryReadRequest,
-    PresenceHistoryRetentionPolicy, PresenceHistoryStore, PresenceHistoryTransitionRecord,
-    PresenceSnapshotRequest,
+    PresenceHistoryCursor, PresenceHistoryDirection, PresenceHistoryEventCause,
+    PresenceHistoryEventKind, PresenceHistoryItem, PresenceHistoryQueryBounds,
+    PresenceHistoryReadRequest, PresenceHistoryRetentionPolicy, PresenceHistoryStore,
+    PresenceHistoryTransitionRecord, PresenceSnapshotRequest,
 };
 use sockudo_core::version_store::{
-    MemoryVersionStore, StoredVersionRecord, VersionReplayRequest, VersionStore,
-    VersionStoreCursor, VersionStoreDirection, VersionStoreReadRequest,
+    StoredVersionRecord, VersionReplayRequest, VersionStore, VersionStoreCursor,
+    VersionStoreDirection, VersionStoreReadRequest,
 };
 use sockudo_core::versioned_messages::{
     FieldPatch, MessageAction, MessageAppend, MessageFieldDelta, MessageSerial, VersionMetadata,
@@ -28,9 +27,9 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use crate::config::{SimulatorConfig, SimulatorMode};
 use crate::error::{SimulatorError, SimulatorResult};
 use crate::push_lab::{PushLab, PushSimulationReport};
+use crate::real_subsystems::{APP_ID, RealSubsystemHarness};
 use crate::workload::{ActionWeights, WorkloadAction, WorkloadActionCounts, WorkloadGenerator};
 
-const APP_ID: &str = "sim-app";
 const BASE_TIME_MS: i64 = 1_893_456_000_000;
 const MAX_TRACE_EVENTS: usize = 96;
 
@@ -81,9 +80,7 @@ pub struct DeterministicSimulator {
     config: SimulatorConfig,
     rng: StdRng,
     tick: u64,
-    history_store: MemoryHistoryStore,
-    version_store: MemoryVersionStore,
-    presence_store: MemoryPresenceHistoryStore,
+    real: RealSubsystemHarness,
     nodes: Vec<NodeState>,
     clients: Vec<ClientState>,
     channels: Vec<String>,
@@ -110,17 +107,7 @@ impl DeterministicSimulator {
             .collect();
         let nodes = (0..config.nodes).map(NodeState::new).collect();
         let push = PushLab::new(&channels, config.clients, config.push.clone())?;
-        let history_store = MemoryHistoryStore::new(MemoryHistoryStoreConfig {
-            retention_window: config.retention_window(),
-            max_messages_per_channel: config.history_retention_messages,
-            max_bytes_per_channel: None,
-        });
-        let presence_store = MemoryPresenceHistoryStore::new(MemoryPresenceHistoryStoreConfig {
-            retention_window: config.retention_window(),
-            max_events_per_channel: config.presence_retention_events,
-            max_bytes_per_channel: None,
-            metrics: None,
-        });
+        let real = RealSubsystemHarness::new(&config);
 
         Ok(Self {
             rng: StdRng::seed_from_u64(config.seed),
@@ -131,9 +118,7 @@ impl DeterministicSimulator {
             ),
             config,
             tick: 0,
-            history_store,
-            version_store: MemoryVersionStore::new(),
-            presence_store,
+            real,
             nodes,
             clients,
             channels,
@@ -152,7 +137,7 @@ impl DeterministicSimulator {
         for tick in 0..self.config.ticks {
             self.tick = tick;
             self.deliver_due_fanout();
-            self.push.on_tick(self.tick, &mut self.rng);
+            self.push.on_tick(self.tick, &mut self.rng).await?;
             self.inject_faults().await?;
             self.drive_workload().await?;
             if self.config.oracle_every > 0 && tick % self.config.oracle_every == 0 {
@@ -164,7 +149,8 @@ impl DeterministicSimulator {
         self.recover_all_clients().await?;
         self.check_oracles().await?;
         self.push
-            .check_oracles(true)
+            .check_oracles(true, self.config.page_limit)
+            .await
             .map_err(|message| self.fail(message))?;
         self.check_liveness_oracles()?;
         Ok(self.report())
@@ -237,28 +223,21 @@ impl DeterministicSimulator {
             WorkloadAction::PurgeHistory => self.purge_history_prefix().await,
             WorkloadAction::PushRegisterDevice => {
                 self.push
-                    .register_or_update_device(self.tick, &mut self.rng);
-                Ok(())
+                    .register_or_update_device(self.tick, &mut self.rng)
+                    .await
             }
             WorkloadAction::PushDeleteDevice => {
-                self.push.delete_device(self.tick, &mut self.rng);
-                Ok(())
+                self.push.delete_device(self.tick, &mut self.rng).await
             }
             WorkloadAction::PushSubscribe => {
-                self.push.subscribe_device(self.tick, &mut self.rng);
-                Ok(())
+                self.push.subscribe_device(self.tick, &mut self.rng).await
             }
             WorkloadAction::PushUnsubscribe => {
-                self.push.unsubscribe_device(self.tick, &mut self.rng);
-                Ok(())
+                self.push.unsubscribe_device(self.tick, &mut self.rng).await
             }
-            WorkloadAction::PushPublish => {
-                self.push.publish_now(self.tick, &mut self.rng);
-                Ok(())
-            }
+            WorkloadAction::PushPublish => self.push.publish_now(self.tick, &mut self.rng).await,
             WorkloadAction::PushScheduledPublish => {
-                self.push.schedule_publish(self.tick, &mut self.rng);
-                Ok(())
+                self.push.schedule_publish(self.tick, &mut self.rng).await
             }
             WorkloadAction::PushProviderFeedback => {
                 self.push
@@ -473,7 +452,8 @@ impl DeterministicSimulator {
     async fn reset_random_stream(&mut self) -> SimulatorResult<()> {
         let channel = self.random_channel();
         let history = self
-            .history_store
+            .real
+            .history
             .reset_stream(
                 APP_ID,
                 &channel,
@@ -486,7 +466,8 @@ impl DeterministicSimulator {
             .reset_history(history.new_stream_id.clone());
 
         let presence = self
-            .presence_store
+            .real
+            .presence
             .reset_stream(
                 APP_ID,
                 &channel,
@@ -535,7 +516,8 @@ impl DeterministicSimulator {
             )
             .await?;
         let delivery = self
-            .version_store
+            .real
+            .version
             .reserve_delivery_position(APP_ID, &channel)
             .await?;
         let message_serial = MessageSerial::new(format!("msg-{:020}", self.next_message_serial))?;
@@ -562,7 +544,7 @@ impl DeterministicSimulator {
             )),
             message: message.clone(),
         };
-        self.version_store.append_version(record.clone()).await?;
+        self.real.version.append_version(record.clone()).await?;
         self.shadow.channel_mut(&channel).append_version(record);
         self.stats.version_commits = self.stats.version_commits.saturating_add(1);
         self.schedule_fanout(&channel, &history);
@@ -600,7 +582,8 @@ impl DeterministicSimulator {
             )
             .await?;
         let delivery = self
-            .version_store
+            .real
+            .version
             .reserve_delivery_position_after(
                 APP_ID,
                 &channel,
@@ -647,7 +630,7 @@ impl DeterministicSimulator {
             original_client_id: current.original_client_id.clone(),
             message: next,
         };
-        self.version_store.append_version(record.clone()).await?;
+        self.real.version.append_version(record.clone()).await?;
         self.shadow.channel_mut(&channel).append_version(record);
         self.stats.version_commits = self.stats.version_commits.saturating_add(1);
         self.schedule_fanout(&channel, &history);
@@ -689,7 +672,7 @@ impl DeterministicSimulator {
             published_at_ms: self.timestamp_ms(),
             retention: self.presence_retention_policy(),
         };
-        self.presence_store.record_transition(record).await?;
+        self.real.presence.record_transition(record).await?;
         if should_record {
             let newest = self
                 .read_presence_page(&channel, PresenceHistoryDirection::NewestFirst)
@@ -719,7 +702,8 @@ impl DeterministicSimulator {
         }
         let idx = self.rng.random_range(1..shadow.history.len());
         let before_serial = shadow.history[idx].serial;
-        self.history_store
+        self.real
+            .history
             .purge_stream(
                 APP_ID,
                 &channel,
@@ -753,7 +737,8 @@ impl DeterministicSimulator {
         payload: Bytes,
     ) -> SimulatorResult<ShadowHistoryMessage> {
         let reservation = self
-            .history_store
+            .real
+            .history
             .reserve_publish_position(APP_ID, channel)
             .await?;
         let record = HistoryAppendRecord {
@@ -768,7 +753,7 @@ impl DeterministicSimulator {
             payload_bytes: payload.clone(),
             retention: self.history_retention_policy(),
         };
-        self.history_store.append(record.clone()).await?;
+        self.real.history.append(record.clone()).await?;
         let message = ShadowHistoryMessage {
             stream_id: record.stream_id,
             serial: record.serial,
@@ -849,7 +834,7 @@ impl DeterministicSimulator {
         for _ in 0..max_steps {
             let Some(next_delivery_tick) = self.network.iter().map(|event| event.deliver_at).min()
             else {
-                self.tick = self.push.quiesce(self.tick, &mut self.rng);
+                self.tick = self.push.quiesce(self.tick, &mut self.rng).await?;
                 return Ok(());
             };
             self.tick = self.tick.saturating_add(1).max(next_delivery_tick);
@@ -861,7 +846,7 @@ impl DeterministicSimulator {
                 self.network.len()
             )));
         }
-        self.tick = self.push.quiesce(self.tick, &mut self.rng);
+        self.tick = self.push.quiesce(self.tick, &mut self.rng).await?;
         Ok(())
     }
 
@@ -992,7 +977,8 @@ impl DeterministicSimulator {
             self.check_client_recovery_oracle(channel)?;
         }
         self.push
-            .check_oracles(false)
+            .check_oracles(false, self.config.page_limit)
+            .await
             .map_err(|message| self.fail(message))?;
         Ok(())
     }
@@ -1039,7 +1025,7 @@ impl DeterministicSimulator {
             }
         }
 
-        let head = self.history_store.channel_head(APP_ID, channel).await?;
+        let head = self.real.history.channel_head(APP_ID, channel).await?;
         if head.retained_messages != expected.len() as u64 {
             return Err(self.fail(format!(
                 "history retained_messages mismatch on {channel}: expected {}, got {}",
@@ -1071,10 +1057,7 @@ impl DeterministicSimulator {
             )));
         }
         if shadow.history_stream_id.is_some() {
-            let inspection = self
-                .history_store
-                .stream_inspection(APP_ID, channel)
-                .await?;
+            let inspection = self.real.history.stream_inspection(APP_ID, channel).await?;
             let expected_next = expected
                 .last()
                 .map_or(1, |message| message.serial.saturating_add(1));
@@ -1118,7 +1101,8 @@ impl DeterministicSimulator {
     async fn check_version_oracle(&self, channel: &str) -> SimulatorResult<()> {
         let shadow = self.shadow.channel(channel);
         let replay = self
-            .version_store
+            .real
+            .version
             .replay_after(VersionReplayRequest {
                 app_id: APP_ID.to_string(),
                 channel: channel.to_string(),
@@ -1147,7 +1131,7 @@ impl DeterministicSimulator {
             }
         }
 
-        let state = self.version_store.stream_state(APP_ID, channel).await?;
+        let state = self.real.version.stream_state(APP_ID, channel).await?;
         if shadow.version_replay.is_empty() {
             if state.newest_available_delivery_serial.is_some() {
                 return Err(self.fail(format!(
@@ -1167,7 +1151,8 @@ impl DeterministicSimulator {
 
         for (message_serial, chain) in &shadow.version_messages {
             let latest = self
-                .version_store
+                .real
+                .version
                 .get_latest(
                     APP_ID,
                     channel,
@@ -1220,10 +1205,7 @@ impl DeterministicSimulator {
             }
         }
 
-        let latest_by_history = self
-            .version_store
-            .latest_by_history(APP_ID, channel)
-            .await?;
+        let latest_by_history = self.real.version.latest_by_history(APP_ID, channel).await?;
         let expected_latest = shadow.latest_versions_by_history();
         if latest_by_history.len() != expected_latest.len() {
             return Err(self.fail(format!(
@@ -1309,7 +1291,8 @@ impl DeterministicSimulator {
         }
 
         let snapshot = self
-            .presence_store
+            .real
+            .presence
             .snapshot_at(PresenceSnapshotRequest {
                 app_id: APP_ID.to_string(),
                 channel: channel.to_string(),
@@ -1342,7 +1325,8 @@ impl DeterministicSimulator {
 
         if shadow.presence_stream_id.is_some() {
             let inspection = self
-                .presence_store
+                .real
+                .presence
                 .stream_inspection(APP_ID, channel)
                 .await?;
             let expected_next = expected
@@ -1435,7 +1419,8 @@ impl DeterministicSimulator {
         let mut cursor: Option<HistoryCursor> = None;
         loop {
             let page = self
-                .history_store
+                .real
+                .history
                 .read_page(HistoryReadRequest {
                     app_id: APP_ID.to_string(),
                     channel: channel.to_string(),
@@ -1477,7 +1462,8 @@ impl DeterministicSimulator {
         };
         loop {
             let page = self
-                .history_store
+                .real
+                .history
                 .read_page(HistoryReadRequest {
                     app_id: APP_ID.to_string(),
                     channel: channel.to_string(),
@@ -1509,7 +1495,8 @@ impl DeterministicSimulator {
         let mut cursor: Option<VersionStoreCursor> = None;
         loop {
             let page = self
-                .version_store
+                .real
+                .version
                 .get_versions(VersionStoreReadRequest {
                     app_id: APP_ID.to_string(),
                     channel: channel.to_string(),
@@ -1542,7 +1529,8 @@ impl DeterministicSimulator {
         let mut cursor: Option<PresenceHistoryCursor> = None;
         loop {
             let page = self
-                .presence_store
+                .real
+                .presence
                 .read_page(PresenceHistoryReadRequest {
                     app_id: APP_ID.to_string(),
                     channel: channel.to_string(),
@@ -2061,6 +2049,46 @@ mod tests {
 
         assert_eq!(left_report, right_report);
         assert_eq!(left_report.queued_fanout, 0);
+    }
+
+    #[tokio::test]
+    async fn same_seed_replays_across_real_push_boundary() {
+        let mut config = test_config(0x5150_600d);
+        config.ticks = 180;
+        config.workload.weights = ActionWeights {
+            publish_message: 0,
+            create_versioned_message: 0,
+            mutate_versioned_message: 0,
+            presence_transition: 0,
+            recovery_probe: 0,
+            purge_history: 0,
+            push_register_device: 24,
+            push_delete_device: 4,
+            push_subscribe: 20,
+            push_unsubscribe: 5,
+            push_publish: 32,
+            push_scheduled_publish: 10,
+            push_provider_feedback: 4,
+            push_repair: 6,
+            oracle_check: 3,
+        };
+        config.push.queue_produce_lost_probability = 0.04;
+        config.push.queue_ack_lost_probability = 0.02;
+        config.push.provider_retryable_probability = 0.18;
+        config.push.provider_invalid_token_probability = 0.03;
+
+        let mut left = DeterministicSimulator::new(config.clone()).unwrap();
+        let mut right = DeterministicSimulator::new(config).unwrap();
+
+        let left_report = left.run().await.unwrap();
+        let right_report = right.run().await.unwrap();
+
+        assert_eq!(left_report, right_report);
+        assert!(left_report.push.accepted_publishes > 0);
+        assert_eq!(
+            left_report.push.durable_statuses,
+            left_report.push.durable_publish_logs
+        );
     }
 
     #[tokio::test]

--- a/docs/content/docs/server/indestructibility-simulator.mdx
+++ b/docs/content/docs/server/indestructibility-simulator.mdx
@@ -5,8 +5,9 @@ icon: ShieldCheck
 ---
 
 The Sockudo simulator is a seed-replayable disaster lab for durable Protocol V2 state. It runs
-inside one process, drives real `sockudo-core` memory stores, models Sockudo-side push storage and
-queues, injects node, network, IO, queue, and fake-provider faults, and checks a shadow model
+inside one process, drives real `sockudo-core` memory stores, calls the real `sockudo-push` memory
+store and accept pipeline for durable push boundaries, injects node, network, IO, queue, and
+fake-provider faults, and checks a shadow model
 continuously.
 
 Use it to prove that Sockudo-side durability contracts survive dropped live fanout, duplicated
@@ -54,10 +55,26 @@ The simulator covers these high-value durability surfaces:
 | Connection recovery | Simulated clients recover dropped live fanout from durable history unless retention has legitimately truncated the gap. |
 | Versioned messages | Delivery serial replay is contiguous, version chains page in both directions, latest reads match the shadow, and `latest_by_history` preserves original history ordering. |
 | Presence history | Transition dedupe, retained events, cursor paging, stream inspection, and reconstructed snapshots match the shadow model. |
-| Push workflow | Accepted publishes have durable status and publish logs, idempotency maps to one publish, queue loss is repaired from durable state, provider outcomes converge to terminal/retry/dead-letter states, and invalid devices stop receiving sends. |
+| Push workflow | Device registration, channel subscription, scheduled-job storage, publish acceptance, initial status, publish logs, and publish-id idempotency go through real `sockudo-push` memory store/pipeline APIs. The simulator then faults modeled worker queues and provider outcomes and checks they converge. |
 
 It does not replace live multi-node integration or Jepsen-style external testing. It is the fast,
 deterministic inner loop for the durable primitives those tests rely on.
+
+## Real-Code Boundary
+
+The simulator is intentionally not a full server-in-a-process. Its current real-code boundary is:
+
+| Path | Boundary |
+| --- | --- |
+| History | Real `MemoryHistoryStore` reservations, appends, reads, cursors, stream inspection, purges, and resets. |
+| Versioned messages | Real `MemoryVersionStore` delivery reservations, version appends, replay, latest reads, paged chain reads, and `latest_by_history`. |
+| Presence history | Real `MemoryPresenceHistoryStore` transition recording, dedupe, reads, cursors, stream inspection, snapshot reconstruction, and resets. |
+| Push durable state | Real `MemoryPushStore` device, subscription, schedule, status, publish-log, and idempotency APIs, with publish acceptance through `PushPipeline::accept_publish`. |
+
+Still modeled: live socket fanout, horizontal transport timing, replay-buffer hot recovery,
+operator routing, push worker queues after accept, provider dispatch, provider feedback, and repair
+timing. Those modeled paths exist to make deterministic faults cheap and replayable; they are
+checked against the durable stores above rather than replacing them.
 
 ## VOPR-Style Maturity
 


### PR DESCRIPTION
## Summary

- Add a simulator-facing `real_subsystems` harness for real Sockudo core memory stores and real `sockudo-push` durable APIs.
- Route push device registration, subscription changes, scheduled-job storage, publish acceptance, status/log/idempotency reads through `MemoryPushStore` and `PushPipeline::accept_publish` before the simulator shadow advances.
- Keep deterministic queue/provider/fanout fault modeling in the simulator and document the real-code boundary versus modeled paths.

## Verification

- `cargo fmt --all`
- `cargo test -p sockudo-simulator`
- `cargo clippy -p sockudo-simulator --all-targets -- -D warnings`
- `cargo run -p sockudo-simulator --bin sockudo-sim -- --seed 3735928559 --ticks 5000 --mode liveness --swarm --json`
- `cd docs && npm run types:check && npm run build`

Docs build emitted the existing Next.js workspace-root warning about multiple lockfiles, but completed successfully.