### PR TITLE
Fix dashboard user activation for Postgres-backed installs

### DIFF
--- a/dashboard/api/src/db/users-repository.ts
+++ b/dashboard/api/src/db/users-repository.ts
@@ -7,6 +7,16 @@ import type {
   UserRole,
 } from "../types/user.ts";
 
+function toBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "1" || normalized === "t" || normalized === "true";
+  }
+  return false;
+}
+
 function mapUser(row: Record<string, unknown>): DashboardUser {
   return {
     id: String(row.id),
@@ -14,7 +24,7 @@ function mapUser(row: Record<string, unknown>): DashboardUser {
     password_hash: String(row.password_hash),
     name: String(row.name ?? ""),
     role: String(row.role) as UserRole,
-    active: row.active === true || row.active === 1 || row.active === "1",
+    active: toBoolean(row.active),
     created_at: String(row.created_at),
     updated_at: String(row.updated_at),
   };
@@ -67,7 +77,7 @@ export class UsersRepository {
     await this.db.execute(
       `INSERT INTO dashboard_users (id, email, password_hash, name, role, active)
        VALUES (?, ?, ?, ?, ?, ?)`,
-      [id, email, password_hash, name, role, active ? 1 : 0],
+      [id, email, password_hash, name, role, active],
     );
 
     const created = await this.findById(id);
@@ -91,7 +101,7 @@ export class UsersRepository {
       `UPDATE dashboard_users
        SET email = ?, password_hash = ?, name = ?, role = ?, active = ?, updated_at = CURRENT_TIMESTAMP
        WHERE id = ?`,
-      [email, password_hash, name, role, active ? 1 : 0, id],
+      [email, password_hash, name, role, active, id],
     );
 
     const updated = await this.findById(id);


### PR DESCRIPTION
## Description

Fix dashboard user activation across database backends by passing `active` as a native boolean instead of converting it to `1/0`. This lets Postgres serialize BOOLEAN values correctly while remaining compatible with MySQL/SQLite. Also hardens user row mapping to recognize common boolean representations returned by different drivers.

The `toBoolean` method might be a bit of an verbose overkill, but it ensures conversion for all db types.
The code was written by Codex (GTP 5.5) review by myself.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [X] Manual testing completed

Tested with Postgres "live". Verified for mysql and sqlite using provided docker compose and "raw" `DASHBOARD_DATABASE_DRIVER=sqlite`.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
