### PR TITLE
Add deterministic simulator scheduling harness

### DIFF
--- a/crates/sockudo-simulator/src/io.rs
+++ b/crates/sockudo-simulator/src/io.rs
@@ -4,6 +4,7 @@ use std::collections::VecDeque;
 
 const BASE_TIME_MS: i64 = 1_893_456_000_000;
 const MAX_IO_TRACE_EVENTS: usize = 128;
+const SCHEDULE_SEED_DOMAIN: u64 = 0x5c4e_d11e_d15c_100d;
 
 /// Seeded logical clock for simulator timers and durable timestamps.
 #[derive(Debug, Clone)]
@@ -34,10 +35,6 @@ impl DeterministicClock {
         self.tick = self.tick.max(tick);
     }
 
-    pub(crate) fn advance_by(&mut self, ticks: u64) {
-        self.tick = self.tick.saturating_add(ticks);
-    }
-
     pub(crate) fn timestamp_ms(&self) -> i64 {
         self.base_time_ms.saturating_add(self.tick as i64)
     }
@@ -47,6 +44,7 @@ impl DeterministicClock {
 #[derive(Debug, Clone)]
 pub(crate) struct DeterministicFaultScheduler {
     rng: StdRng,
+    schedule_rng: StdRng,
     trace: VecDeque<String>,
 }
 
@@ -54,6 +52,7 @@ impl DeterministicFaultScheduler {
     pub(crate) fn new(seed: u64) -> Self {
         Self {
             rng: StdRng::seed_from_u64(seed),
+            schedule_rng: StdRng::seed_from_u64(seed ^ SCHEDULE_SEED_DOMAIN),
             trace: VecDeque::new(),
         }
     }
@@ -68,6 +67,46 @@ impl DeterministicFaultScheduler {
 
     pub(crate) fn recent_trace(&self) -> Vec<String> {
         self.trace.iter().cloned().collect()
+    }
+
+    pub(crate) fn schedule_order(&mut self, tick: u64, label: &str, len: usize) -> Vec<usize> {
+        let mut order = (0..len).collect::<Vec<_>>();
+        self.shuffle_order(&mut order);
+        self.record(
+            tick,
+            format!("schedule {label} order={}", format_order(&order)),
+        );
+        order
+    }
+
+    pub(crate) fn shuffle_scheduled<T>(&mut self, tick: u64, label: &str, items: &mut [T]) {
+        if items.len() <= 1 {
+            return;
+        }
+
+        let mut order = (0..items.len()).collect::<Vec<_>>();
+        for idx in (1..items.len()).rev() {
+            let swap_idx = self.schedule_rng.random_range(0..=idx);
+            items.swap(idx, swap_idx);
+            order.swap(idx, swap_idx);
+        }
+        self.record(
+            tick,
+            format!("schedule {label} order={}", format_order(&order)),
+        );
+    }
+
+    pub(crate) fn timer_advance(&mut self, tick: u64, label: &str, target: u64) -> u64 {
+        if target > tick {
+            self.record(
+                tick,
+                format!(
+                    "timer {label} advance_to={target} delta={}",
+                    target.saturating_sub(tick)
+                ),
+            );
+        }
+        target
     }
 
     pub(crate) fn roll(&mut self, tick: u64, label: &str, probability: f64) -> bool {
@@ -95,6 +134,25 @@ impl DeterministicFaultScheduler {
         debug_assert!(upper > 0, "deterministic choice requires a non-empty set");
         self.rng.random_range(0..upper)
     }
+
+    fn shuffle_order(&mut self, order: &mut [usize]) {
+        for idx in (1..order.len()).rev() {
+            let swap_idx = self.schedule_rng.random_range(0..=idx);
+            order.swap(idx, swap_idx);
+        }
+    }
+}
+
+fn format_order(order: &[usize]) -> String {
+    let mut rendered = String::from("[");
+    for (idx, value) in order.iter().enumerate() {
+        if idx > 0 {
+            rendered.push(',');
+        }
+        rendered.push_str(&value.to_string());
+    }
+    rendered.push(']');
+    rendered
 }
 
 /// Event queued against a logical simulator tick.
@@ -147,8 +205,47 @@ impl<E: ScheduledIoEvent> DeterministicNetwork<E> {
         due
     }
 
+    pub(crate) fn drain_due_ordered(
+        &mut self,
+        tick: u64,
+        scheduler: &mut DeterministicFaultScheduler,
+        label: &str,
+    ) -> Vec<E> {
+        let mut due = self.drain_due(tick);
+        scheduler.shuffle_scheduled(tick, label, &mut due);
+        due
+    }
+
     pub(crate) fn next_delivery_tick(&self) -> Option<u64> {
         self.events.iter().map(ScheduledIoEvent::deliver_at).min()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schedule_order_replays_for_same_seed() {
+        let mut left = DeterministicFaultScheduler::new(0x5eed);
+        let mut right = DeterministicFaultScheduler::new(0x5eed);
+
+        assert_eq!(
+            left.schedule_order(7, "test.tasks", 6),
+            right.schedule_order(7, "test.tasks", 6)
+        );
+        assert_eq!(left.recent_trace(), right.recent_trace());
+    }
+
+    #[test]
+    fn schedule_order_varies_by_seed() {
+        let mut left = DeterministicFaultScheduler::new(0x5eed);
+        let mut right = DeterministicFaultScheduler::new(0xbeef);
+
+        assert_ne!(
+            left.schedule_order(7, "test.tasks", 12),
+            right.schedule_order(7, "test.tasks", 12)
+        );
     }
 }
 

--- a/crates/sockudo-simulator/src/push_lab.rs
+++ b/crates/sockudo-simulator/src/push_lab.rs
@@ -395,6 +395,10 @@ impl PushLab {
         self.real
             .put_scheduled_publish(&publish_id, &channel, due_tick)
             .await?;
+        scheduler.record(
+            tick,
+            format!("schedule push.scheduled_publish publish={publish_id} due_tick={due_tick}"),
+        );
         self.schedules.push(ScheduledPush {
             due_tick,
             channel: channel.clone(),
@@ -448,6 +452,13 @@ impl PushLab {
                 result,
             },
         };
+        scheduler.record(
+            tick,
+            format!(
+                "schedule push.provider_feedback_duplicate item={} deliver_at={}",
+                item.id, item.deliver_at
+            ),
+        );
         self.queue.push_back(item);
         self.trace(tick, "push duplicate provider feedback queued".to_string());
     }
@@ -479,7 +490,7 @@ impl PushLab {
                 self.quiescing = previous_quiescing;
                 return Ok(tick);
             }
-            tick = tick.saturating_add(1);
+            tick = scheduler.timer_advance(tick, "push.quiesce", tick.saturating_add(1));
             self.backend_outage = false;
             self.release_due_schedules(tick, scheduler).await?;
             self.repair(tick, scheduler);
@@ -880,22 +891,27 @@ impl PushLab {
         scheduler: &mut DeterministicFaultScheduler,
     ) -> SimulatorResult<()> {
         let mut pending = Vec::with_capacity(self.schedules.len());
+        let mut due = Vec::new();
         let schedules = std::mem::take(&mut self.schedules);
         for schedule in schedules {
             if schedule.due_tick <= tick {
-                self.real
-                    .delete_scheduled_publish(&schedule.publish_id)
-                    .await?;
-                self.accept_publish(
-                    tick,
-                    scheduler,
-                    schedule.channel,
-                    Some((schedule.publish_id, schedule.idempotency_key)),
-                )
-                .await?;
+                due.push(schedule);
             } else {
                 pending.push(schedule);
             }
+        }
+        scheduler.shuffle_scheduled(tick, "push.schedules.due", &mut due);
+        for schedule in due {
+            self.real
+                .delete_scheduled_publish(&schedule.publish_id)
+                .await?;
+            self.accept_publish(
+                tick,
+                scheduler,
+                schedule.channel,
+                Some((schedule.publish_id, schedule.idempotency_key)),
+            )
+            .await?;
         }
         self.schedules = pending;
         Ok(())
@@ -911,12 +927,17 @@ impl PushLab {
         }
 
         let mut pending = VecDeque::with_capacity(self.queue.len());
+        let mut due = Vec::new();
         let queue = self.queue.take_all();
         for item in queue {
             if item.deliver_at > tick {
                 pending.push_back(item);
                 continue;
             }
+            due.push(item);
+        }
+        scheduler.shuffle_scheduled(tick, "push.queue.due", &mut due);
+        for item in due {
             if !self.quiescing
                 && self.roll(
                     tick,
@@ -1334,6 +1355,13 @@ impl PushLab {
             deliver_at: tick.saturating_add(self.random_queue_delay(scheduler)),
             stage,
         };
+        scheduler.record(
+            tick,
+            format!(
+                "schedule push.queue item={} deliver_at={} stage={:?}",
+                item.id, item.deliver_at, item.stage
+            ),
+        );
         self.queue.push_back(item.clone());
         if !self.quiescing
             && self.roll(
@@ -1348,6 +1376,13 @@ impl PushLab {
             duplicate.deliver_at = duplicate
                 .deliver_at
                 .saturating_add(self.random_queue_delay(scheduler).max(1));
+            scheduler.record(
+                tick,
+                format!(
+                    "schedule push.queue.duplicate item={} deliver_at={} stage={:?}",
+                    duplicate.id, duplicate.deliver_at, duplicate.stage
+                ),
+            );
             self.queue.push_back(duplicate);
             self.stats.queue_duplicates = self.stats.queue_duplicates.saturating_add(1);
         }

--- a/crates/sockudo-simulator/src/simulator.rs
+++ b/crates/sockudo-simulator/src/simulator.rs
@@ -178,10 +178,16 @@ impl DeterministicSimulator {
         for tick in 0..self.config.ticks {
             self.clock.set_tick(tick);
             self.storage_visibility.flush(tick);
-            self.deliver_due_fanout()?;
-            self.push.on_tick(self.tick(), &mut self.scheduler).await?;
-            self.inject_faults().await?;
-            self.drive_workload().await?;
+            for task in self.tick_task_order(tick) {
+                match task {
+                    TickTask::DeliverFanout => self.deliver_due_fanout()?,
+                    TickTask::PushTick => {
+                        self.push.on_tick(tick, &mut self.scheduler).await?;
+                    }
+                    TickTask::InjectFaults => self.inject_faults().await?,
+                    TickTask::DriveWorkload => self.drive_workload().await?,
+                }
+            }
             if self.config.oracle_every > 0 && tick % self.config.oracle_every == 0 {
                 self.check_oracles().await?;
             }
@@ -247,6 +253,21 @@ impl DeterministicSimulator {
             workload_weights: self.workload.weights(),
             workload_actions: self.workload.selected().clone(),
         }
+    }
+
+    fn tick_task_order(&mut self, tick: u64) -> Vec<TickTask> {
+        const TASKS: [TickTask; 4] = [
+            TickTask::DeliverFanout,
+            TickTask::PushTick,
+            TickTask::InjectFaults,
+            TickTask::DriveWorkload,
+        ];
+
+        self.scheduler
+            .schedule_order(tick, "tick.tasks", TASKS.len())
+            .into_iter()
+            .map(|idx| TASKS[idx])
+            .collect()
     }
 
     async fn drive_workload(&mut self) -> SimulatorResult<()> {
@@ -373,6 +394,10 @@ impl DeterministicSimulator {
             return;
         }
         let victim = live[self.scheduler.usize_below(live.len())];
+        self.scheduler.record(
+            self.tick(),
+            format!("schedule node.crash candidates={live:?} chosen={victim}"),
+        );
         if let Some(node) = self.nodes.get_mut(victim) {
             node.alive = false;
             node.partitioned = false;
@@ -392,6 +417,10 @@ impl DeterministicSimulator {
             return false;
         }
         let node_idx = down[self.scheduler.usize_below(down.len())];
+        self.scheduler.record(
+            self.tick(),
+            format!("schedule node.restart candidates={down:?} chosen={node_idx}"),
+        );
         if let Some(node) = self.nodes.get_mut(node_idx) {
             node.alive = true;
             node.paused = false;
@@ -413,6 +442,10 @@ impl DeterministicSimulator {
             return;
         }
         let node_idx = eligible[self.scheduler.usize_below(eligible.len())];
+        self.scheduler.record(
+            self.tick(),
+            format!("schedule node.pause candidates={eligible:?} chosen={node_idx}"),
+        );
         if let Some(node) = self.nodes.get_mut(node_idx) {
             node.paused = true;
             self.stats.node_pauses = self.stats.node_pauses.saturating_add(1);
@@ -431,6 +464,10 @@ impl DeterministicSimulator {
             return;
         }
         let node_idx = paused[self.scheduler.usize_below(paused.len())];
+        self.scheduler.record(
+            self.tick(),
+            format!("schedule node.resume candidates={paused:?} chosen={node_idx}"),
+        );
         if let Some(node) = self.nodes.get_mut(node_idx) {
             node.paused = false;
             self.stats.node_resumes = self.stats.node_resumes.saturating_add(1);
@@ -1017,10 +1054,11 @@ impl DeterministicSimulator {
     }
 
     fn drain_storage_visibility(&mut self) {
+        let current = self.tick();
+        let tick = self.storage_visibility.next_due_tick().unwrap_or(current);
         let tick = self
-            .storage_visibility
-            .next_due_tick()
-            .unwrap_or(self.tick());
+            .scheduler
+            .timer_advance(current, "storage.visibility", tick);
         self.clock.advance_to(tick);
         self.storage_visibility.force_visible();
     }
@@ -1042,11 +1080,12 @@ impl DeterministicSimulator {
             } else {
                 0
             };
+            let deliver_at = self
+                .tick()
+                .saturating_add(self.random_delay())
+                .saturating_add(slow_delay);
             let event = NetworkEvent {
-                deliver_at: self
-                    .tick()
-                    .saturating_add(self.random_delay())
-                    .saturating_add(slow_delay),
+                deliver_at,
                 client_idx,
                 channel: channel.to_string(),
                 stream_id: message.stream_id.clone(),
@@ -1055,6 +1094,13 @@ impl DeterministicSimulator {
                 message: message.clone(),
                 source: DeliverySource::LiveFanout,
             };
+            self.scheduler.record(
+                tick,
+                format!(
+                    "schedule fanout serial={} client={} source_node={} deliver_at={deliver_at}",
+                    message.serial, client_idx, source_node
+                ),
+            );
             self.network.schedule(event.clone());
             if self.roll(
                 "fanout_duplicate",
@@ -1062,6 +1108,13 @@ impl DeterministicSimulator {
             ) {
                 let mut duplicate = event;
                 duplicate.deliver_at = duplicate.deliver_at.saturating_add(self.random_delay());
+                self.scheduler.record(
+                    tick,
+                    format!(
+                        "schedule fanout.duplicate serial={} client={} deliver_at={}",
+                        message.serial, client_idx, duplicate.deliver_at
+                    ),
+                );
                 self.network.schedule(duplicate);
                 self.stats.duplicated_fanout = self.stats.duplicated_fanout.saturating_add(1);
             }
@@ -1069,7 +1122,11 @@ impl DeterministicSimulator {
     }
 
     fn deliver_due_fanout(&mut self) -> SimulatorResult<()> {
-        for event in self.network.drain_due(self.tick()) {
+        let tick = self.tick();
+        for event in self
+            .network
+            .drain_due_ordered(tick, &mut self.scheduler, "fanout.due")
+        {
             self.check_delivery_protocol_oracles(&event)?;
             let accepted = self.clients[event.client_idx].deliver(&event);
             if accepted {
@@ -1095,8 +1152,12 @@ impl DeterministicSimulator {
                 self.drain_storage_visibility();
                 return Ok(());
             };
-            self.clock.advance_by(1);
-            self.clock.advance_to(next_delivery_tick);
+            let current = self.tick();
+            let target = next_delivery_tick.max(current.saturating_add(1));
+            let target = self
+                .scheduler
+                .timer_advance(current, "fanout.quiesce", target);
+            self.clock.set_tick(target);
             self.storage_visibility.flush(self.tick());
             self.deliver_due_fanout()?;
         }
@@ -2732,6 +2793,14 @@ enum DeliverySource {
     Recovery,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum TickTask {
+    DeliverFanout,
+    PushTick,
+    InjectFaults,
+    DriveWorkload,
+}
+
 #[derive(Debug, Default)]
 struct RecoveryRead {
     items: Vec<HistoryItem>,
@@ -3256,6 +3325,74 @@ mod tests {
 
         assert_eq!(left_report, right_report);
         assert_eq!(left_report.queued_fanout, 0);
+    }
+
+    #[tokio::test]
+    async fn same_seed_replays_schedule_and_timer_trace() {
+        let mut config = test_config(0x5c4e_d11e);
+        config.ticks = 1;
+        config.oracle_every = 0;
+        config.workload.weights = ActionWeights {
+            publish_message: 1,
+            create_versioned_message: 0,
+            mutate_versioned_message: 0,
+            presence_transition: 0,
+            recovery_probe: 0,
+            purge_history: 0,
+            push_register_device: 0,
+            push_delete_device: 0,
+            push_subscribe: 0,
+            push_unsubscribe: 0,
+            push_publish: 0,
+            push_scheduled_publish: 0,
+            push_provider_feedback: 0,
+            push_repair: 0,
+            oracle_check: 0,
+        };
+        config.fault.fanout_drop_probability = 0.0;
+        config.fault.fanout_duplicate_probability = 0.0;
+        config.fault.max_fanout_delay_ticks = 0;
+        config.fault.node_crash_probability = 0.0;
+        config.fault.node_restart_probability = 0.0;
+        config.fault.node_pause_probability = 0.0;
+        config.fault.node_resume_probability = 0.0;
+        config.fault.node_partition_probability = 0.0;
+        config.fault.node_heal_probability = 0.0;
+        config.fault.node_slow_probability = 0.0;
+        config.fault.node_stale_probability = 0.0;
+        config.fault.stream_reset_probability = 0.0;
+        config.fault.storage.delayed_commit_probability = 1.0;
+        config.fault.storage.max_commit_delay_ticks = 8;
+
+        let mut left = DeterministicSimulator::new(config.clone()).unwrap();
+        let mut right = DeterministicSimulator::new(config).unwrap();
+
+        let left_report = left.run().await.unwrap();
+        let right_report = right.run().await.unwrap();
+
+        assert_eq!(left_report, right_report);
+        assert_eq!(left_report.io_trace, right_report.io_trace);
+        assert!(
+            left_report
+                .io_trace
+                .iter()
+                .any(|event| event.contains("schedule tick.tasks")),
+            "top-level task ordering should be traced"
+        );
+        assert!(
+            left_report
+                .io_trace
+                .iter()
+                .any(|event| event.contains("schedule fanout")),
+            "fanout scheduling should be traced"
+        );
+        assert!(
+            left_report
+                .io_trace
+                .iter()
+                .any(|event| event.contains("timer ")),
+            "logical timer advancement should be traced"
+        );
     }
 
     #[tokio::test]

--- a/docs/content/docs/server/indestructibility-simulator.mdx
+++ b/docs/content/docs/server/indestructibility-simulator.mdx
@@ -90,13 +90,32 @@ memory-store calls.
 | --- | --- |
 | `DeterministicClock` | The logical tick and durable timestamps. Timer advancement during quiesce jumps through due fanout and push work instead of sleeping wall-clock time. |
 | `DeterministicFaultScheduler` | Seeded random choices, operation trace entries, and named fault rolls such as `fanout_drop`, `queue.ack_lost`, and `storage.push_publish.write_after_commit`. |
+| Schedule harness | A separate seed domain for simulator-executed task ordering: top-level tick tasks, due fanout deliveries, due push schedules, and ready push queue items. |
 | `DeterministicNetwork` | Modeled live fanout delivery order, delivery tick, dropped messages, duplicates, and delayed delivery. |
 | `DeterministicQueue` | Modeled push worker queue order, delayed delivery, redelivery, lease timeout duplication, and repair requeueing. |
 | `DeterministicStorage` | Storage read/write behavior around real memory-store calls: dropped writes before reservation, torn multi-record writes, fail-after-commit, lost responses, stale reads, corrupted reads, delayed commit visibility, and backend outages. |
 
-The final JSON report includes a bounded `io_trace` with the most recent operation and fault
-decisions. That trace is intentionally compact: it is for replay orientation, not a full event log.
-Use the seed, tick count, mode, fault flags, and workload weights as the canonical replay input.
+The final JSON report includes a bounded `io_trace` with the most recent operation, fault,
+scheduling, and logical-timer decisions. That trace is intentionally compact: it is for replay
+orientation, not a full event log. Use the seed, tick count, mode, fault flags, and workload
+weights as the canonical replay input.
+
+To inspect scheduler and timer decisions for a seed:
+
+```bash
+cargo run -p sockudo-simulator --bin sockudo-sim -- \
+  --seed 42 \
+  --ticks 10000 \
+  --json | jq -r '.io_trace[]'
+```
+
+To replay a saved failure capsule and print the same trace window:
+
+```bash
+cargo run -p sockudo-simulator --bin sockudo-sim -- \
+  --corpus-file /tmp/sockudo-sim-failure.json \
+  --json | jq -r '.[0].io_trace[]'
+```
 
 Current limitations:
 


### PR DESCRIPTION
## Summary

- Add a simulator-local deterministic scheduling domain for top-level tick tasks, due fanout deliveries, due push schedules, and ready push queue items.
- Trace scheduling choices, node lifecycle selections, queue enqueue timing, and logical timer advancement in `io_trace`.
- Add replay-stability tests for the schedule harness and full simulator schedule/timer traces.
- Document JSON replay commands for inspecting scheduler and timer decisions.

## Verification

- `cargo fmt --all`
- `cargo test -p sockudo-simulator same_seed_replays_schedule_and_timer_trace -- --nocapture`
- `cargo test -p sockudo-simulator`
- `cargo run -p sockudo-simulator --bin sockudo-sim -- --seed 42 --ticks 10 --json`

No CI was added.
