### PR TITLE
Fix cache key clippy lint

### DIFF
--- a/crates/sockudo-adapter/src/filter_index.rs
+++ b/crates/sockudo-adapter/src/filter_index.rs
@@ -339,16 +339,13 @@ impl FilterIndex {
                     let mut common_key: Option<String> = None;
 
                     for child in filter.nodes() {
-                        if let Some(indexable) = Self::extract_indexable_filter(child) {
-                            match &common_key {
-                                None => common_key = Some(indexable.key.clone()),
-                                Some(k) if k != &indexable.key => return None, // Different keys
-                                _ => {}
-                            }
-                            all_values.extend(indexable.values);
-                        } else {
-                            return None; // Child is not indexable
+                        let indexable = Self::extract_indexable_filter(child)?;
+                        match &common_key {
+                            None => common_key = Some(indexable.key.clone()),
+                            Some(k) if k != &indexable.key => return None, // Different keys
+                            _ => {}
                         }
+                        all_values.extend(indexable.values);
                     }
 
                     common_key.map(|key| IndexableFilter {

--- a/crates/sockudo-server/src/http_handler/events/processor.rs
+++ b/crates/sockudo-server/src/http_handler/events/processor.rs
@@ -324,7 +324,7 @@ pub(super) async fn process_single_event_parallel(
                 match build_cache_payload(&event_name_for_task, &message_data, &target_channel_str) {
                     Ok(cache_payload_str) => {
                         let cache_key_str =
-                            format!("app:{}:channel:{}:cache_miss", &app.id, target_channel_str);
+                            format!("app:{}:channel:{}:cache_miss", app.id, target_channel_str);
 
                         match handler_clone
                             .cache_manager()


### PR DESCRIPTION
## Summary
- remove the redundant reference in the cache-miss key format argument that trips clippy with `-D warnings`
- unblock the AI Transport release feature matrix jobs that hit the same lint across feature combinations

## Validation
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p sockudo --all-targets --no-default-features --features ai-transport -- -D warnings`
- `cargo clippy -p sockudo --all-targets --no-default-features --features "ai-transport,redis" -- -D warnings`
- `cargo clippy -p sockudo --all-targets --no-default-features --features "ai-transport,nats" -- -D warnings`
- `cargo clippy -p sockudo --all-targets --no-default-features --features "ai-transport,redis,postgres" -- -D warnings`
- `cargo clippy -p sockudo --all-targets --features full -- -D warnings`