### PR TITLE
feat(kotlin-sdk): add reconnection parity with Swift SDK

### DIFF
--- a/client-sdks/sockudo-kotlin/lib/build.gradle.kts
+++ b/client-sdks/sockudo-kotlin/lib/build.gradle.kts
@@ -33,8 +33,8 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_23
-    targetCompatibility = JavaVersion.VERSION_23
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 
     withJavadocJar()
     withSourcesJar()
@@ -42,7 +42,7 @@ java {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_23)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
         freeCompilerArgs.add("-Xjsr305=strict")
     }
 }

--- a/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/Models.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/Models.kt
@@ -24,6 +24,7 @@ enum class SockudoAppendMode(
 enum class ConnectionState {
     INITIALIZED,
     CONNECTING,
+    RECONNECTING,
     CONNECTED,
     DISCONNECTED,
     UNAVAILABLE,
@@ -475,6 +476,8 @@ data class SockudoOptions(
     val wireFormat: SockudoWireFormat = SockudoWireFormat.json,
     val appendMode: SockudoAppendMode = SockudoAppendMode.delta,
     val appendRollupWindow: Int? = null,
+    val maxReconnectAttempts: Int? = 6,
+    val maxReconnectGapInSeconds: Double = 120.0,
     val authToken: String? = null,
     val authTokenProvider: ClientAuthTokenProvider? = null,
 ) {

--- a/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/SockudoClient.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/SockudoClient.kt
@@ -43,6 +43,7 @@ class SockudoClient(
     private var activityJob: Job? = null
     private var unavailableJob: Job? = null
     private var retryJob: Job? = null
+    private var reconnectAttempts: Int = 0
     private var authRefreshJob: Job? = null
     private var currentTransport: SockudoTransport? = null
     private var attemptedFallback: Boolean = false
@@ -141,6 +142,7 @@ class SockudoClient(
         }
         manuallyDisconnected = false
         attemptedFallback = false
+        reconnectAttempts = 0
         updateState(ConnectionState.CONNECTING)
         if (options.protocolVersion >= 2 && options.authTokenProvider != null) {
             scope.launch {
@@ -165,6 +167,7 @@ class SockudoClient(
 
     fun disconnect() {
         manuallyDisconnected = true
+        reconnectAttempts = 0
         invalidateTimers()
         webSocket?.close(1000, null)
         webSocket = null
@@ -639,6 +642,7 @@ class SockudoClient(
                         minOf(config.activityTimeout.inWholeMilliseconds.toDouble(), negotiatedTimeout).toLong()
                             .milliseconds()
                     clearUnavailableTimer()
+                    reconnectAttempts = 0
                     updateState(ConnectionState.CONNECTED, mapOf("socket_id" to newSocketId))
                     subscribeAll()
                     if (options.connectionRecovery && channelPositions.isNotEmpty()) {
@@ -770,17 +774,18 @@ class SockudoClient(
         webSocket = null
         channels.values.forEach { it.disconnect() }
 
-        when (closeAction(code)) {
+        val action = closeAction(code)
+        when (action) {
             CloseAction.TlsOnly -> {
                 config.useTls = true
-                scheduleRetry(Duration.ZERO)
+                scheduleRetry(reconnectDelay(action))
             }
 
-            CloseAction.Backoff -> scheduleRetry(1.seconds)
-            CloseAction.Retry -> scheduleRetry(Duration.ZERO)
+            CloseAction.Backoff -> scheduleRetry(reconnectDelay(action))
+            CloseAction.Retry -> scheduleRetry(reconnectDelay(action))
             CloseAction.Refused -> updateState(ConnectionState.DISCONNECTED)
             null -> if (!manuallyDisconnected) {
-                scheduleRetry(1.seconds)
+                scheduleRetry(reconnectDelay(null))
             }
         }
 
@@ -920,17 +925,33 @@ class SockudoClient(
         unavailableJob = null
     }
 
+    private fun reconnectDelay(action: CloseAction?): Duration {
+        if (action == CloseAction.Retry) return Duration.ZERO
+        if (action == CloseAction.TlsOnly) return Duration.ZERO
+        val intervalSeconds = (reconnectAttempts * reconnectAttempts).toDouble()
+        val cappedSeconds = minOf(intervalSeconds, options.maxReconnectGapInSeconds)
+        return cappedSeconds.seconds
+    }
+
     private fun scheduleRetry(after: Duration) {
         if (manuallyDisconnected) {
             return
         }
+
+        val maxAttempts = options.maxReconnectAttempts
+        if (maxAttempts != null && reconnectAttempts >= maxAttempts) {
+            updateState(ConnectionState.DISCONNECTED)
+            return
+        }
+        reconnectAttempts++
+
         retryJob?.cancel()
         retryJob =
             scope.launch {
                 delay(after)
                 webSocket?.cancel()
                 webSocket = null
-                updateState(ConnectionState.CONNECTING)
+                updateState(ConnectionState.RECONNECTING)
                 val transports = transportSequence()
                 if (currentTransport == SockudoTransport.ws && !attemptedFallback && transports.contains(
                         SockudoTransport.wss

--- a/client-sdks/sockudo-kotlin/lib/src/test/kotlin/io/sockudo/client/ReconnectionTest.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/test/kotlin/io/sockudo/client/ReconnectionTest.kt
@@ -1,0 +1,178 @@
+package io.sockudo.client
+
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+
+class ReconnectionTest {
+
+    @Test
+    fun `ConnectionState contains RECONNECTING`() {
+        val states = ConnectionState.entries.map { it.name }
+        assertTrue("RECONNECTING" in states)
+    }
+
+    @Test
+    fun `RECONNECTING name lowercases to reconnecting`() {
+        assertEquals("reconnecting", ConnectionState.RECONNECTING.name.lowercase())
+    }
+
+    @Test
+    fun `SockudoOptions maxReconnectAttempts defaults to 6`() {
+        val options = SockudoOptions(cluster = "test")
+        assertEquals(6, options.maxReconnectAttempts)
+    }
+
+    @Test
+    fun `SockudoOptions maxReconnectGapInSeconds defaults to 120`() {
+        val options = SockudoOptions(cluster = "test")
+        assertEquals(120.0, options.maxReconnectGapInSeconds)
+    }
+
+    @Test
+    fun `SockudoOptions maxReconnectAttempts accepts null for unlimited`() {
+        val options = SockudoOptions(cluster = "test", maxReconnectAttempts = null)
+        assertNull(options.maxReconnectAttempts)
+    }
+
+    @Test
+    fun `state_change emits reconnecting during retry`() =
+        runBlocking {
+            val stateChanges = CopyOnWriteArrayList<String>()
+            val client = testClient()
+            client.bind("state_change") { data, _ ->
+                val map = data as? Map<*, *>
+                val current = map?.get("current") as? String
+                if (current != null) stateChanges += current
+            }
+
+            replayRaw(
+                client,
+                """{"event":"sockudo:connection_established","data":{"socket_id":"1.1","activity_timeout":120}}""",
+            )
+
+            invokeHandleSocketClosed(client, 4100, null)
+
+            waitFor { "reconnecting" in stateChanges }
+
+            assertTrue("reconnecting" in stateChanges, "Expected 'reconnecting' in state_change events, got: $stateChanges")
+        }
+
+    @Test
+    fun `reconnect stops after maxReconnectAttempts exceeded`() =
+        runBlocking {
+            val stateChanges = CopyOnWriteArrayList<String>()
+            val client = testClient(maxReconnectAttempts = 2)
+            client.bind("state_change") { data, _ ->
+                val map = data as? Map<*, *>
+                val current = map?.get("current") as? String
+                if (current != null) stateChanges += current
+            }
+
+            replayRaw(
+                client,
+                """{"event":"sockudo:connection_established","data":{"socket_id":"1.1","activity_timeout":120}}""",
+            )
+
+            repeat(3) {
+                invokeHandleSocketClosed(client, 4100, null)
+                delay(50)
+            }
+
+            waitFor { "disconnected" in stateChanges }
+            assertTrue("disconnected" in stateChanges, "Expected DISCONNECTED after max attempts, got: $stateChanges")
+        }
+
+    @Test
+    fun `connect resets reconnectAttempts`() =
+        runBlocking {
+            val client = testClient(maxReconnectAttempts = 1)
+
+            replayRaw(
+                client,
+                """{"event":"sockudo:connection_established","data":{"socket_id":"1.1","activity_timeout":120}}""",
+            )
+
+            invokeHandleSocketClosed(client, 4100, null)
+            delay(50)
+            invokeHandleSocketClosed(client, 4100, null)
+            delay(50)
+
+            client.connect()
+
+            val reconnectAttempts = getReconnectAttempts(client)
+            assertEquals(0, reconnectAttempts)
+        }
+
+    @Test
+    fun `disconnect resets reconnectAttempts`() =
+        runBlocking {
+            val client = testClient()
+
+            replayRaw(
+                client,
+                """{"event":"sockudo:connection_established","data":{"socket_id":"1.1","activity_timeout":120}}""",
+            )
+
+            invokeHandleSocketClosed(client, 4100, null)
+            delay(50)
+
+            client.disconnect()
+
+            val reconnectAttempts = getReconnectAttempts(client)
+            assertEquals(0, reconnectAttempts)
+        }
+
+    private fun testClient(maxReconnectAttempts: Int? = 6): SockudoClient =
+        SockudoClient(
+            "app-key",
+            SockudoOptions(
+                cluster = "local",
+                forceTls = false,
+                enabledTransports = listOf(SockudoTransport.ws),
+                wsHost = "127.0.0.1",
+                wsPort = 6001,
+                maxReconnectAttempts = maxReconnectAttempts,
+            ),
+        )
+
+    private fun replayRaw(client: SockudoClient, raw: String) {
+        val method = SockudoClient::class.java.getDeclaredMethod("handleRawMessage", Any::class.java)
+        method.isAccessible = true
+        try {
+            method.invoke(client, raw)
+        } catch (error: InvocationTargetException) {
+            throw error.targetException
+        }
+    }
+
+    private fun invokeHandleSocketClosed(client: SockudoClient, code: Int, reason: String?) {
+        val method = SockudoClient::class.java.getDeclaredMethod("handleSocketClosed", Int::class.java, String::class.java)
+        method.isAccessible = true
+        try {
+            method.invoke(client, code, reason)
+        } catch (error: InvocationTargetException) {
+            throw error.targetException
+        }
+    }
+
+    private fun getReconnectAttempts(client: SockudoClient): Int {
+        val field = SockudoClient::class.java.getDeclaredField("reconnectAttempts")
+        field.isAccessible = true
+        return field.getInt(client)
+    }
+
+    private suspend fun waitFor(timeoutMs: Long = 2_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            delay(20)
+        }
+        error("Timed out waiting for condition")
+    }
+}


### PR DESCRIPTION
Port the Swift SDK's reconnection primitives to the Kotlin SDK.

Changes
- Add ConnectionState.RECONNECTING enum value (distinguishes retry from first connect; lowercases to "reconnecting" for state_change events)
- Add SockudoOptions.maxReconnectAttempts: Int? = 6 (null = unlimited)
- Add SockudoOptions.maxReconnectGapInSeconds: Double = 120.0
- Add reconnectAttempts counter with resets on connect(), disconnect(), and connection_established
- Add reconnectDelay() helper: attempt² seconds capped at maxReconnectGapInSeconds; immediate (0s) for Retry and TlsOnly codes
- Rewrite scheduleRetry() to check max attempts, increment counter, and emit RECONNECTING instead of CONNECTING
- Update handleSocketClosed() to use reconnectDelay() instead of hardcoded 1.seconds
- Lower JVM target from 23 to 21
- Add tests ReconnectionTest.kt

The Android provider plan (sockudo-provider-hardening) can now map "reconnecting" directly instead of inferring reconnection from channel subscription state.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
