### PR TITLE
Add production invariant tripwires

### DIFF
--- a/crates/sockudo-adapter/src/handler/recovery.rs
+++ b/crates/sockudo-adapter/src/handler/recovery.rs
@@ -75,6 +75,23 @@ fn map_history_read_error(position: &ResumePosition, error: Error) -> ResumeFail
     }
 }
 
+fn continuity_failure(
+    position: &ResumePosition,
+    reason: &'static str,
+    current_stream_id: Option<String>,
+    oldest_available_serial: Option<u64>,
+    newest_available_serial: Option<u64>,
+) -> ResumeFailure {
+    ResumeFailure {
+        code: "continuity_unverifiable",
+        reason,
+        expected_stream_id: position.stream_id.clone(),
+        current_stream_id,
+        oldest_available_serial,
+        newest_available_serial,
+    }
+}
+
 impl ConnectionHandler {
     /// Handle a `pusher:resume` event from a reconnecting client.
     ///
@@ -243,6 +260,27 @@ impl ConnectionHandler {
                     newest_available_serial: None,
                 });
             }
+            ReplayLookup::Ahead { newest_serial } => {
+                warn!(
+                    app_id = %app_config.id,
+                    channel,
+                    requested_serial = position.serial,
+                    newest_serial,
+                    "resume position is ahead of the node-local replay buffer; consulting durable recovery"
+                );
+            }
+            ReplayLookup::ContinuityGap {
+                expected_serial,
+                observed_serial,
+            } => {
+                warn!(
+                    app_id = %app_config.id,
+                    channel,
+                    expected_serial,
+                    observed_serial,
+                    "hot replay continuity check failed; attempting durable recovery"
+                );
+            }
             ReplayLookup::Expired => {}
         }
 
@@ -287,6 +325,72 @@ impl ConnectionHandler {
                 });
             }
 
+            if stream_state
+                .newest_available_delivery_serial
+                .is_some_and(|newest| position.serial > newest)
+            {
+                return ResumeOutcome::Failed(ResumeFailure {
+                    code: "continuity_unverifiable",
+                    reason: "position_ahead_of_version_stream",
+                    expected_stream_id: position.stream_id.clone(),
+                    current_stream_id: stream_state.stream_id.clone(),
+                    oldest_available_serial: stream_state.oldest_available_delivery_serial,
+                    newest_available_serial: stream_state.newest_available_delivery_serial,
+                });
+            }
+
+            if stream_state.newest_available_delivery_serial.is_none()
+                && let Some(next_serial) = stream_state.next_delivery_serial
+            {
+                let requested_next = position.serial.saturating_add(1);
+                if requested_next < next_serial {
+                    return ResumeOutcome::Failed(ResumeFailure {
+                        code: "position_expired",
+                        reason: "version_replay_empty_after_prior_writes",
+                        expected_stream_id: position.stream_id.clone(),
+                        current_stream_id: stream_state.stream_id.clone(),
+                        oldest_available_serial: None,
+                        newest_available_serial: None,
+                    });
+                }
+                if requested_next > next_serial {
+                    return ResumeOutcome::Failed(ResumeFailure {
+                        code: "continuity_unverifiable",
+                        reason: "position_ahead_of_version_stream",
+                        expected_stream_id: position.stream_id.clone(),
+                        current_stream_id: stream_state.stream_id.clone(),
+                        oldest_available_serial: None,
+                        newest_available_serial: None,
+                    });
+                }
+            }
+            if stream_state.newest_available_delivery_serial.is_none()
+                && stream_state.next_delivery_serial.is_none()
+            {
+                return ResumeOutcome::Failed(ResumeFailure {
+                    code: "continuity_unverifiable",
+                    reason: "version_stream_head_unavailable",
+                    expected_stream_id: position.stream_id.clone(),
+                    current_stream_id: stream_state.stream_id.clone(),
+                    oldest_available_serial: None,
+                    newest_available_serial: None,
+                });
+            }
+
+            if stream_state
+                .oldest_available_delivery_serial
+                .is_some_and(|oldest| position.serial.saturating_add(1) < oldest)
+            {
+                return ResumeOutcome::Failed(ResumeFailure {
+                    code: "position_expired",
+                    reason: "version_replay_floor_is_ahead_of_requested_serial",
+                    expected_stream_id: position.stream_id.clone(),
+                    current_stream_id: stream_state.stream_id.clone(),
+                    oldest_available_serial: stream_state.oldest_available_delivery_serial,
+                    newest_available_serial: stream_state.newest_available_delivery_serial,
+                });
+            }
+
             let replay_limit = stream_state
                 .newest_available_delivery_serial
                 .map(|newest| newest.saturating_sub(position.serial) as usize)
@@ -315,6 +419,34 @@ impl ConnectionHandler {
                     });
                 }
             };
+
+            let mut expected_serial = position.serial.saturating_add(1);
+            for record in &records {
+                if record.delivery_serial() != expected_serial {
+                    return ResumeOutcome::Failed(ResumeFailure {
+                        code: "continuity_unverifiable",
+                        reason: "version_replay_is_not_contiguous",
+                        expected_stream_id: position.stream_id.clone(),
+                        current_stream_id: stream_state.stream_id.clone(),
+                        oldest_available_serial: stream_state.oldest_available_delivery_serial,
+                        newest_available_serial: stream_state.newest_available_delivery_serial,
+                    });
+                }
+                expected_serial = expected_serial.saturating_add(1);
+            }
+            if stream_state
+                .newest_available_delivery_serial
+                .is_some_and(|newest| expected_serial <= newest)
+            {
+                return ResumeOutcome::Failed(ResumeFailure {
+                    code: "continuity_unverifiable",
+                    reason: "version_replay_ended_before_stream_head",
+                    expected_stream_id: position.stream_id.clone(),
+                    current_stream_id: stream_state.stream_id.clone(),
+                    oldest_available_serial: stream_state.oldest_available_delivery_serial,
+                    newest_available_serial: stream_state.newest_available_delivery_serial,
+                });
+            }
 
             let mut messages = Vec::with_capacity(records.len());
             for record in records {
@@ -417,15 +549,104 @@ impl ConnectionHandler {
         position: &ResumePosition,
         max_page_size: usize,
     ) -> std::result::Result<Vec<Bytes>, ResumeFailure> {
+        // Freeze the durable head before pagination. History cursors embed their query bounds, so
+        // changing the end bound after page one would invalidate an otherwise healthy cursor.
+        let frozen_inspection = self
+            .history_store()
+            .stream_inspection(&app_config.id, channel)
+            .await
+            .map_err(|error| map_history_read_error(position, error))?;
+        let frozen_head = frozen_inspection.retained;
+        if frozen_head.stream_id.as_deref() != position.stream_id.as_deref() {
+            return Err(ResumeFailure {
+                code: "stream_reset",
+                reason: "durable_stream_id_mismatch",
+                expected_stream_id: position.stream_id.clone(),
+                current_stream_id: frozen_head.stream_id,
+                oldest_available_serial: frozen_head.oldest_serial,
+                newest_available_serial: frozen_head.newest_serial,
+            });
+        }
+        if frozen_head
+            .newest_serial
+            .is_some_and(|newest| position.serial > newest)
+        {
+            return Err(continuity_failure(
+                position,
+                "position_ahead_of_durable_stream",
+                frozen_head.stream_id,
+                frozen_head.oldest_serial,
+                frozen_head.newest_serial,
+            ));
+        }
+        if frozen_head.newest_serial.is_none()
+            && let Some(next_serial) = frozen_inspection.next_serial
+        {
+            let requested_next = position.serial.saturating_add(1);
+            if requested_next < next_serial {
+                return Err(ResumeFailure {
+                    code: "position_expired",
+                    reason: "durable_history_empty_after_prior_writes",
+                    expected_stream_id: position.stream_id.clone(),
+                    current_stream_id: frozen_head.stream_id,
+                    oldest_available_serial: None,
+                    newest_available_serial: None,
+                });
+            }
+            if requested_next > next_serial {
+                return Err(continuity_failure(
+                    position,
+                    "position_ahead_of_durable_stream",
+                    frozen_head.stream_id,
+                    None,
+                    None,
+                ));
+            }
+        }
+        if frozen_head.newest_serial.is_none() && frozen_inspection.next_serial.is_none() {
+            return Err(continuity_failure(
+                position,
+                "durable_stream_head_unavailable",
+                frozen_head.stream_id,
+                None,
+                None,
+            ));
+        }
+        if frozen_head
+            .oldest_serial
+            .is_some_and(|oldest| position.serial.saturating_add(1) < oldest)
+        {
+            return Err(ResumeFailure {
+                code: "position_expired",
+                reason: "retained_history_floor_is_ahead_of_requested_serial",
+                expected_stream_id: position.stream_id.clone(),
+                current_stream_id: frozen_head.stream_id,
+                oldest_available_serial: frozen_head.oldest_serial,
+                newest_available_serial: frozen_head.newest_serial,
+            });
+        }
+
+        let Some(target_newest_serial) = frozen_head.newest_serial else {
+            return Ok(Vec::new());
+        };
+        if target_newest_serial == position.serial {
+            return Ok(Vec::new());
+        }
+
         let mut cursor = None;
         let mut recovered_messages = Vec::new();
         let bounds = HistoryQueryBounds {
             start_serial: Some(position.serial.saturating_add(1)),
-            end_serial: None,
+            end_serial: Some(target_newest_serial),
             start_time_ms: None,
             end_time_ms: None,
         };
         let mut first_page = true;
+        let mut expected_serial = position.serial.saturating_add(1);
+        let mut previous_cursor_serial = None;
+
+        let gap = target_newest_serial.saturating_sub(position.serial) as usize;
+        recovered_messages.reserve(gap.min(max_page_size * 4));
 
         loop {
             let page = self
@@ -465,39 +686,99 @@ impl ConnectionHandler {
                         newest_available_serial: page.retained.newest_serial,
                     });
                 }
-
-                if let Some(newest_serial) = page.retained.newest_serial
-                    && newest_serial > position.serial
-                {
-                    let gap = newest_serial.saturating_sub(position.serial) as usize;
-                    recovered_messages.reserve(gap.min(max_page_size * 4));
-                }
+            } else if page.retained.stream_id.as_deref() != position.stream_id.as_deref() {
+                return Err(ResumeFailure {
+                    code: "stream_reset",
+                    reason: "durable_stream_changed_during_reconnect",
+                    expected_stream_id: position.stream_id.clone(),
+                    current_stream_id: page.retained.stream_id.clone(),
+                    oldest_available_serial: page.retained.oldest_serial,
+                    newest_available_serial: page.retained.newest_serial,
+                });
             }
 
             let count_this_page = page.items.len();
+            let mut last_item_serial = None;
             for item in page.items {
+                if item.stream_id.as_str() != position.stream_id.as_deref().unwrap_or_default() {
+                    return Err(continuity_failure(
+                        position,
+                        "durable_history_item_stream_mismatch",
+                        Some(item.stream_id),
+                        page.retained.oldest_serial,
+                        Some(target_newest_serial),
+                    ));
+                }
+                if item.serial != expected_serial || item.serial > target_newest_serial {
+                    return Err(continuity_failure(
+                        position,
+                        "durable_history_is_not_contiguous",
+                        page.retained.stream_id.clone(),
+                        page.retained.oldest_serial,
+                        Some(target_newest_serial),
+                    ));
+                }
+                last_item_serial = Some(item.serial);
+                expected_serial = expected_serial.saturating_add(1);
                 if position
                     .last_message_id
                     .as_ref()
                     .is_some_and(|last_id| item.message_id.as_ref() == Some(last_id))
                 {
+                    warn!(
+                        app_id = %app_config.id,
+                        channel,
+                        serial = item.serial,
+                        "suppressed duplicate message identity during durable recovery"
+                    );
                     continue;
                 }
                 recovered_messages.push(item.payload_bytes);
             }
 
             if !page.has_more {
-                if count_this_page == 0
-                    && page
-                        .retained
-                        .newest_serial
-                        .is_some_and(|newest| newest < position.serial)
-                {
-                    return Ok(Vec::new());
+                if !page.complete || expected_serial <= target_newest_serial {
+                    return Err(continuity_failure(
+                        position,
+                        "durable_history_ended_before_stream_head",
+                        page.retained.stream_id.clone(),
+                        page.retained.oldest_serial,
+                        Some(target_newest_serial),
+                    ));
                 }
                 break;
             }
-            cursor = page.next_cursor;
+
+            let next_cursor = page.next_cursor.ok_or_else(|| {
+                continuity_failure(
+                    position,
+                    "durable_history_cursor_missing",
+                    page.retained.stream_id.clone(),
+                    page.retained.oldest_serial,
+                    Some(target_newest_serial),
+                )
+            })?;
+            if count_this_page == 0
+                || next_cursor.version != 1
+                || next_cursor.app_id != app_config.id
+                || next_cursor.channel != channel
+                || Some(next_cursor.serial) != last_item_serial
+                || previous_cursor_serial.is_some_and(|previous| next_cursor.serial <= previous)
+                || next_cursor.stream_id.as_str()
+                    != position.stream_id.as_deref().unwrap_or_default()
+                || next_cursor.direction != HistoryDirection::OldestFirst
+                || next_cursor.bounds != bounds
+            {
+                return Err(continuity_failure(
+                    position,
+                    "durable_history_cursor_did_not_advance",
+                    page.retained.stream_id.clone(),
+                    page.retained.oldest_serial,
+                    Some(target_newest_serial),
+                ));
+            }
+            previous_cursor_serial = Some(next_cursor.serial);
+            cursor = Some(next_cursor);
         }
 
         Ok(recovered_messages)
@@ -677,8 +958,9 @@ mod tests {
     use sockudo_core::app::AppManager;
     use sockudo_core::cache::CacheManager;
     use sockudo_core::history::{
-        HistoryAppendRecord, HistoryDurableState, HistoryPage, HistoryReadRequest,
-        HistoryRuntimeStatus, HistoryStore, HistoryStreamRuntimeState, HistoryWriteReservation,
+        HistoryAppendRecord, HistoryDurableState, HistoryPage, HistoryPurgeMode,
+        HistoryPurgeRequest, HistoryReadRequest, HistoryRuntimeStatus, HistoryStore,
+        HistoryStreamInspection, HistoryStreamRuntimeState, HistoryWriteReservation,
         MemoryHistoryStore, MemoryHistoryStoreConfig,
     };
     use sockudo_core::metrics::MetricsInterface;
@@ -853,6 +1135,14 @@ mod tests {
             self.inner.read_page(request).await
         }
 
+        async fn stream_inspection(
+            &self,
+            app_id: &str,
+            channel: &str,
+        ) -> sockudo_core::error::Result<HistoryStreamInspection> {
+            self.inner.stream_inspection(app_id, channel).await
+        }
+
         async fn runtime_status(&self) -> sockudo_core::error::Result<HistoryRuntimeStatus> {
             let states = self.states.read().await;
             let degraded_channels = states
@@ -915,6 +1205,14 @@ mod tests {
             self.inner.read_page(request).await
         }
 
+        async fn stream_inspection(
+            &self,
+            app_id: &str,
+            channel: &str,
+        ) -> sockudo_core::error::Result<HistoryStreamInspection> {
+            self.inner.stream_inspection(app_id, channel).await
+        }
+
         async fn runtime_status(&self) -> sockudo_core::error::Result<HistoryRuntimeStatus> {
             self.inner.runtime_status().await
         }
@@ -960,6 +1258,65 @@ mod tests {
                 return Err(Error::InvalidMessageFormat(self.expire_reason.to_string()));
             }
             self.inner.read_page(request).await
+        }
+
+        async fn stream_inspection(
+            &self,
+            app_id: &str,
+            channel: &str,
+        ) -> sockudo_core::error::Result<HistoryStreamInspection> {
+            self.inner.stream_inspection(app_id, channel).await
+        }
+
+        async fn runtime_status(&self) -> sockudo_core::error::Result<HistoryRuntimeStatus> {
+            self.inner.runtime_status().await
+        }
+
+        async fn stream_runtime_state(
+            &self,
+            app_id: &str,
+            channel: &str,
+        ) -> sockudo_core::error::Result<HistoryStreamRuntimeState> {
+            self.inner.stream_runtime_state(app_id, channel).await
+        }
+    }
+
+    #[derive(Clone)]
+    struct MissingCursorHistoryStore {
+        inner: Arc<MemoryHistoryStore>,
+    }
+
+    #[async_trait]
+    impl HistoryStore for MissingCursorHistoryStore {
+        async fn reserve_publish_position(
+            &self,
+            app_id: &str,
+            channel: &str,
+        ) -> sockudo_core::error::Result<HistoryWriteReservation> {
+            self.inner.reserve_publish_position(app_id, channel).await
+        }
+
+        async fn append(&self, record: HistoryAppendRecord) -> sockudo_core::error::Result<()> {
+            self.inner.append(record).await
+        }
+
+        async fn read_page(
+            &self,
+            request: HistoryReadRequest,
+        ) -> sockudo_core::error::Result<HistoryPage> {
+            let mut page = self.inner.read_page(request).await?;
+            if page.has_more {
+                page.next_cursor = None;
+            }
+            Ok(page)
+        }
+
+        async fn stream_inspection(
+            &self,
+            app_id: &str,
+            channel: &str,
+        ) -> sockudo_core::error::Result<HistoryStreamInspection> {
+            self.inner.stream_inspection(app_id, channel).await
         }
 
         async fn runtime_status(&self) -> sockudo_core::error::Result<HistoryRuntimeStatus> {
@@ -1195,6 +1552,217 @@ mod tests {
                 assert_eq!(count, 2);
             }
             other => panic!("expected cold recovery, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cold_recovery_keeps_frozen_bounds_across_multiple_pages() {
+        let store = Arc::new(MemoryHistoryStore::new(MemoryHistoryStoreConfig::default()));
+        let handler = build_handler_with_history_store_and_page_size(true, store, 1);
+        append_history(&handler, "app", "chat", &[2, 3, 4], "stream-1").await;
+        let replay_buffer = handler.replay_buffer().unwrap().clone();
+        let app = test_app("app");
+
+        let outcome = handler
+            .resume_channel(
+                &SocketId::new(),
+                &app,
+                &replay_buffer,
+                "chat",
+                &ResumePosition {
+                    serial: 1,
+                    stream_id: Some("stream-1".to_string()),
+                    last_message_id: None,
+                    legacy_serial_only: false,
+                },
+            )
+            .await;
+
+        match outcome {
+            ResumeOutcome::Recovered { source, count, .. } => {
+                assert_eq!(source, "cold");
+                assert_eq!(count, 3);
+            }
+            other => panic!("expected paginated cold recovery, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hot_position_ahead_falls_back_to_authoritative_durable_history() {
+        let handler = build_handler(true);
+        append_history(&handler, "app", "chat", &[1, 2, 3, 4], "stream-1").await;
+        let replay_buffer = handler.replay_buffer().unwrap().clone();
+        replay_buffer.store(
+            "app",
+            "chat",
+            Some("stream-1"),
+            1,
+            Bytes::from_static(b"hot-1"),
+        );
+        let app = test_app("app");
+
+        let outcome = handler
+            .resume_channel(
+                &SocketId::new(),
+                &app,
+                &replay_buffer,
+                "chat",
+                &ResumePosition {
+                    serial: 2,
+                    stream_id: Some("stream-1".to_string()),
+                    last_message_id: None,
+                    legacy_serial_only: false,
+                },
+            )
+            .await;
+
+        match outcome {
+            ResumeOutcome::Recovered { source, count, .. } => {
+                assert_eq!(source, "cold");
+                assert_eq!(count, 2);
+            }
+            other => panic!("expected durable fallback, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fully_evicted_durable_history_does_not_look_like_a_new_empty_stream() {
+        let store = Arc::new(MemoryHistoryStore::new(MemoryHistoryStoreConfig::default()));
+        let handler = build_handler_with_history_store(true, store.clone());
+        append_history(&handler, "app", "chat", &[1, 2], "stream-1").await;
+        store
+            .purge_stream(
+                "app",
+                "chat",
+                HistoryPurgeRequest {
+                    mode: HistoryPurgeMode::All,
+                    before_serial: None,
+                    before_time_ms: None,
+                    reason: "test retention".to_owned(),
+                    requested_by: None,
+                },
+            )
+            .await
+            .unwrap();
+        let replay_buffer = handler.replay_buffer().unwrap().clone();
+        let app = test_app("app");
+
+        let outcome = handler
+            .resume_channel(
+                &SocketId::new(),
+                &app,
+                &replay_buffer,
+                "chat",
+                &ResumePosition {
+                    serial: 0,
+                    stream_id: Some("stream-1".to_string()),
+                    last_message_id: None,
+                    legacy_serial_only: false,
+                },
+            )
+            .await;
+
+        match outcome {
+            ResumeOutcome::Failed(failure) => {
+                assert_eq!(failure.code, "position_expired");
+                assert_eq!(failure.reason, "durable_history_empty_after_prior_writes");
+            }
+            other => panic!("expected fully-evicted history failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cold_recovery_rejects_non_contiguous_history() {
+        let handler = build_handler(true);
+        append_history(&handler, "app", "chat", &[2, 4], "stream-1").await;
+        let replay_buffer = handler.replay_buffer().unwrap().clone();
+        let app = test_app("app");
+
+        let outcome = handler
+            .resume_channel(
+                &SocketId::new(),
+                &app,
+                &replay_buffer,
+                "chat",
+                &ResumePosition {
+                    serial: 1,
+                    stream_id: Some("stream-1".to_string()),
+                    last_message_id: None,
+                    legacy_serial_only: false,
+                },
+            )
+            .await;
+
+        match outcome {
+            ResumeOutcome::Failed(failure) => {
+                assert_eq!(failure.code, "continuity_unverifiable");
+                assert_eq!(failure.reason, "durable_history_is_not_contiguous");
+            }
+            other => panic!("expected continuity failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn recovery_rejects_position_ahead_of_durable_stream() {
+        let handler = build_handler(true);
+        append_history(&handler, "app", "chat", &[2, 3], "stream-1").await;
+        let replay_buffer = handler.replay_buffer().unwrap().clone();
+        let app = test_app("app");
+
+        let outcome = handler
+            .resume_channel(
+                &SocketId::new(),
+                &app,
+                &replay_buffer,
+                "chat",
+                &ResumePosition {
+                    serial: 4,
+                    stream_id: Some("stream-1".to_string()),
+                    last_message_id: None,
+                    legacy_serial_only: false,
+                },
+            )
+            .await;
+
+        match outcome {
+            ResumeOutcome::Failed(failure) => {
+                assert_eq!(failure.code, "continuity_unverifiable");
+                assert_eq!(failure.reason, "position_ahead_of_durable_stream");
+            }
+            other => panic!("expected ahead-of-stream failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn recovery_rejects_has_more_page_without_cursor() {
+        let inner = Arc::new(MemoryHistoryStore::new(MemoryHistoryStoreConfig::default()));
+        let store = Arc::new(MissingCursorHistoryStore { inner });
+        let handler = build_handler_with_history_store_and_page_size(true, store, 1);
+        append_history(&handler, "app", "chat", &[2, 3], "stream-1").await;
+        let replay_buffer = handler.replay_buffer().unwrap().clone();
+        let app = test_app("app");
+
+        let outcome = handler
+            .resume_channel(
+                &SocketId::new(),
+                &app,
+                &replay_buffer,
+                "chat",
+                &ResumePosition {
+                    serial: 1,
+                    stream_id: Some("stream-1".to_string()),
+                    last_message_id: None,
+                    legacy_serial_only: false,
+                },
+            )
+            .await;
+
+        match outcome {
+            ResumeOutcome::Failed(failure) => {
+                assert_eq!(failure.code, "continuity_unverifiable");
+                assert_eq!(failure.reason, "durable_history_cursor_missing");
+            }
+            other => panic!("expected cursor failure, got {other:?}"),
         }
     }
 

--- a/crates/sockudo-adapter/src/replay_buffer.rs
+++ b/crates/sockudo-adapter/src/replay_buffer.rs
@@ -35,7 +35,16 @@ struct ChannelBuffer {
 pub enum ReplayLookup {
     Recovered(Vec<Bytes>),
     Expired,
-    StreamReset { current_stream_id: Option<String> },
+    StreamReset {
+        current_stream_id: Option<String>,
+    },
+    Ahead {
+        newest_serial: u64,
+    },
+    ContinuityGap {
+        expected_serial: u64,
+        observed_serial: u64,
+    },
 }
 
 /// Per-channel replay buffer for connection recovery.
@@ -241,7 +250,10 @@ impl ReplayBuffer {
     ) -> Option<Vec<Bytes>> {
         match self.get_messages_after_position(app_id, channel, None, last_serial) {
             ReplayLookup::Recovered(messages) => Some(messages),
-            ReplayLookup::Expired | ReplayLookup::StreamReset { .. } => None,
+            ReplayLookup::Expired
+            | ReplayLookup::StreamReset { .. }
+            | ReplayLookup::Ahead { .. }
+            | ReplayLookup::ContinuityGap { .. } => None,
         }
     }
 
@@ -270,38 +282,60 @@ impl ReplayBuffer {
 
         Self::prune_expired_locked(&mut state.messages, self.buffer_ttl, now);
 
+        let newest_serial = entry.next_serial.load(Ordering::Relaxed).saturating_sub(1);
+        if last_serial > newest_serial {
+            return ReplayLookup::Ahead { newest_serial };
+        }
+        if last_serial == newest_serial {
+            return ReplayLookup::Recovered(Vec::new());
+        }
+
         if state.messages.is_empty() {
             if now.duration_since(state.last_touched) >= self.buffer_ttl {
                 return ReplayLookup::Expired;
             }
-            // No buffered messages — client is either up-to-date or buffer was evicted.
-            // If the requested serial matches or exceeds the next serial, they're caught up.
-            let next = entry.next_serial.load(Ordering::Relaxed);
-            return if last_serial >= next.saturating_sub(1) {
-                ReplayLookup::Recovered(Vec::new())
-            } else {
-                ReplayLookup::Expired
-            };
+            return ReplayLookup::Expired;
         }
 
-        let newest_serial = state.messages.back().map(|m| m.serial).unwrap_or(0);
-        if last_serial >= newest_serial {
-            return ReplayLookup::Recovered(Vec::new());
-        }
-
-        // Check if the buffer goes back far enough
-        let oldest_serial = state.messages.front().map(|m| m.serial).unwrap_or(0);
+        let oldest_serial = state
+            .messages
+            .iter()
+            .map(|message| message.serial)
+            .min()
+            .unwrap_or(newest_serial);
         if last_serial.saturating_add(1) < oldest_serial {
             // The client missed messages that were already evicted
             return ReplayLookup::Expired;
         }
 
-        let contiguous = state.messages.make_contiguous();
-        let start_idx = contiguous.partition_point(|message| message.serial <= last_serial);
-        let mut result = Vec::with_capacity(contiguous.len().saturating_sub(start_idx));
-        for message in &contiguous[start_idx..] {
-            let _ = &message.stream_id;
+        // Concurrent publishers can reach this buffer out of reservation order. Sort the bounded
+        // replay window at read time, then fail closed on any duplicate or gap instead of claiming
+        // a contiguous recovery position.
+        let mut candidates = state
+            .messages
+            .iter()
+            .filter(|message| message.serial > last_serial)
+            .collect::<Vec<_>>();
+        candidates.sort_unstable_by_key(|message| message.serial);
+
+        let mut expected_serial = last_serial.saturating_add(1);
+        let mut result = Vec::with_capacity(candidates.len());
+        for message in candidates {
+            if message.stream_id != state.current_stream_id || message.serial != expected_serial {
+                return ReplayLookup::ContinuityGap {
+                    expected_serial,
+                    observed_serial: message.serial,
+                };
+            }
             result.push(message.message_bytes.clone());
+            expected_serial = expected_serial.saturating_add(1);
+        }
+
+        if expected_serial <= newest_serial {
+            return ReplayLookup::ContinuityGap {
+                expected_serial,
+                observed_serial: newest_serial,
+            };
         }
 
         ReplayLookup::Recovered(result)

--- a/crates/sockudo-adapter/tests/adapter/handler/clustered_runtime_rewind_recovery_redis_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/clustered_runtime_rewind_recovery_redis_test.rs
@@ -14,8 +14,8 @@ use sockudo_app::memory_app_manager::MemoryAppManager;
 use sockudo_core::app::{App, AppManager};
 use sockudo_core::history::{
     HistoryAppendRecord, HistoryDurableState, HistoryPage, HistoryReadRequest,
-    HistoryRuntimeStatus, HistoryStore, HistoryStreamRuntimeState, HistoryWriteReservation,
-    MemoryHistoryStore, MemoryHistoryStoreConfig,
+    HistoryRuntimeStatus, HistoryStore, HistoryStreamInspection, HistoryStreamRuntimeState,
+    HistoryWriteReservation, MemoryHistoryStore, MemoryHistoryStoreConfig,
 };
 use sockudo_core::options::{ClusterHealthConfig, ServerOptions};
 use sockudo_core::version_store::{MemoryVersionStore, StoredVersionRecord, VersionStore};
@@ -139,6 +139,14 @@ impl HistoryStore for ClusterHistoryStore {
             reset_required_channels,
             queue_depth: 0,
         })
+    }
+
+    async fn stream_inspection(
+        &self,
+        app_id: &str,
+        channel: &str,
+    ) -> sockudo_core::error::Result<HistoryStreamInspection> {
+        self.inner.stream_inspection(app_id, channel).await
     }
 
     async fn stream_runtime_state(

--- a/crates/sockudo-adapter/tests/adapter/handler/runtime_rewind_recovery_e2e_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/runtime_rewind_recovery_e2e_test.rs
@@ -11,8 +11,8 @@ use sockudo_app::memory_app_manager::MemoryAppManager;
 use sockudo_core::app::{App, AppManager};
 use sockudo_core::history::{
     HistoryAppendRecord, HistoryPage, HistoryReadRequest, HistoryRetentionPolicy,
-    HistoryRuntimeStatus, HistoryStore, HistoryStreamRuntimeState, HistoryWriteReservation,
-    MemoryHistoryStore, MemoryHistoryStoreConfig,
+    HistoryRuntimeStatus, HistoryStore, HistoryStreamInspection, HistoryStreamRuntimeState,
+    HistoryWriteReservation, MemoryHistoryStore, MemoryHistoryStoreConfig,
 };
 use sockudo_core::options::ServerOptions;
 use sockudo_core::version_store::{MemoryVersionStore, StoredVersionRecord, VersionStore};
@@ -101,6 +101,14 @@ impl HistoryStore for GateHistoryStore {
         self.inner.runtime_status().await
     }
 
+    async fn stream_inspection(
+        &self,
+        app_id: &str,
+        channel: &str,
+    ) -> sockudo_core::error::Result<HistoryStreamInspection> {
+        self.inner.stream_inspection(app_id, channel).await
+    }
+
     async fn stream_runtime_state(
         &self,
         app_id: &str,
@@ -141,6 +149,14 @@ impl HistoryStore for RejectingAppendHistoryStore {
 
     async fn runtime_status(&self) -> sockudo_core::error::Result<HistoryRuntimeStatus> {
         self.inner.runtime_status().await
+    }
+
+    async fn stream_inspection(
+        &self,
+        app_id: &str,
+        channel: &str,
+    ) -> sockudo_core::error::Result<HistoryStreamInspection> {
+        self.inner.stream_inspection(app_id, channel).await
     }
 
     async fn stream_runtime_state(

--- a/crates/sockudo-adapter/tests/adapter/replay_buffer_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/replay_buffer_tests.rs
@@ -37,6 +37,67 @@ mod replay_buffer_regression {
     }
 
     #[test]
+    fn out_of_order_arrival_is_replayed_in_serial_order() {
+        let buf = ReplayBuffer::new(100, Duration::from_secs(60));
+
+        buf.store("app1", "ch", Some("stream-1"), 2, Bytes::from("msg2"));
+        buf.store("app1", "ch", Some("stream-1"), 1, Bytes::from("msg1"));
+        buf.store("app1", "ch", Some("stream-1"), 3, Bytes::from("msg3"));
+
+        match buf.get_messages_after_position("app1", "ch", Some("stream-1"), 0) {
+            ReplayLookup::Recovered(messages) => {
+                assert_eq!(
+                    messages,
+                    vec![
+                        Bytes::from("msg1"),
+                        Bytes::from("msg2"),
+                        Bytes::from("msg3")
+                    ]
+                );
+            }
+            other => panic!("expected ordered recovery, got {}", variant_name(&other)),
+        }
+    }
+
+    #[test]
+    fn gap_and_duplicate_serials_fail_closed() {
+        let gap = ReplayBuffer::new(100, Duration::from_secs(60));
+        gap.store("app1", "ch", Some("stream-1"), 1, Bytes::from("msg1"));
+        gap.store("app1", "ch", Some("stream-1"), 3, Bytes::from("msg3"));
+
+        assert!(matches!(
+            gap.get_messages_after_position("app1", "ch", Some("stream-1"), 0),
+            ReplayLookup::ContinuityGap {
+                expected_serial: 2,
+                observed_serial: 3
+            }
+        ));
+
+        let duplicate = ReplayBuffer::new(100, Duration::from_secs(60));
+        duplicate.store("app1", "ch", Some("stream-1"), 1, Bytes::from("msg1"));
+        duplicate.store("app1", "ch", Some("stream-1"), 1, Bytes::from("msg1-again"));
+
+        assert!(matches!(
+            duplicate.get_messages_after_position("app1", "ch", Some("stream-1"), 0),
+            ReplayLookup::ContinuityGap {
+                expected_serial: 2,
+                observed_serial: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn cursor_ahead_of_hot_stream_fails_closed() {
+        let buf = ReplayBuffer::new(100, Duration::from_secs(60));
+        buf.store("app1", "ch", Some("stream-1"), 1, Bytes::from("msg1"));
+
+        assert!(matches!(
+            buf.get_messages_after_position("app1", "ch", Some("stream-1"), 2),
+            ReplayLookup::Ahead { newest_serial: 1 }
+        ));
+    }
+
+    #[test]
     fn test_store_updates_stream_id() {
         let buf = ReplayBuffer::new(100, Duration::from_secs(60));
 
@@ -224,6 +285,8 @@ mod replay_buffer_regression {
             ReplayLookup::Recovered(_) => "Recovered",
             ReplayLookup::Expired => "Expired",
             ReplayLookup::StreamReset { .. } => "StreamReset",
+            ReplayLookup::Ahead { .. } => "Ahead",
+            ReplayLookup::ContinuityGap { .. } => "ContinuityGap",
         }
     }
 }

--- a/crates/sockudo-core/src/presence_history/store.rs
+++ b/crates/sockudo-core/src/presence_history/store.rs
@@ -59,6 +59,13 @@ pub trait PresenceHistoryStore: Send + Sync {
         let mut snapshot_serial = None;
         let mut snapshot_time_ms = None;
         let mut cursor = None;
+        let mut stream_id: Option<String> = None;
+        let mut first_serial: Option<u64> = None;
+        let mut previous_serial: Option<u64> = None;
+        let mut transition_anomaly: Option<&'static str> = None;
+        // A time bound can legitimately select non-adjacent serials when writers' clocks are
+        // skewed. Serial and unbounded snapshots still require exact adjacency.
+        let require_serial_adjacency = request.at_time_ms.is_none();
         let bounds = PresenceHistoryQueryBounds {
             start_serial: None,
             end_serial: request.at_serial,
@@ -78,11 +85,33 @@ pub trait PresenceHistoryStore: Send + Sync {
                 .await?;
 
             for item in &page.items {
+                if stream_id
+                    .as_deref()
+                    .is_some_and(|expected| expected != item.stream_id)
+                {
+                    return Err(Error::InvalidMessageFormat(
+                        "presence history stream changed while reconstructing snapshot".to_string(),
+                    ));
+                }
+                stream_id.get_or_insert_with(|| item.stream_id.clone());
+                first_serial.get_or_insert(item.serial);
+                if previous_serial.is_some_and(|previous| {
+                    item.serial <= previous
+                        || (require_serial_adjacency && previous.saturating_add(1) != item.serial)
+                }) {
+                    return Err(Error::InvalidMessageFormat(
+                        "presence history serial continuity check failed".to_string(),
+                    ));
+                }
+                previous_serial = Some(item.serial);
                 events_replayed = events_replayed.saturating_add(1);
                 snapshot_serial = Some(item.serial);
                 snapshot_time_ms = Some(item.published_at_ms);
                 match item.event {
                     PresenceHistoryEventKind::MemberAdded => {
+                        if members.contains_key(&item.user_id) {
+                            transition_anomaly.get_or_insert("duplicate_member_added");
+                        }
                         members.insert(
                             item.user_id.clone(),
                             PresenceSnapshotMember {
@@ -98,10 +127,14 @@ pub trait PresenceHistoryStore: Send + Sync {
                             member.last_event = item.event;
                             member.last_event_serial = item.serial;
                             member.last_event_at_ms = item.published_at_ms;
+                        } else {
+                            transition_anomaly.get_or_insert("member_updated_without_join");
                         }
                     }
                     PresenceHistoryEventKind::MemberRemoved => {
-                        members.remove(&item.user_id);
+                        if members.remove(&item.user_id).is_none() {
+                            transition_anomaly.get_or_insert("member_removed_without_join");
+                        }
                     }
                 }
             }
@@ -109,8 +142,46 @@ pub trait PresenceHistoryStore: Send + Sync {
             if !page.has_more {
                 break (page.retained, page.complete, page.truncated_by_retention);
             }
-            cursor = page.next_cursor;
+            let next_cursor = page.next_cursor.ok_or_else(|| {
+                Error::InvalidMessageFormat(
+                    "presence history page has_more without a cursor".to_string(),
+                )
+            })?;
+            if page.items.is_empty()
+                || next_cursor.version != 1
+                || next_cursor.app_id != request.app_id
+                || next_cursor.channel != request.channel
+                || Some(next_cursor.serial) != previous_serial
+                || next_cursor.direction != PresenceHistoryDirection::OldestFirst
+                || next_cursor.bounds != bounds
+                || stream_id.as_deref() != Some(next_cursor.stream_id.as_str())
+            {
+                return Err(Error::InvalidMessageFormat(
+                    "presence history cursor did not advance".to_string(),
+                ));
+            }
+            cursor = Some(next_cursor);
         };
+
+        if complete
+            && !truncated_by_retention
+            && require_serial_adjacency
+            && first_serial.is_some_and(|serial| serial != 1)
+        {
+            return Err(Error::InvalidMessageFormat(
+                "presence history complete snapshot is missing its serial prefix".to_string(),
+            ));
+        }
+
+        if complete
+            && !truncated_by_retention
+            && request.at_time_ms.is_none()
+            && let Some(anomaly) = transition_anomaly
+        {
+            return Err(Error::InvalidMessageFormat(format!(
+                "presence history transition anomaly: {anomaly}"
+            )));
+        }
 
         Ok(PresenceSnapshot {
             channel: request.channel,
@@ -176,8 +247,49 @@ impl PresenceHistoryStore for NoopPresenceHistoryStore {
 mod tests {
     use super::*;
     use crate::history::now_ms;
-    use crate::presence_history::MemoryPresenceHistoryStore;
     use crate::presence_history::test_support::transition;
+    use crate::presence_history::{
+        MemoryPresenceHistoryStore, PresenceHistoryEventCause, PresenceHistoryItem,
+    };
+    use async_trait::async_trait;
+    use bytes::Bytes;
+
+    struct StaticPresenceHistoryStore {
+        page: PresenceHistoryPage,
+    }
+
+    #[async_trait]
+    impl PresenceHistoryStore for StaticPresenceHistoryStore {
+        async fn record_transition(&self, _record: PresenceHistoryTransitionRecord) -> Result<()> {
+            Ok(())
+        }
+
+        async fn read_page(
+            &self,
+            _request: PresenceHistoryReadRequest,
+        ) -> Result<PresenceHistoryPage> {
+            Ok(self.page.clone())
+        }
+    }
+
+    fn history_item(
+        serial: u64,
+        event: PresenceHistoryEventKind,
+        user_id: &str,
+    ) -> PresenceHistoryItem {
+        PresenceHistoryItem {
+            stream_id: "stream-1".to_string(),
+            serial,
+            published_at_ms: serial as i64,
+            event,
+            cause: PresenceHistoryEventCause::Join,
+            user_id: user_id.to_string(),
+            connection_id: None,
+            dead_node_id: None,
+            payload_size_bytes: 0,
+            payload_bytes: Bytes::new(),
+        }
+    }
 
     #[tokio::test]
     async fn snapshot_at_reconstructs_membership_from_events() {
@@ -257,5 +369,185 @@ mod tests {
 
         assert_eq!(snapshot_at_time.members.len(), 2);
         assert_eq!(snapshot_at_time.events_replayed, 2);
+    }
+
+    #[tokio::test]
+    async fn snapshot_rejects_impossible_complete_presence_transition_sequence() {
+        let store = StaticPresenceHistoryStore {
+            page: PresenceHistoryPage {
+                items: vec![
+                    history_item(1, PresenceHistoryEventKind::MemberAdded, "u1"),
+                    history_item(2, PresenceHistoryEventKind::MemberAdded, "u1"),
+                ],
+                next_cursor: None,
+                retained: PresenceHistoryRetentionStats {
+                    stream_id: Some("stream-1".to_string()),
+                    retained_events: 2,
+                    oldest_serial: Some(1),
+                    newest_serial: Some(2),
+                    ..Default::default()
+                },
+                has_more: false,
+                complete: true,
+                truncated_by_retention: false,
+                degraded: false,
+            },
+        };
+
+        let error = store
+            .snapshot_at(PresenceSnapshotRequest {
+                app_id: "app".to_string(),
+                channel: "presence-room".to_string(),
+                at_time_ms: None,
+                at_serial: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("duplicate_member_added"));
+    }
+
+    #[tokio::test]
+    async fn snapshot_allows_missing_prefix_when_retention_truncated_history() {
+        let store = StaticPresenceHistoryStore {
+            page: PresenceHistoryPage {
+                items: vec![history_item(
+                    7,
+                    PresenceHistoryEventKind::MemberRemoved,
+                    "u1",
+                )],
+                next_cursor: None,
+                retained: PresenceHistoryRetentionStats {
+                    stream_id: Some("stream-1".to_string()),
+                    retained_events: 1,
+                    oldest_serial: Some(7),
+                    newest_serial: Some(7),
+                    ..Default::default()
+                },
+                has_more: false,
+                complete: false,
+                truncated_by_retention: true,
+                degraded: false,
+            },
+        };
+
+        let snapshot = store
+            .snapshot_at(PresenceSnapshotRequest {
+                app_id: "app".to_string(),
+                channel: "presence-room".to_string(),
+                at_time_ms: None,
+                at_serial: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(snapshot.members.is_empty());
+        assert!(snapshot.truncated_by_retention);
+    }
+
+    #[tokio::test]
+    async fn snapshot_rejects_internal_presence_serial_gap() {
+        let store = StaticPresenceHistoryStore {
+            page: PresenceHistoryPage {
+                items: vec![
+                    history_item(1, PresenceHistoryEventKind::MemberAdded, "u1"),
+                    history_item(3, PresenceHistoryEventKind::MemberRemoved, "u1"),
+                ],
+                next_cursor: None,
+                retained: PresenceHistoryRetentionStats {
+                    stream_id: Some("stream-1".to_string()),
+                    retained_events: 2,
+                    oldest_serial: Some(1),
+                    newest_serial: Some(3),
+                    ..Default::default()
+                },
+                has_more: false,
+                complete: true,
+                truncated_by_retention: false,
+                degraded: false,
+            },
+        };
+
+        let error = store
+            .snapshot_at(PresenceSnapshotRequest {
+                app_id: "app".to_string(),
+                channel: "presence-room".to_string(),
+                at_time_ms: None,
+                at_serial: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("serial continuity"));
+    }
+
+    #[tokio::test]
+    async fn complete_snapshot_rejects_a_missing_serial_prefix() {
+        let store = StaticPresenceHistoryStore {
+            page: PresenceHistoryPage {
+                items: vec![history_item(3, PresenceHistoryEventKind::MemberAdded, "u1")],
+                next_cursor: None,
+                retained: PresenceHistoryRetentionStats {
+                    stream_id: Some("stream-1".to_string()),
+                    retained_events: 1,
+                    oldest_serial: Some(3),
+                    newest_serial: Some(3),
+                    ..Default::default()
+                },
+                has_more: false,
+                complete: true,
+                truncated_by_retention: false,
+                degraded: false,
+            },
+        };
+
+        let error = store
+            .snapshot_at(PresenceSnapshotRequest {
+                app_id: "app".to_string(),
+                channel: "presence-room".to_string(),
+                at_time_ms: None,
+                at_serial: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("missing its serial prefix"));
+    }
+
+    #[tokio::test]
+    async fn time_bounded_snapshot_allows_clock_skew_serial_gaps_and_missing_prefixes() {
+        let store = StaticPresenceHistoryStore {
+            page: PresenceHistoryPage {
+                items: vec![
+                    history_item(1, PresenceHistoryEventKind::MemberAdded, "u2"),
+                    history_item(3, PresenceHistoryEventKind::MemberRemoved, "u1"),
+                ],
+                next_cursor: None,
+                retained: PresenceHistoryRetentionStats {
+                    stream_id: Some("stream-1".to_string()),
+                    retained_events: 3,
+                    oldest_serial: Some(1),
+                    newest_serial: Some(3),
+                    ..Default::default()
+                },
+                has_more: false,
+                complete: true,
+                truncated_by_retention: false,
+                degraded: false,
+            },
+        };
+
+        let snapshot = store
+            .snapshot_at(PresenceSnapshotRequest {
+                app_id: "app".to_string(),
+                channel: "presence-room".to_string(),
+                at_time_ms: Some(250),
+                at_serial: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(snapshot.members.len(), 1);
+        assert_eq!(snapshot.members[0].user_id, "u2");
     }
 }

--- a/crates/sockudo-core/src/websocket/buffer.rs
+++ b/crates/sockudo-core/src/websocket/buffer.rs
@@ -163,9 +163,118 @@ pub struct BufferedRewindMessage {
     pub message: PusherMessage,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RewindGateLimit {
+    Messages,
+    Bytes,
+}
+
+impl RewindGateLimit {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Messages => "messages",
+            Self::Bytes => "bytes",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RewindGateOverflow {
+    pub(super) limit_kind: RewindGateLimit,
+    pub(super) limit: usize,
+    pub(super) buffered_messages: usize,
+    pub(super) buffered_bytes: usize,
+    pub(super) incoming_message_bytes: usize,
+}
+
+#[derive(Debug)]
 pub struct RewindGate {
-    pub buffered: Vec<BufferedRewindMessage>,
+    buffered: Vec<BufferedRewindMessage>,
+    buffered_bytes: usize,
+    max_messages: usize,
+    max_bytes: Option<usize>,
+    overflowed: bool,
+}
+
+impl Default for RewindGate {
+    fn default() -> Self {
+        Self::new(WebSocketBufferConfig::default())
+    }
+}
+
+impl RewindGate {
+    pub(super) fn new(config: WebSocketBufferConfig) -> Self {
+        Self {
+            buffered: Vec::new(),
+            buffered_bytes: 0,
+            max_messages: config.channel_capacity(),
+            max_bytes: config.limit.byte_limit(),
+            overflowed: false,
+        }
+    }
+
+    pub(super) fn try_buffer(
+        &mut self,
+        message: BufferedRewindMessage,
+        message_bytes: usize,
+    ) -> Result<(), RewindGateOverflow> {
+        debug_assert!(!self.overflowed, "invalid rewind gate accepted new work");
+
+        if self.buffered.len() >= self.max_messages {
+            return Err(self.invalidate(RewindGateOverflow {
+                limit_kind: RewindGateLimit::Messages,
+                limit: self.max_messages,
+                buffered_messages: self.buffered.len(),
+                buffered_bytes: self.buffered_bytes,
+                incoming_message_bytes: message_bytes,
+            }));
+        }
+
+        let Some(next_buffered_bytes) = self.buffered_bytes.checked_add(message_bytes) else {
+            return Err(self.invalidate(RewindGateOverflow {
+                limit_kind: RewindGateLimit::Bytes,
+                limit: self.max_bytes.unwrap_or(usize::MAX),
+                buffered_messages: self.buffered.len(),
+                buffered_bytes: self.buffered_bytes,
+                incoming_message_bytes: message_bytes,
+            }));
+        };
+        if let Some(max_bytes) = self.max_bytes
+            && next_buffered_bytes > max_bytes
+        {
+            return Err(self.invalidate(RewindGateOverflow {
+                limit_kind: RewindGateLimit::Bytes,
+                limit: max_bytes,
+                buffered_messages: self.buffered.len(),
+                buffered_bytes: self.buffered_bytes,
+                incoming_message_bytes: message_bytes,
+            }));
+        }
+
+        self.buffered.push(message);
+        self.buffered_bytes = next_buffered_bytes;
+        Ok(())
+    }
+
+    pub(super) fn drain(&mut self) -> Vec<BufferedRewindMessage> {
+        self.buffered_bytes = 0;
+        std::mem::take(&mut self.buffered)
+    }
+
+    pub(super) fn is_overflowed(&self) -> bool {
+        self.overflowed
+    }
+
+    pub(super) fn fail_closed(&mut self) {
+        self.buffered.clear();
+        self.buffered_bytes = 0;
+        self.overflowed = true;
+    }
+
+    fn invalidate(&mut self, overflow: RewindGateOverflow) -> RewindGateOverflow {
+        self.fail_closed();
+        overflow
+    }
 }
 
 pub(super) type MessageChannelFlavor = mpsc::Array<Message>;

--- a/crates/sockudo-core/src/websocket/reference.rs
+++ b/crates/sockudo-core/src/websocket/reference.rs
@@ -352,7 +352,7 @@ impl WebSocketRef {
         self.channel_state
             .entry(Arc::<str>::from(channel))
             .or_default()
-            .rewind_gate = Some(Arc::new(Mutex::new(RewindGate::default())));
+            .rewind_gate = Some(Arc::new(Mutex::new(RewindGate::new(self.buffer_config))));
     }
 
     pub async fn buffer_rewind_message(&self, channel: &str, message: &PusherMessage) -> bool {
@@ -365,11 +365,47 @@ impl WebSocketRef {
         };
 
         let mut gate = gate.lock().await;
-        gate.buffered.push(BufferedRewindMessage {
+        if gate.is_overflowed() {
+            return true;
+        }
+
+        let message_bytes = match sockudo_protocol::wire::serialize_message(
+            message,
+            self.wire_format,
+        ) {
+            Ok(payload) => payload.len(),
+            Err(_) => {
+                warn!(
+                    socket_id = %self.socket_id,
+                    channel,
+                    reason = "serialization_failed",
+                    "Rewind gate rejected a live message; shutting down connection to preserve continuity"
+                );
+                gate.fail_closed();
+                drop(gate);
+                self.shutdown();
+                return true;
+            }
+        };
+        let buffered = BufferedRewindMessage {
             serial: message.serial,
             message_id: message.message_id.clone(),
             message: message.clone(),
-        });
+        };
+        if let Err(overflow) = gate.try_buffer(buffered, message_bytes) {
+            warn!(
+                socket_id = %self.socket_id,
+                channel,
+                limit_kind = overflow.limit_kind.as_str(),
+                limit = overflow.limit,
+                buffered_messages = overflow.buffered_messages,
+                buffered_bytes = overflow.buffered_bytes,
+                incoming_message_bytes = overflow.incoming_message_bytes,
+                "Rewind gate overflow; shutting down connection to preserve continuity"
+            );
+            drop(gate);
+            self.shutdown();
+        }
         true
     }
 
@@ -382,7 +418,7 @@ impl WebSocketRef {
             return Vec::new();
         };
         let mut gate = gate.lock().await;
-        std::mem::take(&mut gate.buffered)
+        gate.drain()
     }
 
     fn upsert_channel_state(

--- a/crates/sockudo-core/src/websocket/tests/mod.rs
+++ b/crates/sockudo-core/src/websocket/tests/mod.rs
@@ -217,12 +217,12 @@ fn test_rewind_gate_buffers_and_drains_messages() {
             delta_conflation_key: None,
         },
     };
-    gate.buffered.push(message.clone());
-    let drained = std::mem::take(&mut gate.buffered);
+    gate.try_buffer(message.clone(), 128).unwrap();
+    let drained = gate.drain();
     assert_eq!(drained.len(), 1);
     assert_eq!(drained[0].serial, Some(1));
     assert_eq!(drained[0].message_id.as_deref(), Some("msg-1"));
-    assert!(gate.buffered.is_empty());
+    assert!(gate.drain().is_empty());
 }
 
 #[test]
@@ -292,9 +292,19 @@ async fn create_server_writer_with_client() -> (WebSocketWriter, ClientWs) {
 }
 
 async fn create_websocket_ref() -> WebSocketRef {
+    create_websocket_ref_with_buffer_config(WebSocketBufferConfig::default()).await
+}
+
+async fn create_websocket_ref_with_buffer_config(
+    buffer_config: WebSocketBufferConfig,
+) -> WebSocketRef {
     let socket_id = SocketId::new();
     let (writer, _client) = create_server_writer_with_client().await;
-    WebSocketRef::new(WebSocket::new(socket_id, writer))
+    WebSocketRef::new(WebSocket::with_buffer_config(
+        socket_id,
+        writer,
+        buffer_config,
+    ))
 }
 
 fn create_test_pong_message(channel: &str, serial: u64, message_id: &str) -> PusherMessage {
@@ -502,7 +512,10 @@ async fn unsubscribe_removes_all_per_channel_state() {
 
 #[tokio::test]
 async fn finish_rewind_gate_drains_buffered_messages() {
-    let ws_ref = create_websocket_ref().await;
+    let ws_ref = create_websocket_ref_with_buffer_config(WebSocketBufferConfig::with_both_limits(
+        2, 1024, true,
+    ))
+    .await;
 
     ws_ref.start_rewind_gate("presence-room".to_string());
     assert!(
@@ -526,6 +539,7 @@ async fn finish_rewind_gate_drains_buffered_messages() {
     assert_eq!(drained.len(), 2);
     assert_eq!(drained[0].message_id.as_deref(), Some("msg-1"));
     assert_eq!(drained[1].message_id.as_deref(), Some("msg-2"));
+    assert!(!ws_ref.cancellation_token().is_cancelled());
     assert!(ws_ref.finish_rewind_gate("presence-room").await.is_empty());
     assert!(
         !ws_ref
@@ -535,6 +549,66 @@ async fn finish_rewind_gate_drains_buffered_messages() {
             )
             .await
     );
+}
+
+#[tokio::test]
+async fn rewind_gate_message_overflow_shuts_down_connection() {
+    let ws_ref = create_websocket_ref_with_buffer_config(
+        WebSocketBufferConfig::with_message_limit(2, false),
+    )
+    .await;
+    ws_ref.start_rewind_gate("presence-room".to_string());
+
+    for serial in 1..=2 {
+        assert!(
+            ws_ref
+                .buffer_rewind_message(
+                    "presence-room",
+                    &create_test_pong_message("presence-room", serial, &format!("msg-{serial}"),),
+                )
+                .await
+        );
+    }
+    assert!(!ws_ref.cancellation_token().is_cancelled());
+
+    assert!(
+        ws_ref
+            .buffer_rewind_message(
+                "presence-room",
+                &create_test_pong_message("presence-room", 3, "msg-3"),
+            )
+            .await
+    );
+    assert!(ws_ref.cancellation_token().is_cancelled());
+    assert!(ws_ref.finish_rewind_gate("presence-room").await.is_empty());
+}
+
+#[tokio::test]
+async fn rewind_gate_byte_overflow_shuts_down_connection() {
+    let first = create_test_pong_message("presence-room", 1, "msg-1");
+    let first_size =
+        sockudo_protocol::wire::serialize_message(&first, sockudo_protocol::WireFormat::Json)
+            .unwrap()
+            .len();
+    let ws_ref = create_websocket_ref_with_buffer_config(WebSocketBufferConfig::with_byte_limit(
+        first_size, false,
+    ))
+    .await;
+    ws_ref.start_rewind_gate("presence-room".to_string());
+
+    assert!(ws_ref.buffer_rewind_message("presence-room", &first).await);
+    assert!(!ws_ref.cancellation_token().is_cancelled());
+
+    assert!(
+        ws_ref
+            .buffer_rewind_message(
+                "presence-room",
+                &create_test_pong_message("presence-room", 2, "msg-2"),
+            )
+            .await
+    );
+    assert!(ws_ref.cancellation_token().is_cancelled());
+    assert!(ws_ref.finish_rewind_gate("presence-room").await.is_empty());
 }
 
 #[tokio::test]

--- a/crates/sockudo-push/src/cleanup.rs
+++ b/crates/sockudo-push/src/cleanup.rs
@@ -200,16 +200,7 @@ impl PushCleanupWorker {
 }
 
 pub fn terminal_publish_state(state: PublishLifecycleState) -> bool {
-    matches!(
-        state,
-        PublishLifecycleState::Succeeded
-            | PublishLifecycleState::PartiallySucceeded
-            | PublishLifecycleState::Failed
-            | PublishLifecycleState::Expired
-            | PublishLifecycleState::Cancelled
-            | PublishLifecycleState::QuotaExceeded
-            | PublishLifecycleState::DeadLettered
-    )
+    state.is_terminal()
 }
 
 pub fn days_to_ms(days: u64) -> u64 {

--- a/crates/sockudo-push/src/conformance.rs
+++ b/crates/sockudo-push/src/conformance.rs
@@ -88,6 +88,40 @@ impl PushStoreConformance {
                 .await
                 .is_err()
         );
+
+        // Regression: `list_subscriptions` paginates by the `"{channel}:{device_id}"` cursor
+        // string. When one channel name is a prefix of another, tuple order (`chan-1` < `chan-11`)
+        // and cursor-string order (`"chan-1:.." > "chan-11:.."`, since `:` outranks digits)
+        // disagree. A store that emits rows in tuple order but resumes by string comparison silently
+        // drops the second subscription once `limit` forces a page break. Walk every page at
+        // `limit = 1` and require the full set back.
+        let probe = sample_device("prefix-probe", 90_000_000);
+        store.upsert_device(probe.clone()).await?;
+        for channel in ["chan-1", "chan-11"] {
+            store
+                .upsert_subscription(ChannelSubscription::from_device(channel, &probe))
+                .await?;
+        }
+        let mut probe_channels = std::collections::BTreeSet::new();
+        let mut cursor = None;
+        loop {
+            let page = store.list_subscriptions("app-1", 1, cursor).await?;
+            assert!(page.items.len() <= 1, "page exceeded the requested limit");
+            for subscription in page.items {
+                if subscription.device_id == "prefix-probe" {
+                    probe_channels.insert(subscription.channel);
+                }
+            }
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+        assert_eq!(
+            probe_channels,
+            std::collections::BTreeSet::from(["chan-1".to_owned(), "chan-11".to_owned()]),
+            "paginated list_subscriptions dropped a prefix-colliding channel"
+        );
         Ok(())
     }
 

--- a/crates/sockudo-push/src/conformance.rs
+++ b/crates/sockudo-push/src/conformance.rs
@@ -10,10 +10,11 @@ use crate::domain::{
     PublishStatus, PushCursor, PushProviderKind, PushRecipient, SecretString, TemplateContent,
 };
 use crate::storage::{
-    DeviceRegistrationChange, IdempotencyRecord, PushCredentialStore, PushDeliveryEventStore,
-    PushDeviceStore, PushIdempotencyStore, PushPublishLogStore, PushPublishStatusStore,
-    PushScheduleStore, PushStorageBackendKind, PushStorageError, PushStorageResult,
-    PushSubscriptionStore, PushTemplateStore, ScheduledPushJob,
+    DeviceRegistrationChange, IdempotencyRecord, PublishStatusCasOutcome, PushCredentialStore,
+    PushDeliveryEventStore, PushDeviceStore, PushIdempotencyStore, PushPublishLogStore,
+    PushPublishStatusStore, PushScheduleStore, PushStorageBackendKind, PushStorageError,
+    PushStorageResult, PushSubscriptionStore, PushTemplateStore, ScheduledPushJob,
+    VersionedPublishStatus,
 };
 
 pub struct PushStoreConformance;
@@ -185,10 +186,59 @@ impl PushStoreConformance {
             retry_after_ms: None,
             error_reason: None,
         };
-        store.put_publish_status(status.clone()).await?;
+        assert_eq!(
+            store
+                .create_publish_status_if_absent(status.clone())
+                .await?,
+            PublishStatusCasOutcome::Inserted { revision: 1 }
+        );
+        let mut conflicting_create = status.clone();
+        conflicting_create.state = PublishLifecycleState::Failed;
+        assert_eq!(
+            store
+                .create_publish_status_if_absent(conflicting_create)
+                .await?,
+            PublishStatusCasOutcome::Conflict
+        );
+        let initial = store
+            .get_versioned_publish_status("app-1", "publish-1")
+            .await?
+            .expect("inserted status must be readable");
+        assert_eq!(initial.revision, 1);
+        assert_eq!(initial.status, status);
+
+        let mut planning = status.clone();
+        planning.state = PublishLifecycleState::Planning;
+        assert_eq!(
+            store
+                .compare_and_swap_publish_status(&initial, planning.clone())
+                .await?,
+            PublishStatusCasOutcome::Updated { revision: 2 }
+        );
+        assert_eq!(
+            store
+                .compare_and_swap_publish_status(&initial, status.clone())
+                .await?,
+            PublishStatusCasOutcome::Conflict
+        );
         assert_eq!(
             store.get_publish_status("app-1", "publish-1").await?,
-            Some(status)
+            Some(planning)
+        );
+
+        let missing = VersionedPublishStatus {
+            status: PublishStatus {
+                publish_id: "missing".to_owned(),
+                ..status.clone()
+            },
+            revision: 1,
+            updated_at_ms: 0,
+        };
+        assert_eq!(
+            store
+                .compare_and_swap_publish_status(&missing, missing.status.clone())
+                .await?,
+            PublishStatusCasOutcome::Missing
         );
 
         let event = crate::domain::PublishLogEvent {

--- a/crates/sockudo-push/src/domain.rs
+++ b/crates/sockudo-push/src/domain.rs
@@ -957,6 +957,54 @@ pub enum PublishLifecycleState {
     PartiallySucceeded,
 }
 
+impl PublishLifecycleState {
+    /// Returns whether this state is an absorbing publish outcome.
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Cancelled
+                | Self::Expired
+                | Self::Failed
+                | Self::DeadLettered
+                | Self::Succeeded
+                | Self::PartiallySucceeded
+                | Self::QuotaExceeded
+        )
+    }
+
+    /// Returns whether moving from this state to `next` preserves lifecycle monotonicity.
+    ///
+    /// Repeating a state is idempotent, terminal states are absorbing, and active states may
+    /// advance but never return to an earlier planning phase.
+    pub fn can_transition_to(self, next: Self) -> bool {
+        if self == next {
+            return true;
+        }
+        if self.is_terminal() {
+            return false;
+        }
+
+        match next {
+            Self::Queued => false,
+            Self::Planning => matches!(self, Self::Queued),
+            Self::Throttled | Self::Dispatching => {
+                matches!(
+                    self,
+                    Self::Queued | Self::Planning | Self::Throttled | Self::Dispatching
+                )
+            }
+            state if state.is_terminal() => true,
+            Self::Cancelled
+            | Self::Expired
+            | Self::Failed
+            | Self::DeadLettered
+            | Self::Succeeded
+            | Self::PartiallySucceeded
+            | Self::QuotaExceeded => true,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum FanoutRegime {
@@ -1032,6 +1080,37 @@ pub struct PublishCounters {
     pub retry_attempted: u64,
     #[serde(default)]
     pub dead_lettered: u64,
+}
+
+impl PublishCounters {
+    /// Count delivery outcomes that permanently consume a planned recipient slot.
+    pub fn terminal_outcomes(&self) -> u128 {
+        u128::from(self.succeeded)
+            + u128::from(self.failed)
+            + u128::from(self.expired)
+            + u128::from(self.dead_lettered)
+    }
+
+    /// Derive the lifecycle state implied by terminal delivery counters.
+    pub fn resolve_lifecycle_state(&self, current: PublishLifecycleState) -> PublishLifecycleState {
+        // `planned` is an acceptance-time audience estimate for mutable channel/client targets.
+        // Zero therefore means "not yet known", not necessarily an empty publish.
+        if self.planned == 0 || self.terminal_outcomes() < u128::from(self.planned) {
+            return current;
+        }
+
+        if self.failed == 0 && self.expired == 0 && self.dead_lettered == 0 {
+            PublishLifecycleState::Succeeded
+        } else if self.succeeded > 0 {
+            PublishLifecycleState::PartiallySucceeded
+        } else if self.expired > 0 {
+            PublishLifecycleState::Expired
+        } else if self.dead_lettered > 0 {
+            PublishLifecycleState::DeadLettered
+        } else {
+            PublishLifecycleState::Failed
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1873,6 +1952,57 @@ mod tests {
 
     fn secret(value: &str) -> SecretString {
         SecretString::new(value).unwrap()
+    }
+
+    #[test]
+    fn publish_lifecycle_transitions_are_monotonic_and_terminal_states_are_absorbing() {
+        assert!(PublishLifecycleState::Queued.can_transition_to(PublishLifecycleState::Planning));
+        assert!(
+            PublishLifecycleState::Planning.can_transition_to(PublishLifecycleState::Dispatching)
+        );
+        assert!(
+            PublishLifecycleState::Dispatching.can_transition_to(PublishLifecycleState::Succeeded)
+        );
+        assert!(
+            !PublishLifecycleState::Dispatching.can_transition_to(PublishLifecycleState::Planning)
+        );
+
+        for terminal in [
+            PublishLifecycleState::Cancelled,
+            PublishLifecycleState::Expired,
+            PublishLifecycleState::Failed,
+            PublishLifecycleState::DeadLettered,
+            PublishLifecycleState::Succeeded,
+            PublishLifecycleState::PartiallySucceeded,
+            PublishLifecycleState::QuotaExceeded,
+        ] {
+            assert!(terminal.is_terminal());
+            assert!(terminal.can_transition_to(terminal));
+            assert!(!terminal.can_transition_to(PublishLifecycleState::Dispatching));
+        }
+    }
+
+    #[test]
+    fn zero_planned_publish_keeps_its_current_state() {
+        let counters = PublishCounters::default();
+        assert_eq!(
+            counters.resolve_lifecycle_state(PublishLifecycleState::Dispatching),
+            PublishLifecycleState::Dispatching
+        );
+    }
+
+    #[test]
+    fn terminal_outcome_count_does_not_overflow_u64() {
+        let counters = PublishCounters {
+            planned: u64::MAX,
+            succeeded: u64::MAX,
+            failed: u64::MAX,
+            expired: u64::MAX,
+            dead_lettered: u64::MAX,
+            ..PublishCounters::default()
+        };
+
+        assert_eq!(counters.terminal_outcomes(), u128::from(u64::MAX) * 4);
     }
 
     fn encrypted(value: &str) -> EncryptedSecret {

--- a/crates/sockudo-push/src/feedback.rs
+++ b/crates/sockudo-push/src/feedback.rs
@@ -6,7 +6,9 @@ use crate::domain::{
 };
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::{PushMetrics, provider_label};
-use crate::pipeline::{PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage, now_ms};
+use crate::pipeline::{
+    PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage, lock_publish_status, now_ms,
+};
 use crate::retry::RetryPolicy;
 use crate::storage::{DynPushStore, IdempotencyRecord};
 
@@ -250,13 +252,15 @@ impl PushFeedbackProcessor {
         &self,
         result: &DeliveryResult,
     ) -> PushPipelineResult<Option<PublishStatus>> {
-        let Some(mut status) = self
+        let _status_guard = lock_publish_status(&result.app_id, &result.publish_id).await;
+        let Some(current) = self
             .store
             .get_publish_status(&result.app_id, &result.publish_id)
             .await?
         else {
             return Ok(None);
         };
+        let mut status = current.clone();
 
         match result.outcome {
             DeliveryOutcome::Accepted => {
@@ -276,14 +280,10 @@ impl PushFeedbackProcessor {
         if let Some(retry_after_ms) = result.error.as_ref().and_then(|error| error.retry_after_ms) {
             status.retry_after_ms = Some(retry_after_ms);
         }
-        status.state = terminal_state(
-            status.counters.succeeded,
-            status.counters.failed,
-            status.counters.expired,
-            status.counters.dead_lettered,
-            status.counters.planned,
-            status.state,
-        );
+        let next = status.counters.resolve_lifecycle_state(current.state);
+        // Audience counts for channel/client targets are estimates until fanout. A late valid
+        // outcome may refine one terminal delivery summary into another, but never reactivates it.
+        status.state = next;
         self.metrics
             .delivery_status(&result.app_id, outcome_label(result.outcome));
         if matches!(
@@ -422,6 +422,7 @@ impl PushFeedbackProcessor {
         result: &DeliveryResult,
         next_attempt_at_ms: u64,
     ) -> PushPipelineResult<()> {
+        let _status_guard = lock_publish_status(&result.app_id, &result.publish_id).await;
         if let Some(mut status) = self
             .store
             .get_publish_status(&result.app_id, &result.publish_id)
@@ -435,21 +436,17 @@ impl PushFeedbackProcessor {
     }
 
     async fn mark_retry_context_missing(&self, result: &DeliveryResult) -> PushPipelineResult<()> {
-        if let Some(mut status) = self
+        let _status_guard = lock_publish_status(&result.app_id, &result.publish_id).await;
+        if let Some(current) = self
             .store
             .get_publish_status(&result.app_id, &result.publish_id)
             .await?
         {
+            let mut status = current.clone();
             status.counters.dead_lettered = status.counters.dead_lettered.saturating_add(1);
             status.error_reason = Some("retryable result missing retry context".to_owned());
-            status.state = terminal_state(
-                status.counters.succeeded,
-                status.counters.failed,
-                status.counters.expired,
-                status.counters.dead_lettered,
-                status.counters.planned,
-                status.state,
-            );
+            let next = status.counters.resolve_lifecycle_state(current.state);
+            status.state = next;
             self.store.put_publish_status(status).await?;
         }
         Ok(())
@@ -492,32 +489,6 @@ fn lifecycle_label(state: PublishLifecycleState) -> &'static str {
         PublishLifecycleState::DeadLettered => "dead_lettered",
         PublishLifecycleState::Succeeded => "succeeded",
         PublishLifecycleState::PartiallySucceeded => "partially_succeeded",
-    }
-}
-
-fn terminal_state(
-    succeeded: u64,
-    failed: u64,
-    expired: u64,
-    dead_lettered: u64,
-    planned: u64,
-    current: PublishLifecycleState,
-) -> PublishLifecycleState {
-    let terminal = succeeded.saturating_add(failed).saturating_add(expired);
-    let terminal = terminal.saturating_add(dead_lettered);
-    if planned == 0 || terminal < planned {
-        return current;
-    }
-    if failed == 0 && expired == 0 && dead_lettered == 0 {
-        PublishLifecycleState::Succeeded
-    } else if succeeded > 0 {
-        PublishLifecycleState::PartiallySucceeded
-    } else if expired > 0 {
-        PublishLifecycleState::Expired
-    } else if dead_lettered > 0 {
-        PublishLifecycleState::DeadLettered
-    } else {
-        PublishLifecycleState::Failed
     }
 }
 
@@ -682,6 +653,77 @@ mod tests {
         assert_eq!(status.counters.dispatched, 1);
         assert_eq!(status.counters.succeeded, 1);
         assert_eq!(status.state, PublishLifecycleState::Succeeded);
+    }
+
+    #[tokio::test]
+    async fn feedback_can_refine_a_terminal_summary_without_reactivating_it() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        let mut terminal = status_with_planned("publish-1", 2);
+        terminal.state = PublishLifecycleState::Succeeded;
+        terminal.counters.dispatched = 1;
+        terminal.counters.succeeded = 1;
+        store.put_publish_status(terminal).await.unwrap();
+        let processor = PushFeedbackProcessor::new(store.clone(), queue);
+
+        let observed = processor
+            .update_publish_status(&rejected_result(
+                "publish-1",
+                "device-2",
+                "rejected",
+                ProviderFailureClass::CallerPayload,
+            ))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(observed.state, PublishLifecycleState::PartiallySucceeded);
+        assert_eq!(observed.counters.failed, 1);
+        let persisted = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted, observed);
+    }
+
+    #[tokio::test]
+    async fn concurrent_feedback_updates_do_not_lose_publish_counters() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store
+            .put_publish_status(status_with_planned("publish-1", 2))
+            .await
+            .unwrap();
+        let processor = PushFeedbackProcessor::new(store.clone(), queue);
+        let first = rejected_result(
+            "publish-1",
+            "device-1",
+            "rejected-1",
+            ProviderFailureClass::CallerPayload,
+        );
+        let second = rejected_result(
+            "publish-1",
+            "device-2",
+            "rejected-2",
+            ProviderFailureClass::CallerPayload,
+        );
+
+        let (first_result, second_result) = tokio::join!(
+            processor.update_publish_status(&first),
+            processor.update_publish_status(&second)
+        );
+        first_result.unwrap();
+        second_result.unwrap();
+
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.counters.dispatched, 2);
+        assert_eq!(status.counters.failed, 2);
+        assert_eq!(status.state, PublishLifecycleState::Failed);
     }
 
     #[tokio::test]

--- a/crates/sockudo-push/src/feedback.rs
+++ b/crates/sockudo-push/src/feedback.rs
@@ -7,7 +7,8 @@ use crate::domain::{
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::{PushMetrics, provider_label};
 use crate::pipeline::{
-    PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage, lock_publish_status, now_ms,
+    PublishStatusMutationOutcome, PushPipelineResult, PushQueuePayload, PushQueueStage,
+    QueueMessage, mutate_publish_status_with_cas, now_ms,
 };
 use crate::retry::RetryPolicy;
 use crate::storage::{DynPushStore, IdempotencyRecord};
@@ -252,38 +253,49 @@ impl PushFeedbackProcessor {
         &self,
         result: &DeliveryResult,
     ) -> PushPipelineResult<Option<PublishStatus>> {
-        let _status_guard = lock_publish_status(&result.app_id, &result.publish_id).await;
-        let Some(current) = self
-            .store
-            .get_publish_status(&result.app_id, &result.publish_id)
-            .await?
-        else {
-            return Ok(None);
+        let outcome = mutate_publish_status_with_cas(
+            self.store.as_ref(),
+            &self.metrics,
+            "feedback",
+            &result.app_id,
+            &result.publish_id,
+            |current| {
+                let mut status = current.clone();
+                match result.outcome {
+                    DeliveryOutcome::Accepted => {
+                        status.counters.dispatched = status.counters.dispatched.saturating_add(1);
+                        status.counters.succeeded = status.counters.succeeded.saturating_add(1);
+                    }
+                    DeliveryOutcome::Rejected => {
+                        status.counters.dispatched = status.counters.dispatched.saturating_add(1);
+                        status.counters.failed = status.counters.failed.saturating_add(1);
+                    }
+                    DeliveryOutcome::Expired => {
+                        status.counters.dispatched = status.counters.dispatched.saturating_add(1);
+                        status.counters.expired = status.counters.expired.saturating_add(1);
+                    }
+                    DeliveryOutcome::Retryable | DeliveryOutcome::Cancelled => {}
+                }
+                if let Some(retry_after_ms) =
+                    result.error.as_ref().and_then(|error| error.retry_after_ms)
+                {
+                    status.retry_after_ms = Some(retry_after_ms);
+                }
+                let next = status.counters.resolve_lifecycle_state(current.state);
+                // Audience counts for channel/client targets are estimates until fanout. A late
+                // valid outcome may refine one terminal delivery summary into another, but never
+                // reactivates it.
+                status.state = next;
+                Ok(Some(status))
+            },
+        )
+        .await?;
+        let status = match outcome {
+            PublishStatusMutationOutcome::Missing => return Ok(None),
+            PublishStatusMutationOutcome::Unchanged(status) => return Ok(Some(status)),
+            PublishStatusMutationOutcome::Updated(status) => status,
         };
-        let mut status = current.clone();
 
-        match result.outcome {
-            DeliveryOutcome::Accepted => {
-                status.counters.dispatched = status.counters.dispatched.saturating_add(1);
-                status.counters.succeeded = status.counters.succeeded.saturating_add(1);
-            }
-            DeliveryOutcome::Rejected => {
-                status.counters.dispatched = status.counters.dispatched.saturating_add(1);
-                status.counters.failed = status.counters.failed.saturating_add(1);
-            }
-            DeliveryOutcome::Expired => {
-                status.counters.dispatched = status.counters.dispatched.saturating_add(1);
-                status.counters.expired = status.counters.expired.saturating_add(1);
-            }
-            DeliveryOutcome::Retryable | DeliveryOutcome::Cancelled => {}
-        }
-        if let Some(retry_after_ms) = result.error.as_ref().and_then(|error| error.retry_after_ms) {
-            status.retry_after_ms = Some(retry_after_ms);
-        }
-        let next = status.counters.resolve_lifecycle_state(current.state);
-        // Audience counts for channel/client targets are estimates until fanout. A late valid
-        // outcome may refine one terminal delivery summary into another, but never reactivates it.
-        status.state = next;
         self.metrics
             .delivery_status(&result.app_id, outcome_label(result.outcome));
         if matches!(
@@ -306,7 +318,6 @@ impl PushFeedbackProcessor {
                 "push publish completed"
             );
         }
-        self.store.put_publish_status(status.clone()).await?;
         Ok(Some(status))
     }
 
@@ -422,33 +433,40 @@ impl PushFeedbackProcessor {
         result: &DeliveryResult,
         next_attempt_at_ms: u64,
     ) -> PushPipelineResult<()> {
-        let _status_guard = lock_publish_status(&result.app_id, &result.publish_id).await;
-        if let Some(mut status) = self
-            .store
-            .get_publish_status(&result.app_id, &result.publish_id)
-            .await?
-        {
-            status.counters.retry_scheduled = status.counters.retry_scheduled.saturating_add(1);
-            status.retry_after_ms = Some(next_attempt_at_ms);
-            self.store.put_publish_status(status).await?;
-        }
+        mutate_publish_status_with_cas(
+            self.store.as_ref(),
+            &self.metrics,
+            "feedback",
+            &result.app_id,
+            &result.publish_id,
+            |current| {
+                let mut status = current.clone();
+                status.counters.retry_scheduled = status.counters.retry_scheduled.saturating_add(1);
+                status.retry_after_ms = Some(next_attempt_at_ms);
+                Ok(Some(status))
+            },
+        )
+        .await?;
         Ok(())
     }
 
     async fn mark_retry_context_missing(&self, result: &DeliveryResult) -> PushPipelineResult<()> {
-        let _status_guard = lock_publish_status(&result.app_id, &result.publish_id).await;
-        if let Some(current) = self
-            .store
-            .get_publish_status(&result.app_id, &result.publish_id)
-            .await?
-        {
-            let mut status = current.clone();
-            status.counters.dead_lettered = status.counters.dead_lettered.saturating_add(1);
-            status.error_reason = Some("retryable result missing retry context".to_owned());
-            let next = status.counters.resolve_lifecycle_state(current.state);
-            status.state = next;
-            self.store.put_publish_status(status).await?;
-        }
+        mutate_publish_status_with_cas(
+            self.store.as_ref(),
+            &self.metrics,
+            "feedback",
+            &result.app_id,
+            &result.publish_id,
+            |current| {
+                let mut status = current.clone();
+                status.counters.dead_lettered = status.counters.dead_lettered.saturating_add(1);
+                status.error_reason = Some("retryable result missing retry context".to_owned());
+                let next = status.counters.resolve_lifecycle_state(current.state);
+                status.state = next;
+                Ok(Some(status))
+            },
+        )
+        .await?;
         Ok(())
     }
 }

--- a/crates/sockudo-push/src/lib.rs
+++ b/crates/sockudo-push/src/lib.rs
@@ -116,11 +116,11 @@ pub use sql::PostgresPushStore;
 pub use storage::{
     DeviceRegistrationChange, DeviceRegistrationOutcome, DynPushStore,
     EXPECTED_PUSH_SCHEMA_VERSION, IdempotencyRecord, OperatorInvalidationEvent, Page,
-    PushCleanupStore, PushCredentialStore, PushDeliveryEventStore, PushDeviceStore,
-    PushFanoutShardStore, PushIdempotencyStore, PushOperatorEventStore, PushPublishLogStore,
-    PushPublishStatusStore, PushScheduleStore, PushSchedulerLockStore, PushStorageBackendKind,
-    PushStorageError, PushStorageResult, PushStore, PushSubscriptionStore, PushTemplateStore,
-    ScheduledPushJob, SchedulerLock,
+    PublishStatusCasOutcome, PushCleanupStore, PushCredentialStore, PushDeliveryEventStore,
+    PushDeviceStore, PushFanoutShardStore, PushIdempotencyStore, PushOperatorEventStore,
+    PushPublishLogStore, PushPublishStatusStore, PushScheduleStore, PushSchedulerLockStore,
+    PushStorageBackendKind, PushStorageError, PushStorageResult, PushStore, PushSubscriptionStore,
+    PushTemplateStore, ScheduledPushJob, SchedulerLock, VersionedPublishStatus,
 };
 pub use transform::{
     EffectivePushPayload, PUSH_PROVIDER_RENDER_ORDER, PayloadTransformError,

--- a/crates/sockudo-push/src/memory.rs
+++ b/crates/sockudo-push/src/memory.rs
@@ -13,10 +13,12 @@ use crate::domain::{
 };
 use crate::storage::{
     DeviceRegistrationChange, DeviceRegistrationOutcome, IdempotencyRecord,
-    OperatorInvalidationEvent, Page, PushCleanupStore, PushCredentialStore, PushDeliveryEventStore,
-    PushDeviceStore, PushFanoutShardStore, PushIdempotencyStore, PushOperatorEventStore,
-    PushPublishLogStore, PushPublishStatusStore, PushScheduleStore, PushSchedulerLockStore,
-    PushStorageResult, PushSubscriptionStore, PushTemplateStore, ScheduledPushJob, SchedulerLock,
+    OperatorInvalidationEvent, Page, PublishStatusCasOutcome, PushCleanupStore,
+    PushCredentialStore, PushDeliveryEventStore, PushDeviceStore, PushFanoutShardStore,
+    PushIdempotencyStore, PushOperatorEventStore, PushPublishLogStore, PushPublishStatusStore,
+    PushScheduleStore, PushSchedulerLockStore, PushStorageError, PushStorageResult,
+    PushSubscriptionStore, PushTemplateStore, ScheduledPushJob, SchedulerLock,
+    VersionedPublishStatus,
 };
 
 const MEMORY_DELIVERY_EVENT_CAP: usize = 100_000;
@@ -32,8 +34,7 @@ struct MemoryPushState {
     subscriptions: BTreeMap<(String, String, String), ChannelSubscription>,
     credentials: BTreeMap<(String, String), ProviderCredential>,
     templates: BTreeMap<(String, String), NotificationTemplate>,
-    publish_status: BTreeMap<(String, String), PublishStatus>,
-    publish_status_updated_at: BTreeMap<(String, String), u64>,
+    publish_status: BTreeMap<(String, String), VersionedPublishStatus>,
     publish_log: BTreeMap<(String, u64, String), PublishLogEvent>,
     fanout_shards: BTreeMap<(String, String, String), ShardJob>,
     scheduled_by_id: BTreeMap<(String, String), ScheduledPushJob>,
@@ -55,11 +56,15 @@ impl MemoryPushStore {
         publish_id: &str,
         updated_at_ms: u64,
     ) {
-        self.inner
+        if let Some(status) = self
+            .inner
             .write()
             .await
-            .publish_status_updated_at
-            .insert((app_id.to_owned(), publish_id.to_owned()), updated_at_ms);
+            .publish_status
+            .get_mut(&(app_id.to_owned(), publish_id.to_owned()))
+        {
+            status.updated_at_ms = updated_at_ms;
+        }
     }
 }
 
@@ -512,21 +517,31 @@ impl PushTemplateStore for MemoryPushStore {
 
 #[async_trait]
 impl PushPublishStatusStore for MemoryPushStore {
-    async fn put_publish_status(&self, status: PublishStatus) -> PushStorageResult<()> {
+    async fn create_publish_status_if_absent(
+        &self,
+        status: PublishStatus,
+    ) -> PushStorageResult<PublishStatusCasOutcome> {
         let key = (status.app_id.clone(), status.publish_id.clone());
         let mut inner = self.inner.write().await;
-        inner
-            .publish_status_updated_at
-            .insert(key.clone(), crate::pipeline::now_ms());
-        inner.publish_status.insert(key, status);
-        Ok(())
+        if inner.publish_status.contains_key(&key) {
+            return Ok(PublishStatusCasOutcome::Conflict);
+        }
+        inner.publish_status.insert(
+            key,
+            VersionedPublishStatus {
+                status,
+                revision: 1,
+                updated_at_ms: crate::pipeline::now_ms(),
+            },
+        );
+        Ok(PublishStatusCasOutcome::Inserted { revision: 1 })
     }
 
-    async fn get_publish_status(
+    async fn get_versioned_publish_status(
         &self,
         app_id: &str,
         publish_id: &str,
-    ) -> PushStorageResult<Option<PublishStatus>> {
+    ) -> PushStorageResult<Option<VersionedPublishStatus>> {
         Ok(self
             .inner
             .read()
@@ -534,6 +549,42 @@ impl PushPublishStatusStore for MemoryPushStore {
             .publish_status
             .get(&(app_id.to_owned(), publish_id.to_owned()))
             .cloned())
+    }
+
+    async fn compare_and_swap_publish_status(
+        &self,
+        expected: &VersionedPublishStatus,
+        next: PublishStatus,
+    ) -> PushStorageResult<PublishStatusCasOutcome> {
+        if expected.status.app_id != next.app_id
+            || expected.status.publish_id != next.publish_id
+            || expected.revision == 0
+        {
+            return Err(PushStorageError::Backend(
+                "invalid publish status compare-and-swap identity or revision".to_owned(),
+            ));
+        }
+        let next_revision = expected.revision.checked_add(1).ok_or_else(|| {
+            PushStorageError::Backend("publish status revision overflow".to_owned())
+        })?;
+        let key = (next.app_id.clone(), next.publish_id.clone());
+        let mut inner = self.inner.write().await;
+        let Some(current) = inner.publish_status.get_mut(&key) else {
+            return Ok(PublishStatusCasOutcome::Missing);
+        };
+        if current.revision != expected.revision || current.updated_at_ms != expected.updated_at_ms
+        {
+            return Ok(PublishStatusCasOutcome::Conflict);
+        }
+        let updated_at_ms = crate::pipeline::now_ms().max(current.updated_at_ms.saturating_add(1));
+        *current = VersionedPublishStatus {
+            status: next,
+            revision: next_revision,
+            updated_at_ms,
+        };
+        Ok(PublishStatusCasOutcome::Updated {
+            revision: next_revision,
+        })
     }
 }
 
@@ -917,7 +968,6 @@ impl PushCleanupStore for MemoryPushStore {
             let (counters, keys) = cleanup_status_keys(&inner, cutoff_ms, limit);
             for key in keys {
                 inner.publish_status.remove(&key);
-                inner.publish_status_updated_at.remove(&key);
             }
             remaining = remaining.saturating_sub(counters.deleted as usize);
             report.publish_statuses = counters;
@@ -1066,12 +1116,8 @@ fn cleanup_status_keys(
         inner.publish_status.iter(),
         limit,
         |item| {
-            let (key, status) = *item;
-            terminal_publish_state(status.state)
-                && inner
-                    .publish_status_updated_at
-                    .get(key)
-                    .is_some_and(|updated_at_ms| *updated_at_ms < cutoff_ms)
+            let (_, status) = *item;
+            terminal_publish_state(status.status.state) && status.updated_at_ms < cutoff_ms
         },
         |item| item.0.clone(),
     )
@@ -1206,6 +1252,109 @@ mod tests {
         PushStoreConformance::assert_concurrent_registration_update(MemoryPushStore::new())
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn memory_status_cas_allows_exactly_one_writer_per_revision() {
+        let store = MemoryPushStore::new();
+        let status = PublishStatus {
+            app_id: "app-1".to_owned(),
+            publish_id: "publish-1".to_owned(),
+            state: crate::domain::PublishLifecycleState::Queued,
+            counters: crate::domain::PublishCounters::default(),
+            fanout_regime: None,
+            retry_after_ms: None,
+            error_reason: None,
+        };
+        assert_eq!(
+            store
+                .create_publish_status_if_absent(status.clone())
+                .await
+                .unwrap(),
+            PublishStatusCasOutcome::Inserted { revision: 1 }
+        );
+        let expected = store
+            .get_versioned_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        let mut planning = status.clone();
+        planning.state = crate::domain::PublishLifecycleState::Planning;
+        let mut failed = status;
+        failed.state = crate::domain::PublishLifecycleState::Failed;
+
+        let (left, right) = tokio::join!(
+            store.compare_and_swap_publish_status(&expected, planning),
+            store.compare_and_swap_publish_status(&expected, failed),
+        );
+        let outcomes = [left.unwrap(), right.unwrap()];
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, PublishStatusCasOutcome::Updated { .. }))
+                .count(),
+            1
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome, PublishStatusCasOutcome::Conflict))
+                .count(),
+            1
+        );
+        assert_eq!(
+            store
+                .get_versioned_publish_status("app-1", "publish-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .revision,
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_status_cas_rejects_stale_snapshot_after_recreation() {
+        let store = MemoryPushStore::new();
+        let status = PublishStatus {
+            app_id: "app-1".to_owned(),
+            publish_id: "publish-1".to_owned(),
+            state: crate::domain::PublishLifecycleState::Queued,
+            counters: crate::domain::PublishCounters::default(),
+            fanout_regime: None,
+            retry_after_ms: None,
+            error_reason: None,
+        };
+        store
+            .create_publish_status_if_absent(status.clone())
+            .await
+            .unwrap();
+        store
+            .set_publish_status_updated_at_for_test("app-1", "publish-1", 1)
+            .await;
+        let stale = store
+            .get_versioned_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        store
+            .inner
+            .write()
+            .await
+            .publish_status
+            .remove(&("app-1".to_owned(), "publish-1".to_owned()));
+        store
+            .create_publish_status_if_absent(status.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .compare_and_swap_publish_status(&stale, status)
+                .await
+                .unwrap(),
+            PublishStatusCasOutcome::Conflict
+        );
     }
 
     #[test]

--- a/crates/sockudo-push/src/memory.rs
+++ b/crates/sockudo-push/src/memory.rs
@@ -1020,10 +1020,17 @@ fn page_from_rows<T: Clone>(
     start_after: Option<String>,
 ) -> Page<T> {
     let limit = limit.max(1);
-    let filtered = rows
+    // Cursor pagination compares `position` strings (`position > start_after`), so the page must be
+    // emitted in ascending `position` order. Callers build `rows` in backing-map order, which does
+    // not always match position-string order — e.g. subscription rows are keyed by the
+    // `(channel, device_id)` tuple, but the position string `"{channel}:{device_id}"` orders
+    // differently whenever one channel name is a prefix of another (`:` outranks digits). Sort here
+    // so the helper owns the invariant its cursor contract depends on.
+    let mut filtered = rows
         .into_iter()
         .filter(|(position, _)| start_after.as_ref().is_none_or(|start| position > start))
         .collect::<Vec<_>>();
+    filtered.sort_by(|(a, _), (b, _)| a.cmp(b));
 
     let mut items = Vec::with_capacity(limit.min(filtered.len()));
     let mut last_position = None;

--- a/crates/sockudo-push/src/metrics.rs
+++ b/crates/sockudo-push/src/metrics.rs
@@ -55,6 +55,7 @@ pub const PUSH_METRIC_SPECS: &[PushMetricSpec] = &[
         &["provider", "tenant"],
     ),
     PushMetricSpec::counter("sockudo_push_duplicate_suppressed_total", &[]),
+    PushMetricSpec::counter("sockudo_push_invariant_violations_total", &["invariant"]),
     PushMetricSpec::gauge("sockudo_push_devices_total", &["app", "state"]),
     PushMetricSpec::counter(
         "sockudo_push_device_state_transitions_total",
@@ -404,6 +405,14 @@ impl PushMetrics {
 
     pub fn duplicate_suppressed(&self) {
         self.counter("sockudo_push_duplicate_suppressed_total", &[], 1);
+    }
+
+    pub fn status_transition_invariant_violation(&self) {
+        self.counter(
+            "sockudo_push_invariant_violations_total",
+            &[("invariant", "status_transition")],
+            1,
+        );
     }
 
     pub fn devices_total(&self, app_id: &str, state: DevicePushState, count: u64) {
@@ -809,6 +818,7 @@ mod tests {
             .iter()
             .map(|spec| spec.name)
             .collect::<BTreeSet<_>>();
+        assert!(names.contains("sockudo_push_invariant_violations_total"));
         let required = [
             "sockudo_push_dispatched_total",
             "sockudo_push_dispatch_duration_seconds",
@@ -880,10 +890,26 @@ mod tests {
             Duration::from_millis(100),
         );
         metrics.duplicate_suppressed();
+        metrics.status_transition_invariant_violation();
 
         assert_eq!(metrics.get("sockudo_push_publish_accepted_total"), 1);
         assert_eq!(metrics.get("sockudo_push_dispatched_total"), 1);
         assert_eq!(metrics.get("sockudo_push_duplicate_suppressed_total"), 1);
+        assert_eq!(metrics.get("sockudo_push_invariant_violations_total"), 1);
+        let invariant_labels = metrics
+            .snapshot()
+            .into_iter()
+            .filter_map(|((name, labels), _)| {
+                (name == "sockudo_push_invariant_violations_total")
+                    .then(|| labels.into_iter().find(|(key, _)| *key == "invariant"))
+                    .flatten()
+                    .map(|(_, value)| value)
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            invariant_labels,
+            BTreeSet::from(["status_transition".to_owned()])
+        );
         assert_eq!(
             metrics
                 .snapshot()

--- a/crates/sockudo-push/src/metrics.rs
+++ b/crates/sockudo-push/src/metrics.rs
@@ -56,6 +56,8 @@ pub const PUSH_METRIC_SPECS: &[PushMetricSpec] = &[
     ),
     PushMetricSpec::counter("sockudo_push_duplicate_suppressed_total", &[]),
     PushMetricSpec::counter("sockudo_push_invariant_violations_total", &["invariant"]),
+    PushMetricSpec::counter("sockudo_push_status_cas_conflicts_total", &["component"]),
+    PushMetricSpec::counter("sockudo_push_status_cas_exhausted_total", &["component"]),
     PushMetricSpec::gauge("sockudo_push_devices_total", &["app", "state"]),
     PushMetricSpec::counter(
         "sockudo_push_device_state_transitions_total",
@@ -411,6 +413,22 @@ impl PushMetrics {
         self.counter(
             "sockudo_push_invariant_violations_total",
             &[("invariant", "status_transition")],
+            1,
+        );
+    }
+
+    pub fn publish_status_cas_conflict(&self, component: &'static str) {
+        self.counter(
+            "sockudo_push_status_cas_conflicts_total",
+            &[("component", component)],
+            1,
+        );
+    }
+
+    pub fn publish_status_cas_exhausted(&self, component: &'static str) {
+        self.counter(
+            "sockudo_push_status_cas_exhausted_total",
+            &[("component", component)],
             1,
         );
     }
@@ -819,6 +837,8 @@ mod tests {
             .map(|spec| spec.name)
             .collect::<BTreeSet<_>>();
         assert!(names.contains("sockudo_push_invariant_violations_total"));
+        assert!(names.contains("sockudo_push_status_cas_conflicts_total"));
+        assert!(names.contains("sockudo_push_status_cas_exhausted_total"));
         let required = [
             "sockudo_push_dispatched_total",
             "sockudo_push_dispatch_duration_seconds",
@@ -891,11 +911,15 @@ mod tests {
         );
         metrics.duplicate_suppressed();
         metrics.status_transition_invariant_violation();
+        metrics.publish_status_cas_conflict("feedback");
+        metrics.publish_status_cas_exhausted("feedback");
 
         assert_eq!(metrics.get("sockudo_push_publish_accepted_total"), 1);
         assert_eq!(metrics.get("sockudo_push_dispatched_total"), 1);
         assert_eq!(metrics.get("sockudo_push_duplicate_suppressed_total"), 1);
         assert_eq!(metrics.get("sockudo_push_invariant_violations_total"), 1);
+        assert_eq!(metrics.get("sockudo_push_status_cas_conflicts_total"), 1);
+        assert_eq!(metrics.get("sockudo_push_status_cas_exhausted_total"), 1);
         let invariant_labels = metrics
             .snapshot()
             .into_iter()

--- a/crates/sockudo-push/src/nosql/document.rs
+++ b/crates/sockudo-push/src/nosql/document.rs
@@ -40,6 +40,36 @@ pub trait DocumentBackend: Clone + Send + Sync + 'static {
         sk: &str,
     ) -> PushStorageResult<Option<String>>;
 
+    /// Read the latest committed value suitable for a following conditional write.
+    async fn get_consistent(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+    ) -> PushStorageResult<Option<String>>;
+
+    /// Replace a document only when its complete serialized value still matches `expected`.
+    async fn compare_and_swap(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        expected: &str,
+        data: String,
+    ) -> PushStorageResult<bool>;
+
+    /// Delete a document only when its complete serialized value still matches `expected`.
+    async fn compare_and_delete(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        expected: &str,
+    ) -> PushStorageResult<bool>;
+
     async fn delete(
         &self,
         family: &'static str,

--- a/crates/sockudo-push/src/nosql/dynamodb.rs
+++ b/crates/sockudo-push/src/nosql/dynamodb.rs
@@ -86,6 +86,31 @@ impl DynamoDbDocumentBackend {
     fn key(family: &'static str, app_id: &str, pk: &str, sk: &str) -> (String, String) {
         (family_app(family, app_id), document_key(pk, sk))
     }
+
+    async fn get_document(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        consistent: bool,
+    ) -> PushStorageResult<Option<String>> {
+        use aws_sdk_dynamodb::types::AttributeValue;
+        let (family_app, doc_key) = Self::key(family, app_id, pk, sk);
+        Ok(self
+            .client
+            .get_item()
+            .table_name(&self.table)
+            .key("family_app", AttributeValue::S(family_app))
+            .key("doc_key", AttributeValue::S(doc_key))
+            .consistent_read(consistent)
+            .send()
+            .await
+            .map_err(dynamodb_error)?
+            .item
+            .and_then(|mut item| item.remove("data"))
+            .and_then(|value| value.as_s().ok().cloned()))
+    }
 }
 
 #[cfg(feature = "dynamodb")]
@@ -159,20 +184,90 @@ impl DocumentBackend for DynamoDbDocumentBackend {
         pk: &str,
         sk: &str,
     ) -> PushStorageResult<Option<String>> {
+        self.get_document(family, app_id, pk, sk, false).await
+    }
+
+    async fn get_consistent(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+    ) -> PushStorageResult<Option<String>> {
+        self.get_document(family, app_id, pk, sk, true).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        expected: &str,
+        data: String,
+    ) -> PushStorageResult<bool> {
         use aws_sdk_dynamodb::types::AttributeValue;
         let (family_app, doc_key) = Self::key(family, app_id, pk, sk);
-        Ok(self
+        let result = self
             .client
-            .get_item()
+            .put_item()
+            .table_name(&self.table)
+            .condition_expression("#data = :expected_data")
+            .expression_attribute_names("#data", "data")
+            .expression_attribute_values(":expected_data", AttributeValue::S(expected.to_owned()))
+            .item("family_app", AttributeValue::S(family_app))
+            .item("doc_key", AttributeValue::S(doc_key))
+            .item("app_id", AttributeValue::S(app_id.to_owned()))
+            .item("pk", AttributeValue::S(pk.to_owned()))
+            .item("sk", AttributeValue::S(sk.to_owned()))
+            .item("data", AttributeValue::S(data))
+            .send()
+            .await;
+        match result {
+            Ok(_) => Ok(true),
+            Err(error)
+                if error
+                    .as_service_error()
+                    .is_some_and(|error| error.is_conditional_check_failed_exception()) =>
+            {
+                Ok(false)
+            }
+            Err(error) => Err(dynamodb_error(error)),
+        }
+    }
+
+    async fn compare_and_delete(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        expected: &str,
+    ) -> PushStorageResult<bool> {
+        use aws_sdk_dynamodb::types::AttributeValue;
+        let (family_app, doc_key) = Self::key(family, app_id, pk, sk);
+        let result = self
+            .client
+            .delete_item()
             .table_name(&self.table)
             .key("family_app", AttributeValue::S(family_app))
             .key("doc_key", AttributeValue::S(doc_key))
+            .condition_expression("#data = :expected_data")
+            .expression_attribute_names("#data", "data")
+            .expression_attribute_values(":expected_data", AttributeValue::S(expected.to_owned()))
             .send()
-            .await
-            .map_err(dynamodb_error)?
-            .item
-            .and_then(|mut item| item.remove("data"))
-            .and_then(|value| value.as_s().ok().cloned()))
+            .await;
+        match result {
+            Ok(_) => Ok(true),
+            Err(error)
+                if error
+                    .as_service_error()
+                    .is_some_and(|error| error.is_conditional_check_failed_exception()) =>
+            {
+                Ok(false)
+            }
+            Err(error) => Err(dynamodb_error(error)),
+        }
     }
 
     async fn delete(

--- a/crates/sockudo-push/src/nosql/helpers.rs
+++ b/crates/sockudo-push/src/nosql/helpers.rs
@@ -176,6 +176,12 @@ pub(super) fn surreal_error<E: std::fmt::Display>(error: E) -> PushStorageError 
     PushStorageError::Backend(format!("push SurrealDB backend error: {error}"))
 }
 
+#[cfg(feature = "surrealdb")]
+pub(super) fn surreal_conflict_error<E: std::fmt::Display>(error: &E) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("already") || message.contains("duplicate") || message.contains("unique")
+}
+
 #[cfg(feature = "scylladb")]
 pub(super) fn scylla_error<E: std::fmt::Display>(error: E) -> PushStorageError {
     PushStorageError::Backend(format!("push ScyllaDB backend error: {error}"))

--- a/crates/sockudo-push/src/nosql/publishing.rs
+++ b/crates/sockudo-push/src/nosql/publishing.rs
@@ -9,72 +9,345 @@ use crate::domain::{
 };
 use crate::storage::{
     DeviceRegistrationChange, DeviceRegistrationOutcome, IdempotencyRecord,
-    OperatorInvalidationEvent, Page, PushCredentialStore, PushDeliveryEventStore, PushDeviceStore,
-    PushFanoutShardStore, PushIdempotencyStore, PushOperatorEventStore, PushPublishLogStore,
-    PushPublishStatusStore, PushScheduleStore, PushSchedulerLockStore, PushStorageResult,
-    PushSubscriptionStore, PushTemplateStore, ScheduledPushJob, SchedulerLock,
+    OperatorInvalidationEvent, Page, PublishStatusCasOutcome, PushCredentialStore,
+    PushDeliveryEventStore, PushDeviceStore, PushFanoutShardStore, PushIdempotencyStore,
+    PushOperatorEventStore, PushPublishLogStore, PushPublishStatusStore, PushScheduleStore,
+    PushSchedulerLockStore, PushStorageError, PushStorageResult, PushSubscriptionStore,
+    PushTemplateStore, ScheduledPushJob, SchedulerLock, VersionedPublishStatus,
 };
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+const INITIAL_PUBLISH_STATUS_REVISION: u64 = 1;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredPublishStatus {
+    revision: u64,
+    updated_at_ms: u64,
+    status: PublishStatus,
+}
+
+struct DecodedPublishStatus {
+    versioned: VersionedPublishStatus,
+    legacy: bool,
+}
+
+fn encode_publish_status(status: &VersionedPublishStatus) -> PushStorageResult<String> {
+    to_json_string(&StoredPublishStatus {
+        revision: status.revision,
+        updated_at_ms: status.updated_at_ms,
+        status: status.status.clone(),
+    })
+}
+
+fn decode_publish_status(data: &str) -> PushStorageResult<DecodedPublishStatus> {
+    if let Ok(stored) = from_json_str::<StoredPublishStatus>(data) {
+        if stored.revision == 0 {
+            return Err(PushStorageError::Backend(
+                "push publish status revision must be greater than zero".to_owned(),
+            ));
+        }
+        return Ok(DecodedPublishStatus {
+            versioned: VersionedPublishStatus {
+                status: stored.status,
+                revision: stored.revision,
+                updated_at_ms: stored.updated_at_ms,
+            },
+            legacy: false,
+        });
+    }
+
+    Ok(DecodedPublishStatus {
+        versioned: VersionedPublishStatus {
+            status: from_json_str::<PublishStatus>(data)?,
+            revision: INITIAL_PUBLISH_STATUS_REVISION,
+            updated_at_ms: 0,
+        },
+        legacy: true,
+    })
+}
+
+fn next_publish_status_updated_at(previous: u64) -> u64 {
+    crate::pipeline::now_ms().max(previous.saturating_add(1))
+}
+
+impl<B> DocumentPushStore<B>
+where
+    B: DocumentBackend,
+{
+    async fn read_versioned_publish_status(
+        &self,
+        app_id: &str,
+        publish_id: &str,
+    ) -> PushStorageResult<Option<(String, VersionedPublishStatus)>> {
+        let Some(data) = self
+            .backend
+            .get_consistent(FAMILY_STATUS, app_id, publish_id, DEFAULT_SK)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let mut decoded = decode_publish_status(&data)?;
+        if decoded.legacy {
+            decoded.versioned.updated_at_ms = self
+                .backend
+                .get_consistent(FAMILY_STATUS_UPDATED, app_id, publish_id, DEFAULT_SK)
+                .await?
+                .map(|updated_at| from_json_str::<u64>(&updated_at))
+                .transpose()?
+                .unwrap_or(0);
+        }
+        Ok(Some((data, decoded.versioned)))
+    }
+
+    async fn prepare_publish_status_index(
+        &self,
+        status: &VersionedPublishStatus,
+    ) -> PushStorageResult<String> {
+        let app_id = &status.status.app_id;
+        let publish_id = &status.status.publish_id;
+        self.remember_cleanup_app(app_id).await?;
+        let indexed_data = to_json_string(publish_id)?;
+        self.backend
+            .put(
+                FAMILY_STATUS_UPDATED_TIME,
+                app_id,
+                "time",
+                &status_updated_position(status.updated_at_ms, publish_id),
+                indexed_data.clone(),
+            )
+            .await?;
+        Ok(indexed_data)
+    }
+
+    async fn discard_publish_status_index_if_stale(
+        &self,
+        candidate: &VersionedPublishStatus,
+        indexed_data: &str,
+    ) {
+        let app_id = &candidate.status.app_id;
+        let publish_id = &candidate.status.publish_id;
+        let canonical_updated_at_ms = match self
+            .backend
+            .get_consistent(FAMILY_STATUS, app_id, publish_id, DEFAULT_SK)
+            .await
+        {
+            Ok(Some(data)) => match decode_publish_status(&data) {
+                Ok(decoded) => Some(decoded.versioned.updated_at_ms),
+                Err(error) => {
+                    tracing::warn!(
+                        app_id,
+                        publish_id,
+                        operation = "decode-after-status-conflict",
+                        error = %error,
+                        "push publish status advisory index cleanup failed"
+                    );
+                    return;
+                }
+            },
+            Ok(None) => None,
+            Err(error) => {
+                tracing::warn!(
+                    app_id,
+                    publish_id,
+                    operation = "read-after-status-conflict",
+                    error = %error,
+                    "push publish status advisory index cleanup failed"
+                );
+                return;
+            }
+        };
+        if canonical_updated_at_ms == Some(candidate.updated_at_ms) {
+            return;
+        }
+        if let Err(error) = self
+            .backend
+            .compare_and_delete(
+                FAMILY_STATUS_UPDATED_TIME,
+                app_id,
+                "time",
+                &status_updated_position(candidate.updated_at_ms, publish_id),
+                indexed_data,
+            )
+            .await
+        {
+            tracing::warn!(
+                app_id,
+                publish_id,
+                operation = "delete-conflicting-time-index",
+                error = %error,
+                "push publish status advisory index cleanup failed"
+            );
+        }
+    }
+
+    async fn refresh_publish_status_indexes(
+        &self,
+        status: &VersionedPublishStatus,
+        previous_updated_at_ms: Option<u64>,
+    ) {
+        let app_id = &status.status.app_id;
+        let publish_id = &status.status.publish_id;
+        let updated_at_ms = status.updated_at_ms;
+
+        // The discoverability index was durably staged before the canonical conditional write.
+        // These remaining records are advisory, so interruption can only delay pointer cleanup.
+        if let Err(error) = self
+            .put_json(
+                FAMILY_STATUS_UPDATED,
+                app_id,
+                publish_id,
+                DEFAULT_SK,
+                &updated_at_ms,
+            )
+            .await
+        {
+            tracing::warn!(
+                app_id,
+                publish_id,
+                operation = "write-updated-pointer",
+                error = %error,
+                "push publish status advisory index update failed"
+            );
+        }
+        if let Some(previous_updated_at_ms) = previous_updated_at_ms
+            && previous_updated_at_ms != updated_at_ms
+            && let Err(error) = self
+                .backend
+                .delete(
+                    FAMILY_STATUS_UPDATED_TIME,
+                    app_id,
+                    "time",
+                    &status_updated_position(previous_updated_at_ms, publish_id),
+                )
+                .await
+        {
+            tracing::warn!(
+                app_id,
+                publish_id,
+                operation = "delete-old-time-index",
+                error = %error,
+                "push publish status advisory index update failed"
+            );
+        }
+    }
+}
 
 #[async_trait]
 impl<B> PushPublishStatusStore for DocumentPushStore<B>
 where
     B: DocumentBackend,
 {
-    async fn put_publish_status(&self, status: PublishStatus) -> PushStorageResult<()> {
-        let now_ms = crate::pipeline::now_ms();
-        if let Some(previous_updated_at_ms) = self
-            .get_json::<u64>(
-                FAMILY_STATUS_UPDATED,
+    async fn create_publish_status_if_absent(
+        &self,
+        status: PublishStatus,
+    ) -> PushStorageResult<PublishStatusCasOutcome> {
+        if self
+            .backend
+            .get_consistent(
+                FAMILY_STATUS,
                 &status.app_id,
                 &status.publish_id,
                 DEFAULT_SK,
             )
             .await?
+            .is_some()
         {
-            self.backend
-                .delete(
-                    FAMILY_STATUS_UPDATED_TIME,
-                    &status.app_id,
-                    "time",
-                    &status_updated_position(previous_updated_at_ms, &status.publish_id),
-                )
-                .await?;
+            return Ok(PublishStatusCasOutcome::Conflict);
         }
-        self.remember_cleanup_app(&status.app_id).await?;
-        self.put_json(
-            FAMILY_STATUS_UPDATED,
-            &status.app_id,
-            &status.publish_id,
-            DEFAULT_SK,
-            &now_ms,
-        )
-        .await?;
-        self.put_json(
-            FAMILY_STATUS_UPDATED_TIME,
-            &status.app_id,
-            "time",
-            &status_updated_position(now_ms, &status.publish_id),
-            &status.publish_id,
-        )
-        .await?;
-        self.put_json(
-            FAMILY_STATUS,
-            &status.app_id,
-            &status.publish_id,
-            DEFAULT_SK,
-            &status,
-        )
-        .await
+        let versioned = VersionedPublishStatus {
+            status,
+            revision: INITIAL_PUBLISH_STATUS_REVISION,
+            updated_at_ms: next_publish_status_updated_at(0),
+        };
+        let indexed_data = self.prepare_publish_status_index(&versioned).await?;
+        if !self
+            .backend
+            .put_if_absent(
+                FAMILY_STATUS,
+                &versioned.status.app_id,
+                &versioned.status.publish_id,
+                DEFAULT_SK,
+                encode_publish_status(&versioned)?,
+            )
+            .await?
+        {
+            self.discard_publish_status_index_if_stale(&versioned, &indexed_data)
+                .await;
+            return Ok(PublishStatusCasOutcome::Conflict);
+        }
+
+        self.refresh_publish_status_indexes(&versioned, None).await;
+        Ok(PublishStatusCasOutcome::Inserted {
+            revision: versioned.revision,
+        })
     }
 
-    async fn get_publish_status(
+    async fn get_versioned_publish_status(
         &self,
         app_id: &str,
         publish_id: &str,
-    ) -> PushStorageResult<Option<PublishStatus>> {
-        self.get_json(FAMILY_STATUS, app_id, publish_id, DEFAULT_SK)
-            .await
+    ) -> PushStorageResult<Option<VersionedPublishStatus>> {
+        Ok(self
+            .read_versioned_publish_status(app_id, publish_id)
+            .await?
+            .map(|(_, status)| status))
+    }
+
+    async fn compare_and_swap_publish_status(
+        &self,
+        expected: &VersionedPublishStatus,
+        next: PublishStatus,
+    ) -> PushStorageResult<PublishStatusCasOutcome> {
+        if expected.revision == 0
+            || expected.status.app_id != next.app_id
+            || expected.status.publish_id != next.publish_id
+        {
+            return Err(PushStorageError::Backend(
+                "invalid push publish status CAS identity or revision".to_owned(),
+            ));
+        }
+
+        let Some((expected_data, current)) = self
+            .read_versioned_publish_status(&next.app_id, &next.publish_id)
+            .await?
+        else {
+            return Ok(PublishStatusCasOutcome::Missing);
+        };
+        if current != *expected {
+            return Ok(PublishStatusCasOutcome::Conflict);
+        }
+
+        let revision = current.revision.checked_add(1).ok_or_else(|| {
+            PushStorageError::Backend("push publish status revision exhausted".to_owned())
+        })?;
+        let updated = VersionedPublishStatus {
+            status: next,
+            revision,
+            updated_at_ms: next_publish_status_updated_at(current.updated_at_ms),
+        };
+        let indexed_data = self.prepare_publish_status_index(&updated).await?;
+        if !self
+            .backend
+            .compare_and_swap(
+                FAMILY_STATUS,
+                &updated.status.app_id,
+                &updated.status.publish_id,
+                DEFAULT_SK,
+                &expected_data,
+                encode_publish_status(&updated)?,
+            )
+            .await?
+        {
+            self.discard_publish_status_index_if_stale(&updated, &indexed_data)
+                .await;
+            return Ok(PublishStatusCasOutcome::Conflict);
+        }
+
+        self.refresh_publish_status_indexes(&updated, Some(current.updated_at_ms))
+            .await;
+        Ok(PublishStatusCasOutcome::Updated { revision })
     }
 }
 
@@ -358,7 +631,8 @@ where
     B: DocumentBackend,
 {
     let rows = store
-        .scan_pk_page_json::<String>(
+        .backend
+        .scan_pk_page(
             FAMILY_STATUS_UPDATED_TIME,
             app_id,
             "time",
@@ -367,41 +641,133 @@ where
         )
         .await?;
     let mut counters = crate::cleanup::PushCleanupCounters::default();
-    for (_, position, publish_id) in rows {
+    for document in rows {
         counters.scanned = counters.scanned.saturating_add(1);
-        let Some((updated_at_ms, _)) = parse_status_updated_position(&position) else {
+        let position = document.sk;
+        let indexed_data = document.data;
+        let publish_id = from_json_str::<String>(&indexed_data)?;
+        let Some((indexed_updated_at_ms, indexed_publish_id)) =
+            parse_status_updated_position(&position)
+        else {
             continue;
         };
-        if updated_at_ms >= cutoff_ms {
+        if indexed_updated_at_ms >= cutoff_ms {
             continue;
         }
-        let Some(status) = store
-            .get_json::<PublishStatus>(FAMILY_STATUS, app_id, &publish_id, DEFAULT_SK)
-            .await?
-        else {
+        if indexed_publish_id != publish_id {
             store
                 .backend
-                .delete(FAMILY_STATUS_UPDATED_TIME, app_id, "time", &position)
+                .compare_and_delete(
+                    FAMILY_STATUS_UPDATED_TIME,
+                    app_id,
+                    "time",
+                    &position,
+                    &indexed_data,
+                )
+                .await?;
+            continue;
+        }
+
+        let Some(status_data) = store
+            .backend
+            .get_consistent(FAMILY_STATUS, app_id, &publish_id, DEFAULT_SK)
+            .await?
+        else {
+            if let Some(updated_data) = store
+                .backend
+                .get_consistent(FAMILY_STATUS_UPDATED, app_id, &publish_id, DEFAULT_SK)
+                .await?
+                && from_json_str::<u64>(&updated_data)? == indexed_updated_at_ms
+            {
+                store
+                    .backend
+                    .compare_and_delete(
+                        FAMILY_STATUS_UPDATED,
+                        app_id,
+                        &publish_id,
+                        DEFAULT_SK,
+                        &updated_data,
+                    )
+                    .await?;
+            }
+            store
+                .backend
+                .compare_and_delete(
+                    FAMILY_STATUS_UPDATED_TIME,
+                    app_id,
+                    "time",
+                    &position,
+                    &indexed_data,
+                )
                 .await?;
             continue;
         };
-        if !terminal_publish_state(status.state) {
+
+        let mut decoded = decode_publish_status(&status_data)?;
+        if decoded.legacy {
+            let Some(legacy_updated_at_ms) = store
+                .backend
+                .get_consistent(FAMILY_STATUS_UPDATED, app_id, &publish_id, DEFAULT_SK)
+                .await?
+                .map(|data| from_json_str::<u64>(&data))
+                .transpose()?
+            else {
+                // The old format did not carry an authoritative timestamp. Without its matching
+                // pointer, fail closed and retain the status rather than guessing from an index.
+                continue;
+            };
+            decoded.versioned.updated_at_ms = legacy_updated_at_ms;
+        }
+
+        if decoded.versioned.updated_at_ms != indexed_updated_at_ms {
+            store
+                .backend
+                .compare_and_delete(
+                    FAMILY_STATUS_UPDATED_TIME,
+                    app_id,
+                    "time",
+                    &position,
+                    &indexed_data,
+                )
+                .await?;
+            continue;
+        }
+        if !terminal_publish_state(decoded.versioned.status.state) {
             continue;
         }
         if store
             .backend
-            .delete(FAMILY_STATUS, app_id, &publish_id, DEFAULT_SK)
+            .compare_and_delete(FAMILY_STATUS, app_id, &publish_id, DEFAULT_SK, &status_data)
             .await?
         {
             counters.deleted = counters.deleted.saturating_add(1);
+            if let Some(updated_data) = store
+                .backend
+                .get_consistent(FAMILY_STATUS_UPDATED, app_id, &publish_id, DEFAULT_SK)
+                .await?
+                && from_json_str::<u64>(&updated_data)? == indexed_updated_at_ms
+            {
+                store
+                    .backend
+                    .compare_and_delete(
+                        FAMILY_STATUS_UPDATED,
+                        app_id,
+                        &publish_id,
+                        DEFAULT_SK,
+                        &updated_data,
+                    )
+                    .await?;
+            }
         }
         store
             .backend
-            .delete(FAMILY_STATUS_UPDATED, app_id, &publish_id, DEFAULT_SK)
-            .await?;
-        store
-            .backend
-            .delete(FAMILY_STATUS_UPDATED_TIME, app_id, "time", &position)
+            .compare_and_delete(
+                FAMILY_STATUS_UPDATED_TIME,
+                app_id,
+                "time",
+                &position,
+                &indexed_data,
+            )
             .await?;
     }
     Ok(counters)

--- a/crates/sockudo-push/src/nosql/scylla.rs
+++ b/crates/sockudo-push/src/nosql/scylla.rs
@@ -1,7 +1,7 @@
 use super::ScyllaDbPushStore;
 use super::document::{DocumentBackend, StoredDocument};
 use super::helpers::*;
-use crate::storage::PushStorageResult;
+use crate::storage::{PushStorageError, PushStorageResult};
 use async_trait::async_trait;
 
 #[cfg(feature = "scylladb")]
@@ -69,6 +69,34 @@ impl ScyllaDbDocumentBackend {
             .map_err(scylla_error)?;
         Ok(())
     }
+
+    fn serial_lwt_statement(query: String) -> scylla::statement::unprepared::Statement {
+        use scylla::statement::SerialConsistency;
+
+        let mut statement = scylla::statement::unprepared::Statement::new(query);
+        statement.set_serial_consistency(Some(SerialConsistency::Serial));
+        statement
+    }
+
+    fn lwt_applied(result: scylla::response::query_result::QueryResult) -> PushStorageResult<bool> {
+        use scylla::value::{CqlValue, Row};
+
+        let rows = result.into_rows_result().map_err(scylla_error)?;
+        let row = rows
+            .maybe_first_row::<Row>()
+            .map_err(scylla_error)?
+            .ok_or_else(|| {
+                PushStorageError::Backend(
+                    "push ScyllaDB LWT response did not contain an applied row".to_owned(),
+                )
+            })?;
+        match row.columns.first().and_then(Option::as_ref) {
+            Some(CqlValue::Boolean(applied)) => Ok(*applied),
+            _ => Err(PushStorageError::Backend(
+                "push ScyllaDB LWT response did not contain an applied boolean".to_owned(),
+            )),
+        }
+    }
 }
 
 #[cfg(feature = "scylladb")]
@@ -103,24 +131,19 @@ impl DocumentBackend for ScyllaDbDocumentBackend {
         sk: &str,
         data: String,
     ) -> PushStorageResult<bool> {
+        let statement = Self::serial_lwt_statement(format!(
+            "INSERT INTO {} (family_app, pk, sk, app_id, data) VALUES (?, ?, ?, ?, ?) IF NOT EXISTS",
+            self.fq_table()
+        ));
         let result = self
             .session
             .query_unpaged(
-                format!(
-                    "INSERT INTO {} (family_app, pk, sk, app_id, data) VALUES (?, ?, ?, ?, ?) IF NOT EXISTS",
-                    self.fq_table()
-                ),
+                statement,
                 (family_app(family, app_id), pk, sk, app_id, data),
             )
             .await
             .map_err(scylla_error)?;
-        let rows = result.into_rows_result().map_err(scylla_error)?;
-        let applied = rows
-            .maybe_first_row::<(bool,)>()
-            .map_err(scylla_error)?
-            .map(|row| row.0)
-            .unwrap_or(false);
-        Ok(applied)
+        Self::lwt_applied(result)
     }
 
     async fn get(
@@ -147,6 +170,75 @@ impl DocumentBackend for ScyllaDbDocumentBackend {
             .map(|row| row.map(|row| row.0))
     }
 
+    async fn get_consistent(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+    ) -> PushStorageResult<Option<String>> {
+        use scylla::statement::Consistency;
+
+        let mut statement = scylla::statement::unprepared::Statement::new(format!(
+            "SELECT data FROM {} WHERE family_app = ? AND pk = ? AND sk = ?",
+            self.fq_table()
+        ));
+        statement.set_consistency(Consistency::Serial);
+        let result = self
+            .session
+            .query_unpaged(statement, (family_app(family, app_id), pk, sk))
+            .await
+            .map_err(scylla_error)?;
+        let rows = result.into_rows_result().map_err(scylla_error)?;
+        rows.maybe_first_row::<(String,)>()
+            .map_err(scylla_error)
+            .map(|row| row.map(|row| row.0))
+    }
+
+    async fn compare_and_swap(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        expected: &str,
+        data: String,
+    ) -> PushStorageResult<bool> {
+        let statement = Self::serial_lwt_statement(format!(
+            "UPDATE {} SET app_id = ?, data = ? WHERE family_app = ? AND pk = ? AND sk = ? IF data = ?",
+            self.fq_table()
+        ));
+        let result = self
+            .session
+            .query_unpaged(
+                statement,
+                (app_id, data, family_app(family, app_id), pk, sk, expected),
+            )
+            .await
+            .map_err(scylla_error)?;
+        Self::lwt_applied(result)
+    }
+
+    async fn compare_and_delete(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        expected: &str,
+    ) -> PushStorageResult<bool> {
+        let statement = Self::serial_lwt_statement(format!(
+            "DELETE FROM {} WHERE family_app = ? AND pk = ? AND sk = ? IF data = ?",
+            self.fq_table()
+        ));
+        let result = self
+            .session
+            .query_unpaged(statement, (family_app(family, app_id), pk, sk, expected))
+            .await
+            .map_err(scylla_error)?;
+        Self::lwt_applied(result)
+    }
+
     async fn delete(
         &self,
         family: &'static str,
@@ -154,21 +246,16 @@ impl DocumentBackend for ScyllaDbDocumentBackend {
         pk: &str,
         sk: &str,
     ) -> PushStorageResult<bool> {
+        let statement = Self::serial_lwt_statement(format!(
+            "DELETE FROM {} WHERE family_app = ? AND pk = ? AND sk = ? IF EXISTS",
+            self.fq_table()
+        ));
         let result = self
             .session
-            .query_unpaged(
-                format!(
-                    "DELETE FROM {} WHERE family_app = ? AND pk = ? AND sk = ? IF EXISTS",
-                    self.fq_table()
-                ),
-                (family_app(family, app_id), pk, sk),
-            )
+            .query_unpaged(statement, (family_app(family, app_id), pk, sk))
             .await
             .map_err(scylla_error)?;
-        let rows = result.into_rows_result().map_err(scylla_error)?;
-        rows.maybe_first_row::<(bool,)>()
-            .map_err(scylla_error)
-            .map(|row| row.map(|row| row.0).unwrap_or(false))
+        Self::lwt_applied(result)
     }
 
     async fn scan_app(

--- a/crates/sockudo-push/src/nosql/surreal.rs
+++ b/crates/sockudo-push/src/nosql/surreal.rs
@@ -38,8 +38,20 @@ struct SurrealDocumentRow {
 
 #[cfg(feature = "surrealdb")]
 impl SurrealDbDocumentBackend {
+    fn ensure_response_ok(mut response: surrealdb::IndexedResults) -> PushStorageResult<()> {
+        if let Some((statement, error)) =
+            response.take_errors().into_iter().min_by_key(|item| item.0)
+        {
+            return Err(surreal_error(format!(
+                "statement {statement} failed: {error}"
+            )));
+        }
+        Ok(())
+    }
+
     async fn ensure_schema(&self) -> PushStorageResult<()> {
-        self.db
+        let response = self
+            .db
             .query(format!(
                 "DEFINE TABLE IF NOT EXISTS {} SCHEMALESS;\
                  DEFINE INDEX IF NOT EXISTS {}_key ON TABLE {} FIELDS family_app, pk, sk UNIQUE;\
@@ -48,7 +60,7 @@ impl SurrealDbDocumentBackend {
             ))
             .await
             .map_err(surreal_error)?;
-        Ok(())
+        Self::ensure_response_ok(response)
     }
 
     fn record_id(family: &'static str, app_id: &str, pk: &str, sk: &str) -> String {
@@ -69,7 +81,8 @@ impl DocumentBackend for SurrealDbDocumentBackend {
         sk: &str,
         data: String,
     ) -> PushStorageResult<()> {
-        self.db
+        let response = self
+            .db
             .query("UPSERT type::record($table, $id) SET family_app = $family_app, app_id = $app_id, pk = $pk, sk = $sk, data = $data")
             .bind(("table", self.table.clone()))
             .bind(("id", Self::record_id(family, app_id, pk, sk)))
@@ -80,7 +93,7 @@ impl DocumentBackend for SurrealDbDocumentBackend {
             .bind(("data", data))
             .await
             .map_err(surreal_error)?;
-        Ok(())
+        Self::ensure_response_ok(response)
     }
 
     async fn put_if_absent(
@@ -104,16 +117,14 @@ impl DocumentBackend for SurrealDbDocumentBackend {
             .await;
         let mut response = match result {
             Ok(response) => response,
-            Err(error)
-                if error.to_string().to_ascii_lowercase().contains("already")
-                    || error.to_string().to_ascii_lowercase().contains("duplicate")
-                    || error.to_string().to_ascii_lowercase().contains("unique") =>
-            {
-                return Ok(false);
-            }
+            Err(error) if surreal_conflict_error(&error) => return Ok(false),
             Err(error) => return Err(surreal_error(error)),
         };
-        let rows: Vec<SurrealDocumentRow> = response.take(0usize).map_err(surreal_error)?;
+        let rows: Vec<SurrealDocumentRow> = match response.take(0usize) {
+            Ok(rows) => rows,
+            Err(error) if surreal_conflict_error(&error) => return Ok(false),
+            Err(error) => return Err(surreal_error(error)),
+        };
         Ok(!rows.is_empty())
     }
 
@@ -137,6 +148,64 @@ impl DocumentBackend for SurrealDbDocumentBackend {
             .map_err(surreal_error)?;
         let rows: Vec<SurrealDocumentRow> = response.take(0usize).map_err(surreal_error)?;
         Ok(rows.into_iter().next().map(|row| row.data))
+    }
+
+    async fn get_consistent(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+    ) -> PushStorageResult<Option<String>> {
+        // Every SurrealDB statement runs in its own transaction. A point read therefore observes
+        // a committed value suitable for the conditional statement that follows it.
+        self.get(family, app_id, pk, sk).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        expected: &str,
+        data: String,
+    ) -> PushStorageResult<bool> {
+        let mut response = self
+            .db
+            .query("UPDATE type::record($table, $id) SET family_app = $family_app, app_id = $app_id, pk = $pk, sk = $sk, data = $data WHERE data = $expected RETURN AFTER")
+            .bind(("table", self.table.clone()))
+            .bind(("id", Self::record_id(family, app_id, pk, sk)))
+            .bind(("family_app", family_app(family, app_id)))
+            .bind(("app_id", app_id.to_owned()))
+            .bind(("pk", pk.to_owned()))
+            .bind(("sk", sk.to_owned()))
+            .bind(("expected", expected.to_owned()))
+            .bind(("data", data))
+            .await
+            .map_err(surreal_error)?;
+        let rows: Vec<SurrealDocumentRow> = response.take(0usize).map_err(surreal_error)?;
+        Ok(!rows.is_empty())
+    }
+
+    async fn compare_and_delete(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        expected: &str,
+    ) -> PushStorageResult<bool> {
+        let mut response = self
+            .db
+            .query("DELETE type::record($table, $id) WHERE data = $expected RETURN BEFORE")
+            .bind(("table", self.table.clone()))
+            .bind(("id", Self::record_id(family, app_id, pk, sk)))
+            .bind(("expected", expected.to_owned()))
+            .await
+            .map_err(surreal_error)?;
+        let rows: Vec<SurrealDocumentRow> = response.take(0usize).map_err(surreal_error)?;
+        Ok(!rows.is_empty())
     }
 
     async fn delete(

--- a/crates/sockudo-push/src/nosql/tests/mod.rs
+++ b/crates/sockudo-push/src/nosql/tests/mod.rs
@@ -1,7 +1,8 @@
 use super::helpers::*;
 use super::*;
 use crate::conformance::PushStoreConformance;
-use crate::storage::PushStorageResult;
+use crate::domain::{PublishCounters, PublishLifecycleState, PublishStatus};
+use crate::storage::{PublishStatusCasOutcome, PushPublishStatusStore, PushStorageResult};
 use async_trait::async_trait;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -64,6 +65,51 @@ impl DocumentBackend for TestDocumentBackend {
             .cloned())
     }
 
+    async fn get_consistent(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+    ) -> PushStorageResult<Option<String>> {
+        self.get(family, app_id, pk, sk).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        expected: &str,
+        data: String,
+    ) -> PushStorageResult<bool> {
+        let key = (family_app(family, app_id), pk.to_owned(), sk.to_owned());
+        let mut inner = self.inner.write().await;
+        if inner.get(&key).map(String::as_str) != Some(expected) {
+            return Ok(false);
+        }
+        inner.insert(key, data);
+        Ok(true)
+    }
+
+    async fn compare_and_delete(
+        &self,
+        family: &'static str,
+        app_id: &str,
+        pk: &str,
+        sk: &str,
+        expected: &str,
+    ) -> PushStorageResult<bool> {
+        let key = (family_app(family, app_id), pk.to_owned(), sk.to_owned());
+        let mut inner = self.inner.write().await;
+        if inner.get(&key).map(String::as_str) != Some(expected) {
+            return Ok(false);
+        }
+        inner.remove(&key);
+        Ok(true)
+    }
+
     async fn delete(
         &self,
         family: &'static str,
@@ -101,6 +147,293 @@ impl DocumentBackend for TestDocumentBackend {
 
 fn test_store() -> DocumentPushStore<TestDocumentBackend> {
     DocumentPushStore::with_backend(TestDocumentBackend::default())
+}
+
+#[cfg(feature = "surrealdb")]
+#[test]
+fn surreal_duplicate_statement_errors_are_classified_as_conflicts() {
+    assert!(surreal_conflict_error(&"record already exists"));
+    assert!(surreal_conflict_error(&"duplicate key"));
+    assert!(surreal_conflict_error(&"unique index violation"));
+    assert!(!surreal_conflict_error(&"connection closed"));
+}
+
+fn test_publish_status(state: PublishLifecycleState) -> PublishStatus {
+    PublishStatus {
+        app_id: "app-1".to_owned(),
+        publish_id: "publish-1".to_owned(),
+        state,
+        counters: PublishCounters {
+            planned: 2,
+            dispatched: 0,
+            succeeded: 0,
+            failed: 0,
+            expired: 0,
+            retry_scheduled: 0,
+            retry_attempted: 0,
+            dead_lettered: 0,
+        },
+        fanout_regime: None,
+        retry_after_ms: None,
+        error_reason: None,
+    }
+}
+
+#[tokio::test]
+async fn document_publish_status_create_is_atomic() {
+    let store = test_store();
+    let status = test_publish_status(PublishLifecycleState::Queued);
+
+    assert_eq!(
+        store
+            .create_publish_status_if_absent(status.clone())
+            .await
+            .unwrap(),
+        PublishStatusCasOutcome::Inserted { revision: 1 }
+    );
+    assert_eq!(
+        store.create_publish_status_if_absent(status).await.unwrap(),
+        PublishStatusCasOutcome::Conflict
+    );
+
+    let stored = store
+        .get_versioned_publish_status("app-1", "publish-1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.revision, 1);
+    assert!(stored.updated_at_ms > 0);
+}
+
+#[tokio::test]
+async fn document_publish_status_cas_allows_only_one_concurrent_writer() {
+    let store = test_store();
+    store
+        .create_publish_status_if_absent(test_publish_status(PublishLifecycleState::Queued))
+        .await
+        .unwrap();
+    let expected = store
+        .get_versioned_publish_status("app-1", "publish-1")
+        .await
+        .unwrap()
+        .unwrap();
+    let mut first = expected.status.clone();
+    first.counters.retry_scheduled = 1;
+    let mut second = expected.status.clone();
+    second.counters.retry_scheduled = 2;
+
+    let first_store = store.clone();
+    let first_expected = expected.clone();
+    let (first_outcome, second_outcome) = tokio::join!(
+        async move {
+            first_store
+                .compare_and_swap_publish_status(&first_expected, first)
+                .await
+                .unwrap()
+        },
+        async {
+            store
+                .compare_and_swap_publish_status(&expected, second)
+                .await
+                .unwrap()
+        }
+    );
+
+    assert_eq!(
+        usize::from(first_outcome.applied()) + usize::from(second_outcome.applied()),
+        1
+    );
+    assert!(matches!(
+        (first_outcome, second_outcome),
+        (
+            PublishStatusCasOutcome::Updated { revision: 2 },
+            PublishStatusCasOutcome::Conflict
+        ) | (
+            PublishStatusCasOutcome::Conflict,
+            PublishStatusCasOutcome::Updated { revision: 2 }
+        )
+    ));
+    assert_eq!(
+        store
+            .get_versioned_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap()
+            .revision,
+        2
+    );
+    assert_eq!(
+        store
+            .backend
+            .scan_pk(constants::FAMILY_STATUS_UPDATED_TIME, "app-1", "time",)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn document_publish_status_cas_upgrades_legacy_status_documents() {
+    let store = test_store();
+    let status = test_publish_status(PublishLifecycleState::Queued);
+    store
+        .backend
+        .put(
+            constants::FAMILY_STATUS,
+            "app-1",
+            "publish-1",
+            constants::DEFAULT_SK,
+            to_json_string(&status).unwrap(),
+        )
+        .await
+        .unwrap();
+    store
+        .backend
+        .put(
+            constants::FAMILY_STATUS_UPDATED,
+            "app-1",
+            "publish-1",
+            constants::DEFAULT_SK,
+            to_json_string(&42_u64).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let expected = store
+        .get_versioned_publish_status("app-1", "publish-1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(expected.revision, 1);
+    assert_eq!(expected.updated_at_ms, 42);
+    let mut next = expected.status.clone();
+    next.state = PublishLifecycleState::Planning;
+    assert_eq!(
+        store
+            .compare_and_swap_publish_status(&expected, next)
+            .await
+            .unwrap(),
+        PublishStatusCasOutcome::Updated { revision: 2 }
+    );
+
+    let upgraded = store
+        .get_versioned_publish_status("app-1", "publish-1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(upgraded.revision, 2);
+    assert!(upgraded.updated_at_ms > 42);
+    assert_eq!(upgraded.status.state, PublishLifecycleState::Planning);
+}
+
+#[tokio::test]
+async fn document_status_cleanup_ignores_a_stale_advisory_timestamp() {
+    let store = test_store();
+    let mut terminal = test_publish_status(PublishLifecycleState::Succeeded);
+    terminal.counters.succeeded = 2;
+    store
+        .create_publish_status_if_absent(terminal)
+        .await
+        .unwrap();
+    let first = store
+        .get_versioned_publish_status("app-1", "publish-1")
+        .await
+        .unwrap()
+        .unwrap();
+    let mut next = first.status.clone();
+    next.counters.retry_attempted = 1;
+    store
+        .compare_and_swap_publish_status(&first, next)
+        .await
+        .unwrap();
+    let current = store
+        .get_versioned_publish_status("app-1", "publish-1")
+        .await
+        .unwrap()
+        .unwrap();
+    let current_position =
+        status_updated_position(current.updated_at_ms, &current.status.publish_id);
+    store
+        .backend
+        .delete(
+            constants::FAMILY_STATUS_UPDATED_TIME,
+            "app-1",
+            "time",
+            &current_position,
+        )
+        .await
+        .unwrap();
+    let stale_position = status_updated_position(first.updated_at_ms, &first.status.publish_id);
+    store
+        .backend
+        .put(
+            constants::FAMILY_STATUS_UPDATED_TIME,
+            "app-1",
+            "time",
+            &stale_position,
+            r#"{ "data": "publish-1", "_v": 1 }"#.to_owned(),
+        )
+        .await
+        .unwrap();
+
+    let report = publishing::document_cleanup_publish_statuses(&store, "app-1", u64::MAX, 10)
+        .await
+        .unwrap();
+
+    assert_eq!(report.deleted, 0);
+    assert!(
+        store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        store
+            .backend
+            .get(
+                constants::FAMILY_STATUS_UPDATED_TIME,
+                "app-1",
+                "time",
+                &stale_position,
+            )
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn document_status_cleanup_survives_missing_updated_pointer() {
+    let store = test_store();
+    store
+        .create_publish_status_if_absent(test_publish_status(PublishLifecycleState::Succeeded))
+        .await
+        .unwrap();
+    store
+        .backend
+        .delete(
+            constants::FAMILY_STATUS_UPDATED,
+            "app-1",
+            "publish-1",
+            constants::DEFAULT_SK,
+        )
+        .await
+        .unwrap();
+
+    let report = publishing::document_cleanup_publish_statuses(&store, "app-1", u64::MAX, 10)
+        .await
+        .unwrap();
+
+    assert_eq!(report.deleted, 1);
+    assert!(
+        store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[tokio::test]

--- a/crates/sockudo-push/src/pipeline.rs
+++ b/crates/sockudo-push/src/pipeline.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::sync::{Arc, Mutex};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
@@ -21,6 +22,9 @@ pub type DynPushQueue = Arc<dyn PushQueue + Send + Sync>;
 pub type PushQueueResult<T> = Result<T, PushQueueError>;
 pub type PushPipelineResult<T> = Result<T, PushPipelineError>;
 const DEFAULT_IDEMPOTENCY_TTL_MS: u64 = 24 * 60 * 60 * 1000;
+const PUBLISH_STATUS_LOCK_SHARDS: usize = 256;
+
+static PUBLISH_STATUS_LOCKS: OnceLock<Box<[tokio::sync::Mutex<()>]>> = OnceLock::new();
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -959,6 +963,49 @@ pub enum PushPipelineError {
     InvalidPayload(String),
 }
 
+/// Serialize publish-status read/modify/write sections within a process without an unbounded
+/// per-publish lock map. This closes local worker races; storage-level CAS remains the authority
+/// needed to prevent conflicting writes from separate nodes.
+pub(crate) async fn lock_publish_status(
+    app_id: &str,
+    publish_id: &str,
+) -> tokio::sync::MutexGuard<'static, ()> {
+    let locks = PUBLISH_STATUS_LOCKS.get_or_init(|| {
+        (0..PUBLISH_STATUS_LOCK_SHARDS)
+            .map(|_| tokio::sync::Mutex::new(()))
+            .collect::<Vec<_>>()
+            .into_boxed_slice()
+    });
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    app_id.hash(&mut hasher);
+    publish_id.hash(&mut hasher);
+    let index = (hasher.finish() as usize) % locks.len();
+    locks[index].lock().await
+}
+
+pub(crate) fn guard_publish_status_transition(
+    metrics: &PushMetrics,
+    component: &'static str,
+    status: &PublishStatus,
+    next: PublishLifecycleState,
+) -> bool {
+    if status.state.can_transition_to(next) {
+        return true;
+    }
+
+    metrics.status_transition_invariant_violation();
+    tracing::warn!(
+        invariant = "status_transition",
+        component,
+        app_id = %status.app_id,
+        publish_id = %status.publish_id,
+        from = ?status.state,
+        to = ?next,
+        "ignored non-monotonic push publish status transition"
+    );
+    false
+}
+
 impl PushPipeline {
     pub fn new(store: DynPushStore, queue: DynPushQueue, config: FanoutConfig) -> Self {
         Self {
@@ -1202,6 +1249,7 @@ impl PushPipeline {
                     "duplicate publish is missing persisted status".to_owned(),
                 )
             })?;
+        self.metrics.duplicate_suppressed();
         Ok(PushAcceptOutcome {
             publish_id: publish_id.to_owned(),
             publish_event: PublishLogEvent {
@@ -1561,6 +1609,28 @@ mod tests {
                 .ready_depth,
             1
         );
+    }
+
+    #[tokio::test]
+    async fn duplicate_accept_increments_duplicate_suppressed_metric() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        let metrics = PushMetrics::default();
+        let pipeline =
+            PushPipeline::new(store, queue, FanoutConfig::default()).with_metrics(metrics.clone());
+        let request = PushAcceptRequest {
+            intent: sample_intent(vec![PublishTarget::Recipient {
+                recipient: recipient(PushProviderKind::Fcm),
+            }]),
+            expected_recipients: 1,
+        };
+
+        let accepted = pipeline.accept_publish(request.clone(), 10).await.unwrap();
+        let duplicate = pipeline.accept_publish(request, 11).await.unwrap();
+
+        assert!(!accepted.duplicate);
+        assert!(duplicate.duplicate);
+        assert_eq!(metrics.get("sockudo_push_duplicate_suppressed_total"), 1);
     }
 
     #[tokio::test]

--- a/crates/sockudo-push/src/pipeline.rs
+++ b/crates/sockudo-push/src/pipeline.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::hash::{Hash, Hasher};
-use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -15,16 +14,17 @@ use crate::domain::{
 };
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::PushMetrics;
-use crate::storage::{DynPushStore, IdempotencyRecord, Page, PushStorageError};
+use crate::storage::{
+    DynPushStore, IdempotencyRecord, Page, PublishStatusCasOutcome, PushPublishStatusStore,
+    PushStorageError,
+};
 use crate::transform::{render_all_provider_payloads, resolve_template_payload};
 
 pub type DynPushQueue = Arc<dyn PushQueue + Send + Sync>;
 pub type PushQueueResult<T> = Result<T, PushQueueError>;
 pub type PushPipelineResult<T> = Result<T, PushPipelineError>;
 const DEFAULT_IDEMPOTENCY_TTL_MS: u64 = 24 * 60 * 60 * 1000;
-const PUBLISH_STATUS_LOCK_SHARDS: usize = 256;
-
-static PUBLISH_STATUS_LOCKS: OnceLock<Box<[tokio::sync::Mutex<()>]>> = OnceLock::new();
+const MAX_PUBLISH_STATUS_CAS_ATTEMPTS: usize = 8;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -961,26 +961,97 @@ pub enum PushPipelineError {
     Backpressure(String),
     #[error("push pipeline invalid payload: {0}")]
     InvalidPayload(String),
+    #[error("push publish status CAS retries exhausted for {component} ({app_id}/{publish_id})")]
+    PublishStatusCasExhausted {
+        component: &'static str,
+        app_id: String,
+        publish_id: String,
+    },
+    #[error("unexpected push publish status CAS outcome during {operation}: {outcome:?}")]
+    UnexpectedPublishStatusCasOutcome {
+        operation: &'static str,
+        outcome: PublishStatusCasOutcome,
+    },
 }
 
-/// Serialize publish-status read/modify/write sections within a process without an unbounded
-/// per-publish lock map. This closes local worker races; storage-level CAS remains the authority
-/// needed to prevent conflicting writes from separate nodes.
-pub(crate) async fn lock_publish_status(
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum PublishStatusMutationOutcome {
+    Missing,
+    Unchanged(PublishStatus),
+    Updated(PublishStatus),
+}
+
+/// Apply a pure publish-status mutation with bounded optimistic-concurrency retries.
+///
+/// The mutation can be evaluated more than once, so callers must emit metrics, logs, queue work,
+/// and other side effects only after this function returns `Updated`.
+pub(crate) async fn mutate_publish_status_with_cas<S, F>(
+    store: &S,
+    metrics: &PushMetrics,
+    component: &'static str,
     app_id: &str,
     publish_id: &str,
-) -> tokio::sync::MutexGuard<'static, ()> {
-    let locks = PUBLISH_STATUS_LOCKS.get_or_init(|| {
-        (0..PUBLISH_STATUS_LOCK_SHARDS)
-            .map(|_| tokio::sync::Mutex::new(()))
-            .collect::<Vec<_>>()
-            .into_boxed_slice()
-    });
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    app_id.hash(&mut hasher);
-    publish_id.hash(&mut hasher);
-    let index = (hasher.finish() as usize) % locks.len();
-    locks[index].lock().await
+    mut mutate: F,
+) -> PushPipelineResult<PublishStatusMutationOutcome>
+where
+    S: PushPublishStatusStore + ?Sized,
+    F: FnMut(&PublishStatus) -> PushPipelineResult<Option<PublishStatus>>,
+{
+    for attempt in 0..MAX_PUBLISH_STATUS_CAS_ATTEMPTS {
+        let Some(expected) = store
+            .get_versioned_publish_status(app_id, publish_id)
+            .await?
+        else {
+            return Ok(PublishStatusMutationOutcome::Missing);
+        };
+        let Some(next) = mutate(&expected.status)? else {
+            return Ok(PublishStatusMutationOutcome::Unchanged(expected.status));
+        };
+        if next.app_id != app_id || next.publish_id != publish_id {
+            return Err(PushPipelineError::InvalidPayload(
+                "publish status CAS mutation changed its storage identity".to_owned(),
+            ));
+        }
+
+        match store
+            .compare_and_swap_publish_status(&expected, next.clone())
+            .await?
+        {
+            PublishStatusCasOutcome::Updated { .. } => {
+                return Ok(PublishStatusMutationOutcome::Updated(next));
+            }
+            PublishStatusCasOutcome::Conflict => {
+                metrics.publish_status_cas_conflict(component);
+                if attempt + 1 < MAX_PUBLISH_STATUS_CAS_ATTEMPTS {
+                    let delay_ms = 1_u64 << attempt.min(5);
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+            }
+            PublishStatusCasOutcome::Missing => {
+                return Ok(PublishStatusMutationOutcome::Missing);
+            }
+            outcome @ PublishStatusCasOutcome::Inserted { .. } => {
+                return Err(PushPipelineError::UnexpectedPublishStatusCasOutcome {
+                    operation: "compare-and-swap",
+                    outcome,
+                });
+            }
+        }
+    }
+
+    metrics.publish_status_cas_exhausted(component);
+    tracing::warn!(
+        component,
+        app_id,
+        publish_id,
+        attempts = MAX_PUBLISH_STATUS_CAS_ATTEMPTS,
+        "push publish status CAS retries exhausted"
+    );
+    Err(PushPipelineError::PublishStatusCasExhausted {
+        component,
+        app_id: app_id.to_owned(),
+        publish_id: publish_id.to_owned(),
+    })
 }
 
 pub(crate) fn guard_publish_status_transition(
@@ -1116,7 +1187,35 @@ impl PushPipeline {
             retry_after_ms: None,
             error_reason: None,
         };
-        self.store.put_publish_status(status.clone()).await?;
+        match self
+            .store
+            .create_publish_status_if_absent(status.clone())
+            .await?
+        {
+            PublishStatusCasOutcome::Inserted { .. } => {}
+            PublishStatusCasOutcome::Conflict => {
+                let existing = self
+                    .store
+                    .get_publish_status(&status.app_id, &status.publish_id)
+                    .await?
+                    .ok_or_else(|| {
+                        PushPipelineError::Backpressure(
+                            "conflicting publish status disappeared".to_owned(),
+                        )
+                    })?;
+                if existing != status {
+                    return self
+                        .duplicate_accept(&status.app_id, &status.publish_id)
+                        .await;
+                }
+            }
+            outcome => {
+                return Err(PushPipelineError::UnexpectedPublishStatusCasOutcome {
+                    operation: "create",
+                    outcome,
+                });
+            }
+        }
 
         let publish_id_record = IdempotencyRecord {
             app_id: request.intent.app_id.clone(),
@@ -1331,8 +1430,12 @@ pub(crate) fn dedupe_key(seed: impl AsRef<str>, existing: &mut BTreeSet<String>)
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
+    use async_trait::async_trait;
     use sonic_rs::json;
 
     use crate::dispatch::{AcceptAllDispatcher, ProviderDispatchWorker, RetryAfterDispatcher};
@@ -1347,11 +1450,48 @@ mod tests {
     use crate::planner::{PushPlanner, PushShardWorker};
     use crate::retry::{PushRetryScheduler, RetryPolicy};
     use crate::storage::{
-        PushDeviceStore, PushFanoutShardStore, PushPublishStatusStore, PushSubscriptionStore,
-        PushTemplateStore,
+        PushDeviceStore, PushFanoutShardStore, PushPublishStatusStore, PushStorageResult,
+        PushSubscriptionStore, PushTemplateStore, VersionedPublishStatus,
     };
 
     use super::*;
+
+    struct AlwaysConflictStatusStore {
+        current: VersionedPublishStatus,
+        conflicts: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl PushPublishStatusStore for AlwaysConflictStatusStore {
+        async fn create_publish_status_if_absent(
+            &self,
+            _status: PublishStatus,
+        ) -> PushStorageResult<PublishStatusCasOutcome> {
+            Ok(PublishStatusCasOutcome::Conflict)
+        }
+
+        async fn get_versioned_publish_status(
+            &self,
+            app_id: &str,
+            publish_id: &str,
+        ) -> PushStorageResult<Option<VersionedPublishStatus>> {
+            if self.current.status.app_id == app_id && self.current.status.publish_id == publish_id
+            {
+                Ok(Some(self.current.clone()))
+            } else {
+                Ok(None)
+            }
+        }
+
+        async fn compare_and_swap_publish_status(
+            &self,
+            _expected: &VersionedPublishStatus,
+            _next: PublishStatus,
+        ) -> PushStorageResult<PublishStatusCasOutcome> {
+            self.conflicts.fetch_add(1, Ordering::Relaxed);
+            Ok(PublishStatusCasOutcome::Conflict)
+        }
+    }
 
     #[test]
     fn push_queue_startup_checks_are_feature_aware() {
@@ -1609,6 +1749,147 @@ mod tests {
                 .ready_depth,
             1
         );
+    }
+
+    #[tokio::test]
+    async fn accept_recovers_status_created_before_idempotency_election() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        let status = PublishStatus {
+            app_id: "app-1".to_owned(),
+            publish_id: "publish-1".to_owned(),
+            state: PublishLifecycleState::Queued,
+            counters: PublishCounters {
+                planned: 1,
+                ..PublishCounters::default()
+            },
+            fanout_regime: Some(FanoutRegime::FastPath),
+            retry_after_ms: None,
+            error_reason: None,
+        };
+        store.put_publish_status(status).await.unwrap();
+        let pipeline = PushPipeline::new(store, queue.clone(), FanoutConfig::default());
+
+        let outcome = pipeline
+            .accept_publish(
+                PushAcceptRequest {
+                    intent: sample_intent(vec![PublishTarget::Recipient {
+                        recipient: recipient(PushProviderKind::Fcm),
+                    }]),
+                    expected_recipients: 1,
+                },
+                10,
+            )
+            .await
+            .unwrap();
+
+        assert!(!outcome.duplicate);
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::PublishLog)
+                .await
+                .unwrap()
+                .ready_depth,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn accept_does_not_attach_new_work_to_a_conflicting_status() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        let status = PublishStatus {
+            app_id: "app-1".to_owned(),
+            publish_id: "publish-1".to_owned(),
+            state: PublishLifecycleState::Queued,
+            counters: PublishCounters {
+                planned: 99,
+                ..PublishCounters::default()
+            },
+            fanout_regime: Some(FanoutRegime::ShardPath),
+            retry_after_ms: None,
+            error_reason: None,
+        };
+        store.put_publish_status(status.clone()).await.unwrap();
+        let pipeline = PushPipeline::new(store, queue.clone(), FanoutConfig::default());
+
+        let outcome = pipeline
+            .accept_publish(
+                PushAcceptRequest {
+                    intent: sample_intent(vec![PublishTarget::Recipient {
+                        recipient: recipient(PushProviderKind::Fcm),
+                    }]),
+                    expected_recipients: 1,
+                },
+                10,
+            )
+            .await
+            .unwrap();
+
+        assert!(outcome.duplicate);
+        assert_eq!(outcome.status, status);
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::PublishLog)
+                .await
+                .unwrap()
+                .ready_depth,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_status_cas_conflict_retries_are_bounded() {
+        let status = PublishStatus {
+            app_id: "app-1".to_owned(),
+            publish_id: "publish-1".to_owned(),
+            state: PublishLifecycleState::Dispatching,
+            counters: PublishCounters::default(),
+            fanout_regime: None,
+            retry_after_ms: None,
+            error_reason: None,
+        };
+        let store = AlwaysConflictStatusStore {
+            current: VersionedPublishStatus {
+                status,
+                revision: 7,
+                updated_at_ms: 10,
+            },
+            conflicts: AtomicUsize::new(0),
+        };
+        let metrics = PushMetrics::default();
+
+        let error = mutate_publish_status_with_cas(
+            &store,
+            &metrics,
+            "feedback",
+            "app-1",
+            "publish-1",
+            |current| {
+                let mut next = current.clone();
+                next.counters.succeeded = next.counters.succeeded.saturating_add(1);
+                Ok(Some(next))
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            PushPipelineError::PublishStatusCasExhausted {
+                component: "feedback",
+                ..
+            }
+        ));
+        assert_eq!(
+            store.conflicts.load(Ordering::Relaxed),
+            MAX_PUBLISH_STATUS_CAS_ATTEMPTS
+        );
+        assert_eq!(
+            metrics.get("sockudo_push_status_cas_conflicts_total"),
+            MAX_PUBLISH_STATUS_CAS_ATTEMPTS as u64
+        );
+        assert_eq!(metrics.get("sockudo_push_status_cas_exhausted_total"), 1);
     }
 
     #[tokio::test]

--- a/crates/sockudo-push/src/planner.rs
+++ b/crates/sockudo-push/src/planner.rs
@@ -10,7 +10,7 @@ use crate::domain::{
 use crate::metrics::PushMetrics;
 use crate::pipeline::{
     PushPipelineError, PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage,
-    dedupe_key, guard_publish_status_transition, lock_publish_status,
+    dedupe_key, guard_publish_status_transition, mutate_publish_status_with_cas,
 };
 use crate::storage::{DynPushStore, SchedulerLock};
 use crate::transform::render_all_provider_payloads;
@@ -173,44 +173,52 @@ impl PushPlanner {
         event: &PublishLogEvent,
         state: PublishLifecycleState,
     ) -> PushPipelineResult<()> {
-        let _status_guard = lock_publish_status(&event.app_id, &event.publish_id).await;
-        if let Some(mut status) = self
-            .store
-            .get_publish_status(&event.app_id, &event.publish_id)
-            .await?
-        {
-            let next = state;
-            if !guard_publish_status_transition(&self.metrics, "planner", &status, next) {
-                return Ok(());
-            }
-            status.state = next;
-            if next == PublishLifecycleState::Dispatching {
-                status.retry_after_ms = event
-                    .intent
-                    .not_before_ms
-                    .filter(|not_before_ms| *not_before_ms > crate::pipeline::now_ms());
-            }
-            self.store.put_publish_status(status).await?;
-        }
+        mutate_publish_status_with_cas(
+            self.store.as_ref(),
+            &self.metrics,
+            "planner",
+            &event.app_id,
+            &event.publish_id,
+            |current| {
+                let next = state;
+                if !guard_publish_status_transition(&self.metrics, "planner", current, next) {
+                    return Ok(None);
+                }
+                let mut status = current.clone();
+                status.state = next;
+                if next == PublishLifecycleState::Dispatching {
+                    status.retry_after_ms = event
+                        .intent
+                        .not_before_ms
+                        .filter(|not_before_ms| *not_before_ms > crate::pipeline::now_ms());
+                }
+                Ok(Some(status))
+            },
+        )
+        .await?;
         Ok(())
     }
 
     async fn mark_failed(&self, event: &PublishLogEvent, reason: String) -> PushPipelineResult<()> {
-        let _status_guard = lock_publish_status(&event.app_id, &event.publish_id).await;
-        if let Some(mut status) = self
-            .store
-            .get_publish_status(&event.app_id, &event.publish_id)
-            .await?
-        {
-            let next = PublishLifecycleState::Failed;
-            if !guard_publish_status_transition(&self.metrics, "planner", &status, next) {
-                return Ok(());
-            }
-            status.state = next;
-            status.error_reason = Some(reason);
-            status.retry_after_ms = None;
-            self.store.put_publish_status(status).await?;
-        }
+        mutate_publish_status_with_cas(
+            self.store.as_ref(),
+            &self.metrics,
+            "planner",
+            &event.app_id,
+            &event.publish_id,
+            |current| {
+                let next = PublishLifecycleState::Failed;
+                if !guard_publish_status_transition(&self.metrics, "planner", current, next) {
+                    return Ok(None);
+                }
+                let mut status = current.clone();
+                status.state = next;
+                status.error_reason = Some(reason.clone());
+                status.retry_after_ms = None;
+                Ok(Some(status))
+            },
+        )
+        .await?;
         Ok(())
     }
 

--- a/crates/sockudo-push/src/planner.rs
+++ b/crates/sockudo-push/src/planner.rs
@@ -10,7 +10,7 @@ use crate::domain::{
 use crate::metrics::PushMetrics;
 use crate::pipeline::{
     PushPipelineError, PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage,
-    dedupe_key,
+    dedupe_key, guard_publish_status_transition, lock_publish_status,
 };
 use crate::storage::{DynPushStore, SchedulerLock};
 use crate::transform::render_all_provider_payloads;
@@ -173,13 +173,18 @@ impl PushPlanner {
         event: &PublishLogEvent,
         state: PublishLifecycleState,
     ) -> PushPipelineResult<()> {
+        let _status_guard = lock_publish_status(&event.app_id, &event.publish_id).await;
         if let Some(mut status) = self
             .store
             .get_publish_status(&event.app_id, &event.publish_id)
             .await?
         {
-            status.state = state;
-            if state == PublishLifecycleState::Dispatching {
+            let next = state;
+            if !guard_publish_status_transition(&self.metrics, "planner", &status, next) {
+                return Ok(());
+            }
+            status.state = next;
+            if next == PublishLifecycleState::Dispatching {
                 status.retry_after_ms = event
                     .intent
                     .not_before_ms
@@ -191,12 +196,17 @@ impl PushPlanner {
     }
 
     async fn mark_failed(&self, event: &PublishLogEvent, reason: String) -> PushPipelineResult<()> {
+        let _status_guard = lock_publish_status(&event.app_id, &event.publish_id).await;
         if let Some(mut status) = self
             .store
             .get_publish_status(&event.app_id, &event.publish_id)
             .await?
         {
-            status.state = PublishLifecycleState::Failed;
+            let next = PublishLifecycleState::Failed;
+            if !guard_publish_status_transition(&self.metrics, "planner", &status, next) {
+                return Ok(());
+            }
+            status.state = next;
             status.error_reason = Some(reason);
             status.retry_after_ms = None;
             self.store.put_publish_status(status).await?;
@@ -756,6 +766,7 @@ mod tests {
         PushProviderKind, PushRecipient, SecretString,
     };
     use crate::memory::MemoryPushStore;
+    use crate::metrics::PushMetrics;
     use crate::pipeline::{
         MemoryPushQueue, PushAcceptRequest, PushPipeline, PushQueue, PushQueuePayload,
         PushQueueStage, QueueLagMetrics,
@@ -812,6 +823,44 @@ mod tests {
                 .state,
             PublishLifecycleState::Dispatching
         );
+    }
+
+    #[tokio::test]
+    async fn planner_does_not_regress_a_terminal_publish_to_dispatching() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        accept_direct_publish(store.clone(), queue.clone(), 1_000).await;
+        let event = store
+            .list_publish_log_events("app-1", 1, None)
+            .await
+            .unwrap()
+            .items
+            .pop()
+            .unwrap();
+        let mut status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        status.state = PublishLifecycleState::Succeeded;
+        status.counters.succeeded = 1;
+        store.put_publish_status(status).await.unwrap();
+
+        let metrics = PushMetrics::default();
+        let planner = PushPlanner::new(store.clone(), queue, FanoutConfig::default())
+            .with_metrics(metrics.clone());
+        planner
+            .mark_state(&event, PublishLifecycleState::Dispatching)
+            .await
+            .unwrap();
+
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.state, PublishLifecycleState::Succeeded);
+        assert_eq!(metrics.get("sockudo_push_invariant_violations_total"), 1);
     }
 
     async fn accept_direct_publish(

--- a/crates/sockudo-push/src/retry.rs
+++ b/crates/sockudo-push/src/retry.rs
@@ -9,7 +9,7 @@ use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::PushMetrics;
 use crate::pipeline::{
     PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage,
-    guard_publish_status_transition, lock_publish_status, now_ms,
+    guard_publish_status_transition, mutate_publish_status_with_cas, now_ms,
 };
 use crate::storage::{DynPushStore, IdempotencyRecord, SchedulerLock};
 
@@ -339,8 +339,7 @@ impl PushRetryScheduler {
             batch_id: retry_job.batch_id.clone(),
             jobs: vec![retry_job],
         };
-        let _status_guard = lock_publish_status(&entry.app_id, &entry.publish_id).await;
-        let mut status = self
+        let status = self
             .store
             .get_publish_status(&entry.app_id, &entry.publish_id)
             .await?;
@@ -358,7 +357,6 @@ impl PushRetryScheduler {
                     PublishLifecycleState::Dispatching,
                 )
             {
-                drop(_status_guard);
                 self.put_retry_idempotency(&entry).await?;
                 self.queue.ack(message.ack).await?;
                 return Ok(());
@@ -371,16 +369,43 @@ impl PushRetryScheduler {
                 PushQueuePayload::DeliveryBatch(Box::new(batch)),
             )
             .await?;
-        if let Some(status) = status.as_mut() {
-            status.counters.retry_attempted = status.counters.retry_attempted.saturating_add(1);
-            if !status.state.is_terminal() {
-                status.state = PublishLifecycleState::Dispatching;
-            }
-            status.retry_after_ms = None;
-            self.store.put_publish_status(status.clone()).await?;
-        }
-        drop(_status_guard);
+        // The successor job is already visible. Record its deterministic retry key before status
+        // accounting so a status-store failure cannot make source-message redelivery enqueue the
+        // same provider attempt again.
         self.put_retry_idempotency(&entry).await?;
+        mutate_publish_status_with_cas(
+            self.store.as_ref(),
+            &self.metrics,
+            "retry",
+            &entry.app_id,
+            &entry.publish_id,
+            |current| {
+                let scheduled_retry_is_pending = current.state.is_terminal()
+                    && current.counters.retry_attempted < current.counters.retry_scheduled;
+                if current.state.is_terminal() && !scheduled_retry_is_pending {
+                    return Ok(None);
+                }
+                if !current.state.is_terminal()
+                    && !guard_publish_status_transition(
+                        &self.metrics,
+                        "retry",
+                        current,
+                        PublishLifecycleState::Dispatching,
+                    )
+                {
+                    return Ok(None);
+                }
+
+                let mut status = current.clone();
+                status.counters.retry_attempted = status.counters.retry_attempted.saturating_add(1);
+                if !status.state.is_terminal() {
+                    status.state = PublishLifecycleState::Dispatching;
+                }
+                status.retry_after_ms = None;
+                Ok(Some(status))
+            },
+        )
+        .await?;
         self.metrics.retry_attempted(provider, &entry.app_id);
         emit_push_meta_event(PushMetaEvent::scheduler_event(
             &entry.app_id,
@@ -450,29 +475,33 @@ impl PushRetryScheduler {
         kind: RetryTerminalKind,
         reason: &str,
     ) -> PushPipelineResult<()> {
-        let _status_guard = lock_publish_status(&entry.app_id, &entry.publish_id).await;
-        let Some(mut status) = self
-            .store
-            .get_publish_status(&entry.app_id, &entry.publish_id)
-            .await?
-        else {
-            return Ok(());
-        };
-
-        match kind {
-            RetryTerminalKind::Expired => {
-                status.counters.expired = status.counters.expired.saturating_add(1);
-            }
-            RetryTerminalKind::DeadLettered => {
-                status.counters.dead_lettered = status.counters.dead_lettered.saturating_add(1);
-            }
-        }
-        status.error_reason = Some(redact_retry_reason(reason, entry.last_error.as_ref()));
-        let next = status.counters.resolve_lifecycle_state(status.state);
-        // Like feedback, a terminal retry outcome may refine a summary after a mutable audience
-        // exceeded its acceptance-time estimate. It never moves the publish back to an active state.
-        status.state = next;
-        self.store.put_publish_status(status).await?;
+        mutate_publish_status_with_cas(
+            self.store.as_ref(),
+            &self.metrics,
+            "retry",
+            &entry.app_id,
+            &entry.publish_id,
+            |current| {
+                let mut status = current.clone();
+                match kind {
+                    RetryTerminalKind::Expired => {
+                        status.counters.expired = status.counters.expired.saturating_add(1);
+                    }
+                    RetryTerminalKind::DeadLettered => {
+                        status.counters.dead_lettered =
+                            status.counters.dead_lettered.saturating_add(1);
+                    }
+                }
+                status.error_reason = Some(redact_retry_reason(reason, entry.last_error.as_ref()));
+                let next = status.counters.resolve_lifecycle_state(status.state);
+                // Like feedback, a terminal retry outcome may refine a summary after a mutable
+                // audience exceeded its acceptance-time estimate. It never moves the publish back
+                // to an active state.
+                status.state = next;
+                Ok(Some(status))
+            },
+        )
+        .await?;
         Ok(())
     }
 

--- a/crates/sockudo-push/src/retry.rs
+++ b/crates/sockudo-push/src/retry.rs
@@ -2,12 +2,15 @@ use crate::domain::{
     DEFAULT_PUSH_RETRY_INITIAL_BACKOFF_MS, DEFAULT_PUSH_RETRY_JITTER_RATIO_PERCENT,
     DEFAULT_PUSH_RETRY_MAX_AGE_MS, DEFAULT_PUSH_RETRY_MAX_ATTEMPTS,
     DEFAULT_PUSH_RETRY_MAX_BACKOFF_MS, DeliveryBatch, DeliveryFeedback, DeliveryJob,
-    DeliveryOutcome, ProviderError, PublishLifecycleState, PublishStatus, PushProviderKind,
-    RetryScheduleEntry, provider_key, stable_hash,
+    DeliveryOutcome, ProviderError, PublishLifecycleState, PushProviderKind, RetryScheduleEntry,
+    provider_key, stable_hash,
 };
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::PushMetrics;
-use crate::pipeline::{PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage, now_ms};
+use crate::pipeline::{
+    PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage,
+    guard_publish_status_transition, lock_publish_status, now_ms,
+};
 use crate::storage::{DynPushStore, IdempotencyRecord, SchedulerLock};
 
 const MAX_RETRY_ATTEMPTS: u32 = 100;
@@ -336,6 +339,31 @@ impl PushRetryScheduler {
             batch_id: retry_job.batch_id.clone(),
             jobs: vec![retry_job],
         };
+        let _status_guard = lock_publish_status(&entry.app_id, &entry.publish_id).await;
+        let mut status = self
+            .store
+            .get_publish_status(&entry.app_id, &entry.publish_id)
+            .await?;
+        if let Some(current) = status.as_ref() {
+            // A terminal summary can be based on a mutable audience estimate. An explicitly
+            // scheduled-but-unattempted retry is still real work; dispatch it without regressing
+            // the terminal lifecycle state. Otherwise a terminal retry entry is stale.
+            let scheduled_retry_is_pending = current.state.is_terminal()
+                && current.counters.retry_attempted < current.counters.retry_scheduled;
+            if !scheduled_retry_is_pending
+                && !guard_publish_status_transition(
+                    &self.metrics,
+                    "retry",
+                    current,
+                    PublishLifecycleState::Dispatching,
+                )
+            {
+                drop(_status_guard);
+                self.put_retry_idempotency(&entry).await?;
+                self.queue.ack(message.ack).await?;
+                return Ok(());
+            }
+        }
         self.queue
             .produce(
                 PushQueueStage::DeliveryJobs(provider),
@@ -343,7 +371,15 @@ impl PushRetryScheduler {
                 PushQueuePayload::DeliveryBatch(Box::new(batch)),
             )
             .await?;
-        self.mark_retry_attempted(&entry).await?;
+        if let Some(status) = status.as_mut() {
+            status.counters.retry_attempted = status.counters.retry_attempted.saturating_add(1);
+            if !status.state.is_terminal() {
+                status.state = PublishLifecycleState::Dispatching;
+            }
+            status.retry_after_ms = None;
+            self.store.put_publish_status(status.clone()).await?;
+        }
+        drop(_status_guard);
         self.put_retry_idempotency(&entry).await?;
         self.metrics.retry_attempted(provider, &entry.app_id);
         emit_push_meta_event(PushMetaEvent::scheduler_event(
@@ -408,26 +444,13 @@ impl PushRetryScheduler {
         Ok(())
     }
 
-    async fn mark_retry_attempted(&self, entry: &RetryScheduleEntry) -> PushPipelineResult<()> {
-        if let Some(mut status) = self
-            .store
-            .get_publish_status(&entry.app_id, &entry.publish_id)
-            .await?
-        {
-            status.counters.retry_attempted = status.counters.retry_attempted.saturating_add(1);
-            status.state = PublishLifecycleState::Dispatching;
-            status.retry_after_ms = None;
-            self.store.put_publish_status(status).await?;
-        }
-        Ok(())
-    }
-
     async fn mark_terminal_status(
         &self,
         entry: &RetryScheduleEntry,
         kind: RetryTerminalKind,
         reason: &str,
     ) -> PushPipelineResult<()> {
+        let _status_guard = lock_publish_status(&entry.app_id, &entry.publish_id).await;
         let Some(mut status) = self
             .store
             .get_publish_status(&entry.app_id, &entry.publish_id)
@@ -445,7 +468,10 @@ impl PushRetryScheduler {
             }
         }
         status.error_reason = Some(redact_retry_reason(reason, entry.last_error.as_ref()));
-        status.state = retry_terminal_state(&status);
+        let next = status.counters.resolve_lifecycle_state(status.state);
+        // Like feedback, a terminal retry outcome may refine a summary after a mutable audience
+        // exceeded its acceptance-time estimate. It never moves the publish back to an active state.
+        status.state = next;
         self.store.put_publish_status(status).await?;
         Ok(())
     }
@@ -478,32 +504,6 @@ impl PushRetryScheduler {
 enum RetryTerminalKind {
     Expired,
     DeadLettered,
-}
-
-fn retry_terminal_state(status: &PublishStatus) -> PublishLifecycleState {
-    let terminal = status
-        .counters
-        .succeeded
-        .saturating_add(status.counters.failed)
-        .saturating_add(status.counters.expired)
-        .saturating_add(status.counters.dead_lettered);
-    if status.counters.planned == 0 || terminal < status.counters.planned {
-        return status.state;
-    }
-    if status.counters.failed == 0
-        && status.counters.expired == 0
-        && status.counters.dead_lettered == 0
-    {
-        PublishLifecycleState::Succeeded
-    } else if status.counters.succeeded > 0 {
-        PublishLifecycleState::PartiallySucceeded
-    } else if status.counters.expired > 0 {
-        PublishLifecycleState::Expired
-    } else if status.counters.dead_lettered > 0 {
-        PublishLifecycleState::DeadLettered
-    } else {
-        PublishLifecycleState::Failed
-    }
 }
 
 fn normalize_retry_entry(entry: &mut RetryScheduleEntry) {
@@ -591,10 +591,11 @@ mod tests {
     use sonic_rs::json;
 
     use crate::domain::{
-        DeliveryOutcome, DeliveryResult, ProviderFailureClass, PushPayload, PushProviderKind,
-        PushRecipient, SecretString,
+        DeliveryOutcome, DeliveryResult, ProviderFailureClass, PublishStatus, PushPayload,
+        PushProviderKind, PushRecipient, SecretString,
     };
     use crate::memory::MemoryPushStore;
+    use crate::metrics::PushMetrics;
     use crate::pipeline::{MemoryPushQueue, PushQueue, PushQueueError, QueueAckToken};
     use crate::storage::PushPublishStatusStore;
 
@@ -711,6 +712,119 @@ mod tests {
                 .ready_depth,
             1
         );
+    }
+
+    #[tokio::test]
+    async fn retry_status_write_does_not_regress_a_terminal_publish() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        let mut terminal = status();
+        terminal.state = PublishLifecycleState::Succeeded;
+        terminal.counters.succeeded = 1;
+        store.put_publish_status(terminal).await.unwrap();
+        let entry = retry_entry(2, now_ms());
+        queue
+            .produce(
+                PushQueueStage::RetrySchedule,
+                entry.key.clone(),
+                PushQueuePayload::RetrySchedule(Box::new(entry)),
+            )
+            .await
+            .unwrap();
+        let metrics = PushMetrics::default();
+        let scheduler = PushRetryScheduler::new(store.clone(), queue.clone(), "node-a")
+            .with_metrics(metrics.clone());
+
+        assert_eq!(scheduler.run_once("retry").await.unwrap(), 1);
+
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.state, PublishLifecycleState::Succeeded);
+        assert_eq!(status.counters.retry_attempted, 0);
+        assert_eq!(metrics.get("sockudo_push_invariant_violations_total"), 1);
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::DeliveryJobs(PushProviderKind::Fcm))
+                .await
+                .unwrap()
+                .ready_depth,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduled_retry_after_estimated_terminal_state_dispatches_without_regression() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        let mut terminal = status();
+        terminal.state = PublishLifecycleState::Succeeded;
+        terminal.counters.succeeded = 1;
+        terminal.counters.retry_scheduled = 1;
+        store.put_publish_status(terminal).await.unwrap();
+        let entry = retry_entry(2, now_ms());
+        queue
+            .produce(
+                PushQueueStage::RetrySchedule,
+                entry.key.clone(),
+                PushQueuePayload::RetrySchedule(Box::new(entry)),
+            )
+            .await
+            .unwrap();
+
+        let scheduler = PushRetryScheduler::new(store.clone(), queue.clone(), "node-a");
+        assert_eq!(scheduler.run_once("retry").await.unwrap(), 1);
+
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.state, PublishLifecycleState::Succeeded);
+        assert_eq!(status.counters.retry_attempted, 1);
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::DeliveryJobs(PushProviderKind::Fcm))
+                .await
+                .unwrap()
+                .ready_depth,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_terminal_outcome_can_refine_an_estimated_terminal_summary() {
+        let store = Arc::new(MemoryPushStore::new());
+        let mut terminal = status();
+        terminal.state = PublishLifecycleState::Succeeded;
+        terminal.counters.succeeded = 1;
+        store.put_publish_status(terminal).await.unwrap();
+        let queue = Arc::new(MemoryPushQueue::new());
+        let mut entry = retry_entry(2, now_ms());
+        if let Some(job) = entry.job.as_mut() {
+            job.expires_at_ms = Some(now_ms().saturating_sub(1));
+        }
+        queue
+            .produce(
+                PushQueueStage::RetrySchedule,
+                entry.key.clone(),
+                PushQueuePayload::RetrySchedule(Box::new(entry)),
+            )
+            .await
+            .unwrap();
+
+        let scheduler = PushRetryScheduler::new(store.clone(), queue, "node-a");
+        assert_eq!(scheduler.run_once("retry").await.unwrap(), 1);
+
+        let status = store
+            .get_publish_status("app-1", "publish-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(status.counters.expired, 1);
+        assert_eq!(status.state, PublishLifecycleState::PartiallySucceeded);
     }
 
     #[tokio::test]

--- a/crates/sockudo-push/src/sql/common_traits.rs
+++ b/crates/sockudo-push/src/sql/common_traits.rs
@@ -9,10 +9,11 @@ use crate::domain::{
     PublishStatus, PushCursor, PushCursorKind, ShardJob,
 };
 use crate::storage::{
-    IdempotencyRecord, OperatorInvalidationEvent, Page, PushCleanupStore, PushCredentialStore,
-    PushDeliveryEventStore, PushFanoutShardStore, PushIdempotencyStore, PushOperatorEventStore,
-    PushPublishLogStore, PushPublishStatusStore, PushScheduleStore, PushSchedulerLockStore,
-    PushStorageResult, PushTemplateStore, ScheduledPushJob, SchedulerLock,
+    IdempotencyRecord, OperatorInvalidationEvent, Page, PublishStatusCasOutcome, PushCleanupStore,
+    PushCredentialStore, PushDeliveryEventStore, PushFanoutShardStore, PushIdempotencyStore,
+    PushOperatorEventStore, PushPublishLogStore, PushPublishStatusStore, PushScheduleStore,
+    PushSchedulerLockStore, PushStorageError, PushStorageResult, PushTemplateStore,
+    ScheduledPushJob, SchedulerLock, VersionedPublishStatus,
 };
 use async_trait::async_trait;
 use sqlx::Row;
@@ -149,35 +150,155 @@ macro_rules! impl_common_sql_traits {
 
         #[async_trait]
         impl PushPublishStatusStore for $store {
-            async fn put_publish_status(&self, status: PublishStatus) -> PushStorageResult<()> {
+            async fn create_publish_status_if_absent(
+                &self,
+                status: PublishStatus,
+            ) -> PushStorageResult<PublishStatusCasOutcome> {
+                let now_ms = now_ms_i64();
                 let q = sql_query(format!(
-                    "INSERT INTO push_publish_status (app_id, publish_id, state, counters_json, error_reason, created_at_ms, updated_at_ms) VALUES ({0}, {0}, {0}, {1}, {0}, {0}, {0}) {2}",
-                    $bind, $json_cast, upsert_status_clause($postgres)
+                    "INSERT INTO push_publish_status (app_id, publish_id, state, counters_json, error_reason, created_at_ms, updated_at_ms, revision) VALUES ({0}, {0}, {0}, {1}, {0}, {0}, {0}, {0})",
+                    $bind, $json_cast
                 ), $postgres);
-                sqlx::query(sqlx::AssertSqlSafe(q.as_str()))
+                let result = sqlx::query(sqlx::AssertSqlSafe(q.as_str()))
                     .bind(&status.app_id)
                     .bind(&status.publish_id)
                     .bind(format!("{:?}", status.state).to_ascii_lowercase())
                     .bind(to_json_string(&status)?)
                     .bind(&status.error_reason)
-                    .bind(now_ms_i64())
-                    .bind(now_ms_i64())
+                    .bind(now_ms)
+                    .bind(now_ms)
+                    .bind(1_i64)
                     .execute(&self.$pool)
-                    .await
-                    .map_err(sql_error)?;
-                Ok(())
+                    .await;
+
+                match result {
+                    Ok(_) => Ok(PublishStatusCasOutcome::Inserted { revision: 1 }),
+                    Err(error) if is_unique_violation(&error) => {
+                        Ok(PublishStatusCasOutcome::Conflict)
+                    }
+                    Err(error) => Err(sql_error(error)),
+                }
             }
 
-            async fn get_publish_status(&self, app_id: &str, publish_id: &str) -> PushStorageResult<Option<PublishStatus>> {
-                let q = sql_query(format!("SELECT {1} AS counters_json FROM push_publish_status WHERE app_id = {0} AND publish_id = {0}", $bind, json_text_expr("counters_json", $json_text)), $postgres);
+            async fn get_versioned_publish_status(
+                &self,
+                app_id: &str,
+                publish_id: &str,
+            ) -> PushStorageResult<Option<VersionedPublishStatus>> {
+                let q = sql_query(format!(
+                    "SELECT {1} AS counters_json, {2} AS revision, {3} AS updated_at_ms FROM push_publish_status WHERE app_id = {0} AND publish_id = {0}",
+                    $bind,
+                    json_text_expr("counters_json", $json_text),
+                    signed_i64_expr("revision", $postgres),
+                    signed_i64_expr("updated_at_ms", $postgres)
+                ), $postgres);
                 sqlx::query(sqlx::AssertSqlSafe(q.as_str()))
                     .bind(app_id)
                     .bind(publish_id)
                     .fetch_optional(&self.$pool)
                     .await
                     .map_err(sql_error)?
-                    .map(|row| from_json_str(&row.try_get::<String, _>("counters_json").map_err(sql_error)?))
+                    .map(|row| {
+                        let status: PublishStatus = from_json_str(
+                            &row.try_get::<String, _>("counters_json")
+                                .map_err(sql_error)?,
+                        )?;
+                        if status.app_id != app_id || status.publish_id != publish_id {
+                            return Err(PushStorageError::Backend(
+                                "publish status row identity does not match stored payload"
+                                    .to_owned(),
+                            ));
+                        }
+                        Ok(VersionedPublishStatus {
+                            status,
+                            revision: positive_sql_u64(
+                                row.try_get::<i64, _>("revision").map_err(sql_error)?,
+                                "publish status revision",
+                            )?,
+                            updated_at_ms: nonnegative_sql_u64(
+                                row.try_get::<i64, _>("updated_at_ms").map_err(sql_error)?,
+                                "publish status updated_at_ms",
+                            )?,
+                        })
+                    })
                     .transpose()
+            }
+
+            async fn compare_and_swap_publish_status(
+                &self,
+                expected: &VersionedPublishStatus,
+                next: PublishStatus,
+            ) -> PushStorageResult<PublishStatusCasOutcome> {
+                if expected.status.app_id != next.app_id
+                    || expected.status.publish_id != next.publish_id
+                {
+                    return Err(PushStorageError::Backend(
+                        "publish status compare-and-swap identity mismatch".to_owned(),
+                    ));
+                }
+
+                let expected_revision = sql_i64_revision(expected.revision)?;
+                let expected_updated_at_ms = sql_i64_timestamp(
+                    expected.updated_at_ms,
+                    "publish status expected updated_at_ms",
+                )?;
+                let next_revision_u64 = expected.revision.checked_add(1).ok_or_else(|| {
+                    PushStorageError::Backend(
+                        "publish status revision exhausted storage range".to_owned(),
+                    )
+                })?;
+                let next_revision = sql_i64_revision(next_revision_u64)?;
+                let updated_at_ms = next_status_updated_at_ms(expected.updated_at_ms);
+                let q = sql_query(format!(
+                    "UPDATE push_publish_status SET state = {0}, counters_json = {1}, error_reason = {0}, updated_at_ms = {0}, revision = {0} WHERE app_id = {0} AND publish_id = {0} AND revision = {0} AND updated_at_ms = {0}",
+                    $bind, $json_cast
+                ), $postgres);
+                let updated = sqlx::query(sqlx::AssertSqlSafe(q.as_str()))
+                    .bind(format!("{:?}", next.state).to_ascii_lowercase())
+                    .bind(to_json_string(&next)?)
+                    .bind(&next.error_reason)
+                    .bind(updated_at_ms)
+                    .bind(next_revision)
+                    .bind(&next.app_id)
+                    .bind(&next.publish_id)
+                    .bind(expected_revision)
+                    .bind(expected_updated_at_ms)
+                    .execute(&self.$pool)
+                    .await
+                    .map_err(sql_error)?
+                    .rows_affected();
+
+                if updated == 1 {
+                    return Ok(PublishStatusCasOutcome::Updated {
+                        revision: next_revision_u64,
+                    });
+                }
+                if updated > 1 {
+                    return Err(PushStorageError::Backend(
+                        "publish status compare-and-swap updated multiple rows".to_owned(),
+                    ));
+                }
+
+                let q = sql_query(
+                    format!(
+                        "SELECT {1} AS revision FROM push_publish_status WHERE app_id = {0} AND publish_id = {0}",
+                        $bind,
+                        signed_i64_expr("revision", $postgres)
+                    ),
+                    $postgres,
+                );
+                let current_revision = sqlx::query_scalar::<_, i64>(sqlx::AssertSqlSafe(q.as_str()))
+                    .bind(&next.app_id)
+                    .bind(&next.publish_id)
+                    .fetch_optional(&self.$pool)
+                    .await
+                    .map_err(sql_error)?;
+
+                Ok(if current_revision.is_some() {
+                    PublishStatusCasOutcome::Conflict
+                } else {
+                    PublishStatusCasOutcome::Missing
+                })
             }
         }
 
@@ -550,27 +671,32 @@ macro_rules! impl_common_sql_traits {
                         let limit = request.limit_for(remaining) as i64;
                         let raw = if $postgres {
                             "WITH doomed AS (
-                                SELECT app_id, publish_id
+                                SELECT app_id, publish_id, revision
                                 FROM push_publish_status
                                 WHERE updated_at_ms < ?
                                   AND state IN ('succeeded', 'partiallysucceeded', 'failed', 'expired', 'cancelled', 'quotaexceeded', 'deadlettered')
                                 ORDER BY updated_at_ms, app_id, publish_id
                                 LIMIT ?
                              )
-                             DELETE FROM push_publish_status
-                             WHERE (app_id, publish_id) IN (SELECT app_id, publish_id FROM doomed)"
+                             DELETE FROM push_publish_status AS status
+                             USING doomed
+                             WHERE status.app_id = doomed.app_id
+                               AND status.publish_id = doomed.publish_id
+                               AND status.revision = doomed.revision"
                                 .to_owned()
                         } else {
                             "DELETE s
                              FROM push_publish_status s
                              JOIN (
-                                SELECT app_id, publish_id
+                                SELECT app_id, publish_id, revision
                                 FROM push_publish_status
                                 WHERE updated_at_ms < ?
                                   AND state IN ('succeeded', 'partiallysucceeded', 'failed', 'expired', 'cancelled', 'quotaexceeded', 'deadlettered')
                                 ORDER BY updated_at_ms, app_id, publish_id
                                 LIMIT ?
-                             ) doomed ON doomed.app_id = s.app_id AND doomed.publish_id = s.publish_id"
+                             ) doomed ON doomed.app_id = s.app_id
+                                AND doomed.publish_id = s.publish_id
+                                AND doomed.revision = s.revision"
                                 .to_owned()
                         };
                         let q = sql_query(raw, $postgres);

--- a/crates/sockudo-push/src/sql/helpers.rs
+++ b/crates/sockudo-push/src/sql/helpers.rs
@@ -249,6 +249,47 @@ pub(super) fn sql_error(error: sqlx::Error) -> PushStorageError {
     PushStorageError::Backend(format!("push SQL backend error: {error}"))
 }
 
+pub(super) fn is_unique_violation(error: &sqlx::Error) -> bool {
+    matches!(error, sqlx::Error::Database(database) if database.is_unique_violation())
+}
+
+pub(super) fn positive_sql_u64(value: i64, field: &str) -> PushStorageResult<u64> {
+    if value <= 0 {
+        return Err(PushStorageError::Backend(format!(
+            "push SQL {field} must be positive"
+        )));
+    }
+    Ok(value as u64)
+}
+
+pub(super) fn nonnegative_sql_u64(value: i64, field: &str) -> PushStorageResult<u64> {
+    u64::try_from(value)
+        .map_err(|_| PushStorageError::Backend(format!("push SQL {field} must be nonnegative")))
+}
+
+pub(super) fn sql_i64_revision(revision: u64) -> PushStorageResult<i64> {
+    if revision == 0 {
+        return Err(PushStorageError::Backend(
+            "publish status revision must be positive".to_owned(),
+        ));
+    }
+    i64::try_from(revision).map_err(|_| {
+        PushStorageError::Backend("publish status revision exhausted storage range".to_owned())
+    })
+}
+
+pub(super) fn sql_i64_timestamp(timestamp_ms: u64, field: &'static str) -> PushStorageResult<i64> {
+    i64::try_from(timestamp_ms)
+        .map_err(|_| PushStorageError::Backend(format!("{field} exceeds SQL storage range")))
+}
+
+pub(super) fn next_status_updated_at_ms(previous: u64) -> i64 {
+    let next = crate::pipeline::now_ms()
+        .max(previous.saturating_add(1))
+        .min(i64::MAX as u64);
+    next as i64
+}
+
 pub(super) fn assert_expected_schema_version(version: u32) -> PushStorageResult<()> {
     if version == EXPECTED_PUSH_SCHEMA_VERSION {
         return Ok(());
@@ -277,6 +318,14 @@ pub(super) fn now_ms_i64() -> i64 {
 
 pub(super) fn json_text_expr(column: &str, template: &str) -> String {
     template.replace('?', column).replace("$1", column)
+}
+
+pub(super) fn signed_i64_expr(column: &str, postgres: bool) -> String {
+    if postgres {
+        column.to_owned()
+    } else {
+        format!("CAST({column} AS SIGNED)")
+    }
 }
 
 pub(super) fn sql_query(raw: String, postgres: bool) -> String {
@@ -311,14 +360,6 @@ pub(super) fn upsert_template_clause(postgres: bool) -> &'static str {
         "ON CONFLICT (app_id, template_id) DO UPDATE SET default_locale = EXCLUDED.default_locale, locales_json = EXCLUDED.locales_json, provider_overrides_json = EXCLUDED.provider_overrides_json, updated_at_ms = EXCLUDED.updated_at_ms"
     } else {
         "ON DUPLICATE KEY UPDATE default_locale = VALUES(default_locale), locales_json = VALUES(locales_json), provider_overrides_json = VALUES(provider_overrides_json), updated_at_ms = VALUES(updated_at_ms)"
-    }
-}
-
-pub(super) fn upsert_status_clause(postgres: bool) -> &'static str {
-    if postgres {
-        "ON CONFLICT (app_id, publish_id) DO UPDATE SET state = EXCLUDED.state, counters_json = EXCLUDED.counters_json, error_reason = EXCLUDED.error_reason, updated_at_ms = EXCLUDED.updated_at_ms"
-    } else {
-        "ON DUPLICATE KEY UPDATE state = VALUES(state), counters_json = VALUES(counters_json), error_reason = VALUES(error_reason), updated_at_ms = VALUES(updated_at_ms)"
     }
 }
 

--- a/crates/sockudo-push/src/sql/tests/mod.rs
+++ b/crates/sockudo-push/src/sql/tests/mod.rs
@@ -1,5 +1,14 @@
 use super::helpers::*;
 
+const POSTGRES_PUSH_SCHEMA: &str =
+    include_str!("../../../../../ops/migrations/postgres/001_push_schema.sql");
+const POSTGRES_STATUS_CAS_UPGRADE: &str =
+    include_str!("../../../../../ops/migrations/postgres/002_push_status_revision.sql");
+const MYSQL_PUSH_SCHEMA: &str =
+    include_str!("../../../../../ops/migrations/mysql/003_push_schema.sql");
+const MYSQL_STATUS_CAS_UPGRADE: &str =
+    include_str!("../../../../../ops/migrations/mysql/004_push_status_revision.sql");
+
 #[test]
 fn postgres_query_conversion_numbers_each_placeholder() {
     let sql = sql_query(
@@ -18,4 +27,61 @@ fn mysql_query_conversion_leaves_placeholders_unchanged() {
     let sql = sql_query("SELECT ? AS a, CAST(? AS JSON) AS b".to_owned(), false);
 
     assert_eq!(sql, "SELECT ? AS a, CAST(? AS JSON) AS b");
+}
+
+#[test]
+fn unsigned_mysql_status_metadata_is_selected_as_portable_signed_values() {
+    assert_eq!(signed_i64_expr("revision", true), "revision");
+    assert_eq!(
+        signed_i64_expr("revision", false),
+        "CAST(revision AS SIGNED)"
+    );
+}
+
+#[test]
+fn fresh_sql_schemas_include_publish_status_revision_and_version_two() {
+    assert_eq!(crate::storage::EXPECTED_PUSH_SCHEMA_VERSION, 2);
+    for required in [
+        "revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0)",
+        "SELECT 2, 0",
+        "information_schema.columns",
+        "column_name = 'revision'",
+    ] {
+        assert!(
+            POSTGRES_PUSH_SCHEMA.contains(required),
+            "postgres fresh schema: {required}"
+        );
+    }
+    for required in [
+        "revision BIGINT UNSIGNED NOT NULL DEFAULT 1",
+        "SELECT 2, 0",
+        "information_schema.columns",
+        "column_name = 'revision'",
+    ] {
+        assert!(
+            MYSQL_PUSH_SCHEMA.contains(required),
+            "mysql fresh schema: {required}"
+        );
+    }
+}
+
+#[test]
+fn sql_publish_status_revision_upgrades_record_version_after_column() {
+    let postgres_column = POSTGRES_STATUS_CAS_UPGRADE
+        .find("ADD COLUMN revision")
+        .expect("postgres upgrade adds revision");
+    let postgres_version = POSTGRES_STATUS_CAS_UPGRADE
+        .find("VALUES (2, 0)")
+        .expect("postgres upgrade records schema version 2");
+    assert!(POSTGRES_STATUS_CAS_UPGRADE.contains("BEGIN;"));
+    assert!(POSTGRES_STATUS_CAS_UPGRADE.contains("COMMIT;"));
+    assert!(postgres_column < postgres_version);
+
+    let mysql_column = MYSQL_STATUS_CAS_UPGRADE
+        .find("ADD COLUMN revision")
+        .expect("mysql upgrade adds revision");
+    let mysql_version = MYSQL_STATUS_CAS_UPGRADE
+        .find("VALUES (2, 0)")
+        .expect("mysql upgrade records schema version 2");
+    assert!(mysql_column < mysql_version);
 }

--- a/crates/sockudo-push/src/storage.rs
+++ b/crates/sockudo-push/src/storage.rs
@@ -12,7 +12,8 @@ use crate::domain::{
 
 pub type PushStorageResult<T> = Result<T, PushStorageError>;
 pub type DynPushStore = Arc<dyn PushStore + Send + Sync>;
-pub const EXPECTED_PUSH_SCHEMA_VERSION: u32 = 1;
+pub const EXPECTED_PUSH_SCHEMA_VERSION: u32 = 2;
+const MAX_UNCONDITIONAL_STATUS_WRITE_ATTEMPTS: usize = 8;
 
 #[derive(Debug, Error)]
 pub enum PushStorageError {
@@ -27,6 +28,32 @@ pub enum PushStorageError {
     BackendDeferred { backend: &'static str },
     #[error("push storage backend error: {0}")]
     Backend(String),
+}
+
+/// A publish status together with the storage metadata used for optimistic concurrency.
+///
+/// The revision and update timestamp are storage-only fields. They are intentionally absent from
+/// the public publish-status wire representation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VersionedPublishStatus {
+    pub status: PublishStatus,
+    pub revision: u64,
+    pub updated_at_ms: u64,
+}
+
+/// Result of an atomic publish-status create or compare-and-swap operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PublishStatusCasOutcome {
+    Inserted { revision: u64 },
+    Updated { revision: u64 },
+    Conflict,
+    Missing,
+}
+
+impl PublishStatusCasOutcome {
+    pub const fn applied(self) -> bool {
+        matches!(self, Self::Inserted { .. } | Self::Updated { .. })
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -281,13 +308,64 @@ pub trait PushTemplateStore: Send + Sync {
 
 #[async_trait]
 pub trait PushPublishStatusStore: Send + Sync {
-    async fn put_publish_status(&self, status: PublishStatus) -> PushStorageResult<()>;
+    /// Create the initial status without replacing an existing publish.
+    async fn create_publish_status_if_absent(
+        &self,
+        status: PublishStatus,
+    ) -> PushStorageResult<PublishStatusCasOutcome>;
+
+    /// Load the status and the storage revision required for a later compare-and-swap.
+    async fn get_versioned_publish_status(
+        &self,
+        app_id: &str,
+        publish_id: &str,
+    ) -> PushStorageResult<Option<VersionedPublishStatus>>;
+
+    /// Replace `expected` only if its storage revision is still current.
+    async fn compare_and_swap_publish_status(
+        &self,
+        expected: &VersionedPublishStatus,
+        next: PublishStatus,
+    ) -> PushStorageResult<PublishStatusCasOutcome>;
+
+    /// Unconditionally seed or replace a status using bounded conditional writes.
+    ///
+    /// Production read/modify/write paths should call `compare_and_swap_publish_status` directly.
+    /// This compatibility helper remains useful for fixtures and administrative repairs without
+    /// reintroducing a blind write in any backend.
+    async fn put_publish_status(&self, status: PublishStatus) -> PushStorageResult<()> {
+        for _ in 0..MAX_UNCONDITIONAL_STATUS_WRITE_ATTEMPTS {
+            let outcome = match self
+                .get_versioned_publish_status(&status.app_id, &status.publish_id)
+                .await?
+            {
+                Some(expected) => {
+                    self.compare_and_swap_publish_status(&expected, status.clone())
+                        .await?
+                }
+                None => self.create_publish_status_if_absent(status.clone()).await?,
+            };
+            if outcome.applied() {
+                return Ok(());
+            }
+            tokio::task::yield_now().await;
+        }
+
+        Err(PushStorageError::Backend(
+            "publish status conditional write retries exhausted".to_owned(),
+        ))
+    }
 
     async fn get_publish_status(
         &self,
         app_id: &str,
         publish_id: &str,
-    ) -> PushStorageResult<Option<PublishStatus>>;
+    ) -> PushStorageResult<Option<PublishStatus>> {
+        Ok(self
+            .get_versioned_publish_status(app_id, publish_id)
+            .await?
+            .map(|versioned| versioned.status))
+    }
 }
 
 #[async_trait]
@@ -474,6 +552,8 @@ mod migration_smoke_tests {
             "push_idempotency",
             "push_schema_version",
             "VALUES (1, 0)",
+            "SELECT 2, 0",
+            "revision BIGINT NOT NULL DEFAULT 1",
             "Online rollout",
             "Credential security",
             "Rollback",
@@ -496,6 +576,8 @@ mod migration_smoke_tests {
             "push_idempotency",
             "push_schema_version",
             "VALUES (1, 0)",
+            "SELECT 2, 0",
+            "revision BIGINT UNSIGNED NOT NULL DEFAULT 1",
             "Online rollout",
             "Credential security",
             "Rollback",
@@ -591,5 +673,12 @@ mod migration_smoke_tests {
                 "surrealdb: {required}"
             );
         }
+    }
+
+    #[test]
+    fn hyperscale_status_contracts_include_cas_revisions() {
+        assert!(DYNAMODB_PUSH_SCHEMA.contains("strictly positive `revision`"));
+        assert!(SURREALDB_PUSH_SCHEMA.contains("revision ON push_publish_status"));
+        assert!(SCYLLADB_PUSH_SCHEMA.contains("revision bigint"));
     }
 }

--- a/crates/sockudo-server/src/bootstrap/push/queue.rs
+++ b/crates/sockudo-server/src/bootstrap/push/queue.rs
@@ -21,6 +21,8 @@ pub(crate) struct QueueManagerPushQueue {
     state: Arc<tokio::sync::Mutex<QueueManagerPushQueueState>>,
     notify: Arc<tokio::sync::Notify>,
     metrics: sockudo_push::PushMetrics,
+    local_ready_cap_per_stage: usize,
+    local_pending_cap_per_stage: usize,
 }
 
 #[cfg(feature = "push")]
@@ -106,9 +108,20 @@ enum PushQueueAction {
 }
 
 #[cfg(feature = "push")]
+enum LocalQueueAdmission {
+    Admitted {
+        action_rx: tokio::sync::oneshot::Receiver<PushQueueAction>,
+        completion_tx: tokio::sync::watch::Sender<Option<bool>>,
+    },
+    AtCapacity,
+    Duplicate(tokio::sync::watch::Receiver<Option<bool>>),
+}
+
+#[cfg(feature = "push")]
 struct QueueManagerPendingMessage {
     enqueued_at_ms: u64,
-    tx: tokio::sync::oneshot::Sender<PushQueueAction>,
+    tx: Option<tokio::sync::oneshot::Sender<PushQueueAction>>,
+    completion_tx: tokio::sync::watch::Sender<Option<bool>>,
 }
 
 #[cfg(feature = "push")]
@@ -213,7 +226,18 @@ impl QueueManagerPushQueue {
             )),
             notify: Arc::new(tokio::sync::Notify::new()),
             metrics: sockudo_push::PushMetrics::default(),
+            local_ready_cap_per_stage: LOCAL_READY_CAP_PER_STAGE,
+            local_pending_cap_per_stage: LOCAL_PENDING_CAP_PER_STAGE,
         }
+    }
+
+    #[cfg(test)]
+    fn with_local_caps(mut self, ready: usize, pending: usize) -> Self {
+        assert!(ready > 0, "local ready capacity must be positive");
+        assert!(pending > 0, "local pending capacity must be positive");
+        self.local_ready_cap_per_stage = ready;
+        self.local_pending_cap_per_stage = pending;
+        self
     }
 
     async fn next_message_id(&self) -> String {
@@ -293,58 +317,112 @@ impl QueueManagerPushQueue {
         let route =
             sockudo_push::QueueRoute::for_message(envelope.stage, &envelope.key, &envelope.payload);
         let now = push_queue_now_ms();
-        let should_requeue = {
-            let state = self.state.lock().await;
-            let ready_depth = state
-                .ready
-                .get(&envelope.stage)
-                .map_or(0, std::collections::VecDeque::len);
-            let pending_depth = state
-                .pending
-                .keys()
-                .filter(|(pending_stage, _)| pending_stage == &envelope.stage)
-                .count();
-            ready_depth >= LOCAL_READY_CAP_PER_STAGE || pending_depth >= LOCAL_PENDING_CAP_PER_STAGE
-        };
-        if should_requeue {
-            self.requeue_envelope(envelope, Some(now.saturating_add(1_000)), "local_capacity")
-                .await?;
-            return Ok(());
-        }
-
-        let token = sockudo_push::QueueAckToken {
-            stage: envelope.stage,
-            message_id: envelope.message_id.clone(),
-        };
-        let message = sockudo_push::QueueMessage {
-            message_id: envelope.message_id.clone(),
-            stage: envelope.stage,
-            key: envelope.key.clone(),
-            partition_key: route.partition_key,
-            partition: route.partition,
-            payload: envelope.payload.clone(),
-            attempt: envelope.attempt,
-            enqueued_at_ms: envelope.enqueued_at_ms,
-            not_before_ms: envelope.not_before_ms,
-            lease_deadline_ms: now.saturating_add(LOCAL_LEASE_TIMEOUT_MS),
-            ack: token.clone(),
-        };
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        {
+        let admission = {
             let mut state = self.state.lock().await;
-            state.pending.insert(
-                (envelope.stage, envelope.message_id.clone()),
-                QueueManagerPendingMessage {
-                    enqueued_at_ms: envelope.enqueued_at_ms,
-                    tx,
-                },
-            );
-            state
-                .ready
-                .entry(envelope.stage)
-                .or_default()
-                .push_back(message);
-        }
+            let pending_key = (envelope.stage, envelope.message_id.clone());
+            if let Some(pending) = state.pending.get(&pending_key) {
+                LocalQueueAdmission::Duplicate(pending.completion_tx.subscribe())
+            } else {
+                let ready_depth = state
+                    .ready
+                    .get(&envelope.stage)
+                    .map_or(0, std::collections::VecDeque::len);
+                let pending_depth = state
+                    .pending
+                    .keys()
+                    .filter(|(pending_stage, _)| pending_stage == &envelope.stage)
+                    .count();
+                if ready_depth >= self.local_ready_cap_per_stage
+                    || pending_depth >= self.local_pending_cap_per_stage
+                {
+                    LocalQueueAdmission::AtCapacity
+                } else {
+                    let token = sockudo_push::QueueAckToken {
+                        stage: envelope.stage,
+                        message_id: envelope.message_id.clone(),
+                    };
+                    let message = sockudo_push::QueueMessage {
+                        message_id: envelope.message_id.clone(),
+                        stage: envelope.stage,
+                        key: envelope.key.clone(),
+                        partition_key: route.partition_key,
+                        partition: route.partition,
+                        payload: envelope.payload.clone(),
+                        attempt: envelope.attempt,
+                        enqueued_at_ms: envelope.enqueued_at_ms,
+                        not_before_ms: envelope.not_before_ms,
+                        lease_deadline_ms: now.saturating_add(LOCAL_LEASE_TIMEOUT_MS),
+                        ack: token,
+                    };
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    let (completion_tx, _) = tokio::sync::watch::channel(None);
+                    let previous = state.pending.insert(
+                        pending_key,
+                        QueueManagerPendingMessage {
+                            enqueued_at_ms: envelope.enqueued_at_ms,
+                            tx: Some(tx),
+                            completion_tx: completion_tx.clone(),
+                        },
+                    );
+                    debug_assert!(
+                        previous.is_none(),
+                        "duplicate pending push message passed the admission check"
+                    );
+                    let ready_depth = {
+                        let ready = state.ready.entry(envelope.stage).or_default();
+                        ready.push_back(message);
+                        ready.len()
+                    };
+                    debug_assert!(ready_depth <= self.local_ready_cap_per_stage);
+                    debug_assert!(
+                        pending_depth.saturating_add(1) <= self.local_pending_cap_per_stage
+                    );
+                    LocalQueueAdmission::Admitted {
+                        action_rx: rx,
+                        completion_tx,
+                    }
+                }
+            }
+        };
+
+        let (rx, completion_tx) = match admission {
+            LocalQueueAdmission::Admitted {
+                action_rx,
+                completion_tx,
+            } => (action_rx, completion_tx),
+            LocalQueueAdmission::AtCapacity => {
+                self.requeue_envelope(envelope, Some(now.saturating_add(1_000)), "local_capacity")
+                    .await?;
+                return Ok(());
+            }
+            LocalQueueAdmission::Duplicate(mut completion_rx) => {
+                self.metrics.duplicate_suppressed();
+                let completed = if let Some(completed) = *completion_rx.borrow() {
+                    completed
+                } else {
+                    match tokio::time::timeout(
+                        Duration::from_millis(LOCAL_LEASE_TIMEOUT_MS.saturating_add(5_000)),
+                        completion_rx.wait_for(Option::is_some),
+                    )
+                    .await
+                    {
+                        Ok(Ok(completed)) => completed.unwrap_or(false),
+                        Ok(Err(_)) | Err(_) => {
+                            return Err(sockudo_push::PushQueueError::Backend(
+                                "canonical duplicate push work did not complete".to_owned(),
+                            ));
+                        }
+                    }
+                };
+                return if completed {
+                    Ok(())
+                } else {
+                    Err(sockudo_push::PushQueueError::Backend(
+                        "canonical duplicate push work failed".to_owned(),
+                    ))
+                };
+            }
+        };
         self.notify.notify_waiters();
 
         let action = match tokio::time::timeout(Duration::from_millis(LOCAL_LEASE_TIMEOUT_MS), rx)
@@ -355,10 +433,9 @@ impl QueueManagerPushQueue {
             Err(_) => PushQueueAction::Nack(Some(push_queue_now_ms().saturating_add(1_000))),
         };
 
-        self.remove_pending_and_ready(envelope.stage, &envelope.message_id)
-            .await;
-
-        match action {
+        let pending_stage = envelope.stage;
+        let pending_message_id = envelope.message_id.clone();
+        let result = match action {
             PushQueueAction::Ack => Ok(()),
             PushQueueAction::Nack(retry_at_ms) => {
                 self.requeue_envelope(envelope, retry_at_ms, "nack_or_lease_timeout")
@@ -401,7 +478,11 @@ impl QueueManagerPushQueue {
                 };
                 self.enqueue_envelope(dlq).await
             }
-        }
+        };
+        let _ = completion_tx.send(Some(result.is_ok()));
+        self.remove_pending_and_ready(pending_stage, &pending_message_id)
+            .await;
+        result
     }
 
     async fn requeue_envelope(
@@ -438,14 +519,29 @@ impl QueueManagerPushQueue {
         token: sockudo_push::QueueAckToken,
         action: PushQueueAction,
     ) -> sockudo_push::PushQueueResult<()> {
-        if let Some(pending) = self
-            .state
-            .lock()
-            .await
-            .pending
-            .remove(&(token.stage, token.message_id))
+        let key = (token.stage, token.message_id);
+        let mut state = self.state.lock().await;
+        let send_failed = if let Some(pending) = state.pending.get_mut(&key)
+            && let Some(tx) = pending.tx.take()
         {
-            let _ = pending.tx.send(action);
+            match tx.send(action) {
+                Ok(()) => None,
+                Err(_) => Some(pending.completion_tx.clone()),
+            }
+        } else {
+            None
+        };
+        if let Some(completion_tx) = send_failed {
+            let _ = completion_tx.send(Some(false));
+            state.pending.remove(&key);
+            if let Some(ready) = state.ready.get_mut(&key.0)
+                && let Some(index) = ready.iter().position(|message| message.message_id == key.1)
+            {
+                ready.remove(index);
+            }
+            return Err(sockudo_push::PushQueueError::Backend(
+                "canonical local push work is no longer running".to_owned(),
+            ));
         }
         Ok(())
     }
@@ -945,6 +1041,7 @@ mod tests {
         PushQueueStage, PushRecipient, SecretString,
     };
     use sonic_rs::json;
+    use tokio::sync::Barrier;
 
     use super::*;
 
@@ -1005,9 +1102,133 @@ mod tests {
         assert!(lag.oldest_inflight_age_ms.is_some());
 
         queue.ack(message.ack).await.unwrap();
-        let lag = queue.lag(stage).await.unwrap();
+        let lag = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let lag = queue.lag(stage).await.unwrap();
+                if lag.inflight_depth == 0 {
+                    break lag;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("acknowledged local fixture should leave inflight state");
         assert_eq!(lag.inflight_depth, 0);
         assert!(lag.oldest_inflight_age_ms.is_none());
+    }
+
+    #[tokio::test]
+    async fn duplicate_broker_envelope_does_not_replace_pending_work() {
+        let stage = PushQueueStage::DeliveryJobs(PushProviderKind::Fcm);
+        let queue =
+            test_queue(QueueManagerPushQueueStageOwnership::testing([stage])).with_local_caps(2, 2);
+        let envelope = sample_queue_envelope("external-duplicate", stage);
+        let original = spawn_queue_job(&queue, envelope.clone());
+        wait_for_local_depths(&queue, stage, 1, 1).await;
+
+        let duplicate_job = push_queue_job_data(&envelope).unwrap();
+        let duplicate_queue = queue.clone();
+        let duplicate =
+            tokio::spawn(async move { duplicate_queue.handle_queue_job(duplicate_job).await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while queue.metrics.get("sockudo_push_duplicate_suppressed_total") == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("duplicate should reach local suppression");
+
+        assert!(
+            !original.is_finished(),
+            "original pending work was replaced"
+        );
+        assert!(
+            !duplicate.is_finished(),
+            "duplicate broker work acknowledged before the canonical job"
+        );
+        assert_eq!(local_depths(&queue, stage).await, (1, 1));
+        assert_eq!(
+            queue.metrics.get("sockudo_push_duplicate_suppressed_total"),
+            1
+        );
+
+        queue
+            .ack(first_ready_ack(&queue, stage).await)
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), original)
+            .await
+            .expect("original pending work should finish after acknowledgement")
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), duplicate)
+            .await
+            .expect("duplicate should finish with the canonical acknowledgement")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_canonical_job_releases_pending_capacity() {
+        let stage = PushQueueStage::DeliveryJobs(PushProviderKind::Fcm);
+        let queue =
+            test_queue(QueueManagerPushQueueStageOwnership::testing([stage])).with_local_caps(1, 1);
+        let canonical = spawn_queue_job(&queue, sample_queue_envelope("external-cancelled", stage));
+        wait_for_local_depths(&queue, stage, 1, 1).await;
+        let ack = first_ready_ack(&queue, stage).await;
+
+        canonical.abort();
+        assert!(canonical.await.unwrap_err().is_cancelled());
+        let error = queue.ack(ack).await.unwrap_err();
+
+        assert!(error.to_string().contains("no longer running"));
+        assert_eq!(local_depths(&queue, stage).await, (0, 0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_local_admission_respects_ready_and_pending_caps() {
+        const JOBS: usize = 8;
+
+        let stage = PushQueueStage::DeliveryJobs(PushProviderKind::Fcm);
+        let queue =
+            test_queue(QueueManagerPushQueueStageOwnership::testing([stage])).with_local_caps(1, 1);
+        let barrier = Arc::new(Barrier::new(JOBS));
+        let mut handles = Vec::with_capacity(JOBS);
+
+        for index in 0..JOBS {
+            let queue = queue.clone();
+            let barrier = Arc::clone(&barrier);
+            let envelope = sample_queue_envelope(&format!("external-{index}"), stage);
+            handles.push(tokio::spawn(async move {
+                let job = push_queue_job_data(&envelope).unwrap();
+                barrier.wait().await;
+                queue.handle_queue_job(job).await.unwrap();
+            }));
+        }
+
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if queue.metrics.get("sockudo_push_queue_local_requeued_total") == (JOBS - 1) as u64
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("excess local work should be requeued");
+
+        assert_eq!(local_depths(&queue, stage).await, (1, 1));
+        queue
+            .ack(first_ready_ack(&queue, stage).await)
+            .await
+            .unwrap();
+
+        for handle in handles {
+            tokio::time::timeout(Duration::from_secs(1), handle)
+                .await
+                .expect("queue job should finish after capacity handling")
+                .unwrap();
+        }
     }
 
     #[tokio::test]
@@ -1162,6 +1383,54 @@ mod tests {
         })
     }
 
+    async fn wait_for_local_depths(
+        queue: &QueueManagerPushQueue,
+        stage: PushQueueStage,
+        ready: usize,
+        pending: usize,
+    ) {
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if local_depths(queue, stage).await == (ready, pending) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("local queue depths should reach the expected values");
+    }
+
+    async fn local_depths(queue: &QueueManagerPushQueue, stage: PushQueueStage) -> (usize, usize) {
+        let state = queue.state.lock().await;
+        let ready = state
+            .ready
+            .get(&stage)
+            .map_or(0, std::collections::VecDeque::len);
+        let pending = state
+            .pending
+            .keys()
+            .filter(|(pending_stage, _)| *pending_stage == stage)
+            .count();
+        (ready, pending)
+    }
+
+    async fn first_ready_ack(
+        queue: &QueueManagerPushQueue,
+        stage: PushQueueStage,
+    ) -> sockudo_push::QueueAckToken {
+        queue
+            .state
+            .lock()
+            .await
+            .ready
+            .get(&stage)
+            .and_then(|ready| ready.front())
+            .expect("one local ready message")
+            .ack
+            .clone()
+    }
+
     async fn next_dead_letter_entry(
         queue: &QueueManagerPushQueue,
     ) -> sockudo_push::DeadLetterQueueEntry {
@@ -1190,16 +1459,23 @@ mod tests {
         let payload = PushQueuePayload::DeliveryBatch(Box::new(sample_batch()));
         let route = sockudo_push::QueueRoute::for_message(stage, "delivery", &payload);
         let message_id = "external-1".to_owned();
+        let cleanup_message_id = message_id.clone();
         let token = sockudo_push::QueueAckToken {
             stage,
             message_id: message_id.clone(),
         };
         let enqueued_at_ms = push_queue_now_ms();
-        let (tx, _rx) = tokio::sync::oneshot::channel();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let (completion_tx, _) = tokio::sync::watch::channel(None);
+        let cleanup_completion_tx = completion_tx.clone();
         let mut state = queue.state.lock().await;
         state.pending.insert(
             (stage, message_id.clone()),
-            QueueManagerPendingMessage { enqueued_at_ms, tx },
+            QueueManagerPendingMessage {
+                enqueued_at_ms,
+                tx: Some(tx),
+                completion_tx,
+            },
         );
         state
             .ready
@@ -1218,6 +1494,29 @@ mod tests {
                 lease_deadline_ms: 0,
                 ack: token,
             });
+        drop(state);
+
+        let cleanup_queue = queue.clone();
+        tokio::spawn(async move {
+            if rx.await.is_ok() {
+                cleanup_queue
+                    .remove_pending_and_ready(stage, &cleanup_message_id)
+                    .await;
+                let _ = cleanup_completion_tx.send(Some(true));
+            }
+        });
+    }
+
+    fn sample_queue_envelope(message_id: &str, stage: PushQueueStage) -> PushQueueEnvelope {
+        PushQueueEnvelope {
+            message_id: message_id.to_owned(),
+            stage,
+            key: format!("delivery-{message_id}"),
+            payload: PushQueuePayload::DeliveryBatch(Box::new(sample_batch())),
+            attempt: 1,
+            enqueued_at_ms: push_queue_now_ms(),
+            not_before_ms: None,
+        }
     }
 
     fn sample_batch() -> DeliveryBatch {

--- a/crates/sockudo-server/src/http_handler/presence_history/tests.rs
+++ b/crates/sockudo-server/src/http_handler/presence_history/tests.rs
@@ -13,6 +13,46 @@ use sockudo_core::presence_history::{
 };
 use sonic_rs::{JsonContainerTrait, JsonValueTrait};
 
+async fn seed_valid_snapshot_history(
+    store: &Arc<MemoryPresenceHistoryStore>,
+    count: usize,
+    base_ts: i64,
+) {
+    let transitions = [
+        (PresenceHistoryEventKind::MemberAdded, "user-1"),
+        (PresenceHistoryEventKind::MemberAdded, "user-2"),
+        (PresenceHistoryEventKind::MemberRemoved, "user-1"),
+        (PresenceHistoryEventKind::MemberRemoved, "user-2"),
+    ];
+
+    for (index, (event_kind, user_id)) in transitions.into_iter().take(count).enumerate() {
+        store
+            .record_transition(PresenceHistoryTransitionRecord {
+                app_id: "app-1".to_string(),
+                channel: "presence-room".to_string(),
+                event_kind,
+                cause: if event_kind == PresenceHistoryEventKind::MemberAdded {
+                    PresenceHistoryEventCause::Join
+                } else {
+                    PresenceHistoryEventCause::Disconnect
+                },
+                user_id: user_id.to_string(),
+                connection_id: Some(format!("socket-{}", index + 1)),
+                user_info: Some(sonic_rs::json!({ "n": index + 1 })),
+                dead_node_id: None,
+                dedupe_key: format!("snapshot-transition-{}", index + 1),
+                published_at_ms: base_ts + index as i64 + 1,
+                retention: PresenceHistoryRetentionPolicy {
+                    retention_window_seconds: 3600,
+                    max_events_per_channel: None,
+                    max_bytes_per_channel: None,
+                },
+            })
+            .await
+            .unwrap();
+    }
+}
+
 #[tokio::test]
 async fn channel_presence_history_state_endpoint_returns_authoritative_stream_state() {
     let inner = Arc::new(MemoryPresenceHistoryStore::new(Default::default()));
@@ -560,7 +600,7 @@ async fn channel_presence_history_snapshot_reconstructs_membership() {
     let base_ts = sockudo_core::history::now_ms();
 
     // Seed: u1 joins, u2 joins, u1 leaves
-    seed_presence_history(&store, "app-1", "presence-room", 3, base_ts).await;
+    seed_valid_snapshot_history(&store, 3, base_ts).await;
 
     let response = channel_presence_history_snapshot(
         Path(("app-1".to_string(), "presence-room".to_string())),
@@ -589,8 +629,8 @@ async fn channel_presence_history_snapshot_at_serial_bound() {
     let app = test_app();
     let base_ts = sockudo_core::history::now_ms();
 
-    // Seed: alternating joins/leaves for u1, u2
-    seed_presence_history(&store, "app-1", "presence-room", 4, base_ts).await;
+    // Seed: u1 joins, u2 joins, then both leave.
+    seed_valid_snapshot_history(&store, 4, base_ts).await;
 
     // Snapshot at serial 2 only replays events with serial <= 2
     let response = channel_presence_history_snapshot(

--- a/crates/sockudo-server/src/push_http.rs
+++ b/crates/sockudo-server/src/push_http.rs
@@ -26,11 +26,12 @@ use sockudo_push::{
     EncryptedSecret, FanoutRegime, IdempotencyRecord, NotificationTemplate,
     OperatorInvalidationEvent, ProviderCredential, ProviderCredentialMaterial,
     ProviderOverridePayload, PublishCounters, PublishIntent, PublishLifecycleState,
-    PublishLogEvent, PublishStatus, PublishTarget, PushCursor, PushMetaEvent, PushMetrics,
-    PushPayload, PushProviderKind, PushQueuePayload, PushQueueStage, PushRecipient,
-    PushRulePayloadMapping, RenderedProviderPayload, SecretString, emit_push_meta_event,
-    generate_device_identity_token, hash_device_identity_token, render_all_provider_payloads,
-    resolve_template_payload, verify_device_identity_token,
+    PublishLogEvent, PublishStatus, PublishStatusCasOutcome, PublishTarget, PushCursor,
+    PushMetaEvent, PushMetrics, PushPayload, PushProviderKind, PushQueuePayload, PushQueueStage,
+    PushRecipient, PushRulePayloadMapping, RenderedProviderPayload, SecretString,
+    emit_push_meta_event, generate_device_identity_token, hash_device_identity_token,
+    publish_idempotency_key, render_all_provider_payloads, resolve_template_payload,
+    verify_device_identity_token,
 };
 use sonic_rs::{Value, json};
 use tracing::{info, warn};
@@ -1050,11 +1051,20 @@ async fn accept_publish_inner(
 
     let rendered_payloads = render_all_payloads(&intent.payload, &intent.provider_overrides)?;
     let idempotency_key = intent.idempotency_key();
-    let existing_idempotency = context
+    let publish_record_key = publish_idempotency_key(app_id, &publish_id);
+    let existing_idempotency = match context
         .store
-        .get_idempotency_record(app_id, &idempotency_key)
+        .get_idempotency_record(app_id, &publish_record_key)
         .await
-        .map_err(push_error)?;
+        .map_err(push_error)?
+    {
+        Some(existing) => Some(existing),
+        None => context
+            .store
+            .get_idempotency_record(app_id, &idempotency_key)
+            .await
+            .map_err(push_error)?,
+    };
     let existing_status = if let Some(existing) = existing_idempotency.as_ref() {
         context
             .store
@@ -1109,36 +1119,114 @@ async fn accept_publish_inner(
     } else {
         PublishLifecycleState::Queued
     };
-    context
+    let initial_status = PublishStatus {
+        app_id: app_id.to_owned(),
+        publish_id: publish_id.clone(),
+        state: status_state,
+        counters: PublishCounters {
+            planned: expected_recipients,
+            dispatched: 0,
+            succeeded: 0,
+            failed: 0,
+            expired: 0,
+            retry_scheduled: 0,
+            retry_attempted: 0,
+            dead_lettered: 0,
+        },
+        fanout_regime: Some(fanout_regime),
+        retry_after_ms: None,
+        error_reason: quota_failure.clone(),
+    };
+    let create_outcome = context
         .store
-        .put_publish_status(PublishStatus {
-            app_id: app_id.to_owned(),
-            publish_id: publish_id.clone(),
-            state: status_state,
-            counters: PublishCounters {
-                planned: expected_recipients,
-                dispatched: 0,
-                succeeded: 0,
-                failed: 0,
-                expired: 0,
-                retry_scheduled: 0,
-                retry_attempted: 0,
-                dead_lettered: 0,
-            },
-            fanout_regime: Some(fanout_regime),
-            retry_after_ms: None,
-            error_reason: quota_failure.clone(),
-        })
+        .create_publish_status_if_absent(initial_status.clone())
         .await
         .map_err(push_error)?;
+    match create_outcome {
+        PublishStatusCasOutcome::Inserted { .. } => {}
+        PublishStatusCasOutcome::Conflict => {
+            let existing = context
+                .store
+                .get_publish_status(app_id, &publish_id)
+                .await
+                .map_err(push_error)?
+                .ok_or_else(|| {
+                    AppError::InternalError("conflicting publish status disappeared".to_owned())
+                })?;
+            if existing != initial_status {
+                PUSH_HTTP_METRICS.duplicate_suppressed();
+                return Ok((
+                    StatusCode::ACCEPTED,
+                    Json(PublishAcceptedResponse {
+                        publish_id,
+                        status: publish_state_label(existing.state),
+                        expected_recipients: existing.counters.planned,
+                        fanout_regime: existing.fanout_regime.unwrap_or(fanout_regime),
+                        rendered_payloads,
+                    }),
+                    forced_async,
+                ));
+            }
+        }
+        outcome => {
+            return Err(AppError::InternalError(format!(
+                "unexpected push publish status create outcome: {outcome:?}"
+            )));
+        }
+    }
+
+    let idempotency_expires_at_ms = request
+        .expires_at_ms
+        .unwrap_or_else(|| now_ms().saturating_add(PUSH_HTTP_DEFAULT_IDEMPOTENCY_TTL_MS));
+    let publish_idempotency = IdempotencyRecord {
+        app_id: app_id.to_owned(),
+        key: publish_record_key.clone(),
+        publish_id: publish_id.clone(),
+        expires_at_ms: idempotency_expires_at_ms,
+    };
+    if !context
+        .store
+        .put_idempotency_record_if_absent(publish_idempotency)
+        .await
+        .map_err(push_error)?
+    {
+        let existing = context
+            .store
+            .get_idempotency_record(app_id, &publish_record_key)
+            .await
+            .map_err(push_error)?
+            .ok_or_else(|| {
+                AppError::InternalError("duplicate publish id record disappeared".to_owned())
+            })?;
+        if let Some(status) = context
+            .store
+            .get_publish_status(app_id, &existing.publish_id)
+            .await
+            .map_err(push_error)?
+        {
+            PUSH_HTTP_METRICS.duplicate_suppressed();
+            return Ok((
+                StatusCode::ACCEPTED,
+                Json(PublishAcceptedResponse {
+                    publish_id: existing.publish_id,
+                    status: publish_state_label(status.state),
+                    expected_recipients: status.counters.planned,
+                    fanout_regime: status.fanout_regime.unwrap_or(fanout_regime),
+                    rendered_payloads,
+                }),
+                forced_async,
+            ));
+        }
+        return Err(AppError::InternalError(
+            "duplicate publish is missing persisted status".to_owned(),
+        ));
+    }
 
     let idempotency = IdempotencyRecord {
         app_id: app_id.to_owned(),
-        key: idempotency_key,
+        key: idempotency_key.clone(),
         publish_id: publish_id.clone(),
-        expires_at_ms: request
-            .expires_at_ms
-            .unwrap_or_else(|| now_ms().saturating_add(PUSH_HTTP_DEFAULT_IDEMPOTENCY_TTL_MS)),
+        expires_at_ms: idempotency_expires_at_ms,
     };
     if !context
         .store
@@ -1148,7 +1236,7 @@ async fn accept_publish_inner(
     {
         let existing = context
             .store
-            .get_idempotency_record(app_id, &intent.idempotency_key())
+            .get_idempotency_record(app_id, &idempotency_key)
             .await
             .map_err(push_error)?
             .ok_or_else(|| {
@@ -2921,6 +3009,154 @@ mod tests {
                 .unwrap()
                 .ready_depth,
             0
+        );
+    }
+
+    #[tokio::test]
+    async fn quota_rejection_recovers_status_created_before_idempotency_election() {
+        let _guard = PUSH_TEST_ENV_LOCK.lock().await;
+        let _quota = EnvVarGuard::set("PUSH_FANOUT_MAX", "0");
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.upsert_device(sample_device()).await.unwrap();
+        store
+            .put_publish_status(PublishStatus {
+                app_id: "app-1".to_owned(),
+                publish_id: "quota-publish-recovery".to_owned(),
+                state: PublishLifecycleState::QuotaExceeded,
+                counters: PublishCounters {
+                    planned: 1,
+                    ..PublishCounters::default()
+                },
+                fanout_regime: Some(FanoutRegime::FastPath),
+                retry_after_ms: None,
+                error_reason: Some("fanout_max exceeded for app app-1".to_owned()),
+            })
+            .await
+            .unwrap();
+        let dyn_store: DynPushStore = store.clone();
+        let dyn_queue: DynPushQueue = queue.clone();
+        let admission = PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]);
+
+        let (_, Json(body), _) = accept_publish_inner(
+            "app-1",
+            sample_publish_request("quota-publish-recovery"),
+            false,
+            &HeaderMap::new(),
+            test_publish_context(&dyn_store, &dyn_queue, &admission),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(body.status, "quota_exceeded");
+        let idempotency = idempotency_record_for_request(
+            "app-1",
+            "quota-publish-recovery",
+            &sample_publish_request("quota-publish-recovery"),
+        );
+        assert!(
+            store
+                .get_idempotency_record("app-1", &idempotency.key)
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_conflict_does_not_attach_request_to_mismatched_status() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.upsert_device(sample_device()).await.unwrap();
+        store
+            .put_publish_status(PublishStatus {
+                app_id: "app-1".to_owned(),
+                publish_id: "publish-conflict".to_owned(),
+                state: PublishLifecycleState::Succeeded,
+                counters: PublishCounters {
+                    planned: 99,
+                    succeeded: 99,
+                    ..PublishCounters::default()
+                },
+                fanout_regime: Some(FanoutRegime::ShardPath),
+                retry_after_ms: None,
+                error_reason: None,
+            })
+            .await
+            .unwrap();
+        let dyn_store: DynPushStore = store;
+        let dyn_queue: DynPushQueue = queue.clone();
+        let admission = PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]);
+
+        let (_, Json(body), _) = accept_publish_inner(
+            "app-1",
+            sample_publish_request("publish-conflict"),
+            false,
+            &HeaderMap::new(),
+            test_publish_context(&dyn_store, &dyn_queue, &admission),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(body.status, "succeeded");
+        assert_eq!(body.expected_recipients, 99);
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::PublishLog)
+                .await
+                .unwrap()
+                .ready_depth,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_id_election_suppresses_a_different_intent_with_matching_status_shape() {
+        let store = Arc::new(MemoryPushStore::new());
+        let queue = Arc::new(MemoryPushQueue::new());
+        store.upsert_device(sample_device()).await.unwrap();
+        let dyn_store: DynPushStore = store.clone();
+        let dyn_queue: DynPushQueue = queue.clone();
+        let admission = PushAdmissionSnapshot::testing_active([PushProviderKind::Fcm]);
+        let first = sample_publish_request("shared-publish-id");
+        let mut second = sample_publish_request("shared-publish-id");
+        second.payload.body = Some("different body".to_owned());
+
+        accept_publish_inner(
+            "app-1",
+            first,
+            false,
+            &HeaderMap::new(),
+            test_publish_context(&dyn_store, &dyn_queue, &admission),
+        )
+        .await
+        .unwrap();
+        accept_publish_inner(
+            "app-1",
+            second,
+            false,
+            &HeaderMap::new(),
+            test_publish_context(&dyn_store, &dyn_queue, &admission),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            queue
+                .lag(PushQueueStage::PublishLog)
+                .await
+                .unwrap()
+                .ready_depth,
+            1
+        );
+        assert_eq!(
+            store
+                .list_publish_log_events("app-1", 10, None)
+                .await
+                .unwrap()
+                .items
+                .len(),
+            1
         );
     }
 

--- a/crates/sockudo-simulator/src/push_lab.rs
+++ b/crates/sockudo-simulator/src/push_lab.rs
@@ -338,7 +338,9 @@ impl PushLab {
         tick: u64,
         scheduler: &mut DeterministicFaultScheduler,
     ) -> SimulatorResult<()> {
-        let device_id = self.ensure_active_device(tick, scheduler).await?;
+        let Some(device_id) = self.ensure_active_device(tick, scheduler).await? else {
+            return Ok(());
+        };
         let channel = self.random_channel(scheduler);
         if self.backend_outage || self.write_fails_before_commit(tick, scheduler, "subscribe") {
             return Ok(());
@@ -1575,7 +1577,9 @@ impl PushLab {
         }) {
             return Ok(());
         }
-        let device_id = self.ensure_active_device(tick, scheduler).await?;
+        let Some(device_id) = self.ensure_active_device(tick, scheduler).await? else {
+            return Ok(());
+        };
         if let Some(device) = self.devices.get_mut(&device_id) {
             self.real.upsert_subscription(channel, &device_id).await?;
             device.subscriptions.insert(channel.to_string());
@@ -1583,25 +1587,30 @@ impl PushLab {
         Ok(())
     }
 
+    /// Return the id of a device that is active in the model, registering a new one if none exist.
+    ///
+    /// Returns `None` when no active device can be guaranteed — for example when a fresh
+    /// registration is dropped by an injected pre-commit write fault. Callers must not record model
+    /// state (subscriptions, reactivation) against a `None`/absent device, because the real
+    /// subsystem never persisted it and the shadow model would then diverge from it.
     async fn ensure_active_device(
         &mut self,
         tick: u64,
         scheduler: &mut DeterministicFaultScheduler,
-    ) -> SimulatorResult<String> {
+    ) -> SimulatorResult<Option<String>> {
         if let Some(device) = self
             .devices
             .values()
             .find(|device| device.state == DeviceState::Active)
         {
-            return Ok(device.id.clone());
+            return Ok(Some(device.id.clone()));
         }
         self.register_or_update_device(tick, scheduler).await?;
         Ok(self
             .devices
             .values()
             .find(|device| device.state == DeviceState::Active)
-            .map(|device| device.id.clone())
-            .unwrap_or_else(|| "device-00000000000000000001".to_string()))
+            .map(|device| device.id.clone()))
     }
 
     fn random_device_id(&self, scheduler: &mut DeterministicFaultScheduler) -> Option<String> {

--- a/docs/content/docs/server/history-recovery.mdx
+++ b/docs/content/docs/server/history-recovery.mdx
@@ -41,6 +41,8 @@ client.bind("sockudo:resume_success", (payload) => {
 
 If a channel emits `sockudo:resume_failed` with `code: "position_expired"`, the hot replay buffer and durable recovery window could not prove continuity. Resubscribe, then backfill with V2 channel history using `until_attach: true` so the history page is bounded at the subscription's attach serial.
 
+`code: "continuity_unverifiable"` means Sockudo rejected an ahead, non-contiguous, duplicate, or non-progressing recovery position. Treat it the same way: resubscribe and backfill instead of advancing the client cursor.
+
 Recovery is two-tier:
 
 1. Hot replay uses the bounded per-channel replay buffer.

--- a/docs/content/docs/server/push-notifications.mdx
+++ b/docs/content/docs/server/push-notifications.mdx
@@ -120,6 +120,10 @@ and dead-letter queue lag through the health/backpressure surfaces, and metrics 
 `sockudo_push_retry_dead_lettered_total`, `sockudo_push_retry_malformed_total`, and
 `sockudo_push_provider_failures_total{failure_class=...}`.
 
+Lifecycle safety checks expose `sockudo_push_invariant_violations_total{invariant=...}`. The bounded
+`status_transition` label means a stale, non-monotonic status write was ignored. The metric does
+not include payloads, device tokens, or provider credentials.
+
 Upgrade note: provider workers now enqueue internal `deliveryFeedback` payloads on
 `push.results.v1` so feedback workers can schedule retries with replayable job context. Older
 `deliveryResult` payloads are still accepted, but retryable legacy results without job context are

--- a/docs/content/docs/server/push-notifications.mdx
+++ b/docs/content/docs/server/push-notifications.mdx
@@ -124,6 +124,19 @@ Lifecycle safety checks expose `sockudo_push_invariant_violations_total{invarian
 `status_transition` label means a stale, non-monotonic status write was ignored. The metric does
 not include payloads, device tokens, or provider credentials.
 
+Publish-status mutations use storage-level compare-and-swap in every backend. Short-lived write
+contention increments `sockudo_push_status_cas_conflicts_total{component=...}` and is retried with
+a fixed bound. `sockudo_push_status_cas_exhausted_total{component=...}` means that bound was
+exhausted; the worker returns a structured error instead of silently accepting a lost update.
+Component labels come from a fixed internal set and neither metric includes payloads, tokens,
+credentials, app IDs, or publish IDs.
+
+All installations must stop old push admission and worker processes before starting
+revision-aware workers; do not run old blind status writers alongside them. PostgreSQL and MySQL
+must apply the push schema-version-2 migration while workers are stopped. DynamoDB, SurrealDB, and
+ScyllaDB store the revision in the status document envelope and need no table migration, but still
+require the same drain-and-replace deployment boundary.
+
 Upgrade note: provider workers now enqueue internal `deliveryFeedback` payloads on
 `push.results.v1` so feedback workers can schedule retries with replayable job context. Older
 `deliveryResult` payloads are still accepted, but retryable legacy results without job context are

--- a/ops/migrations/README.md
+++ b/ops/migrations/README.md
@@ -13,6 +13,10 @@ How to use it:
   [postgres/001_push_schema.sql](/Users/radudiaconu/Desktop/Code/Rust/sockudo/ops/migrations/postgres/001_push_schema.sql)
 - Push MySQL schema: use
   [mysql/003_push_schema.sql](/Users/radudiaconu/Desktop/Code/Rust/sockudo/ops/migrations/mysql/003_push_schema.sql)
+- Existing push PostgreSQL schema version 1: apply
+  [postgres/002_push_status_revision.sql](/Users/radudiaconu/Desktop/Code/Rust/sockudo/ops/migrations/postgres/002_push_status_revision.sql)
+- Existing push MySQL/MariaDB schema version 1: apply
+  [mysql/004_push_status_revision.sql](/Users/radudiaconu/Desktop/Code/Rust/sockudo/ops/migrations/mysql/004_push_status_revision.sql)
 - Test-only MySQL grants/user setup: use
   [mysql/002_test_access.sql](/Users/radudiaconu/Desktop/Code/Rust/sockudo/ops/migrations/mysql/002_test_access.sql)
 
@@ -28,6 +32,26 @@ Backend notes:
   additive and side by side with immutable history. Fresh schemas now include
   version-store and annotation tables for SQL backends, and runtime-provisioned
   backends are expected to create equivalent collections automatically.
+
+Push publish-status CAS upgrade:
+
+- The current push schema version is 2. Fresh push schemas already include the
+  `push_publish_status.revision` column and both schema-version records.
+- Re-running a fresh-schema script against version 1 does not mark version 2
+  unless the revision column already exists; existing installations must still
+  use the additive upgrade script.
+- For an existing schema version 1 deployment, pause push admission, drain and
+  stop every old push worker, apply the backend-specific upgrade, deploy the
+  new binary to every node, and only then resume push work.
+- Do not run schema-version-1 and schema-version-2 push workers together. Older
+  workers use blind status writes and can overwrite a CAS-protected update.
+- PostgreSQL applies the column and version record transactionally. MySQL and
+  MariaDB commit DDL implicitly, so the version record is deliberately written
+  only after the column addition succeeds. If the process stops between those
+  statements, verify the column and then apply the version insert manually.
+- Rollback requires stopping all schema-version-2 workers before removing the
+  version-2 record and revision column. Do not drop the column while a new
+  worker can still issue conditional status writes.
 
 Presence history:
 

--- a/ops/migrations/dynamodb/001_push_schema.md
+++ b/ops/migrations/dynamodb/001_push_schema.md
@@ -34,6 +34,12 @@ partitions.
 | `push_dead_letters` | `push_dead_letters` | `APP#<app_id>#PUBLISH#<publish_id>` | `DLQ#<occurred_at_ms>#<dead_letter_id>` |
 | `push_idempotency` | `push_idempotency` | `APP#<app_id>#IDEMPOTENCY#<idempotency_key>` | `META` |
 
+`publish_status` data is a versioned envelope containing the public status, a
+strictly positive `revision`, and authoritative `updated_at_ms`. Creation uses a
+conditional put and every replacement conditions on the complete prior
+envelope. The update-time index is advisory; cleanup conditionally deletes only
+the envelope revision and timestamp it inspected.
+
 Hot channels must derive `bucket` from stable hashing of `device_id`. Bucket
 counts are part of app-level capacity configuration and may increase only
 through dual-write/backfill.

--- a/ops/migrations/mysql/003_push_schema.sql
+++ b/ops/migrations/mysql/003_push_schema.sql
@@ -124,6 +124,7 @@ CREATE TABLE IF NOT EXISTS `push_publish_status` (
     error_reason TEXT NULL,
     created_at_ms BIGINT UNSIGNED NOT NULL,
     updated_at_ms BIGINT UNSIGNED NOT NULL,
+    revision BIGINT UNSIGNED NOT NULL DEFAULT 1,
     PRIMARY KEY (app_id, publish_id),
     KEY push_publish_status_state_idx (app_id, state, updated_at_ms, publish_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -196,3 +197,10 @@ CREATE TABLE IF NOT EXISTS `push_schema_version` (
 
 INSERT IGNORE INTO `push_schema_version` (version, applied_at_ms)
 VALUES (1, 0);
+
+INSERT IGNORE INTO `push_schema_version` (version, applied_at_ms)
+SELECT 2, 0
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'push_publish_status'
+  AND column_name = 'revision';

--- a/ops/migrations/mysql/004_push_status_revision.sql
+++ b/ops/migrations/mysql/004_push_status_revision.sql
@@ -1,0 +1,16 @@
+-- =============================================================================
+-- Sockudo MySQL/MariaDB push publish-status CAS upgrade (schema version 2)
+-- =============================================================================
+-- Stop push admission and all old push workers before applying this migration.
+-- A mixed deployment is unsafe because schema-version-1 workers use blind status writes.
+-- MySQL DDL commits implicitly: add the column before recording schema version 2.
+
+ALTER TABLE `push_publish_status`
+    ADD COLUMN revision BIGINT UNSIGNED NOT NULL DEFAULT 1 AFTER updated_at_ms;
+
+INSERT IGNORE INTO `push_schema_version` (version, applied_at_ms)
+VALUES (2, 0);
+
+-- Rollback requires stopping all schema-version-2 workers first, then running:
+-- DELETE FROM `push_schema_version` WHERE version = 2;
+-- ALTER TABLE `push_publish_status` DROP COLUMN revision;

--- a/ops/migrations/postgres/001_push_schema.sql
+++ b/ops/migrations/postgres/001_push_schema.sql
@@ -151,6 +151,7 @@ CREATE TABLE IF NOT EXISTS push_publish_status (
     error_reason TEXT NULL,
     created_at_ms BIGINT NOT NULL,
     updated_at_ms BIGINT NOT NULL,
+    revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0),
     PRIMARY KEY (app_id, publish_id)
 ) PARTITION BY HASH (app_id);
 
@@ -233,4 +234,15 @@ CREATE TABLE IF NOT EXISTS push_schema_version (
 
 INSERT INTO push_schema_version (version, applied_at_ms)
 VALUES (1, 0)
+ON CONFLICT (version) DO NOTHING;
+
+INSERT INTO push_schema_version (version, applied_at_ms)
+SELECT 2, 0
+WHERE EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'push_publish_status'
+      AND column_name = 'revision'
+)
 ON CONFLICT (version) DO NOTHING;

--- a/ops/migrations/postgres/002_push_status_revision.sql
+++ b/ops/migrations/postgres/002_push_status_revision.sql
@@ -1,0 +1,22 @@
+-- =============================================================================
+-- Sockudo PostgreSQL push publish-status CAS upgrade (schema version 2)
+-- =============================================================================
+-- Stop push admission and all old push workers before applying this migration.
+-- A mixed deployment is unsafe because schema-version-1 workers use blind status writes.
+-- The constant default initializes retained statuses at revision 1.
+
+BEGIN;
+
+ALTER TABLE push_publish_status
+    ADD COLUMN revision BIGINT NOT NULL DEFAULT 1
+    CHECK (revision > 0);
+
+INSERT INTO push_schema_version (version, applied_at_ms)
+VALUES (2, 0)
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;
+
+-- Rollback requires stopping all schema-version-2 workers first, then running:
+-- DELETE FROM push_schema_version WHERE version = 2;
+-- ALTER TABLE push_publish_status DROP COLUMN revision;

--- a/ops/migrations/scylladb/001_push_schema.cql
+++ b/ops/migrations/scylladb/001_push_schema.cql
@@ -181,6 +181,7 @@ CREATE TABLE IF NOT EXISTS sockudo_push.publish_status (
     state text,
     counters_json text,
     error_reason text,
+    revision bigint,
     created_at_ms bigint,
     updated_at_ms bigint,
     PRIMARY KEY ((app_id, publish_id))

--- a/ops/migrations/surrealdb/001_push_schema.surql
+++ b/ops/migrations/surrealdb/001_push_schema.surql
@@ -93,6 +93,8 @@ DEFINE FIELD publish_id ON push_publish_status TYPE string;
 DEFINE FIELD state ON push_publish_status TYPE string;
 DEFINE FIELD counters_json ON push_publish_status TYPE object;
 DEFINE FIELD error_reason ON push_publish_status TYPE option<string>;
+DEFINE FIELD revision ON push_publish_status TYPE int ASSERT $value > 0;
+DEFINE FIELD updated_at_ms ON push_publish_status TYPE int;
 DEFINE INDEX publish_status ON push_publish_status FIELDS app_id, publish_id UNIQUE;
 
 DEFINE TABLE push_delivery_events SCHEMAFULL;


### PR DESCRIPTION
## Summary

- fail closed when hot, durable-history, or version-store recovery cannot prove serial and cursor continuity, while preserving durable fallback for node-local hot-buffer misses
- validate complete presence snapshots for ordered serials and impossible join/update/remove sequences without rejecting retention-truncated or time-bounded clock-skew cases
- bound rewind handoff buffers by the configured message/byte ceilings and disconnect on overflow rather than silently breaking continuity
- enforce monotonic push lifecycle changes through revisioned compare-and-swap storage across memory, PostgreSQL, MySQL, DynamoDB, SurrealDB, and ScyllaDB
- use conditional creation for initial publish status, bounded CAS retries for planner/feedback/retry mutations, and publish-ID election so concurrent requests cannot attach different intents to the same ID
- make queue admission atomic and bounded per stage; duplicate broker callbacks wait for canonical completion and cancelled canonical work releases capacity
- retain the simulator-discovered in-memory subscription pagination fix for prefix-colliding channel names

## Storage and rollout

- PostgreSQL and MySQL status rows move to push schema version 2 with a `revision` column; upgrade scripts are included in `ops/migrations/postgres/002_push_status_revision.sql` and `ops/migrations/mysql/004_push_status_revision.sql`
- DynamoDB, SurrealDB, and ScyllaDB store revisioned status envelopes and lazily upgrade legacy raw status values; no table recreation is required
- apply SQL migrations before deploying this build and drain old push workers before enabling writers; mixed old/new writers can bypass revision updates
- status cleanup matches revision plus the authoritative timestamp, preventing a stale cleanup worker from deleting a recreated publish ID

## Observability

- `sockudo_push_invariant_violations_total{invariant="status_transition"}`
- `sockudo_push_status_cas_conflicts_total{component}`
- `sockudo_push_status_cas_exhausted_total{component}`

All labels are fixed-cardinality and contain no payloads, device tokens, provider credentials, or other secrets. Existing duplicate-suppression and local-capacity counters remain in use for queue paths.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sockudo-push --no-fail-fast`
- `cargo test -p sockudo-push --no-default-features --features postgres,mysql`
- `cargo test -p sockudo-push --no-default-features --features dynamodb,surrealdb,scylladb`
- `cargo test --workspace --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p sockudo --features push --all-targets -- -D warnings`
- `cargo clippy -p sockudo-push --no-default-features --features postgres,mysql,dynamodb,surrealdb,scylladb --all-targets -- -D warnings`
- `cd docs && npm run types:check && npm run build`
- `git diff --check`

Backend-specific feature paths compile and the shared conformance suites pass locally. Native CAS queries were not exercised against live external database services in this environment.

## Operational boundary

Status CAS is atomic within each storage backend. Queue publication and status persistence remain separate systems, so they are not presented as a cross-system transaction; retry ordering favors suppressing duplicate provider sends if the status store becomes unavailable after queueing.

No CI configuration was added or changed.
