### PR TITLE
feat: add POST /users/{userId}/force_reconnect endpoint

### DIFF
--- a/crates/sockudo-adapter/src/connection_manager.rs
+++ b/crates/sockudo-adapter/src/connection_manager.rs
@@ -232,6 +232,7 @@ pub trait ConnectionManager: Send + Sync {
         Ok(None)
     }
     async fn terminate_user_connections(&self, app_id: &str, user_id: &str) -> Result<()>;
+    async fn force_reconnect_user(&self, app_id: &str, user_id: &str) -> Result<()>;
     async fn add_user(&self, ws: WebSocketRef) -> Result<()>;
     async fn remove_user(&self, ws: WebSocketRef) -> Result<()>;
     async fn remove_user_socket(

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -656,7 +656,10 @@ impl ConnectionHandler {
             let mut conn_locked = conn_arc.inner.lock().await;
 
             if let Some(ref member) = subscription_result.member {
-                conn_locked.state.user_id = Some(member.user_id.clone());
+                // Only set connection user_id from presence if signin hasn't set it already
+                if conn_locked.state.user_id.is_none() {
+                    conn_locked.state.user_id = Some(member.user_id.clone());
+                }
 
                 let presence_info = PresenceMemberInfo {
                     user_id: member.user_id.clone(),

--- a/crates/sockudo-adapter/src/horizontal_adapter/mod.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter/mod.rs
@@ -35,6 +35,7 @@ pub enum RequestType {
     SocketExistsInChannel,    // Check if socket exists in a channel
     TerminateUserConnections, // Terminate user connections
     ChannelsWithSocketsCount, // Get channels with socket counts
+    ForceReconnect,           // Close sockets with 4200 so clients reconnect
 
     // New request types
     Sockets,                       // Get all sockets

--- a/crates/sockudo-adapter/src/horizontal_adapter/operations.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter/operations.rs
@@ -154,6 +154,14 @@ impl HorizontalAdapter {
                     response.exists = true;
                 }
             }
+            RequestType::ForceReconnect => {
+                if let Some(user_id) = &request.user_id {
+                    self.local_adapter
+                        .force_reconnect_user(&request.app_id, user_id)
+                        .await?;
+                    response.exists = true;
+                }
+            }
             RequestType::ChannelsWithSocketsCount => {
                 // Get channels with socket count from local adapter (returns HashMap now)
                 let channels = self
@@ -834,6 +842,10 @@ impl HorizontalAdapter {
 
                 RequestType::TerminateUserConnections => {
                     // If any node successfully terminated connections, mark as success
+                    combined_response.exists = combined_response.exists || response.exists;
+                }
+
+                RequestType::ForceReconnect => {
                     combined_response.exists = combined_response.exists || response.exists;
                 }
 

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
@@ -646,6 +646,24 @@ where
         self.terminate_connection(app_id, user_id).await
     }
 
+    async fn force_reconnect_user(&self, app_id: &str, user_id: &str) -> Result<()> {
+        self.local_adapter
+            .force_reconnect_user(app_id, user_id)
+            .await?;
+
+        let _response = self
+            .send_request(
+                app_id,
+                RequestType::ForceReconnect,
+                None,
+                None,
+                Some(user_id),
+            )
+            .await?;
+
+        Ok(())
+    }
+
     async fn add_user(&self, ws_ref: WebSocketRef) -> Result<()> {
         self.local_adapter.add_user(ws_ref).await
     }

--- a/crates/sockudo-adapter/src/local_adapter/connection_manager.rs
+++ b/crates/sockudo-adapter/src/local_adapter/connection_manager.rs
@@ -12,7 +12,7 @@ use sockudo_protocol::messages::{PusherMessage, generate_message_id};
 use sockudo_ws::axum_integration::WebSocketWriter;
 use std::any::Any;
 use std::sync::Arc;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 fn partition_by_append_mode(sockets: Vec<WebSocketRef>) -> (Vec<WebSocketRef>, Vec<WebSocketRef>) {
     sockets
@@ -633,6 +633,14 @@ impl ConnectionManager for LocalAdapter {
         let namespace = self.get_or_create_namespace(app_id).await;
         if let Err(e) = namespace.terminate_user_connections(user_id).await {
             error!("Failed to terminate user connections: {}", e);
+        }
+        Ok(())
+    }
+
+    async fn force_reconnect_user(&self, app_id: &str, user_id: &str) -> Result<()> {
+        let namespace = self.get_or_create_namespace(app_id).await;
+        if let Err(e) = namespace.force_reconnect_user_connections(user_id).await {
+            warn!(error = %e, "failed to force reconnect user connections");
         }
         Ok(())
     }

--- a/crates/sockudo-adapter/src/presence.rs
+++ b/crates/sockudo-adapter/src/presence.rs
@@ -1252,6 +1252,9 @@ mod tests {
         async fn terminate_user_connections(&self, _app_id: &str, _user_id: &str) -> Result<()> {
             Ok(())
         }
+        async fn force_reconnect_user(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+            Ok(())
+        }
         async fn add_user(&self, _ws: sockudo_core::websocket::WebSocketRef) -> Result<()> {
             Ok(())
         }

--- a/crates/sockudo-adapter/tests/adapter/connected_gauge_regression_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/connected_gauge_regression_tests.rs
@@ -205,6 +205,9 @@ impl ConnectionManager for FullCapacityAdapter {
     async fn terminate_user_connections(&self, _: &str, _: &str) -> Result<()> {
         Ok(())
     }
+    async fn force_reconnect_user(&self, _: &str, _: &str) -> Result<()> {
+        Ok(())
+    }
     async fn add_user(&self, _: WebSocketRef) -> Result<()> {
         Ok(())
     }

--- a/crates/sockudo-adapter/tests/adapter/handler/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/mod.rs
@@ -1,6 +1,7 @@
 pub mod annotations_test;
 pub mod authentication_test;
 pub mod clustered_runtime_rewind_recovery_redis_test;
+pub mod presence_user_id_guard_test;
 pub mod runtime_rewind_recovery_e2e_test;
 pub mod signin_test;
 pub mod validation_test;

--- a/crates/sockudo-adapter/tests/adapter/handler/presence_user_id_guard_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/presence_user_id_guard_test.rs
@@ -1,0 +1,78 @@
+use sockudo_core::websocket::{SocketId, WebSocket, WebSocketRef};
+use sockudo_ws::axum_integration;
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, WebSocketStream};
+use tokio::net::{TcpListener, TcpStream};
+
+async fn create_test_writer() -> axum_integration::WebSocketWriter {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let _ = sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let ws = axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
+        let (_reader, writer) = ws.split();
+        writer
+    });
+
+    let client_stream = TcpStream::connect(addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+        .connect(client_stream, &addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    server.await.unwrap()
+}
+
+async fn make_ws_ref(user_id: Option<&str>) -> WebSocketRef {
+    let writer = create_test_writer().await;
+    let mut ws = WebSocket::new(SocketId::new(), writer);
+    if let Some(uid) = user_id {
+        ws.state.user_id = Some(uid.to_string());
+    }
+    WebSocketRef::new(ws)
+}
+
+#[tokio::test]
+async fn test_presence_subscription_guard_preserves_signin_user_id() {
+    let ws_ref = make_ws_ref(Some("real-user-42")).await;
+
+    let member_user_id = "real-user-42:123.456".to_string();
+    {
+        let mut conn_locked = ws_ref.inner.lock().await;
+        if conn_locked.state.user_id.is_none() {
+            conn_locked.state.user_id = Some(member_user_id.clone());
+        }
+    }
+
+    let conn_locked = ws_ref.inner.lock().await;
+    assert_eq!(
+        conn_locked.state.user_id.as_deref(),
+        Some("real-user-42"),
+        "user_id set by signin must not be overwritten by presence subscription"
+    );
+}
+
+#[tokio::test]
+async fn test_presence_subscription_guard_sets_user_id_when_none() {
+    let ws_ref = make_ws_ref(None).await;
+
+    let member_user_id = "presence-user-99".to_string();
+    {
+        let mut conn_locked = ws_ref.inner.lock().await;
+        if conn_locked.state.user_id.is_none() {
+            conn_locked.state.user_id = Some(member_user_id.clone());
+        }
+    }
+
+    let conn_locked = ws_ref.inner.lock().await;
+    assert_eq!(
+        conn_locked.state.user_id.as_deref(),
+        Some("presence-user-99"),
+        "user_id should be set from presence member when no signin occurred"
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/presence_concurrency_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_concurrency_tests.rs
@@ -165,6 +165,10 @@ impl ConnectionManager for ScriptedCM {
         Ok(())
     }
 
+    async fn force_reconnect_user(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+        Ok(())
+    }
+
     async fn add_user(&self, _ws: WebSocketRef) -> Result<()> {
         Ok(())
     }

--- a/crates/sockudo-adapter/tests/adapter/presence_lock_scope_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_lock_scope_tests.rs
@@ -193,6 +193,10 @@ impl ConnectionManager for ScriptedCM {
         Ok(())
     }
 
+    async fn force_reconnect_user(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+        Ok(())
+    }
+
     async fn add_user(&self, _ws: WebSocketRef) -> Result<()> {
         Ok(())
     }

--- a/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
+++ b/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
@@ -147,6 +147,9 @@ impl ConnectionManager for MockAdapter {
     async fn terminate_user_connections(&self, _app_id: &str, _user_id: &str) -> Result<()> {
         Ok(())
     }
+    async fn force_reconnect_user(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+        Ok(())
+    }
     async fn add_user(&self, _ws: WebSocketRef) -> Result<()> {
         Ok(())
     }

--- a/crates/sockudo-core/src/namespace.rs
+++ b/crates/sockudo-core/src/namespace.rs
@@ -470,6 +470,28 @@ impl Namespace {
         Ok(())
     }
 
+    pub async fn force_reconnect_user_connections(&self, user_id: &str) -> Result<()> {
+        if let Some(user_sockets_ref) = self.users.get(user_id) {
+            let user_sockets_snapshot = user_sockets_ref.clone();
+            drop(user_sockets_ref);
+
+            let cleanup_tasks: Vec<_> = user_sockets_snapshot
+                .iter()
+                .map(|ws_ref| async move {
+                    if let Err(e) = ws_ref
+                        .close(4200, "Force reconnect requested by the app.".to_string())
+                        .await
+                    {
+                        warn!(error = %e, "failed to close connection");
+                    }
+                })
+                .collect();
+
+            join_all(cleanup_tasks).await;
+        }
+        Ok(())
+    }
+
     /// `activated` reports the first socket joining the channel, computed under
     /// the shard write lock so it is safe against concurrent add/remove.
     pub fn add_channel_to_socket(&self, channel: &str, socket_id: &SocketId) -> (bool, bool) {

--- a/crates/sockudo-server/src/bootstrap/router.rs
+++ b/crates/sockudo-server/src/bootstrap/router.rs
@@ -10,8 +10,9 @@ use crate::http_handler::{
     channel_history_reset, channel_history_state, channel_message, channel_message_annotations,
     channel_message_versions, channel_presence_history, channel_presence_history_reset,
     channel_presence_history_snapshot, channel_presence_history_state, channel_users, channels,
-    delete_annotation, delete_message, events, fallback_404, live, metrics, publish_annotation,
-    revoke_capability_tokens, stats, terminate_user_connections, up, update_message, usage,
+    delete_annotation, delete_message, events, fallback_404, force_reconnect_user, live, metrics,
+    publish_annotation, revoke_capability_tokens, stats, terminate_user_connections, up,
+    update_message, usage,
 };
 use crate::middleware::pusher_api_auth_middleware;
 #[cfg(feature = "push")]
@@ -368,6 +369,13 @@ impl SockudoServer {
             .route(
                 "/apps/{appId}/users/{userId}/terminate_connections",
                 post(terminate_user_connections).route_layer(axum_middleware::from_fn_with_state(
+                    self.handler.clone(),
+                    pusher_api_auth_middleware,
+                )),
+            )
+            .route(
+                "/apps/{appId}/users/{userId}/force_reconnect",
+                post(force_reconnect_user).route_layer(axum_middleware::from_fn_with_state(
                     self.handler.clone(),
                     pusher_api_auth_middleware,
                 )),

--- a/crates/sockudo-server/src/http_handler/channels.rs
+++ b/crates/sockudo-server/src/http_handler/channels.rs
@@ -376,6 +376,32 @@ pub async fn terminate_user_connections(
     Ok((StatusCode::OK, Json(response_payload)))
 }
 
+/// POST /apps/{app_id}/users/{user_id}/force_reconnect
+#[instrument(skip(handler), fields(app_id = %app_id, user_id = %user_id))]
+pub async fn force_reconnect_user(
+    Path((app_id, user_id)): Path<(String, String)>,
+    Query(_auth_q_params_struct): Query<EventQuery>,
+    Extension(app): Extension<App>,
+    State(handler): State<Arc<ConnectionHandler>>,
+    _uri: Uri,
+    RawQuery(_raw_query_str_option): RawQuery,
+) -> Result<impl IntoResponse, AppError> {
+    info!(user_id = %user_id, "force reconnect user requested");
+
+    handler
+        .connection_manager()
+        .force_reconnect_user(&app.id, &user_id)
+        .await?;
+
+    info!(user_id = %user_id, "force reconnect user initiated");
+
+    let response_payload = json!({ "ok": true });
+    let response_size = sonic_rs::to_vec(&response_payload)?.len();
+    record_api_metrics(&handler, &app.id, 0, response_size).await;
+
+    Ok((StatusCode::OK, Json(response_payload)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sockudo-server/src/http_handler/mod.rs
+++ b/crates/sockudo-server/src/http_handler/mod.rs
@@ -23,7 +23,8 @@ pub use ably_compat::{
 };
 pub use annotations::{channel_message_annotations, delete_annotation, publish_annotation};
 pub use channels::{
-    channel, channel_users, channels, revoke_capability_tokens, terminate_user_connections,
+    channel, channel_users, channels, force_reconnect_user, revoke_capability_tokens,
+    terminate_user_connections,
 };
 pub use errors::AppError;
 pub use events::{batch_events, events};

--- a/docs/content/docs/reference/http-endpoints.mdx
+++ b/docs/content/docs/reference/http-endpoints.mdx
@@ -37,6 +37,7 @@ Supported query parameters:
 | `POST` | `/apps/{appId}/batch_events` | Signed app API | Publish multiple events in one request. |
 | `POST` | `/apps/{appId}/revocations` | Signed app API | Revoke Protocol V2 capability tokens by `jti`, `client_id`, or both. Matching local sockets receive `sockudo:token_expired` and close. |
 | `POST` | `/apps/{appId}/users/{userId}/terminate_connections` | Signed app API | Disconnect every active socket for the supplied user ID. |
+| `POST` | `/apps/{appId}/users/{userId}/force_reconnect` | Signed app API | Close every active socket for the supplied user ID with code `4200`, prompting clients to reconnect. |
 
 Useful request controls:
 

--- a/server-sdks/sockudo-http-dotnet/PusherServer.Tests/UnitTests/UserConnections.cs
+++ b/server-sdks/sockudo-http-dotnet/PusherServer.Tests/UnitTests/UserConnections.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using PusherServer.RestfulClient;
+using PusherServer.Tests.Helpers;
+
+namespace PusherServer.Tests.UnitTests
+{
+    [TestFixture]
+    public class When_managing_user_connections
+    {
+        private Pusher _pusher;
+        private IPusherRestClient _restClient;
+        private IApplicationConfig _config;
+
+        [SetUp]
+        public void Setup()
+        {
+            _restClient = Substitute.For<IPusherRestClient>();
+
+            var options = new PusherOptions
+            {
+                RestClient = _restClient
+            };
+
+            _config = new ApplicationConfig
+            {
+                AppId = "test-app-id",
+                AppKey = "test-app-key",
+                AppSecret = "test-app-secret",
+            };
+
+            _pusher = new Pusher(_config.AppId, _config.AppKey, _config.AppSecret, options);
+
+            var okResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            };
+
+            _restClient.ExecutePostRawAsync(Arg.Any<IPusherRestRequest>())
+                .Returns(Task.FromResult(new RawRequestResult(okResponse, "{}")));
+        }
+
+        [Test]
+        public async Task terminate_user_connections_posts_to_correct_path()
+        {
+            await _pusher.TerminateUserConnectionsAsync("user-123").ConfigureAwait(false);
+
+#pragma warning disable 4014
+            _restClient.Received().ExecutePostRawAsync(
+#pragma warning restore 4014
+                Arg.Is<IPusherRestRequest>(request =>
+                    request.ResourceUri.StartsWith("/apps/" + _config.AppId + "/users/user-123/terminate_connections?") &&
+                    request.Method == PusherMethod.POST
+                )
+            );
+        }
+
+        [Test]
+        public async Task force_reconnect_user_posts_to_correct_path()
+        {
+            await _pusher.ForceReconnectUserAsync("user-456").ConfigureAwait(false);
+
+#pragma warning disable 4014
+            _restClient.Received().ExecutePostRawAsync(
+#pragma warning restore 4014
+                Arg.Is<IPusherRestRequest>(request =>
+                    request.ResourceUri.StartsWith("/apps/" + _config.AppId + "/users/user-456/force_reconnect?") &&
+                    request.Method == PusherMethod.POST
+                )
+            );
+        }
+
+        [Test]
+        public void terminate_user_connections_throws_on_null_user_id()
+        {
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _pusher.TerminateUserConnectionsAsync(null).ConfigureAwait(false));
+        }
+
+        [Test]
+        public void terminate_user_connections_throws_on_empty_user_id()
+        {
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _pusher.TerminateUserConnectionsAsync(string.Empty).ConfigureAwait(false));
+        }
+
+        [Test]
+        public void force_reconnect_user_throws_on_null_user_id()
+        {
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _pusher.ForceReconnectUserAsync(null).ConfigureAwait(false));
+        }
+
+        [Test]
+        public void force_reconnect_user_throws_on_empty_user_id()
+        {
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _pusher.ForceReconnectUserAsync(string.Empty).ConfigureAwait(false));
+        }
+    }
+}

--- a/server-sdks/sockudo-http-dotnet/PusherServer/IPusher.cs
+++ b/server-sdks/sockudo-http-dotnet/PusherServer/IPusher.cs
@@ -184,5 +184,19 @@ namespace PusherServer
         Task<IGetResult<T>> GetPublishStatusAsync<T>(string publishId);
         Task<IGetResult<T>> CancelScheduledPushAsync<T>(string publishId);
         Task<IGetResult<T>> PostPushDeliveryStatusAsync<T>(object deliveryEvent);
+
+        /// <summary>
+        /// Terminates all active connections for the specified user.
+        /// </summary>
+        /// <param name="userId">The ID of the user whose connections should be terminated.</param>
+        /// <returns>The result of the call to the REST API</returns>
+        Task<IGetResult<object>> TerminateUserConnectionsAsync(string userId);
+
+        /// <summary>
+        /// Forces all active connections for the specified user to reconnect by closing them with code 4200.
+        /// </summary>
+        /// <param name="userId">The ID of the user whose connections should be forced to reconnect.</param>
+        /// <returns>The result of the call to the REST API</returns>
+        Task<IGetResult<object>> ForceReconnectUserAsync(string userId);
     }
 }

--- a/server-sdks/sockudo-http-dotnet/PusherServer/Pusher.cs
+++ b/server-sdks/sockudo-http-dotnet/PusherServer/Pusher.cs
@@ -31,6 +31,8 @@ namespace PusherServer
         private const string PushPublishStatusResource = "/push/publish/{0}/status";
         private const string PushScheduledResource = "/push/scheduled/{0}";
         private const string PushDeliveryStatusResource = "/push/deliveryStatus";
+        private const string UserTerminateConnectionsResource = "/users/{0}/terminate_connections";
+        private const string UserForceReconnectResource = "/users/{0}/force_reconnect";
 
         private readonly string _appKey;
         private readonly string _appSecret;
@@ -464,6 +466,22 @@ namespace PusherServer
         public Task<IGetResult<T>> PostPushDeliveryStatusAsync<T>(object deliveryEvent)
         {
             return ExecutePushPostAsync<T>(PushDeliveryStatusResource, deliveryEvent, PushHeaders("push-admin"));
+        }
+
+        public async Task<IGetResult<object>> TerminateUserConnectionsAsync(string userId)
+        {
+            ThrowArgumentExceptionIfNullOrEmpty(userId, "userId");
+            var request = _factory.Build(PusherMethod.POST, string.Format(UserTerminateConnectionsResource, userId), requestBody: new { });
+            var response = await _options.RestClient.ExecutePostRawAsync(request).ConfigureAwait(false);
+            return new GetResult<object>(response.Response, response.Body);
+        }
+
+        public async Task<IGetResult<object>> ForceReconnectUserAsync(string userId)
+        {
+            ThrowArgumentExceptionIfNullOrEmpty(userId, "userId");
+            var request = _factory.Build(PusherMethod.POST, string.Format(UserForceReconnectResource, userId), requestBody: new { });
+            var response = await _options.RestClient.ExecutePostRawAsync(request).ConfigureAwait(false);
+            return new GetResult<object>(response.Response, response.Body);
         }
 
         internal static bool IsPrivateEncryptedChannel(string channelName)

--- a/server-sdks/sockudo-http-dotnet/README.md
+++ b/server-sdks/sockudo-http-dotnet/README.md
@@ -347,6 +347,24 @@ else
 }
 ```
 
+## User connection management
+
+### Terminate User Connections
+
+Disconnect every active socket for a user:
+
+```csharp
+var result = await sockudo.TerminateUserConnectionsAsync("user-123");
+```
+
+### Force Reconnect User
+
+Close all active connections for a user with code `4200`, prompting clients to reconnect:
+
+```csharp
+var result = await sockudo.ForceReconnectUserAsync("user-123");
+```
+
 ## License
 
 This code is free to use under the terms of the MIT license.

--- a/server-sdks/sockudo-http-dotnet/SockudoServer.Tests/UnitTests/UserConnections.cs
+++ b/server-sdks/sockudo-http-dotnet/SockudoServer.Tests/UnitTests/UserConnections.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using SockudoServer.RestfulClient;
+using SockudoServer.Tests.Helpers;
+
+namespace SockudoServer.Tests.UnitTests
+{
+    [TestFixture]
+    public class When_managing_user_connections
+    {
+        private Sockudo _sockudo;
+        private ISockudoRestClient _restClient;
+        private IApplicationConfig _config;
+
+        [SetUp]
+        public void Setup()
+        {
+            _restClient = Substitute.For<ISockudoRestClient>();
+
+            var options = new SockudoOptions
+            {
+                RestClient = _restClient
+            };
+
+            _config = new ApplicationConfig
+            {
+                AppId = "test-app-id",
+                AppKey = "test-app-key",
+                AppSecret = "test-app-secret",
+            };
+
+            _sockudo = new Sockudo(_config.AppId, _config.AppKey, _config.AppSecret, options);
+
+            var okResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            };
+
+            _restClient.ExecutePostRawAsync(Arg.Any<ISockudoRestRequest>())
+                .Returns(Task.FromResult(new RawRequestResult(okResponse, "{}")));
+        }
+
+        [Test]
+        public async Task terminate_user_connections_posts_to_correct_path()
+        {
+            await _sockudo.TerminateUserConnectionsAsync("user-123").ConfigureAwait(false);
+
+#pragma warning disable 4014
+            _restClient.Received().ExecutePostRawAsync(
+#pragma warning restore 4014
+                Arg.Is<ISockudoRestRequest>(request =>
+                    request.ResourceUri.StartsWith("/apps/" + _config.AppId + "/users/user-123/terminate_connections?") &&
+                    request.Method == SockudoMethod.POST
+                )
+            );
+        }
+
+        [Test]
+        public async Task force_reconnect_user_posts_to_correct_path()
+        {
+            await _sockudo.ForceReconnectUserAsync("user-456").ConfigureAwait(false);
+
+#pragma warning disable 4014
+            _restClient.Received().ExecutePostRawAsync(
+#pragma warning restore 4014
+                Arg.Is<ISockudoRestRequest>(request =>
+                    request.ResourceUri.StartsWith("/apps/" + _config.AppId + "/users/user-456/force_reconnect?") &&
+                    request.Method == SockudoMethod.POST
+                )
+            );
+        }
+
+        [Test]
+        public void terminate_user_connections_throws_on_null_user_id()
+        {
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _sockudo.TerminateUserConnectionsAsync(null).ConfigureAwait(false));
+        }
+
+        [Test]
+        public void terminate_user_connections_throws_on_empty_user_id()
+        {
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _sockudo.TerminateUserConnectionsAsync(string.Empty).ConfigureAwait(false));
+        }
+
+        [Test]
+        public void force_reconnect_user_throws_on_null_user_id()
+        {
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _sockudo.ForceReconnectUserAsync(null).ConfigureAwait(false));
+        }
+
+        [Test]
+        public void force_reconnect_user_throws_on_empty_user_id()
+        {
+            Assert.ThrowsAsync<ArgumentException>(async () =>
+                await _sockudo.ForceReconnectUserAsync(string.Empty).ConfigureAwait(false));
+        }
+    }
+}

--- a/server-sdks/sockudo-http-dotnet/SockudoServer/ISockudo.cs
+++ b/server-sdks/sockudo-http-dotnet/SockudoServer/ISockudo.cs
@@ -224,5 +224,19 @@ namespace SockudoServer
         Task<IGetResult<T>> GetPublishStatusAsync<T>(string publishId);
         Task<IGetResult<T>> CancelScheduledPushAsync<T>(string publishId);
         Task<IGetResult<T>> PostPushDeliveryStatusAsync<T>(object deliveryEvent);
+
+        /// <summary>
+        /// Terminates all active connections for the specified user.
+        /// </summary>
+        /// <param name="userId">The ID of the user whose connections should be terminated.</param>
+        /// <returns>The result of the call to the REST API</returns>
+        Task<IGetResult<object>> TerminateUserConnectionsAsync(string userId);
+
+        /// <summary>
+        /// Forces all active connections for the specified user to reconnect by closing them with code 4200.
+        /// </summary>
+        /// <param name="userId">The ID of the user whose connections should be forced to reconnect.</param>
+        /// <returns>The result of the call to the REST API</returns>
+        Task<IGetResult<object>> ForceReconnectUserAsync(string userId);
     }
 }

--- a/server-sdks/sockudo-http-dotnet/SockudoServer/Sockudo.cs
+++ b/server-sdks/sockudo-http-dotnet/SockudoServer/Sockudo.cs
@@ -41,6 +41,8 @@ namespace SockudoServer
         private const string PushPublishStatusResource = "/push/publish/{0}/status";
         private const string PushScheduledResource = "/push/scheduled/{0}";
         private const string PushDeliveryStatusResource = "/push/deliveryStatus";
+        private const string UserTerminateConnectionsResource = "/users/{0}/terminate_connections";
+        private const string UserForceReconnectResource = "/users/{0}/force_reconnect";
 
         private readonly string _appKey;
         private readonly string _appSecret;
@@ -680,6 +682,22 @@ namespace SockudoServer
         public Task<IGetResult<T>> PostPushDeliveryStatusAsync<T>(object deliveryEvent)
         {
             return ExecutePushPostAsync<T>(PushDeliveryStatusResource, deliveryEvent, PushHeaders("push-admin"));
+        }
+
+        public async Task<IGetResult<object>> TerminateUserConnectionsAsync(string userId)
+        {
+            ThrowArgumentExceptionIfNullOrEmpty(userId, "userId");
+            var request = _factory.Build(SockudoMethod.POST, string.Format(UserTerminateConnectionsResource, userId), requestBody: new { });
+            var response = await _options.RestClient.ExecutePostRawAsync(request).ConfigureAwait(false);
+            return new GetResult<object>(response.Response, response.Body);
+        }
+
+        public async Task<IGetResult<object>> ForceReconnectUserAsync(string userId)
+        {
+            ThrowArgumentExceptionIfNullOrEmpty(userId, "userId");
+            var request = _factory.Build(SockudoMethod.POST, string.Format(UserForceReconnectResource, userId), requestBody: new { });
+            var response = await _options.RestClient.ExecutePostRawAsync(request).ConfigureAwait(false);
+            return new GetResult<object>(response.Response, response.Body);
         }
 
         internal static bool IsPrivateEncryptedChannel(string channelName)

--- a/server-sdks/sockudo-http-go/README.md
+++ b/server-sdks/sockudo-http-go/README.md
@@ -385,6 +385,30 @@ nextPage, err := client.ChannelHistory("my-channel", sockudo.HistoryParams{
 })
 ```
 
+## User Connection Management
+
+### Terminate User Connections
+
+Disconnect every active socket for a user:
+
+```go
+err := client.TerminateUserConnections("user-123")
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+### Force Reconnect User
+
+Close all active connections for a user with code `4200`, prompting clients to reconnect:
+
+```go
+err := client.ForceReconnectUser("user-123")
+if err != nil {
+    log.Fatal(err)
+}
+```
+
 ## Pusher SDK Compatibility
 
 Sockudo implements the full Pusher HTTP API. If you prefer to use the official `github.com/pusher/pusher-http-go/v5` package or are migrating from Pusher, point it at your Sockudo instance:

--- a/server-sdks/sockudo-http-go/client.go
+++ b/server-sdks/sockudo-http-go/client.go
@@ -331,6 +331,47 @@ func (c *Client) SendToUser(userId string, eventName string, data interface{}) e
 	return err
 }
 
+// TerminateUserConnections disconnects every active socket for the given user.
+func (c *Client) TerminateUserConnections(userId string) error {
+	if !validUserId(userId) {
+		return fmt.Errorf("User id '%s' is invalid", userId)
+	}
+	path := fmt.Sprintf("/apps/%s/users/%s/terminate_connections", c.AppID, userId)
+	u, err := createRequestURL("POST", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, []byte("{}"), nil, c.Cluster)
+	if err != nil {
+		return err
+	}
+	var reqErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		_, reqErr = c.request("POST", u, []byte("{}"))
+		if reqErr == nil || !isRetryableError(reqErr) {
+			break
+		}
+	}
+	return reqErr
+}
+
+// ForceReconnectUser closes all active connections for a user with code 4200,
+// prompting clients to reconnect.
+func (c *Client) ForceReconnectUser(userId string) error {
+	if !validUserId(userId) {
+		return fmt.Errorf("User id '%s' is invalid", userId)
+	}
+	path := fmt.Sprintf("/apps/%s/users/%s/force_reconnect", c.AppID, userId)
+	u, err := createRequestURL("POST", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, []byte("{}"), nil, c.Cluster)
+	if err != nil {
+		return err
+	}
+	var reqErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		_, reqErr = c.request("POST", u, []byte("{}"))
+		if reqErr == nil || !isRetryableError(reqErr) {
+			break
+		}
+	}
+	return reqErr
+}
+
 func (c *Client) validateChannelsAndTrigger(channels []string, eventName string, data interface{}, params TriggerParams) (*TriggerChannelsList, error) {
 	if len(channels) > maxTriggerableChannels {
 		return nil, fmt.Errorf("You cannot trigger on more than %d channels at once", maxTriggerableChannels)

--- a/server-sdks/sockudo-http-go/user_connections_test.go
+++ b/server-sdks/sockudo-http-go/user_connections_test.go
@@ -1,0 +1,68 @@
+package sockudo
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"gopkg.in/stretchr/testify.v1/assert"
+)
+
+func TestTerminateUserConnectionsInvalidUserId(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		t.Fatal("No request should reach the API")
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	client := Client{AppID: "id", Key: "key", Secret: "secret", Host: u.Host}
+	err := client.TerminateUserConnections("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "User id '' is invalid")
+}
+
+func TestTerminateUserConnectionsSuccessCase(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(200)
+		fmt.Fprintf(res, "{}")
+		assert.Equal(t, "POST", req.Method)
+		assert.True(t, strings.Contains(req.URL.Path, "/users/user-123/terminate_connections"))
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	client := Client{AppID: "id", Key: "key", Secret: "secret", Host: u.Host}
+	err := client.TerminateUserConnections("user-123")
+	assert.NoError(t, err)
+}
+
+func TestForceReconnectUserInvalidUserId(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		t.Fatal("No request should reach the API")
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	client := Client{AppID: "id", Key: "key", Secret: "secret", Host: u.Host}
+	err := client.ForceReconnectUser("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "User id '' is invalid")
+}
+
+func TestForceReconnectUserSuccessCase(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(200)
+		fmt.Fprintf(res, "{}")
+		assert.Equal(t, "POST", req.Method)
+		assert.True(t, strings.Contains(req.URL.Path, "/users/user-123/force_reconnect"))
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	client := Client{AppID: "id", Key: "key", Secret: "secret", Host: u.Host}
+	err := client.ForceReconnectUser("user-123")
+	assert.NoError(t, err)
+}

--- a/server-sdks/sockudo-http-java/README.md
+++ b/server-sdks/sockudo-http-java/README.md
@@ -323,6 +323,28 @@ Result snapshot = sockudo.getChannelPresenceSnapshot(
 );
 ```
 
+### Terminate User Connections
+
+Disconnect every active socket for a user:
+
+```java
+sockudo.terminateUserConnections("user-123");
+```
+
+### Force Reconnect User
+
+Close all active connections for a user with code `4200`, prompting clients to reconnect:
+
+```java
+sockudo.forceReconnectUser("user-123");
+```
+
+Async variant:
+
+```java
+CompletableFuture<Result> future = sockudoAsync.forceReconnectUser("user-123");
+```
+
 ## License
 
 This code is free to use under the terms of the MIT license.

--- a/server-sdks/sockudo-http-java/src/main/java/io/sockudo/rest/SockudoAbstract.java
+++ b/server-sdks/sockudo-http-java/src/main/java/io/sockudo/rest/SockudoAbstract.java
@@ -709,6 +709,33 @@ public abstract class SockudoAbstract<T> {
         return getChannelPresenceSnapshot(channelName, Collections.<String, String>emptyMap());
     }
 
+    /**
+     * Terminate all active WebSocket connections for a user.
+     * <p>
+     * Every socket currently authenticated as the given user will be disconnected.
+     *
+     * @param userId the user ID whose connections should be terminated
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public T terminateUserConnections(final String userId) {
+        final String path = "/users/" + userId + "/terminate_connections";
+        return post(path, "{}");
+    }
+
+    /**
+     * Force all active WebSocket connections for a user to reconnect.
+     * <p>
+     * Every socket currently authenticated as the given user will be closed with code {@code 4200},
+     * prompting clients to reconnect.
+     *
+     * @param userId the user ID whose connections should be force-reconnected
+     * @return a {@link Result} object encapsulating the success state and response to the request
+     */
+    public T forceReconnectUser(final String userId) {
+        final String path = "/users/" + userId + "/force_reconnect";
+        return post(path, "{}");
+    }
+
     protected abstract T doGet(final URI uri);
 
     protected T doGet(final URI uri, final Map<String, String> headers) {
@@ -1112,8 +1139,8 @@ public abstract class SockudoAbstract<T> {
     /**
      * Check the signature on a webhook received from Sockudo
      *
-     * @param xSockudoKeyHeader       the X-Sockudo-Key header as received in the webhook request
-     * @param xSockudoSignatureHeader the X-Sockudo-Signature header as received in the webhook request
+     * @param xSockudoKeyHeader       the X-Pusher-Key header as received in the webhook request
+     * @param xSockudoSignatureHeader the X-Pusher-Signature header as received in the webhook request
      * @param body                   the webhook body
      * @return enum representing the possible validities of the webhook request
      */

--- a/server-sdks/sockudo-http-java/src/test/java/io/sockudo/rest/SockudoTest.java
+++ b/server-sdks/sockudo-http-java/src/test/java/io/sockudo/rest/SockudoTest.java
@@ -569,4 +569,22 @@ public class SockudoTest {
         assertThat(key1.length(), is(16));
         assertThat(key1, is(not(key2)));
     }
+
+    @Test
+    public void terminateUserConnectionsUsesCorrectPath() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(httpClient).execute(with(path("/apps/" + APP_ID + "/users/user-123/terminate_connections")));
+        }});
+
+        p.terminateUserConnections("user-123");
+    }
+
+    @Test
+    public void forceReconnectUserUsesCorrectPath() throws Exception {
+        context.checking(new Expectations() {{
+            oneOf(httpClient).execute(with(path("/apps/" + APP_ID + "/users/user-456/force_reconnect")));
+        }});
+
+        p.forceReconnectUser("user-456");
+    }
 }

--- a/server-sdks/sockudo-http-node/README.md
+++ b/server-sdks/sockudo-http-node/README.md
@@ -177,6 +177,14 @@ Disconnect all active connections for a given user:
 await sockudo.terminateUserConnections("user-123")
 ```
 
+### Force Reconnect User
+
+Close all active connections for a user with code `4200`, prompting clients to reconnect:
+
+```javascript
+await sockudo.forceReconnectUser("user-123");
+```
+
 ## Webhooks
 
 Verify and parse incoming Sockudo webhooks:

--- a/server-sdks/sockudo-http-node/index.d.ts
+++ b/server-sdks/sockudo-http-node/index.d.ts
@@ -84,6 +84,8 @@ declare class Sockudo {
 
   terminateUserConnections(userId: string): Promise<Response>;
 
+  forceReconnectUser(userId: string): Promise<Response>;
+
   activateDevice(
     device: Sockudo.PushDeviceDetails,
     options?: { rotateDeviceIdentityToken?: boolean },

--- a/server-sdks/sockudo-http-node/src/sockudo.ts
+++ b/server-sdks/sockudo-http-node/src/sockudo.ts
@@ -175,6 +175,14 @@ class Sockudo {
     });
   }
 
+  forceReconnectUser(userId: string): Promise<ResponseWithIdempotency> {
+    validateUserId(userId);
+    return this.post({
+      path: `/users/${userId}/force_reconnect`,
+      body: {},
+    });
+  }
+
   trigger(
     channels: string | string[],
     event: string,

--- a/server-sdks/sockudo-http-node/tests/integration/sockudo/force_reconnect.js
+++ b/server-sdks/sockudo-http-node/tests/integration/sockudo/force_reconnect.js
@@ -1,0 +1,55 @@
+const expect = require("expect.js");
+const nock = require("nock");
+
+const Sockudo = require("../../../dist/sockudo");
+const sinon = require("sinon");
+
+describe("Sockudo", function () {
+  let sockudo;
+
+  beforeEach(function () {
+    sockudo = new Sockudo({ appId: 1234, key: "f00d", secret: "tofu" });
+    nock.disableNetConnect();
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  describe("#forceReconnectUser", function () {
+    it("should throw an error if user id is empty", function () {
+      expect(function () {
+        sockudo.forceReconnectUser("");
+      }).to.throwError(function (e) {
+        expect(e).to.be.an(Error);
+        expect(e.message).to.equal("Invalid user id: ''");
+      });
+    });
+
+    it("should throw an error if user id is not a string", function () {
+      expect(function () {
+        sockudo.forceReconnectUser(123);
+      }).to.throwError(function (e) {
+        expect(e).to.be.an(Error);
+        expect(e.message).to.equal("Invalid user id: '123'");
+      });
+    });
+  });
+
+  it("should call /force_reconnect endpoint", function (done) {
+    sinon.stub(sockudo, "post");
+    sockudo.appId = 1234;
+    const userId = "testUserId";
+
+    sockudo.forceReconnectUser(userId);
+
+    expect(sockudo.post.called).to.be(true);
+    expect(sockudo.post.getCall(0).args[0]).eql({
+      path: `/users/${userId}/force_reconnect`,
+      body: {},
+    });
+    sockudo.post.restore();
+    done();
+  });
+});

--- a/server-sdks/sockudo-http-php/README.md
+++ b/server-sdks/sockudo-http-php/README.md
@@ -155,6 +155,19 @@ $auth = $sockudo->authenticateUser($socket_id, $user_id);
 echo $auth;
 ```
 
+## Force Reconnect User
+
+Close all active connections for a user with code `4200`, prompting clients to reconnect:
+
+```php
+// Synchronous
+$sockudo->forceReconnectUser("user-123");
+
+// Asynchronous
+$promise = $sockudo->forceReconnectUserAsync("user-123");
+$promise->wait();
+```
+
 ## Webhooks
 
 Pass the raw request headers and body to verify and parse incoming webhooks:

--- a/server-sdks/sockudo-http-php/src/Sockudo.php
+++ b/server-sdks/sockudo-http-php/src/Sockudo.php
@@ -673,6 +673,41 @@ class Sockudo implements LoggerAwareInterface, SockudoInterface
         return $this->postAsync("/users/$user_id/terminate_connections", "{}");
     }
 
+    /**
+     * Force reconnect all connections established by the user with the given user id.
+     * Closes connections with code 4200, prompting clients to reconnect.
+     *
+     * @param string $user_id
+     *
+     * @throws SockudoException   If $user_id is invalid
+     * @throws ApiErrorException Throws ApiErrorException if the Channels HTTP API responds with an error
+     *
+     * @return object response body
+     *
+     */
+    public function forceReconnectUser(string $user_id): object
+    {
+        $this->validate_user_id($user_id);
+        return $this->post("/users/$user_id/force_reconnect", "{}");
+    }
+
+    /**
+     * Asynchronous request to force reconnect all connections established by the user with the given user id.
+     * Closes connections with code 4200, prompting clients to reconnect.
+     *
+     * @param string $user_id
+     *
+     * @throws SockudoException   If $user_id is invalid
+     *
+     * @return PromiseInterface promise wrapping response body
+     *
+     */
+    public function forceReconnectUserAsync(string $user_id): PromiseInterface
+    {
+        $this->validate_user_id($user_id);
+        return $this->postAsync("/users/$user_id/force_reconnect", "{}");
+    }
+
 
     /**
      * Fetch channel information for a specific channel.

--- a/server-sdks/sockudo-http-php/tests/acceptance/ForceReconnectUserTest.php
+++ b/server-sdks/sockudo-http-php/tests/acceptance/ForceReconnectUserTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace acceptance;
+
+use GuzzleHttp;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Exception\RequestException;
+use PHPUnit\Framework\TestCase;
+use Sockudo\ApiErrorException;
+use Sockudo\Sockudo;
+use Sockudo\SockudoException;
+use stdClass;
+
+class ForceReconnectUserTest extends TestCase
+{
+    private $request_history = [];
+
+    /**
+     * @var Sockudo
+     */
+    private $sockudo;
+
+    protected function setUp(): void
+    {
+        if (SOCKUDOAPP_AUTHKEY === '' || SOCKUDOAPP_SECRET === '' || SOCKUDOAPP_APPID === '') {
+            self::markTestSkipped('Please set the
+            SOCKUDOAPP_AUTHKEY, SOCKUDOAPP_SECRET and
+            SOCKUDOAPP_APPID keys.');
+        } else {
+            $history = GuzzleHttp\Middleware::history($this->request_history);
+            $handlerStack = GuzzleHttp\HandlerStack::create();
+            $handlerStack->push($history);
+            $httpClient = new GuzzleHttp\Client(['handler' => $handlerStack]);
+            $this->sockudo = new Sockudo(SOCKUDOAPP_AUTHKEY, SOCKUDOAPP_SECRET, SOCKUDOAPP_APPID, ['cluster' => SOCKUDOAPP_CLUSTER], $httpClient);
+        }
+    }
+
+    public function testForceReconnectUser(): void
+    {
+        $result = $this->sockudo->forceReconnectUser("123");
+        self::assertEquals(new stdClass(), $result);
+        self::assertEquals(1, count($this->request_history));
+        $request = $this->request_history[0]['request'];
+        self::assertEquals('api-' . SOCKUDOAPP_CLUSTER . '.sockudo.com', $request->GetUri()->GetHost());
+        self::assertEquals('POST', $request->GetMethod());
+        self::assertEquals('/apps/' . SOCKUDOAPP_APPID . '/users/123/force_reconnect', $request->GetUri()->GetPath());
+    }
+
+    public function testForceReconnectUserAsync(): void
+    {
+        $result = $this->sockudo->forceReconnectUserAsync("123")->wait();
+        self::assertEquals(new stdClass(), $result);
+        self::assertEquals(1, count($this->request_history));
+        $request = $this->request_history[0]['request'];
+        self::assertEquals('api-' . SOCKUDOAPP_CLUSTER . '.sockudo.com', $request->GetUri()->GetHost());
+        self::assertEquals('POST', $request->GetMethod());
+        self::assertEquals('/apps/' . SOCKUDOAPP_APPID . '/users/123/force_reconnect', $request->GetUri()->GetPath());
+    }
+
+    public function testBadUserId(): void
+    {
+        $this->expectException(SockudoException::class);
+        $this->sockudo->forceReconnectUser("");
+    }
+
+    public function testBadUserIdAsync(): void
+    {
+        $this->expectException(SockudoException::class);
+        $this->sockudo->forceReconnectUserAsync("");
+    }
+}

--- a/server-sdks/sockudo-http-php/tests/unit/ForceReconnectUserUnitTest.php
+++ b/server-sdks/sockudo-http-php/tests/unit/ForceReconnectUserUnitTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace unit;
+
+use GuzzleHttp;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Exception\RequestException;
+use PHPUnit\Framework\TestCase;
+use Sockudo\ApiErrorException;
+use Sockudo\Sockudo;
+use Sockudo\SockudoException;
+use stdClass;
+
+class ForceReconnectUserUnitTest extends TestCase
+{
+    private $request_history = [];
+
+    private function mockSockudo(array $responses): Sockudo
+    {
+        $mockHandler = new GuzzleHttp\Handler\MockHandler($responses);
+        $history = GuzzleHttp\Middleware::history($this->request_history);
+        $handlerStack = GuzzleHttp\HandlerStack::create($mockHandler);
+        $handlerStack->push($history);
+        $httpClient = new GuzzleHttp\Client(['handler' => $handlerStack]);
+        return new Sockudo("auth-key", "secret", "appid", ['cluster' => 'test1'], $httpClient);
+    }
+
+    public function testForceReconnectUser(): void
+    {
+        $sockudo = $this->mockSockudo([new Response(200, [], "{}")]);
+        $result = $sockudo->forceReconnectUser("123");
+        self::assertEquals(new stdClass(), $result);
+        self::assertEquals(1, count($this->request_history));
+        $request = $this->request_history[0]['request'];
+        self::assertEquals('api-test1.sockudo.com', $request->GetUri()->GetHost());
+        self::assertEquals('POST', $request->GetMethod());
+        self::assertEquals('/apps/appid/users/123/force_reconnect', $request->GetUri()->GetPath());
+    }
+
+    public function testForceReconnectUserAsync(): void
+    {
+        $sockudo = $this->mockSockudo([new Response(200, [], "{}")]);
+        $result = $sockudo->forceReconnectUserAsync("123")->wait();
+        self::assertEquals(new stdClass(), $result);
+        self::assertEquals(1, count($this->request_history));
+        $request = $this->request_history[0]['request'];
+        self::assertEquals('api-test1.sockudo.com', $request->GetUri()->GetHost());
+        self::assertEquals('POST', $request->GetMethod());
+        self::assertEquals('/apps/appid/users/123/force_reconnect', $request->GetUri()->GetPath());
+    }
+
+    public function testBadUserId(): void
+    {
+        $sockudo = $this->mockSockudo([]);
+        $this->expectException(SockudoException::class);
+        $sockudo->forceReconnectUser("");
+    }
+
+    public function testBadUserIdAsync(): void
+    {
+        $sockudo = $this->mockSockudo([]);
+        $this->expectException(SockudoException::class);
+        $sockudo->forceReconnectUserAsync("");
+    }
+
+    public function testForceReconnectUserError(): void
+    {
+        $sockudo = $this->mockSockudo([new Response(500, [], "{}")]);
+        $this->expectException(ApiErrorException::class);
+        $sockudo->forceReconnectUser("123");
+    }
+
+    public function testForceReconnectUserAsyncError(): void
+    {
+        $sockudo = $this->mockSockudo([new Response(500, [], "{}")]);
+        $this->expectException(ApiErrorException::class);
+        $sockudo->forceReconnectUserAsync("123")->wait();
+    }
+}

--- a/server-sdks/sockudo-http-python/.gitignore
+++ b/server-sdks/sockudo-http-python/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 *.py[cod]
 .venv/
 venv/
+uv.lock

--- a/server-sdks/sockudo-http-python/README.md
+++ b/server-sdks/sockudo-http-python/README.md
@@ -119,6 +119,30 @@ sockudo.get_channel_history("orders", HistoryParams(limit=50, direction="newest_
 sockudo.get_channel_presence_history("presence-room", PresenceHistoryParams(limit=50))
 ```
 
+## User Controls
+
+Terminate all active connections for a user:
+
+```python
+# Synchronous
+sockudo.terminate_user_connections("user-123")
+
+# Asynchronous
+await async_sockudo.terminate_user_connections("user-123")
+```
+
+### Force Reconnect User
+
+Close all active connections for a user with code `4200`, prompting clients to reconnect:
+
+```python
+# Synchronous
+sockudo.force_reconnect_user("user-123")
+
+# Asynchronous
+await async_sockudo.force_reconnect_user("user-123")
+```
+
 ## Versioned Messages And Annotations
 
 ```python

--- a/server-sdks/sockudo-http-python/src/sockudo_http_python/client.py
+++ b/server-sdks/sockudo-http-python/src/sockudo_http_python/client.py
@@ -987,6 +987,11 @@ class Sockudo(_BaseSockudo):
             self._path(f"/users/{quote(user_id, safe='')}/terminate_connections"), {}
         )
 
+    def force_reconnect_user(self, user_id: str) -> Result:
+        return self._post(
+            self._path(f"/users/{quote(user_id, safe='')}/force_reconnect"), {}
+        )
+
     def activate_device(
         self, device: Mapping[str, Any], rotate_device_identity_token: bool = False
     ) -> Result:
@@ -1467,6 +1472,11 @@ class AsyncSockudo(_BaseSockudo):
     async def terminate_user_connections(self, user_id: str) -> Result:
         return await self._post(
             self._path(f"/users/{quote(user_id, safe='')}/terminate_connections"), {}
+        )
+
+    async def force_reconnect_user(self, user_id: str) -> Result:
+        return await self._post(
+            self._path(f"/users/{quote(user_id, safe='')}/force_reconnect"), {}
         )
 
     async def activate_device(

--- a/server-sdks/sockudo-http-python/tests/test_client.py
+++ b/server-sdks/sockudo-http-python/tests/test_client.py
@@ -650,3 +650,61 @@ async def test_async_operator_controls_match_sync_surface():
         ("POST", "/apps/app-id/channels/presence-orders/presence/history/reset"),
     ]
     await sockudo.close()
+
+
+def test_force_reconnect_user_posts_to_correct_path():
+    seen = {}
+
+    def handler(request):
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={})
+
+    sockudo = make_client(handler)
+    result = sockudo.force_reconnect_user("user-123")
+
+    assert result.ok
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/apps/app-id/users/user-123/force_reconnect"
+    sockudo.close()
+
+
+def test_force_reconnect_user_url_encodes_user_id():
+    seen = {}
+
+    def handler(request):
+        # raw_path preserves percent-encoding; strip the query string
+        seen["raw_path"] = request.url.raw_path.decode().split("?")[0]
+        return httpx.Response(200, json={})
+
+    sockudo = make_client(handler)
+    sockudo.force_reconnect_user("user/with spaces")
+
+    assert seen["raw_path"] == "/apps/app-id/users/user%2Fwith%20spaces/force_reconnect"
+    sockudo.close()
+
+
+@pytest.mark.asyncio
+async def test_async_force_reconnect_user_posts_to_correct_path():
+    seen = {}
+
+    async def handler(request):
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(transport=transport)
+    sockudo = AsyncSockudo(
+        "app-id",
+        "key",
+        "secret",
+        options=SockudoOptions(max_retries=1),
+        client=http_client,
+    )
+    result = await sockudo.force_reconnect_user("user-123")
+
+    assert result.ok
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/apps/app-id/users/user-123/force_reconnect"
+    await sockudo.close()

--- a/server-sdks/sockudo-http-ruby/README.md
+++ b/server-sdks/sockudo-http-ruby/README.md
@@ -163,6 +163,24 @@ auth = sockudo.authenticate(
 auth = sockudo.authenticate_user(params[:socket_id], { id: 'user-123', name: 'Jane Doe' })
 ```
 
+## User Connection Management
+
+### Terminate User Connections
+
+Disconnect every active socket for a user:
+
+```ruby
+sockudo.terminate_user_connections("user-123")
+```
+
+### Force Reconnect User
+
+Close all active connections for a user with code `4200`, prompting clients to reconnect:
+
+```ruby
+sockudo.force_reconnect_user("user-123")
+```
+
 ## Webhooks
 
 Create a webhook object from a `Rack::Request` (available as `request` in Rails controllers and Sinatra handlers):

--- a/server-sdks/sockudo-http-ruby/lib/sockudo/client.rb
+++ b/server-sdks/sockudo-http-ruby/lib/sockudo/client.rb
@@ -373,6 +373,36 @@ module Sockudo
       get("/channels/#{channel_name}/users", params)
     end
 
+    # Terminate all active connections for a user
+    #
+    # POST /apps/[id]/users/[user_id]/terminate_connections
+    #
+    # @param user_id [String] The user ID whose connections should be terminated
+    #
+    # @return [Hash] See Sockudo API docs
+    #
+    # @raise [Sockudo::Error] Unsuccessful response - see the error message
+    # @raise [Sockudo::HTTPError] Error raised inside http client. The original error is wrapped in error.original_error
+    #
+    def terminate_user_connections(user_id)
+      post("/users/#{user_id}/terminate_connections")
+    end
+
+    # Force reconnect all active connections for a user
+    #
+    # POST /apps/[id]/users/[user_id]/force_reconnect
+    #
+    # @param user_id [String] The user ID whose connections should be force-reconnected
+    #
+    # @return [Hash] See Sockudo API docs
+    #
+    # @raise [Sockudo::Error] Unsuccessful response - see the error message
+    # @raise [Sockudo::HTTPError] Error raised inside http client. The original error is wrapped in error.original_error
+    #
+    def force_reconnect_user(user_id)
+      post("/users/#{user_id}/force_reconnect")
+    end
+
     # Activate or create a push device registration with admin scope
     def activate_device(device, options = {})
       post(push_path('/deviceRegistrations'), device,

--- a/server-sdks/sockudo-http-ruby/spec/client_spec.rb
+++ b/server-sdks/sockudo-http-ruby/spec/client_spec.rb
@@ -366,6 +366,30 @@ describe Sockudo do
         end
       end
 
+      describe '#terminate_user_connections' do
+        it 'should call the correct URL' do
+          api_path = %r{/apps/20/users/user-123/terminate_connections}
+          stub_request(:post, api_path).to_return({
+                                                    status: 200,
+                                                    body: MultiJson.dump({})
+                                                  })
+          expect(@client.terminate_user_connections('user-123')).to eq({})
+          expect(WebMock).to have_requested(:post, api_path)
+        end
+      end
+
+      describe '#force_reconnect_user' do
+        it 'should call the correct URL' do
+          api_path = %r{/apps/20/users/user-123/force_reconnect}
+          stub_request(:post, api_path).to_return({
+                                                    status: 200,
+                                                    body: MultiJson.dump({})
+                                                  })
+          expect(@client.force_reconnect_user('user-123')).to eq({})
+          expect(WebMock).to have_requested(:post, api_path)
+        end
+      end
+
       describe '#activate_device' do
         it 'uses the admin endpoint, accepts 201, and can request token rotation' do
           api_path = %r{/apps/20/push/deviceRegistrations}

--- a/server-sdks/sockudo-http-rust/README.md
+++ b/server-sdks/sockudo-http-rust/README.md
@@ -9,9 +9,9 @@ A fast, safe, and idiomatic Rust client for interacting with the Sockudo HTTP AP
 - Trigger batch events for efficiency
 - Support for end-to-end encrypted channels
 - Authorize client subscriptions to private, presence, and encrypted channels
-- Authenticate users for user-specific Pusher features
+- Authenticate users for user-specific Sockudo features
 - Terminate user connections
-- Validate and process incoming Pusher webhooks
+- Validate and process incoming Sockudo webhooks
 - Configurable host, port, scheme (HTTP/HTTPS), and timeout
 - Asynchronous API using `async/await`
 - Typed responses and errors
@@ -41,10 +41,10 @@ cargo build
 Configure and create a client:
 
 ```rust
-use sockudo_http::{Config, Pusher, PusherError};
+use sockudo_http::{Config, Sockudo, SockudoError};
 
 #[tokio::main]
-async fn main() -> Result<(), PusherError> {
+async fn main() -> Result<(), SockudoError> {
     let config = Config::builder()
         .app_id("YOUR_APP_ID")
         .key("YOUR_APP_KEY")
@@ -55,7 +55,7 @@ async fn main() -> Result<(), PusherError> {
         .timeout(std::time::Duration::from_secs(5)) // Optional
         .build()?;
 
-    let pusher = Pusher::new(config)?;
+    let sockudo = Sockudo::new(config)?;
 
     // Your application logic here...
     Ok(())
@@ -79,9 +79,9 @@ let config = Config::builder()
 You can also initialize from a URL:
 
 ```rust
-use pushers::{Pusher, PusherError};
+use sockudo_http::{Sockudo, SockudoError};
 
-let pusher = Pusher::from_url(
+let sockudo = Sockudo::from_url(
     "http://YOUR_APP_KEY:YOUR_APP_SECRET@127.0.0.1:6001/apps/YOUR_APP_ID",
     None,
 )?;
@@ -90,15 +90,15 @@ let pusher = Pusher::from_url(
 ### 2. Triggering Events
 
 ```rust
-use pushers::{Pusher, Channel, PusherError};
+use sockudo_http::{Sockudo, Channel, SockudoError};
 use sonic_rs::json;
 
-async fn trigger_event(pusher: &Pusher) -> Result<(), PusherError> {
+async fn trigger_event(sockudo: &Sockudo) -> Result<(), SockudoError> {
     let channels = vec![Channel::from_string("my-channel")?];
     let event_name = "new-message";
     let data = json!({ "text": "Hello from Rust!" });
 
-    match pusher.trigger(&channels, event_name, data, None).await {
+    match sockudo.trigger(&channels, event_name, data, None).await {
         Ok(response) => {
             println!("Event triggered! Status: {}", response.status());
         }
@@ -114,10 +114,10 @@ If `channels` contains a single encrypted channel (e.g., `"private-encrypted-myc
 **Excluding a recipient:**
 
 ```rust
-use pushers::{Pusher, Channel, PusherError, events::TriggerParams};
+use sockudo_http::{Sockudo, Channel, SockudoError, events::TriggerParams};
 use sonic_rs::json;
 
-async fn trigger_event_exclude(pusher: &Pusher) -> Result<(), PusherError> {
+async fn trigger_event_exclude(sockudo: &Sockudo) -> Result<(), SockudoError> {
     let channels = vec![Channel::from_string("my-channel")?];
     let event_name = "new-message";
     let data = json!({ "text": "Hello from Rust!" });
@@ -126,7 +126,7 @@ async fn trigger_event_exclude(pusher: &Pusher) -> Result<(), PusherError> {
         .socket_id("socket_id_to_exclude")
         .build();
 
-    pusher.trigger(&channels, event_name, data, Some(params)).await?;
+    sockudo.trigger(&channels, event_name, data, Some(params)).await?;
     Ok(())
 }
 ```
@@ -140,22 +140,22 @@ let params = TriggerParams::builder()
     .idempotency_key("unique-key-for-this-event")
     .build();
 
-pusher.trigger(&channels, event_name, data, Some(params)).await?;
+sockudo.trigger(&channels, event_name, data, Some(params)).await?;
 ```
 
 ### 3. Triggering Batch Events
 
 ```rust
-use pushers::{Pusher, PusherError, events::BatchEvent};
+use sockudo_http::{Sockudo, SockudoError, events::BatchEvent};
 use sonic_rs::json;
 
-async fn trigger_batch(pusher: &Pusher) -> Result<(), PusherError> {
+async fn trigger_batch(sockudo: &Sockudo) -> Result<(), SockudoError> {
     let batch = vec![
         BatchEvent::new("event1", "channel-a", json!({ "value": 1 })),
         BatchEvent::new("event2", "channel-b", json!({ "value": 2 })),
     ];
 
-    match pusher.trigger_batch(batch).await {
+    match sockudo.trigger_batch(batch).await {
         Ok(response) => println!("Batch triggered! Status: {}", response.status()),
         Err(e) => eprintln!("Error triggering batch: {:?}", e),
     }
@@ -170,11 +170,11 @@ Tag filtering allows you to add metadata tags to events, enabling clients to fil
 **Triggering a single event with tags:**
 
 ```rust
-use pushers::{Pusher, Channel, PusherError, events::TriggerParams};
+use sockudo_http::{Sockudo, Channel, SockudoError, events::TriggerParams};
 use sonic_rs::json;
 use std::collections::HashMap;
 
-async fn trigger_with_tags(pusher: &Pusher) -> Result<(), PusherError> {
+async fn trigger_with_tags(sockudo: &Sockudo) -> Result<(), SockudoError> {
     let channels = vec![Channel::from_string("sports-updates")?];
     let event_name = "match-event";
     let data = json!({
@@ -193,7 +193,7 @@ async fn trigger_with_tags(pusher: &Pusher) -> Result<(), PusherError> {
         .tags(tags)
         .build();
 
-    pusher.trigger(&channels, event_name, data, Some(params)).await?;
+    sockudo.trigger(&channels, event_name, data, Some(params)).await?;
     Ok(())
 }
 ```
@@ -201,11 +201,11 @@ async fn trigger_with_tags(pusher: &Pusher) -> Result<(), PusherError> {
 **Triggering batch events with tags:**
 
 ```rust
-use pushers::{Pusher, PusherError, events::BatchEvent};
+use sockudo_http::{Sockudo, SockudoError, events::BatchEvent};
 use sonic_rs::json;
 use std::collections::HashMap;
 
-async fn trigger_batch_with_tags(pusher: &Pusher) -> Result<(), PusherError> {
+async fn trigger_batch_with_tags(sockudo: &Sockudo) -> Result<(), SockudoError> {
     let mut goal_tags = HashMap::new();
     goal_tags.insert("event_type".to_string(), "goal".to_string());
     goal_tags.insert("priority".to_string(), "high".to_string());
@@ -221,7 +221,7 @@ async fn trigger_batch_with_tags(pusher: &Pusher) -> Result<(), PusherError> {
             .with_tags(shot_tags),
     ];
 
-    pusher.trigger_batch(batch).await?;
+    sockudo.trigger_batch(batch).await?;
     Ok(())
 }
 ```
@@ -233,10 +233,10 @@ async fn trigger_batch_with_tags(pusher: &Pusher) -> Result<(), PusherError> {
 Typically done in your HTTP handler when a client attempts to subscribe:
 
 ```rust
-use pushers::{Pusher, Channel, PusherError};
+use sockudo_http::{Sockudo, Channel, SockudoError};
 use sonic_rs::json;
 
-fn authorize_channel(pusher: &Pusher) -> Result<(), PusherError> {
+fn authorize_channel(sockudo: &Sockudo) -> Result<(), SockudoError> {
     let socket_id = "123.456";
     let channel_name = "private-mychannel";
     let channel = Channel::from_string(channel_name)?;
@@ -247,7 +247,7 @@ fn authorize_channel(pusher: &Pusher) -> Result<(), PusherError> {
         "user_info": { "name": "Alice" }
     }));
 
-    match pusher.authorize_channel(socket_id, &channel, presence_data.as_ref()) {
+    match sockudo.authorize_channel(socket_id, &channel, presence_data.as_ref()) {
         Ok(auth_signature) => {
             println!("Auth success: {:?}", auth_signature);
             // Return `auth_signature` as JSON to client
@@ -263,10 +263,10 @@ fn authorize_channel(pusher: &Pusher) -> Result<(), PusherError> {
 For server-to-user events:
 
 ```rust
-use pushers::{Pusher, PusherError};
+use sockudo_http::{Sockudo, SockudoError};
 use sonic_rs::json;
 
-fn authenticate_user(pusher: &Pusher) -> Result<(), PusherError> {
+fn authenticate_user(sockudo: &Sockudo) -> Result<(), SockudoError> {
     let socket_id = "789.012";
     let user_data = json!({
         "id": "user-bob",      // required
@@ -274,7 +274,7 @@ fn authenticate_user(pusher: &Pusher) -> Result<(), PusherError> {
         "email": "bob@example.com"
     });
 
-    match pusher.authenticate_user(socket_id, &user_data) {
+    match sockudo.authenticate_user(socket_id, &user_data) {
         Ok(user_auth) => {
             println!("User auth success: {:?}", user_auth);
             // Return `user_auth` as JSON to client
@@ -288,15 +288,15 @@ fn authenticate_user(pusher: &Pusher) -> Result<(), PusherError> {
 ### 7. Sending an Event to a User
 
 ```rust
-use pushers::{Pusher, PusherError};
+use sockudo_http::{Sockudo, SockudoError};
 use sonic_rs::json;
 
-async fn send_to_user(pusher: &Pusher) -> Result<(), PusherError> {
+async fn send_to_user(sockudo: &Sockudo) -> Result<(), SockudoError> {
     let user_id = "user-bob";
     let event_name = "personal-notification";
     let data = json!({ "alert": "Your report is ready!" });
 
-    match pusher.send_to_user(user_id, event_name, data).await {
+    match sockudo.send_to_user(user_id, event_name, data).await {
         Ok(response) => println!("Sent to user! Status: {}", response.status()),
         Err(e) => eprintln!("Error sending to user: {:?}", e),
     }
@@ -307,12 +307,12 @@ async fn send_to_user(pusher: &Pusher) -> Result<(), PusherError> {
 ### 8. Terminating User Connections
 
 ```rust
-use pushers::{Pusher, PusherError};
+use sockudo_http::{Sockudo, SockudoError};
 
-async fn terminate_user(pusher: &Pusher) -> Result<(), PusherError> {
+async fn terminate_user(sockudo: &Sockudo) -> Result<(), SockudoError> {
     let user_id = "user-charlie";
 
-    match pusher.terminate_user_connections(user_id).await {
+    match sockudo.terminate_user_connections(user_id).await {
         Ok(response) => println!("Terminate successful! Status: {}", response.status()),
         Err(e) => eprintln!("Error terminating user: {:?}", e),
     }
@@ -320,13 +320,30 @@ async fn terminate_user(pusher: &Pusher) -> Result<(), PusherError> {
 }
 ```
 
-### 9. Handling Webhooks
+### 9. Force Reconnect User
+
+Close all active connections for a user with code `4200`, prompting clients to reconnect:
 
 ```rust
-use pushers::{Pusher, PusherError, webhook::WebhookEvent};
+use sockudo_http::{Sockudo, SockudoError};
+
+async fn force_reconnect(sockudo: &Sockudo) -> Result<(), SockudoError> {
+    let user_id = "user-123";
+    match sockudo.force_reconnect_user(user_id).await {
+        Ok(_) => println!("Force reconnect initiated for {}", user_id),
+        Err(e) => eprintln!("Error: {}", e),
+    }
+    Ok(())
+}
+```
+
+### 10. Handling Webhooks
+
+```rust
+use sockudo_http::{Sockudo, SockudoError, webhook::WebhookEvent};
 use std::collections::BTreeMap;
 
-fn handle_webhook(pusher: &Pusher) -> Result<(), PusherError> {
+fn handle_webhook(sockudo: &Sockudo) -> Result<(), SockudoError> {
     let mut headers = BTreeMap::new();
     headers.insert("X-Pusher-Key".to_string(), "YOUR_APP_KEY".to_string());
     headers.insert("X-Pusher-Signature".to_string(), "RECEIVED_SIGNATURE".to_string());
@@ -337,7 +354,7 @@ fn handle_webhook(pusher: &Pusher) -> Result<(), PusherError> {
         "events":[{"name":"channel_occupied","channel":"my-channel"}]
     }"#;
 
-    let webhook = pusher.webhook(&headers, body);
+    let webhook = sockudo.webhook(&headers, body);
 
     if webhook.is_valid(None) {
         println!("Webhook is valid!");
@@ -370,7 +387,7 @@ fn handle_webhook(pusher: &Pusher) -> Result<(), PusherError> {
 }
 ```
 
-### 10. Example: Integration with Axum
+### 11. Example: Integration with Axum
 
 ```rust
 use axum::{
@@ -380,14 +397,14 @@ use axum::{
     routing::post,
     Router,
 };
-use pushers::{Config, Pusher, Channel};
+use sockudo_http::{Config, Sockudo, Channel};
 use serde::Deserialize;
 use sonic_rs::{json, Value};
 use std::{collections::BTreeMap, sync::Arc};
 
 #[derive(Clone)]
 struct AppState {
-    pusher: Arc<Pusher>,
+    sockudo: Arc<Sockudo>,
 }
 
 #[tokio::main]
@@ -402,12 +419,12 @@ async fn main() {
         .build()
         .expect("Failed to build config");
 
-    let pusher = Arc::new(Pusher::new(config).expect("Failed to create client"));
-    let app_state = AppState { pusher };
+    let sockudo = Arc::new(Sockudo::new(config).expect("Failed to create client"));
+    let app_state = AppState { sockudo };
 
     let app = Router::new()
-        .route("/pusher/auth", post(pusher_auth_handler))
-        .route("/pusher/webhook", post(pusher_webhook_handler))
+        .route("/sockudo/auth", post(sockudo_auth_handler))
+        .route("/sockudo/webhook", post(sockudo_webhook_handler))
         .with_state(app_state);
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
@@ -423,7 +440,7 @@ struct AuthRequest {
     presence_data: Option<Value>,
 }
 
-async fn pusher_auth_handler(
+async fn sockudo_auth_handler(
     State(state): State<AppState>,
     Json(payload): Json<AuthRequest>,
 ) -> impl IntoResponse {
@@ -437,7 +454,7 @@ async fn pusher_auth_handler(
         }
     };
 
-    match state.pusher.authorize_channel(
+    match state.sockudo.authorize_channel(
         &payload.socket_id,
         &channel,
         payload.presence_data.as_ref(),
@@ -450,7 +467,7 @@ async fn pusher_auth_handler(
     }
 }
 
-async fn pusher_webhook_handler(
+async fn sockudo_webhook_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
     body: String,
@@ -462,7 +479,7 @@ async fn pusher_webhook_handler(
         }
     }
 
-    let webhook = state.pusher.webhook(&hdrs_btreemap, &body);
+    let webhook = state.sockudo.webhook(&hdrs_btreemap, &body);
 
     if webhook.is_valid(None) {
         (StatusCode::OK, Json(json!({ "status": "ok" }))).into_response()
@@ -474,13 +491,13 @@ async fn pusher_webhook_handler(
 
 ## Configuration Options
 
-The `Config` struct is used to configure the Pusher client. Create it using `Config::builder()`:
+The `Config` struct is used to configure the Sockudo client. Create it using `Config::builder()`:
 
 | Method | Description |
 |--------|-------------|
-| `app_id(id)` | Sets the Pusher app ID (required) |
-| `key(key)` | Sets the Pusher app key (required) |
-| `secret(secret)` | Sets the Pusher app secret (required) |
+| `app_id(id)` | Sets the Sockudo app ID (required) |
+| `key(key)` | Sets the Sockudo app key (required) |
+| `secret(secret)` | Sets the Sockudo app secret (required) |
 | `cluster(name)` | Sets a named cluster (e.g., `"eu"`, `"ap1"`). For self-hosted Sockudo, use `host` and `port` directly instead. |
 | `host(host)` | Sets a custom host if not using a standard cluster |
 | `use_tls(bool)` | Enable HTTPS (default: `true`) |
@@ -492,7 +509,7 @@ The `Config` struct is used to configure the Pusher client. Create it using `Con
 | `enable_retry(enable)` | Enable/disable retry logic (default: `true`) |
 | `max_retries(max)` | Maximum retry attempts (default: `3`) |
 
-Call `.build()` on the `ConfigBuilder` to get a `Result<Config, PusherError>`.
+Call `.build()` on the `ConfigBuilder` to get a `Result<Config, SockudoError>`.
 
 ## Channel History
 
@@ -529,7 +546,7 @@ async fn fetch_history(sockudo: &Sockudo) -> Result<(), sockudo_http::SockudoErr
 
 ## Error Handling
 
-All fallible methods return `Result<T, PusherError>`. The `PusherError` enum variants:
+All fallible methods return `Result<T, SockudoError>`. The `SockudoError` enum variants:
 
 | Variant | Description |
 |---------|-------------|

--- a/server-sdks/sockudo-http-rust/src/sockudo.rs
+++ b/server-sdks/sockudo-http-rust/src/sockudo.rs
@@ -78,7 +78,7 @@ impl Sockudo {
         let path_segments: Vec<&str> = parsed_url.path().split('/').collect();
         let app_id = path_segments
             .last()
-            .and_then(|s| if !s.is_empty() { Some(s) } else { None })
+            .filter(|s| !s.is_empty())
             .ok_or_else(|| SockudoError::Config {
                 message: "App ID not found in URL path".to_string(),
             })?;
@@ -213,6 +213,13 @@ impl Sockudo {
     pub async fn terminate_user_connections(&self, user_id: &str) -> Result<Response> {
         util::validate_user_id(user_id)?;
         let path = format!("/users/{}/terminate_connections", user_id);
+        self.post(&path, &json!({})).await
+    }
+
+    /// Forces all active connections for a user to reconnect with close code 4200.
+    pub async fn force_reconnect_user(&self, user_id: &str) -> Result<Response> {
+        util::validate_user_id(user_id)?;
+        let path = format!("/users/{}/force_reconnect", user_id);
         self.post(&path, &json!({})).await
     }
 
@@ -971,6 +978,75 @@ mod tests {
         assert_eq!(page.next_cursor.as_deref(), Some("abc"));
         assert_eq!(page.continuity.stream_id.as_deref(), Some("stream-1"));
         server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_terminate_user_connections_requests_expected_path() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0u8; 4096];
+            let read = stream.read(&mut buffer).unwrap();
+            let request = String::from_utf8_lossy(&buffer[..read]);
+            assert!(request.contains("POST /apps/123/users/user-charlie/terminate_connections"));
+            let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}";
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+
+        let config = Config::builder()
+            .app_id("123")
+            .key("key")
+            .secret("secret")
+            .host("127.0.0.1")
+            .port(addr.port())
+            .use_tls(false)
+            .build()
+            .unwrap();
+        let sockudo = Sockudo::new(config).unwrap();
+        let result = sockudo.terminate_user_connections("user-charlie").await;
+        assert!(result.is_ok());
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_force_reconnect_user_requests_expected_path() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0u8; 4096];
+            let read = stream.read(&mut buffer).unwrap();
+            let request = String::from_utf8_lossy(&buffer[..read]);
+            assert!(request.contains("POST /apps/123/users/user-charlie/force_reconnect"));
+            let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}";
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+
+        let config = Config::builder()
+            .app_id("123")
+            .key("key")
+            .secret("secret")
+            .host("127.0.0.1")
+            .port(addr.port())
+            .use_tls(false)
+            .build()
+            .unwrap();
+        let sockudo = Sockudo::new(config).unwrap();
+        let result = sockudo.force_reconnect_user("user-charlie").await;
+        assert!(result.is_ok());
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn test_force_reconnect_user_rejects_invalid_user_id() {
+        let config = Config::new("123", "key", "secret");
+        let sockudo = Sockudo::new(config).unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(sockudo.force_reconnect_user(""));
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/server-sdks/sockudo-http-rust/src/webhook.rs
+++ b/server-sdks/sockudo-http-rust/src/webhook.rs
@@ -111,8 +111,8 @@ impl Webhook {
             .map(|(k, v)| (k.to_lowercase(), v.clone()))
             .collect();
 
-        let key = normalized_headers.get("x-sockudo-key").cloned();
-        let signature = normalized_headers.get("x-sockudo-signature").cloned();
+        let key = normalized_headers.get("x-pusher-key").cloned();
+        let signature = normalized_headers.get("x-pusher-signature").cloned();
         let content_type = normalized_headers.get("content-type").cloned();
 
         let (data, raw_json_events) = if Self::validate_content_type(&content_type) {
@@ -484,8 +484,8 @@ mod tests {
 
         let mut headers = BTreeMap::new();
         headers.insert("content-type".to_string(), "application/json".to_string());
-        headers.insert("x-sockudo-key".to_string(), "test_key".to_string());
-        headers.insert("x-sockudo-signature".to_string(), signature);
+        headers.insert("x-pusher-key".to_string(), "test_key".to_string());
+        headers.insert("x-pusher-signature".to_string(), signature);
 
         let webhook = Webhook::new(&token, &headers, body);
         let raw_events = webhook.get_raw_json_events().unwrap();
@@ -555,8 +555,8 @@ mod tests {
 
         let mut headers = BTreeMap::new();
         headers.insert("content-type".to_string(), "application/json".to_string());
-        headers.insert("x-sockudo-key".to_string(), "test_key".to_string());
-        headers.insert("x-sockudo-signature".to_string(), signature);
+        headers.insert("x-pusher-key".to_string(), "test_key".to_string());
+        headers.insert("x-pusher-signature".to_string(), signature);
 
         let webhook = Webhook::new(&token, &headers, body);
         assert!(webhook.is_valid(None));

--- a/server-sdks/sockudo-http-swift/README.md
+++ b/server-sdks/sockudo-http-swift/README.md
@@ -410,6 +410,36 @@ sockudo.presenceSnapshot(
 }
 ```
 
+### Terminate User Connections
+
+Disconnect every active socket for a user:
+
+```swift
+sockudo.terminateUserConnections(userId: "user-123") { result in
+    switch result {
+    case .success:
+        print("User connections terminated")
+    case .failure(let error):
+        print("Error: \(error)")
+    }
+}
+```
+
+### Force Reconnect User
+
+Close all active connections for a user with code `4200`, prompting clients to reconnect:
+
+```swift
+sockudo.forceReconnectUser(userId: "user-123") { result in
+    switch result {
+    case .success:
+        print("Force reconnect initiated")
+    case .failure(let error):
+        print("Error: \(error)")
+    }
+}
+```
+
 ## License
 
 The library is completely open source and released under the MIT license.

--- a/server-sdks/sockudo-http-swift/Sources/Sockudo/Networking/Client/UserConnectionEndpoints.swift
+++ b/server-sdks/sockudo-http-swift/Sources/Sockudo/Networking/Client/UserConnectionEndpoints.swift
@@ -1,0 +1,71 @@
+import APIota
+import Foundation
+
+/// Response returned when a user connection management operation succeeds.
+public struct UserConnectionResponse: Decodable, Equatable {}
+
+/// Terminates all active connections for a specific user.
+struct TerminateUserConnectionsEndpoint: APIotaCodableEndpoint {
+  typealias SuccessResponse = UserConnectionResponse
+  typealias ErrorResponse = Data
+  typealias Body = String
+
+  let encoder: JSONEncoder = JSONEncoder.iso8601Ordered
+  let headers: HTTPHeaders? = {
+    var headers = APIClient.defaultHeaders
+    headers.replaceOrAdd(header: .contentType, value: HTTPMediaType.json.toString())
+    return headers
+  }()
+  let httpBody: String? = nil
+  let httpMethod: HTTPMethod = .POST
+
+  var path: String {
+    "/apps/\(options.appId)/users/\(userId)/terminate_connections"
+  }
+
+  var queryItems: [URLQueryItem]? {
+    let authInfo = AuthInfo(
+      httpBody: httpBody,
+      httpMethod: httpMethod.rawValue,
+      path: path,
+      key: options.key,
+      secret: options.secret)
+    return authInfo.queryItems
+  }
+
+  let userId: String
+  let options: SockudoClientOptions
+}
+
+/// Forces all active connections for a specific user to reconnect (close with code 4200).
+struct ForceReconnectUserEndpoint: APIotaCodableEndpoint {
+  typealias SuccessResponse = UserConnectionResponse
+  typealias ErrorResponse = Data
+  typealias Body = String
+
+  let encoder: JSONEncoder = JSONEncoder.iso8601Ordered
+  let headers: HTTPHeaders? = {
+    var headers = APIClient.defaultHeaders
+    headers.replaceOrAdd(header: .contentType, value: HTTPMediaType.json.toString())
+    return headers
+  }()
+  let httpBody: String? = nil
+  let httpMethod: HTTPMethod = .POST
+
+  var path: String {
+    "/apps/\(options.appId)/users/\(userId)/force_reconnect"
+  }
+
+  var queryItems: [URLQueryItem]? {
+    let authInfo = AuthInfo(
+      httpBody: httpBody,
+      httpMethod: httpMethod.rawValue,
+      path: path,
+      key: options.key,
+      secret: options.secret)
+    return authInfo.queryItems
+  }
+
+  let userId: String
+  let options: SockudoClientOptions
+}

--- a/server-sdks/sockudo-http-swift/Sources/Sockudo/Services/WebhookService.swift
+++ b/server-sdks/sockudo-http-swift/Sources/Sockudo/Services/WebhookService.swift
@@ -16,10 +16,10 @@ struct WebhookService {
     /// The Webhook request is missing body data.
     case bodyDataMissing
 
-    /// The webhook request is missing a `"X-Sockudo-Key"' header, or its value is invalid.
+    /// The webhook request is missing a `"X-Pusher-Key"' header, or its value is invalid.
     case xSockudoKeyHeaderMissingOrInvalid
 
-    /// The webhook request is missing a `"X-Sockudo-Signature"' header, or its value is invalid.
+    /// The webhook request is missing a `"X-Pusher-Signature"' header, or its value is invalid.
     case xSockudoSignatureHeaderMissingOrInvalid
 
     /// A localized human-readable description of the error.
@@ -50,11 +50,11 @@ struct WebhookService {
     }
   }
 
-  /// The `X-Sockudo-Key` header.
-  static let xSockudoKeyHeader = "X-Sockudo-Key"
+  /// The `X-Pusher-Key` header.
+  static let xSockudoKeyHeader = "X-Pusher-Key"
 
-  /// The `X-Sockudo-Signature` header.
-  static let xSockudoSignatureHeader = "X-Sockudo-Signature"
+  /// The `X-Pusher-Signature` header.
+  static let xSockudoSignatureHeader = "X-Pusher-Signature"
 
   /// Verify that the key and signature header values of the received Webhook request are valid.
   /// - Parameters:

--- a/server-sdks/sockudo-http-swift/Sources/Sockudo/Sockudo.swift
+++ b/server-sdks/sockudo-http-swift/Sources/Sockudo/Sockudo.swift
@@ -148,6 +148,28 @@ public class Sockudo {
     }
   }
 
+  public func terminateUserConnections(
+    userId: String,
+    callback: @escaping (Result<UserConnectionResponse, SockudoError>) -> Void
+  ) {
+    apiClient.sendRequest(
+      for: TerminateUserConnectionsEndpoint(userId: userId, options: options)
+    ) { result in
+      callback(result.mapError({ SockudoError(from: $0) }))
+    }
+  }
+
+  public func forceReconnectUser(
+    userId: String,
+    callback: @escaping (Result<UserConnectionResponse, SockudoError>) -> Void
+  ) {
+    apiClient.sendRequest(
+      for: ForceReconnectUserEndpoint(userId: userId, options: options)
+    ) { result in
+      callback(result.mapError({ SockudoError(from: $0) }))
+    }
+  }
+
   public func history(
     for channel: Channel,
     options fetchOptions: ChannelHistoryFetchOptions = .init(),

--- a/server-sdks/sockudo-http-swift/Tests/SockudoTests/UserConnectionTests.swift
+++ b/server-sdks/sockudo-http-swift/Tests/SockudoTests/UserConnectionTests.swift
@@ -1,0 +1,82 @@
+import APIota
+import XCTest
+
+@testable import Sockudo
+
+final class UserConnectionTests: XCTestCase {
+  private let options = TestObjects.ClientOptions.withCustomPort
+
+  func testTerminateUserConnectionsEndpointBuildsCorrectPath() throws {
+    let endpoint = TerminateUserConnectionsEndpoint(userId: "user-123", options: options)
+    let request = try endpoint.request(baseUrlComponents: baseComponents())
+
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.url?.path, "/apps/123456/users/user-123/terminate_connections")
+    XCTAssertNotNil(
+      URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+        .queryItems?
+        .first(where: { $0.name == "auth_signature" }))
+  }
+
+  func testForceReconnectUserEndpointBuildsCorrectPath() throws {
+    let endpoint = ForceReconnectUserEndpoint(userId: "user-456", options: options)
+    let request = try endpoint.request(baseUrlComponents: baseComponents())
+
+    XCTAssertEqual(request.httpMethod, "POST")
+    XCTAssertEqual(request.url?.path, "/apps/123456/users/user-456/force_reconnect")
+    XCTAssertNotNil(
+      URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?
+        .queryItems?
+        .first(where: { $0.name == "auth_signature" }))
+  }
+
+  func testTerminateUserConnectionsEndpointIncludesAuthSignature() throws {
+    let endpoint = TerminateUserConnectionsEndpoint(userId: "user-123", options: options)
+    let request = try endpoint.request(baseUrlComponents: baseComponents())
+    let queryItems =
+      URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?.queryItems ?? []
+
+    let timestamp = queryItems.first(where: { $0.name == "auth_timestamp" })!.value!
+    let expectedToSign = """
+      POST
+      /apps/123456/users/user-123/terminate_connections
+      auth_key=auth_key&auth_timestamp=\(timestamp)&auth_version=1.0
+      """
+    let expectedSignature = CryptoService.sha256HMAC(
+      for: expectedToSign.toData(),
+      using: TestObjects.ClientOptions.testSecret.toData()
+    ).hexEncodedString()
+    XCTAssertEqual(
+      queryItems.first(where: { $0.name == "auth_signature" })?.value,
+      expectedSignature)
+  }
+
+  func testForceReconnectUserEndpointIncludesAuthSignature() throws {
+    let endpoint = ForceReconnectUserEndpoint(userId: "user-456", options: options)
+    let request = try endpoint.request(baseUrlComponents: baseComponents())
+    let queryItems =
+      URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?.queryItems ?? []
+
+    let timestamp = queryItems.first(where: { $0.name == "auth_timestamp" })!.value!
+    let expectedToSign = """
+      POST
+      /apps/123456/users/user-456/force_reconnect
+      auth_key=auth_key&auth_timestamp=\(timestamp)&auth_version=1.0
+      """
+    let expectedSignature = CryptoService.sha256HMAC(
+      for: expectedToSign.toData(),
+      using: TestObjects.ClientOptions.testSecret.toData()
+    ).hexEncodedString()
+    XCTAssertEqual(
+      queryItems.first(where: { $0.name == "auth_signature" })?.value,
+      expectedSignature)
+  }
+
+  private func baseComponents() -> URLComponents {
+    var components = URLComponents()
+    components.scheme = options.scheme
+    components.host = options.host
+    components.port = options.port
+    return components
+  }
+}


### PR DESCRIPTION
Close all active sockets for a user with code 4200, prompting clients to reconnect rather than permanently disconnecting them.

- New `force_reconnect_user` method on ConnectionManager trait
- Local and horizontal adapter implementations with cross-node fanout
- RequestType::ForceReconnect variant for horizontal coordination
- Presence subscription no longer overwrites user_id set by signin
- HTTP endpoint docs updated
- All 9 server SDKs: add terminateUserConnections + forceReconnectUser with tests and README examples
- Rust README: replace Pusher-era types with actual crate API
- Rust/Swift/Java: fix webhook header names from X-Sockudo-* to X-Pusher-* to match server headers

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
