### PR TITLE
Improve simulator failure shrinking

### DIFF
--- a/crates/sockudo-simulator/src/config.rs
+++ b/crates/sockudo-simulator/src/config.rs
@@ -18,6 +18,10 @@ const SWARM_SEED_DOMAIN: u64 = 0x51a9_5a6d_b33f_500d;
 pub struct SimulatorConfig {
     pub seed: u64,
     pub ticks: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_operations: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_faults: Option<u64>,
     #[serde(default)]
     pub mode: SimulatorMode,
     #[serde(default)]
@@ -41,6 +45,8 @@ impl Default for SimulatorConfig {
         Self {
             seed: 0x5eed_5eed_cafe_f00d,
             ticks: 5_000,
+            max_operations: None,
+            max_faults: None,
             mode: SimulatorMode::default(),
             liveness: LivenessConfig::default(),
             nodes: 5,

--- a/crates/sockudo-simulator/src/io.rs
+++ b/crates/sockudo-simulator/src/io.rs
@@ -46,6 +46,9 @@ pub(crate) struct DeterministicFaultScheduler {
     rng: StdRng,
     schedule_rng: StdRng,
     trace: VecDeque<String>,
+    max_faults: Option<u64>,
+    fired_faults: u64,
+    suppressed_faults: u64,
 }
 
 impl DeterministicFaultScheduler {
@@ -54,7 +57,23 @@ impl DeterministicFaultScheduler {
             rng: StdRng::seed_from_u64(seed),
             schedule_rng: StdRng::seed_from_u64(seed ^ SCHEDULE_SEED_DOMAIN),
             trace: VecDeque::new(),
+            max_faults: None,
+            fired_faults: 0,
+            suppressed_faults: 0,
         }
+    }
+
+    pub(crate) fn with_max_faults(mut self, max_faults: Option<u64>) -> Self {
+        self.max_faults = max_faults;
+        self
+    }
+
+    pub(crate) fn fired_faults(&self) -> u64 {
+        self.fired_faults
+    }
+
+    pub(crate) fn suppressed_faults(&self) -> u64 {
+        self.suppressed_faults
     }
 
     pub(crate) fn record(&mut self, tick: u64, event: impl Into<String>) {
@@ -112,6 +131,14 @@ impl DeterministicFaultScheduler {
     pub(crate) fn roll(&mut self, tick: u64, label: &str, probability: f64) -> bool {
         let fired = probability > 0.0 && self.rng.random::<f64>() < probability;
         if fired {
+            if self
+                .max_faults
+                .is_some_and(|max_faults| self.fired_faults >= max_faults)
+            {
+                self.suppressed_faults = self.suppressed_faults.saturating_add(1);
+                return false;
+            }
+            self.fired_faults = self.fired_faults.saturating_add(1);
             self.record(tick, format!("fault {label}"));
         }
         fired

--- a/crates/sockudo-simulator/src/lib.rs
+++ b/crates/sockudo-simulator/src/lib.rs
@@ -10,11 +10,19 @@ mod error;
 mod io;
 mod push_lab;
 mod real_subsystems;
+mod shrink;
 mod simulator;
 mod workload;
 
 pub use config::{FaultConfig, LivenessConfig, SimulatorConfig, SimulatorMode, StorageFaultConfig};
 pub use error::{SimulatorError, SimulatorResult};
 pub use push_lab::{PushLabConfig, PushSimulationReport};
-pub use simulator::{DeterministicSimulator, ProtocolOracleReport, SimulationReport};
+pub use shrink::{
+    FailureArtifact, FailureRun, RunOutcome, SeedDerivedProfile, SeedDerivedProfileKind,
+    ShrinkArtifact, ShrinkError, ShrinkOutcome, ShrinkStep, replay_command_for_artifact,
+    run_simulator_for_failure, shrink_failure, shrink_with_runner,
+};
+pub use simulator::{
+    DeterministicSimulator, FailureObservation, ProtocolOracleReport, SimulationReport,
+};
 pub use workload::{ActionWeights, WorkloadAction, WorkloadActionCounts, WorkloadConfig};

--- a/crates/sockudo-simulator/src/main.rs
+++ b/crates/sockudo-simulator/src/main.rs
@@ -1,7 +1,8 @@
 use clap::{Parser, ValueEnum};
 use sockudo_simulator::{
-    ActionWeights, DeterministicSimulator, FaultConfig, PushLabConfig, SimulationReport,
-    SimulatorConfig, SimulatorMode, StorageFaultConfig, WorkloadConfig,
+    ActionWeights, DeterministicSimulator, FailureArtifact, FaultConfig, PushLabConfig,
+    SeedDerivedProfile, SimulationReport, SimulatorConfig, SimulatorMode, StorageFaultConfig,
+    WorkloadConfig,
 };
 use std::path::PathBuf;
 
@@ -37,12 +38,15 @@ struct Cli {
     /// Randomize topology, workload, and fault distributions deterministically from the seed.
     #[arg(long)]
     swarm: bool,
-    /// Binary-search the smallest tick count that still reproduces a failing seed/config.
+    /// Shrink a failing seed/config or one-entry corpus into a smaller replay artifact.
     #[arg(long)]
     shrink_failure: bool,
     /// Lower bound for shrink search.
     #[arg(long, default_value_t = 1)]
     shrink_min_ticks: u64,
+    /// Write the shrunk replay artifact to this path. Defaults to sockudo-sim-shrunk-failure.json.
+    #[arg(long)]
+    shrink_output: Option<PathBuf>,
     /// Write a deterministic JSON failure capsule when a run fails.
     #[arg(long)]
     failure_artifact: Option<PathBuf>,
@@ -174,6 +178,8 @@ impl Cli {
         let mut config = SimulatorConfig {
             seed,
             ticks: self.ticks,
+            max_operations: None,
+            max_faults: None,
             mode: self.mode.into(),
             liveness: sockudo_simulator::LivenessConfig {
                 max_quiesce_ticks: self.liveness_max_quiesce_ticks,
@@ -252,8 +258,10 @@ impl Cli {
                 provider_duplicate_result_probability: self.duplicate_prob,
             },
         };
+        let mut seed_derived_profile = None;
         if self.swarm {
             config.apply_swarm_profile();
+            seed_derived_profile = Some(SeedDerivedProfile::swarm(&config));
         }
         SimulatorRun {
             config,
@@ -262,7 +270,9 @@ impl Cli {
             swarm: self.swarm,
             shrink_failure: self.shrink_failure,
             shrink_min_ticks: self.shrink_min_ticks,
+            shrink_output: self.shrink_output,
             failure_artifact: self.failure_artifact,
+            seed_derived_profile,
         }
     }
 }
@@ -271,12 +281,40 @@ impl Cli {
 async fn main() {
     let run = Cli::parse().into_run();
     if run.shrink_failure {
-        match shrink_failure(run.config, run.shrink_min_ticks).await {
+        let (config, seed_derived_profile) = match run.corpus_file.clone() {
+            Some(path) => match load_single_corpus_config(run.config.clone(), path, run.swarm) {
+                Ok(loaded) => loaded,
+                Err(error) => {
+                    eprintln!("sockudo-sim: failed to load shrink corpus\n{error}");
+                    std::process::exit(1);
+                }
+            },
+            None => (run.config, run.seed_derived_profile),
+        };
+        let output_path = run
+            .shrink_output
+            .clone()
+            .or_else(|| run.failure_artifact.clone())
+            .unwrap_or_else(|| PathBuf::from("sockudo-sim-shrunk-failure.json"));
+        match sockudo_simulator::shrink_failure(config, run.shrink_min_ticks).await {
             Ok(Some(result)) => {
+                let artifact = result.artifact(&output_path, seed_derived_profile);
+                if let Err(error) = write_failure_artifact(&output_path, &artifact) {
+                    eprintln!("sockudo-sim: failed to write shrunk failure artifact: {error}");
+                    std::process::exit(1);
+                }
                 println!(
-                    "sockudo-sim: shrink reproduced failure seed={} minimal_ticks={} original_ticks={}",
-                    result.seed, result.minimal_failing_ticks, result.original_ticks
+                    "sockudo-sim: shrink reproduced failure seed={} ticks {} -> {} operations {} -> {} faults {} -> {}",
+                    artifact.config.seed,
+                    result.original_config.ticks,
+                    result.config.ticks,
+                    result.original_observation.operations,
+                    result.final_observation.operations,
+                    result.original_observation.fault_events,
+                    result.final_observation.fault_events,
                 );
+                println!("artifact: {}", output_path.display());
+                println!("replay command: {}", artifact.replay_command);
                 println!("failure: {}", result.error);
                 return;
             }
@@ -299,10 +337,21 @@ async fn main() {
             }
         }
     }
-    run_one(run.config, run.json, run.failure_artifact).await;
+    run_one(
+        run.config,
+        run.json,
+        run.failure_artifact,
+        run.seed_derived_profile,
+    )
+    .await;
 }
 
-async fn run_one(config: SimulatorConfig, json: bool, failure_artifact: Option<PathBuf>) {
+async fn run_one(
+    config: SimulatorConfig,
+    json: bool,
+    failure_artifact: Option<PathBuf>,
+    seed_derived_profile: Option<SeedDerivedProfile>,
+) {
     println!(
         "sockudo-sim: seed={} ticks={} mode={:?} nodes={} clients={} channels={}",
         config.seed, config.ticks, config.mode, config.nodes, config.clients, config.channels
@@ -356,8 +405,16 @@ async fn run_one(config: SimulatorConfig, json: bool, failure_artifact: Option<P
             }
         }
         Err(error) => {
-            if let Some(path) = failure_artifact
-                && let Err(write_error) = write_failure_artifact(&path, &config, &error.to_string())
+            if let Some(path) = failure_artifact.as_ref()
+                && let Err(write_error) = write_failure_artifact(
+                    path,
+                    &FailureArtifact::new(
+                        config.clone(),
+                        error.to_string(),
+                        path,
+                        seed_derived_profile.clone(),
+                    ),
+                )
             {
                 eprintln!("sockudo-sim: failed to write failure artifact: {write_error}");
             }
@@ -387,14 +444,7 @@ async fn run_corpus(
             })
             .collect::<Vec<_>>(),
         CorpusSpec::Configs(configs) => configs,
-        CorpusSpec::FailureArtifact {
-            config,
-            error,
-            replay_command,
-        } => {
-            drop((error, replay_command));
-            vec![*config]
-        }
+        CorpusSpec::FailureArtifact(artifact) => vec![*artifact.config],
     };
     let mut reports = Vec::with_capacity(configs.len());
     for config in configs {
@@ -415,63 +465,51 @@ async fn run_corpus(
     Ok(())
 }
 
-async fn shrink_failure(
-    mut config: SimulatorConfig,
-    min_ticks: u64,
-) -> Result<Option<ShrinkResult>, Box<dyn std::error::Error>> {
-    let original_ticks = config.ticks;
-    let original_error = match run_config_once(config.clone()).await {
-        Ok(()) => return Ok(None),
-        Err(error) => error,
-    };
-
-    let mut low = min_ticks.max(1);
-    let mut high = original_ticks;
-    let mut best_error = original_error.clone();
-    while low < high {
-        let mid = low.saturating_add(high.saturating_sub(low) / 2);
-        config.ticks = mid;
-        match run_config_once(config.clone()).await {
-            Ok(()) => {
-                low = mid.saturating_add(1);
-            }
-            Err(error) => {
-                best_error = error;
-                high = mid;
-            }
+fn load_single_corpus_config(
+    base: SimulatorConfig,
+    path: PathBuf,
+    swarm: bool,
+) -> Result<(SimulatorConfig, Option<SeedDerivedProfile>), Box<dyn std::error::Error>> {
+    let contents = std::fs::read_to_string(&path)?;
+    match serde_json::from_str::<CorpusSpec>(&contents)? {
+        CorpusSpec::Seeds(seeds) => {
+            let [seed] = seeds.as_slice() else {
+                return Err(format!(
+                    "shrink corpus must contain exactly one seed, got {}",
+                    seeds.len()
+                )
+                .into());
+            };
+            let mut config = base;
+            config.seed = *seed;
+            let seed_derived_profile = if swarm {
+                config.apply_swarm_profile();
+                Some(SeedDerivedProfile::swarm(&config))
+            } else {
+                None
+            };
+            Ok((config, seed_derived_profile))
+        }
+        CorpusSpec::Configs(configs) => {
+            let [config] = configs.as_slice() else {
+                return Err(format!(
+                    "shrink corpus must contain exactly one config, got {}",
+                    configs.len()
+                )
+                .into());
+            };
+            Ok((config.clone(), None))
+        }
+        CorpusSpec::FailureArtifact(artifact) => {
+            Ok((*artifact.config, artifact.seed_derived_profile))
         }
     }
-
-    Ok(Some(ShrinkResult {
-        seed: config.seed,
-        original_ticks,
-        minimal_failing_ticks: high,
-        error: best_error,
-    }))
-}
-
-async fn run_config_once(config: SimulatorConfig) -> Result<(), String> {
-    let mut simulator = DeterministicSimulator::new(config).map_err(|error| error.to_string())?;
-    simulator
-        .run()
-        .await
-        .map(|_| ())
-        .map_err(|error| error.to_string())
 }
 
 fn write_failure_artifact(
     path: &PathBuf,
-    config: &SimulatorConfig,
-    error: &str,
+    artifact: &FailureArtifact,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let artifact = FailureArtifact {
-        config,
-        error,
-        replay_command: format!(
-            "cargo run -p sockudo-simulator --bin sockudo-sim -- --corpus-file {}",
-            path.display()
-        ),
-    };
     std::fs::write(path, serde_json::to_string_pretty(&artifact)?)?;
     Ok(())
 }
@@ -501,13 +539,7 @@ fn print_corpus_summary(reports: &[SimulationReport]) {
 enum CorpusSpec {
     Seeds(Vec<u64>),
     Configs(Vec<SimulatorConfig>),
-    FailureArtifact {
-        config: Box<SimulatorConfig>,
-        #[serde(default)]
-        error: Option<String>,
-        #[serde(default, rename = "replayCommand")]
-        replay_command: Option<String>,
-    },
+    FailureArtifact(FailureArtifact),
 }
 
 #[derive(Debug)]
@@ -518,21 +550,7 @@ struct SimulatorRun {
     swarm: bool,
     shrink_failure: bool,
     shrink_min_ticks: u64,
+    shrink_output: Option<PathBuf>,
     failure_artifact: Option<PathBuf>,
-}
-
-#[derive(Debug)]
-struct ShrinkResult {
-    seed: u64,
-    original_ticks: u64,
-    minimal_failing_ticks: u64,
-    error: String,
-}
-
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct FailureArtifact<'a> {
-    config: &'a SimulatorConfig,
-    error: &'a str,
-    replay_command: String,
+    seed_derived_profile: Option<SeedDerivedProfile>,
 }

--- a/crates/sockudo-simulator/src/shrink.rs
+++ b/crates/sockudo-simulator/src/shrink.rs
@@ -1,0 +1,1279 @@
+use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::path::Path;
+use thiserror::Error;
+
+use crate::config::SimulatorConfig;
+use crate::simulator::{DeterministicSimulator, FailureObservation};
+use crate::workload::{ActionWeights, WorkloadAction};
+
+#[derive(Debug, Clone)]
+pub struct FailureRun {
+    pub error: String,
+    pub observation: FailureObservation,
+}
+
+#[derive(Debug, Clone)]
+pub enum RunOutcome {
+    Passed,
+    Failed(FailureRun),
+    Invalid(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct ShrinkOutcome {
+    pub original_config: SimulatorConfig,
+    pub original_error: String,
+    pub original_observation: FailureObservation,
+    pub config: SimulatorConfig,
+    pub error: String,
+    pub final_observation: FailureObservation,
+    pub steps: Vec<ShrinkStep>,
+}
+
+impl ShrinkOutcome {
+    #[must_use]
+    pub fn artifact(
+        &self,
+        artifact_path: &Path,
+        seed_derived_profile: Option<SeedDerivedProfile>,
+    ) -> FailureArtifact {
+        FailureArtifact {
+            config: Box::new(self.config.clone()),
+            error: Some(self.error.clone()),
+            replay_command: replay_command_for_artifact(artifact_path),
+            seed_derived_profile,
+            shrink: Some(ShrinkArtifact {
+                original_ticks: self.original_config.ticks,
+                shrunk_ticks: self.config.ticks,
+                original_operations: self.original_observation.operations,
+                shrunk_operations: self.final_observation.operations,
+                operation_limit: self.config.max_operations,
+                original_fault_events: self.original_observation.fault_events,
+                shrunk_fault_events: self.final_observation.fault_events,
+                fault_limit: self.config.max_faults,
+                original_error: self.original_error.clone(),
+                steps: self.steps.clone(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailureArtifact {
+    pub config: Box<SimulatorConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub replay_command: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed_derived_profile: Option<SeedDerivedProfile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shrink: Option<ShrinkArtifact>,
+}
+
+impl FailureArtifact {
+    #[must_use]
+    pub fn new(
+        config: SimulatorConfig,
+        error: String,
+        artifact_path: &Path,
+        seed_derived_profile: Option<SeedDerivedProfile>,
+    ) -> Self {
+        Self {
+            config: Box::new(config),
+            error: Some(error),
+            replay_command: replay_command_for_artifact(artifact_path),
+            seed_derived_profile,
+            shrink: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SeedDerivedProfile {
+    pub kind: SeedDerivedProfileKind,
+    pub seed: u64,
+    pub generated_config: Box<SimulatorConfig>,
+}
+
+impl SeedDerivedProfile {
+    #[must_use]
+    pub fn swarm(generated_config: &SimulatorConfig) -> Self {
+        Self {
+            kind: SeedDerivedProfileKind::Swarm,
+            seed: generated_config.seed,
+            generated_config: Box::new(generated_config.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SeedDerivedProfileKind {
+    Swarm,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShrinkArtifact {
+    pub original_ticks: u64,
+    pub shrunk_ticks: u64,
+    pub original_operations: u64,
+    pub shrunk_operations: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_limit: Option<u64>,
+    pub original_fault_events: u64,
+    pub shrunk_fault_events: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fault_limit: Option<u64>,
+    pub original_error: String,
+    pub steps: Vec<ShrinkStep>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ShrinkStep {
+    pub field: String,
+    pub before: String,
+    pub after: String,
+}
+
+#[derive(Debug, Error)]
+pub enum ShrinkError {
+    #[error("initial simulator config is invalid: {0}")]
+    InvalidInitialConfig(String),
+}
+
+pub async fn shrink_failure(
+    config: SimulatorConfig,
+    min_ticks: u64,
+) -> Result<Option<ShrinkOutcome>, ShrinkError> {
+    shrink_with_runner(config, min_ticks, |config| async move {
+        run_simulator_for_failure(config).await
+    })
+    .await
+}
+
+pub async fn shrink_with_runner<R, Fut>(
+    config: SimulatorConfig,
+    min_ticks: u64,
+    mut runner: R,
+) -> Result<Option<ShrinkOutcome>, ShrinkError>
+where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    let original_failure = match runner(config.clone()).await {
+        RunOutcome::Failed(failure) => failure,
+        RunOutcome::Passed => return Ok(None),
+        RunOutcome::Invalid(error) => return Err(ShrinkError::InvalidInitialConfig(error)),
+    };
+
+    let mut state = ShrinkState {
+        config: config.clone(),
+        failure: original_failure.clone(),
+        steps: Vec::new(),
+    };
+
+    minimize_ticks(&mut state, min_ticks.max(1), &mut runner).await;
+    materialize_operation_limit(&mut state, &mut runner).await;
+    minimize_operation_limit(&mut state, &mut runner).await;
+    materialize_fault_limit(&mut state, &mut runner).await;
+    minimize_fault_limit(&mut state, &mut runner).await;
+    shrink_topology(&mut state, &mut runner).await;
+    simplify_workload_profile(&mut state, &mut runner).await;
+    simplify_fault_profile(&mut state, &mut runner).await;
+    minimize_ticks(&mut state, min_ticks.max(1), &mut runner).await;
+    materialize_operation_limit(&mut state, &mut runner).await;
+    minimize_operation_limit(&mut state, &mut runner).await;
+    materialize_fault_limit(&mut state, &mut runner).await;
+    minimize_fault_limit(&mut state, &mut runner).await;
+
+    Ok(Some(ShrinkOutcome {
+        original_config: config,
+        original_error: original_failure.error,
+        original_observation: original_failure.observation,
+        config: state.config,
+        error: state.failure.error,
+        final_observation: state.failure.observation,
+        steps: state.steps,
+    }))
+}
+
+pub async fn run_simulator_for_failure(config: SimulatorConfig) -> RunOutcome {
+    let mut simulator = match DeterministicSimulator::new(config) {
+        Ok(simulator) => simulator,
+        Err(error) => return RunOutcome::Invalid(error.to_string()),
+    };
+
+    match simulator.run().await {
+        Ok(_) => RunOutcome::Passed,
+        Err(error) => RunOutcome::Failed(FailureRun {
+            error: error.to_string(),
+            observation: simulator.failure_observation(),
+        }),
+    }
+}
+
+#[must_use]
+pub fn replay_command_for_artifact(path: &Path) -> String {
+    format!(
+        "cargo run -p sockudo-simulator --bin sockudo-sim -- --corpus-file {}",
+        shell_quote_path(path)
+    )
+}
+
+struct ShrinkState {
+    config: SimulatorConfig,
+    failure: FailureRun,
+    steps: Vec<ShrinkStep>,
+}
+
+async fn minimize_ticks<R, Fut>(state: &mut ShrinkState, min_ticks: u64, runner: &mut R)
+where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    let current = state.config.ticks;
+    if current <= min_ticks {
+        return;
+    }
+    minimize_u64_field(
+        state,
+        runner,
+        "ticks",
+        min_ticks,
+        current,
+        |config, value| {
+            config.ticks = value;
+            if let Some(max_operations) = config.max_operations
+                && max_operations > value
+            {
+                config.max_operations = Some(value);
+            }
+        },
+    )
+    .await;
+}
+
+async fn materialize_operation_limit<R, Fut>(state: &mut ShrinkState, runner: &mut R)
+where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    if state.config.max_operations.is_some()
+        || state.failure.observation.operations >= state.config.ticks
+    {
+        return;
+    }
+    let operations = state.failure.observation.operations;
+    let mut candidate = state.config.clone();
+    candidate.max_operations = Some(operations);
+    accept_candidate(
+        state,
+        runner,
+        candidate,
+        "max_operations",
+        "none".to_string(),
+        operations.to_string(),
+    )
+    .await;
+}
+
+async fn minimize_operation_limit<R, Fut>(state: &mut ShrinkState, runner: &mut R)
+where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    let current = state
+        .config
+        .max_operations
+        .unwrap_or(state.failure.observation.operations);
+    minimize_u64_field(
+        state,
+        runner,
+        "max_operations",
+        0,
+        current,
+        |config, value| {
+            config.max_operations = Some(value);
+        },
+    )
+    .await;
+}
+
+async fn materialize_fault_limit<R, Fut>(state: &mut ShrinkState, runner: &mut R)
+where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    if state.config.max_faults.is_some() {
+        return;
+    }
+    let faults = state.failure.observation.fault_events;
+    let mut candidate = state.config.clone();
+    candidate.max_faults = Some(faults);
+    accept_candidate(
+        state,
+        runner,
+        candidate,
+        "max_faults",
+        "none".to_string(),
+        faults.to_string(),
+    )
+    .await;
+}
+
+async fn minimize_fault_limit<R, Fut>(state: &mut ShrinkState, runner: &mut R)
+where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    let current = state
+        .config
+        .max_faults
+        .unwrap_or(state.failure.observation.fault_events);
+    minimize_u64_field(state, runner, "max_faults", 0, current, |config, value| {
+        config.max_faults = Some(value);
+    })
+    .await;
+}
+
+async fn shrink_topology<R, Fut>(state: &mut ShrinkState, runner: &mut R)
+where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    minimize_usize_field(
+        state,
+        runner,
+        "nodes",
+        1,
+        |config| config.nodes,
+        |config, value| {
+            config.nodes = value;
+        },
+    )
+    .await;
+    minimize_usize_field(
+        state,
+        runner,
+        "clients",
+        1,
+        |config| config.clients,
+        |config, value| {
+            config.clients = value;
+        },
+    )
+    .await;
+    minimize_usize_field(
+        state,
+        runner,
+        "channels",
+        1,
+        |config| config.channels,
+        |config, value| {
+            config.channels = value;
+        },
+    )
+    .await;
+    minimize_usize_field(
+        state,
+        runner,
+        "users",
+        1,
+        |config| config.users,
+        |config, value| {
+            config.users = value;
+        },
+    )
+    .await;
+    minimize_usize_field(
+        state,
+        runner,
+        "push.devices",
+        1,
+        |config| config.push.devices,
+        |config, value| {
+            config.push.devices = value;
+        },
+    )
+    .await;
+}
+
+async fn simplify_workload_profile<R, Fut>(state: &mut ShrinkState, runner: &mut R)
+where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    for action in WorkloadAction::ALL {
+        let weight = state.config.workload.weights.weight(action);
+        if weight == 0
+            || state.failure.observation.workload_actions.count(action) > 0
+            || state.config.workload.weights.total() <= weight
+        {
+            continue;
+        }
+        let mut candidate = state.config.clone();
+        set_weight(&mut candidate.workload.weights, action, 0);
+        accept_candidate(
+            state,
+            runner,
+            candidate,
+            &format!("workload.weights.{}", action.as_str()),
+            weight.to_string(),
+            "0".to_string(),
+        )
+        .await;
+    }
+
+    for action in WorkloadAction::ALL {
+        let weight = state.config.workload.weights.weight(action);
+        if weight <= 1 {
+            continue;
+        }
+        let mut candidate = state.config.clone();
+        set_weight(&mut candidate.workload.weights, action, 1);
+        accept_candidate(
+            state,
+            runner,
+            candidate,
+            &format!("workload.weights.{}", action.as_str()),
+            weight.to_string(),
+            "1".to_string(),
+        )
+        .await;
+    }
+}
+
+async fn simplify_fault_profile<R, Fut>(state: &mut ShrinkState, runner: &mut R)
+where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    zero_f64(
+        state,
+        runner,
+        "fault.fanout_drop_probability",
+        |config| config.fault.fanout_drop_probability,
+        |config, value| {
+            config.fault.fanout_drop_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.fanout_duplicate_probability",
+        |config| config.fault.fanout_duplicate_probability,
+        |config, value| {
+            config.fault.fanout_duplicate_probability = value;
+        },
+    )
+    .await;
+    zero_u64(
+        state,
+        runner,
+        "fault.max_fanout_delay_ticks",
+        |config| config.fault.max_fanout_delay_ticks,
+        |config, value| {
+            config.fault.max_fanout_delay_ticks = value;
+            config.push.max_queue_delay_ticks = config.push.max_queue_delay_ticks.min(value);
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.node_crash_probability",
+        |config| config.fault.node_crash_probability,
+        |config, value| {
+            config.fault.node_crash_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.node_restart_probability",
+        |config| config.fault.node_restart_probability,
+        |config, value| {
+            config.fault.node_restart_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.node_pause_probability",
+        |config| config.fault.node_pause_probability,
+        |config, value| {
+            config.fault.node_pause_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.node_resume_probability",
+        |config| config.fault.node_resume_probability,
+        |config, value| {
+            config.fault.node_resume_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.node_partition_probability",
+        |config| config.fault.node_partition_probability,
+        |config, value| {
+            config.fault.node_partition_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.node_heal_probability",
+        |config| config.fault.node_heal_probability,
+        |config, value| {
+            config.fault.node_heal_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.node_slow_probability",
+        |config| config.fault.node_slow_probability,
+        |config, value| {
+            config.fault.node_slow_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.node_stale_probability",
+        |config| config.fault.node_stale_probability,
+        |config, value| {
+            config.fault.node_stale_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.stream_reset_probability",
+        |config| config.fault.stream_reset_probability,
+        |config, value| {
+            config.fault.stream_reset_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.storage.dropped_write_probability",
+        |config| config.fault.storage.dropped_write_probability,
+        |config, value| {
+            config.fault.storage.dropped_write_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.storage.torn_write_probability",
+        |config| config.fault.storage.torn_write_probability,
+        |config, value| {
+            config.fault.storage.torn_write_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.storage.stale_read_probability",
+        |config| config.fault.storage.stale_read_probability,
+        |config, value| {
+            config.fault.storage.stale_read_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.storage.corrupt_read_probability",
+        |config| config.fault.storage.corrupt_read_probability,
+        |config, value| {
+            config.fault.storage.corrupt_read_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "fault.storage.delayed_commit_probability",
+        |config| config.fault.storage.delayed_commit_probability,
+        |config, value| {
+            config.fault.storage.delayed_commit_probability = value;
+        },
+    )
+    .await;
+    zero_u64(
+        state,
+        runner,
+        "fault.storage.max_commit_delay_ticks",
+        |config| config.fault.storage.max_commit_delay_ticks,
+        |config, value| {
+            config.fault.storage.max_commit_delay_ticks = value;
+        },
+    )
+    .await;
+
+    zero_f64(
+        state,
+        runner,
+        "push.queue_produce_lost_probability",
+        |config| config.push.queue_produce_lost_probability,
+        |config, value| {
+            config.push.queue_produce_lost_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.queue_duplicate_probability",
+        |config| config.push.queue_duplicate_probability,
+        |config, value| {
+            config.push.queue_duplicate_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.queue_ack_lost_probability",
+        |config| config.push.queue_ack_lost_probability,
+        |config, value| {
+            config.push.queue_ack_lost_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.queue_lease_timeout_probability",
+        |config| config.push.queue_lease_timeout_probability,
+        |config, value| {
+            config.push.queue_lease_timeout_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.backend_outage_probability",
+        |config| config.push.backend_outage_probability,
+        |config, value| {
+            config.push.backend_outage_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.backend_recovery_probability",
+        |config| config.push.backend_recovery_probability,
+        |config, value| {
+            config.push.backend_recovery_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.write_fail_before_commit_probability",
+        |config| config.push.write_fail_before_commit_probability,
+        |config, value| {
+            config.push.write_fail_before_commit_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.write_fail_after_commit_probability",
+        |config| config.push.write_fail_after_commit_probability,
+        |config, value| {
+            config.push.write_fail_after_commit_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.response_lost_probability",
+        |config| config.push.response_lost_probability,
+        |config, value| {
+            config.push.response_lost_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.read_stale_probability",
+        |config| config.push.read_stale_probability,
+        |config, value| {
+            config.push.read_stale_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.provider_retryable_probability",
+        |config| config.push.provider_retryable_probability,
+        |config, value| {
+            config.push.provider_retryable_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.provider_permanent_rejection_probability",
+        |config| config.push.provider_permanent_rejection_probability,
+        |config, value| {
+            config.push.provider_permanent_rejection_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.provider_invalid_token_probability",
+        |config| config.push.provider_invalid_token_probability,
+        |config, value| {
+            config.push.provider_invalid_token_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.provider_lost_response_probability",
+        |config| config.push.provider_lost_response_probability,
+        |config, value| {
+            config.push.provider_lost_response_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.provider_delayed_result_probability",
+        |config| config.push.provider_delayed_result_probability,
+        |config, value| {
+            config.push.provider_delayed_result_probability = value;
+        },
+    )
+    .await;
+    zero_f64(
+        state,
+        runner,
+        "push.provider_duplicate_result_probability",
+        |config| config.push.provider_duplicate_result_probability,
+        |config, value| {
+            config.push.provider_duplicate_result_probability = value;
+        },
+    )
+    .await;
+    zero_u64(
+        state,
+        runner,
+        "push.max_queue_delay_ticks",
+        |config| config.push.max_queue_delay_ticks,
+        |config, value| {
+            config.push.max_queue_delay_ticks = value;
+        },
+    )
+    .await;
+    zero_u64(
+        state,
+        runner,
+        "push.max_provider_delay_ticks",
+        |config| config.push.max_provider_delay_ticks,
+        |config, value| {
+            config.push.max_provider_delay_ticks = value;
+        },
+    )
+    .await;
+    one_u32(
+        state,
+        runner,
+        "push.max_retries",
+        |config| config.push.max_retries,
+        |config, value| {
+            config.push.max_retries = value;
+        },
+    )
+    .await;
+    one_u64(
+        state,
+        runner,
+        "push.repair_every_ticks",
+        |config| config.push.repair_every_ticks,
+        |config, value| {
+            config.push.repair_every_ticks = value;
+        },
+    )
+    .await;
+}
+
+async fn minimize_u64_field<R, Fut>(
+    state: &mut ShrinkState,
+    runner: &mut R,
+    field: &str,
+    min: u64,
+    current: u64,
+    set: impl Fn(&mut SimulatorConfig, u64),
+) where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    if current <= min {
+        return;
+    }
+
+    let base = state.config.clone();
+    let mut low = min;
+    let mut high = current;
+    let mut best = None;
+    while low < high {
+        let mid = low.saturating_add(high.saturating_sub(low) / 2);
+        let mut candidate = base.clone();
+        set(&mut candidate, mid);
+        match runner(candidate).await {
+            RunOutcome::Failed(failure) => {
+                best = Some((mid, failure));
+                high = mid;
+            }
+            RunOutcome::Passed | RunOutcome::Invalid(_) => {
+                low = mid.saturating_add(1);
+            }
+        }
+    }
+
+    if let Some((value, failure)) = best {
+        let mut candidate = base;
+        set(&mut candidate, value);
+        accept_known_failure(
+            state,
+            candidate,
+            failure,
+            field,
+            current.to_string(),
+            value.to_string(),
+        );
+    }
+}
+
+async fn minimize_usize_field<R, Fut>(
+    state: &mut ShrinkState,
+    runner: &mut R,
+    field: &str,
+    min: usize,
+    get: impl Fn(&SimulatorConfig) -> usize,
+    set: impl Fn(&mut SimulatorConfig, usize),
+) where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    let current = get(&state.config);
+    if current <= min {
+        return;
+    }
+
+    let base = state.config.clone();
+    let mut low = min;
+    let mut high = current;
+    let mut best = None;
+    while low < high {
+        let mid = low.saturating_add(high.saturating_sub(low) / 2);
+        let mut candidate = base.clone();
+        set(&mut candidate, mid);
+        match runner(candidate).await {
+            RunOutcome::Failed(failure) => {
+                best = Some((mid, failure));
+                high = mid;
+            }
+            RunOutcome::Passed | RunOutcome::Invalid(_) => {
+                low = mid.saturating_add(1);
+            }
+        }
+    }
+
+    if let Some((value, failure)) = best {
+        let mut candidate = base;
+        set(&mut candidate, value);
+        accept_known_failure(
+            state,
+            candidate,
+            failure,
+            field,
+            current.to_string(),
+            value.to_string(),
+        );
+    }
+}
+
+async fn zero_f64<R, Fut>(
+    state: &mut ShrinkState,
+    runner: &mut R,
+    field: &str,
+    get: impl Fn(&SimulatorConfig) -> f64,
+    set: impl Fn(&mut SimulatorConfig, f64),
+) where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    let current = get(&state.config);
+    if current == 0.0 {
+        return;
+    }
+    let mut candidate = state.config.clone();
+    set(&mut candidate, 0.0);
+    accept_candidate(
+        state,
+        runner,
+        candidate,
+        field,
+        current.to_string(),
+        "0".to_string(),
+    )
+    .await;
+}
+
+async fn zero_u64<R, Fut>(
+    state: &mut ShrinkState,
+    runner: &mut R,
+    field: &str,
+    get: impl Fn(&SimulatorConfig) -> u64,
+    set: impl Fn(&mut SimulatorConfig, u64),
+) where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    let current = get(&state.config);
+    if current == 0 {
+        return;
+    }
+    let mut candidate = state.config.clone();
+    set(&mut candidate, 0);
+    accept_candidate(
+        state,
+        runner,
+        candidate,
+        field,
+        current.to_string(),
+        "0".to_string(),
+    )
+    .await;
+}
+
+async fn one_u64<R, Fut>(
+    state: &mut ShrinkState,
+    runner: &mut R,
+    field: &str,
+    get: impl Fn(&SimulatorConfig) -> u64,
+    set: impl Fn(&mut SimulatorConfig, u64),
+) where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    let current = get(&state.config);
+    if current <= 1 {
+        return;
+    }
+    let mut candidate = state.config.clone();
+    set(&mut candidate, 1);
+    accept_candidate(
+        state,
+        runner,
+        candidate,
+        field,
+        current.to_string(),
+        "1".to_string(),
+    )
+    .await;
+}
+
+async fn one_u32<R, Fut>(
+    state: &mut ShrinkState,
+    runner: &mut R,
+    field: &str,
+    get: impl Fn(&SimulatorConfig) -> u32,
+    set: impl Fn(&mut SimulatorConfig, u32),
+) where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    let current = get(&state.config);
+    if current <= 1 {
+        return;
+    }
+    let mut candidate = state.config.clone();
+    set(&mut candidate, 1);
+    accept_candidate(
+        state,
+        runner,
+        candidate,
+        field,
+        current.to_string(),
+        "1".to_string(),
+    )
+    .await;
+}
+
+async fn accept_candidate<R, Fut>(
+    state: &mut ShrinkState,
+    runner: &mut R,
+    candidate: SimulatorConfig,
+    field: &str,
+    before: String,
+    after: String,
+) -> bool
+where
+    R: FnMut(SimulatorConfig) -> Fut,
+    Fut: Future<Output = RunOutcome>,
+{
+    match runner(candidate.clone()).await {
+        RunOutcome::Failed(failure) => {
+            accept_known_failure(state, candidate, failure, field, before, after);
+            true
+        }
+        RunOutcome::Passed | RunOutcome::Invalid(_) => false,
+    }
+}
+
+fn accept_known_failure(
+    state: &mut ShrinkState,
+    candidate: SimulatorConfig,
+    failure: FailureRun,
+    field: &str,
+    before: String,
+    after: String,
+) {
+    if before == after {
+        return;
+    }
+    state.config = candidate;
+    state.failure = failure;
+    state.steps.push(ShrinkStep {
+        field: field.to_string(),
+        before,
+        after,
+    });
+}
+
+fn set_weight(weights: &mut ActionWeights, action: WorkloadAction, value: u32) {
+    match action {
+        WorkloadAction::PublishMessage => weights.publish_message = value,
+        WorkloadAction::CreateVersionedMessage => weights.create_versioned_message = value,
+        WorkloadAction::MutateVersionedMessage => weights.mutate_versioned_message = value,
+        WorkloadAction::PresenceTransition => weights.presence_transition = value,
+        WorkloadAction::RecoveryProbe => weights.recovery_probe = value,
+        WorkloadAction::PurgeHistory => weights.purge_history = value,
+        WorkloadAction::PushRegisterDevice => weights.push_register_device = value,
+        WorkloadAction::PushDeleteDevice => weights.push_delete_device = value,
+        WorkloadAction::PushSubscribe => weights.push_subscribe = value,
+        WorkloadAction::PushUnsubscribe => weights.push_unsubscribe = value,
+        WorkloadAction::PushPublish => weights.push_publish = value,
+        WorkloadAction::PushScheduledPublish => weights.push_scheduled_publish = value,
+        WorkloadAction::PushProviderFeedback => weights.push_provider_feedback = value,
+        WorkloadAction::PushRepair => weights.push_repair = value,
+        WorkloadAction::OracleCheck => weights.oracle_check = value,
+    }
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    let value = path.display().to_string();
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | ':'))
+    {
+        return value;
+    }
+
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workload::{WorkloadActionCounts, WorkloadConfig};
+
+    #[tokio::test]
+    async fn shrinker_minimizes_controlled_failure_fixture() {
+        let mut config = SimulatorConfig {
+            seed: 7,
+            ticks: 64,
+            nodes: 5,
+            clients: 8,
+            channels: 4,
+            users: 12,
+            workload: WorkloadConfig {
+                weights: ActionWeights {
+                    publish_message: 10,
+                    create_versioned_message: 6,
+                    mutate_versioned_message: 4,
+                    presence_transition: 3,
+                    recovery_probe: 2,
+                    purge_history: 1,
+                    push_register_device: 2,
+                    push_delete_device: 1,
+                    push_subscribe: 2,
+                    push_unsubscribe: 1,
+                    push_publish: 2,
+                    push_scheduled_publish: 1,
+                    push_provider_feedback: 1,
+                    push_repair: 1,
+                    oracle_check: 1,
+                },
+            },
+            ..SimulatorConfig::default()
+        };
+        config.fault.fanout_drop_probability = 0.25;
+        config.fault.fanout_duplicate_probability = 0.25;
+        config.fault.max_fanout_delay_ticks = 9;
+        config.fault.node_crash_probability = 0.10;
+        config.fault.storage.dropped_write_probability = 0.10;
+        config.push.devices = 10;
+        config.push.queue_produce_lost_probability = 0.20;
+        config.push.provider_retryable_probability = 0.20;
+
+        let outcome = shrink_with_runner(
+            config,
+            1,
+            |config| async move { controlled_outcome(config) },
+        )
+        .await
+        .unwrap()
+        .expect("fixture should fail before and after shrinking");
+
+        assert_eq!(outcome.config.ticks, 7);
+        assert_eq!(outcome.config.max_operations, Some(3));
+        assert_eq!(outcome.config.max_faults, Some(1));
+        assert_eq!(outcome.config.nodes, 2);
+        assert_eq!(outcome.config.clients, 2);
+        assert_eq!(outcome.config.channels, 1);
+        assert_eq!(outcome.config.users, 1);
+        assert_eq!(outcome.config.push.devices, 1);
+        assert_eq!(outcome.config.workload.weights.publish_message, 1);
+        assert_eq!(outcome.config.workload.weights.create_versioned_message, 0);
+        assert_eq!(outcome.config.fault.fanout_duplicate_probability, 0.0);
+        assert_eq!(outcome.config.fault.max_fanout_delay_ticks, 0);
+        assert_eq!(outcome.config.push.provider_retryable_probability, 0.0);
+        assert!(outcome.steps.iter().any(|step| step.field == "max_faults"));
+    }
+
+    #[test]
+    fn artifact_preserves_seed_derived_profile_and_replay_command() {
+        let mut generated = SimulatorConfig {
+            seed: 0x51a9,
+            ..SimulatorConfig::default()
+        };
+        generated.apply_swarm_profile();
+        let mut shrunk = generated.clone();
+        shrunk.ticks = 9;
+
+        let outcome = ShrinkOutcome {
+            original_config: generated.clone(),
+            original_error: "original failure".to_string(),
+            original_observation: observation(32, 12, 4, &generated),
+            config: shrunk,
+            error: "shrunk failure".to_string(),
+            final_observation: observation(9, 3, 1, &generated),
+            steps: vec![ShrinkStep {
+                field: "ticks".to_string(),
+                before: "32".to_string(),
+                after: "9".to_string(),
+            }],
+        };
+
+        let path = Path::new("/tmp/sockudo sim failure.json");
+        let artifact = outcome.artifact(path, Some(SeedDerivedProfile::swarm(&generated)));
+        let encoded = serde_json::to_string(&artifact).unwrap();
+
+        assert!(artifact.replay_command.contains("--corpus-file"));
+        assert!(
+            artifact
+                .replay_command
+                .contains("'/tmp/sockudo sim failure.json'")
+        );
+        assert!(encoded.contains("seedDerivedProfile"));
+        assert_eq!(
+            artifact.seed_derived_profile.as_ref().unwrap().kind,
+            SeedDerivedProfileKind::Swarm
+        );
+        assert_eq!(artifact.config.ticks, 9);
+    }
+
+    fn controlled_outcome(config: SimulatorConfig) -> RunOutcome {
+        if config.ticks < 7
+            || config.max_operations.unwrap_or(config.ticks) < 3
+            || config.max_faults.unwrap_or(4) < 1
+            || config.nodes < 2
+            || config.clients < 2
+            || config.channels < 1
+            || config.users < 1
+            || config.push.devices < 1
+            || config.workload.weights.publish_message == 0
+            || config.fault.fanout_drop_probability == 0.0
+            || config.fault.node_crash_probability == 0.0
+            || config.fault.storage.dropped_write_probability == 0.0
+            || config.push.queue_produce_lost_probability == 0.0
+        {
+            return RunOutcome::Passed;
+        }
+
+        RunOutcome::Failed(FailureRun {
+            error: "controlled failure".to_string(),
+            observation: observation(
+                config.ticks,
+                config.max_operations.unwrap_or(3).min(3),
+                config.max_faults.unwrap_or(1).min(1),
+                &config,
+            ),
+        })
+    }
+
+    fn observation(
+        tick: u64,
+        operations: u64,
+        fault_events: u64,
+        config: &SimulatorConfig,
+    ) -> FailureObservation {
+        FailureObservation {
+            tick,
+            operations,
+            fault_events,
+            suppressed_fault_events: 0,
+            nodes: config.nodes,
+            clients: config.clients,
+            channels: config.channels,
+            users: config.users,
+            workload_actions: WorkloadActionCounts {
+                publish_message: operations,
+                ..WorkloadActionCounts::default()
+            },
+        }
+    }
+}

--- a/crates/sockudo-simulator/src/simulator.rs
+++ b/crates/sockudo-simulator/src/simulator.rs
@@ -90,6 +90,20 @@ pub struct SimulationReport {
     pub workload_actions: WorkloadActionCounts,
 }
 
+/// Compact state captured after an intentionally failing simulator replay.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct FailureObservation {
+    pub tick: u64,
+    pub operations: u64,
+    pub fault_events: u64,
+    pub suppressed_fault_events: u64,
+    pub nodes: usize,
+    pub clients: usize,
+    pub channels: usize,
+    pub users: usize,
+    pub workload_actions: WorkloadActionCounts,
+}
+
 /// Protocol-aware oracle counters emitted in the simulator report.
 #[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
 pub struct ProtocolOracleReport {
@@ -149,7 +163,8 @@ impl DeterministicSimulator {
 
         Ok(Self {
             clock: DeterministicClock::default(),
-            scheduler: DeterministicFaultScheduler::new(config.seed),
+            scheduler: DeterministicFaultScheduler::new(config.seed)
+                .with_max_faults(config.max_faults),
             shadow: Shadow::new(
                 &channels,
                 config.history_retention_messages,
@@ -185,7 +200,11 @@ impl DeterministicSimulator {
                         self.push.on_tick(tick, &mut self.scheduler).await?;
                     }
                     TickTask::InjectFaults => self.inject_faults().await?,
-                    TickTask::DriveWorkload => self.drive_workload().await?,
+                    TickTask::DriveWorkload => {
+                        if self.can_drive_workload() {
+                            self.drive_workload().await?;
+                        }
+                    }
                 }
             }
             if self.config.oracle_every > 0 && tick % self.config.oracle_every == 0 {
@@ -202,6 +221,20 @@ impl DeterministicSimulator {
             .map_err(|message| self.fail(message))?;
         self.check_liveness_oracles()?;
         Ok(self.report())
+    }
+
+    pub fn failure_observation(&self) -> FailureObservation {
+        FailureObservation {
+            tick: self.tick(),
+            operations: self.stats.operations,
+            fault_events: self.scheduler.fired_faults(),
+            suppressed_fault_events: self.scheduler.suppressed_faults(),
+            nodes: self.config.nodes,
+            clients: self.config.clients,
+            channels: self.config.channels,
+            users: self.config.users,
+            workload_actions: self.workload.selected().clone(),
+        }
     }
 
     fn report(&self) -> SimulationReport {
@@ -330,6 +363,12 @@ impl DeterministicSimulator {
             }
             WorkloadAction::OracleCheck => self.check_oracles().await,
         }
+    }
+
+    fn can_drive_workload(&self) -> bool {
+        self.config
+            .max_operations
+            .is_none_or(|max_operations| self.stats.operations < max_operations)
     }
 
     fn route_rejects(&mut self) -> bool {
@@ -3284,6 +3323,8 @@ mod tests {
         SimulatorConfig {
             seed,
             ticks: 300,
+            max_operations: None,
+            max_faults: None,
             mode: crate::SimulatorMode::Safety,
             liveness: crate::LivenessConfig::default(),
             nodes: 4,

--- a/crates/sockudo-simulator/tests/shrink.rs
+++ b/crates/sockudo-simulator/tests/shrink.rs
@@ -1,0 +1,90 @@
+use std::path::Path;
+
+use sockudo_simulator::{
+    ActionWeights, FailureArtifact, FailureObservation, FailureRun, RunOutcome, SimulatorConfig,
+    WorkloadActionCounts, WorkloadConfig, shrink_with_runner,
+};
+
+#[tokio::test]
+async fn public_shrink_api_reduces_controlled_failure_artifact() {
+    let config = SimulatorConfig {
+        seed: 0x5eed,
+        ticks: 24,
+        nodes: 4,
+        clients: 3,
+        channels: 2,
+        users: 5,
+        workload: WorkloadConfig {
+            weights: ActionWeights {
+                publish_message: 8,
+                create_versioned_message: 3,
+                mutate_versioned_message: 2,
+                presence_transition: 2,
+                recovery_probe: 1,
+                purge_history: 1,
+                push_register_device: 1,
+                push_delete_device: 1,
+                push_subscribe: 1,
+                push_unsubscribe: 1,
+                push_publish: 1,
+                push_scheduled_publish: 1,
+                push_provider_feedback: 1,
+                push_repair: 1,
+                oracle_check: 1,
+            },
+        },
+        ..SimulatorConfig::default()
+    };
+
+    let outcome = shrink_with_runner(config, 1, |config| async move { fixture_outcome(config) })
+        .await
+        .unwrap()
+        .expect("fixture should keep failing after shrink");
+
+    assert_eq!(outcome.config.ticks, 5);
+    assert_eq!(outcome.config.max_operations, Some(2));
+    assert_eq!(outcome.config.max_faults, Some(1));
+    assert_eq!(outcome.config.nodes, 2);
+    assert_eq!(outcome.config.clients, 1);
+
+    let artifact = outcome.artifact(Path::new("/tmp/shrunk-fixture.json"), None);
+    let encoded = serde_json::to_string(&artifact).unwrap();
+    let decoded: FailureArtifact = serde_json::from_str(&encoded).unwrap();
+
+    assert_eq!(decoded.config.ticks, 5);
+    assert_eq!(decoded.config.max_operations, Some(2));
+    assert_eq!(decoded.config.max_faults, Some(1));
+    assert!(decoded.replay_command.contains("--corpus-file"));
+    assert!(decoded.shrink.unwrap().steps.iter().any(|step| {
+        step.field == "workload.weights.create_versioned_message" && step.after == "0"
+    }));
+}
+
+fn fixture_outcome(config: SimulatorConfig) -> RunOutcome {
+    if config.ticks < 5
+        || config.max_operations.unwrap_or(config.ticks) < 2
+        || config.max_faults.unwrap_or(2) < 1
+        || config.nodes < 2
+        || config.workload.weights.publish_message == 0
+    {
+        return RunOutcome::Passed;
+    }
+
+    RunOutcome::Failed(FailureRun {
+        error: "controlled integration fixture failure".to_string(),
+        observation: FailureObservation {
+            tick: config.ticks,
+            operations: config.max_operations.unwrap_or(2).min(2),
+            fault_events: config.max_faults.unwrap_or(1).min(1),
+            suppressed_fault_events: 0,
+            nodes: config.nodes,
+            clients: config.clients,
+            channels: config.channels,
+            users: config.users,
+            workload_actions: WorkloadActionCounts {
+                publish_message: 2,
+                ..WorkloadActionCounts::default()
+            },
+        },
+    })
+}

--- a/docs/content/docs/server/indestructibility-simulator.mdx
+++ b/docs/content/docs/server/indestructibility-simulator.mdx
@@ -153,15 +153,30 @@ cargo run -p sockudo-simulator --bin sockudo-sim -- \
   --failure-artifact /tmp/sockudo-sim-failure.json
 ```
 
-Use shrink mode to binary-search the smallest tick count that still fails for a seed/config:
+Use shrink mode to reduce the replay before debugging. The shrinker first proves the original
+config still fails, then deterministically tries smaller tick, operation, and fault prefixes,
+topology reductions, and workload/fault profile simplifications. It accepts only candidates that
+still fail and writes a smaller failure capsule:
 
 ```bash
 cargo run -p sockudo-simulator --bin sockudo-sim -- \
-  --seed 42 \
-  --ticks 50000 \
-  --swarm \
-  --shrink-failure
+  --corpus-file /tmp/sockudo-sim-failure.json \
+  --shrink-failure \
+  --shrink-output /tmp/sockudo-sim-failure.shrunk.json
 ```
+
+The shrink command prints the exact replay command, and the artifact stores the same command in
+`replayCommand`:
+
+```bash
+cargo run -p sockudo-simulator --bin sockudo-sim -- \
+  --corpus-file /tmp/sockudo-sim-failure.shrunk.json
+```
+
+When shrinking a `--swarm` run directly from seed flags, the artifact also includes
+`seedDerivedProfile`. That preserves the original seed-generated topology, workload, and fault
+profile before any shrink simplifications, while replay continues to use the explicit shrunk
+`config` from the capsule. Do not pass `--swarm` when replaying a failure capsule.
 
 ## Fault Model
 
@@ -327,7 +342,8 @@ recent trace:
 ```
 
 Failure artifacts written with `--failure-artifact` include the full config and can be replayed
-directly with `--corpus-file`.
+directly with `--corpus-file`. Shrunk artifacts add a `shrink` block with the original and reduced
+tick, operation, and fault counts plus each accepted simplification step.
 
 Treat these as product bugs unless the invariant is deliberately stronger than the subsystem's
 documented contract. If the contract changes, update the simulator shadow and this page in the same


### PR DESCRIPTION
## Summary

- Add replay-safe operation and fault budgets so shrink artifacts can minimize sequence length without changing default simulator behavior.
- Add deterministic shrink passes for ticks, operation/fault prefixes, topology, workload weights, and fault/profile knobs.
- Write shrunk failure capsules with exact `--corpus-file` replay commands and preserve seed-derived swarm profiles in artifact metadata.
- Document the capture, shrink, and replay workflow. No CI was added.

## Validation

- `cargo fmt --all`
- `cargo test -p sockudo-simulator`
- `cargo clippy -p sockudo-simulator --all-targets -- -D warnings`
- `cd docs && npm run types:check`
- `cd docs && npm run build`
- CLI smoke: `cargo run -p sockudo-simulator --bin sockudo-sim -- --seed 1 --ticks 2 --json`
- End-to-end shrink fixture: wrote `/tmp/sockudo-sim-fixture-failure.json`, shrank it to `/tmp/sockudo-sim-fixture-failure.shrunk.json`, then replayed the shrunk capsule and confirmed it fails as expected.