### PR TITLE
Prevent async disconnect task retention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser",
  "html5ever",
@@ -3234,7 +3234,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -403,59 +403,65 @@ impl ConnectionHandler {
 
         debug!("Using async cleanup for socket: {}", socket_id);
 
-        // Step 1: Quick connection state capture (< 1ms)
-        let disconnect_info = {
+        // Step 1: Quick connection state capture (< 1ms).
+        // Retain the WebSocketRef outside the lock scope so we can call shutdown()
+        // before queuing the cleanup task — cleanup queue latency must not extend
+        // the reader/writer task lifetime.
+        let (disconnect_task, connection) = {
             let connection_manager = &self.connection_manager;
-            let connection = connection_manager.get_connection(socket_id, app_id).await;
-
-            if let Some(conn_ref) = connection {
-                // Atomic check-and-set for disconnecting flag to ensure idempotency
-                let mut conn_locked = conn_ref.inner.lock().await;
-
-                if conn_locked.state.disconnecting {
-                    debug!("Connection {} already disconnecting, skipping", socket_id);
+            let conn_ref =
+                if let Some(c) = connection_manager.get_connection(socket_id, app_id).await {
+                    c
+                } else {
+                    // Connection doesn't exist - might have been cleaned up already
+                    debug!("Connection {} not found during disconnect", socket_id);
                     return Ok(());
-                }
+                };
 
-                // Set disconnecting flag atomically
-                conn_locked.state.disconnecting = true;
+            // Atomic check-and-set for disconnecting flag to ensure idempotency
+            let mut conn_locked = conn_ref.inner.lock().await;
 
-                let channels: Vec<String> =
-                    conn_locked.state.get_subscribed_channels_list().to_vec();
-                let user_id = conn_locked.state.user_id.clone();
-
-                // Extract presence channel info for webhook processing
-                let presence_channels: Vec<String> = channels
-                    .iter()
-                    .filter(|ch| ch.starts_with("presence-"))
-                    .cloned()
-                    .collect();
-
-                Some(DisconnectTask {
-                    socket_id: *socket_id,
-                    app_id: app_id.to_string(),
-                    subscribed_channels: channels,
-                    user_id: user_id.clone(),
-                    timestamp: Instant::now(),
-                    connection_info: if !presence_channels.is_empty() {
-                        Some(ConnectionCleanupInfo {
-                            presence_channels,
-                            auth_info: user_id.map(|uid| AuthInfo {
-                                user_id: uid,
-                                user_info: None,
-                            }),
-                        })
-                    } else {
-                        None
-                    },
-                    presence_ungraceful_timeout_seconds,
-                })
-            } else {
-                // Connection doesn't exist - might have been cleaned up already
-                debug!("Connection {} not found during disconnect", socket_id);
+            if conn_locked.state.disconnecting {
+                debug!("Connection {} already disconnecting, skipping", socket_id);
                 return Ok(());
             }
-        }; // Lock released immediately
+
+            // Set disconnecting flag atomically
+            conn_locked.state.disconnecting = true;
+
+            let channels: Vec<String> = conn_locked.state.get_subscribed_channels_list().to_vec();
+            let user_id = conn_locked.state.user_id.clone();
+
+            // Extract presence channel info for webhook processing
+            let presence_channels: Vec<String> = channels
+                .iter()
+                .filter(|ch| ch.starts_with("presence-"))
+                .cloned()
+                .collect();
+
+            let task = DisconnectTask {
+                socket_id: *socket_id,
+                app_id: app_id.to_string(),
+                subscribed_channels: channels,
+                user_id: user_id.clone(),
+                timestamp: Instant::now(),
+                connection_info: if !presence_channels.is_empty() {
+                    Some(ConnectionCleanupInfo {
+                        presence_channels,
+                        auth_info: user_id.map(|uid| AuthInfo {
+                            user_id: uid,
+                            user_info: None,
+                        }),
+                    })
+                } else {
+                    None
+                },
+                presence_ungraceful_timeout_seconds,
+            };
+
+            drop(conn_locked);
+            (task, conn_ref)
+        };
 
         // Step 2: Clear immediate timeouts (these should be fast)
         self.clear_activity_timeout(app_id, socket_id).await.ok();
@@ -475,38 +481,38 @@ impl ConnectionHandler {
         #[cfg(feature = "delta")]
         self.delta_compression.remove_socket(socket_id);
 
+        // Cancel reader/writer tasks immediately, before cleanup queue latency.
+        // shutdown() is idempotent (CancellationToken::cancel) — safe to call
+        // even if the queue-full fallback path calls it again via sync cleanup.
+        connection.shutdown();
+
         // Step 4: Queue cleanup work (non-blocking)
-        if let Some(task) = disconnect_info {
-            if let Err(_send_error) = cleanup_queue.try_send(task) {
-                // Queue is full or closed - don't return error, fall back to sync cleanup
-                warn!(
-                    "Failed to queue async cleanup for socket {} (queue full/closed), falling back to sync cleanup",
-                    socket_id
-                );
+        if let Err(_send_error) = cleanup_queue.try_send(disconnect_task) {
+            // Queue is full or closed - don't return error, fall back to sync cleanup
+            warn!(
+                "Failed to queue async cleanup for socket {} (queue full/closed), falling back to sync cleanup",
+                socket_id
+            );
 
-                // FIX: Reset the disconnecting flag using proper lock (not try_lock) to ensure
-                // the flag is always reset before falling back to sync cleanup.
-                // Using try_lock() could fail and leave the flag stuck at true forever,
-                // preventing future cleanup attempts for this connection.
-                {
-                    let connection_manager = &self.connection_manager;
-                    if let Some(conn_ref) =
-                        connection_manager.get_connection(socket_id, app_id).await
-                    {
-                        // Use .lock().await instead of try_lock() to guarantee we reset the flag
-                        let mut conn_locked = conn_ref.inner.lock().await;
-                        conn_locked.state.disconnecting = false;
-                    }
+            // FIX: Reset the disconnecting flag using proper lock (not try_lock) to ensure
+            // the flag is always reset before falling back to sync cleanup.
+            // Using try_lock() could fail and leave the flag stuck at true forever,
+            // preventing future cleanup attempts for this connection.
+            {
+                let connection_manager = &self.connection_manager;
+                if let Some(conn_ref) = connection_manager.get_connection(socket_id, app_id).await {
+                    // Use .lock().await instead of try_lock() to guarantee we reset the flag
+                    let mut conn_locked = conn_ref.inner.lock().await;
+                    conn_locked.state.disconnecting = false;
                 }
-
-                // Fall back to synchronous cleanup immediately
-                // We already have the disconnect task info, so use sync cleanup
-                return self
-                    .handle_disconnect_sync(app_id, socket_id, presence_ungraceful_timeout_seconds)
-                    .await;
             }
-            debug!("Queued async cleanup for socket: {}", socket_id);
+            // Fall back to synchronous cleanup immediately
+            // We already have the disconnect task info, so use sync cleanup
+            return self
+                .handle_disconnect_sync(app_id, socket_id, presence_ungraceful_timeout_seconds)
+                .await;
         }
+        debug!("Queued async cleanup for socket: {}", socket_id);
 
         // Step 5: Update metrics immediately (outside connection lock to minimize contention)
         if let Some(ref metrics) = self.metrics {
@@ -604,12 +610,13 @@ impl ConnectionHandler {
             .await?;
         }
 
-        // Final cleanup from connection manager (removes socket from users map)
-        self.cleanup_connection_from_manager(socket_id, app_id)
-            .await;
-
-        // Process channel unsubscriptions AFTER cleanup so presence checks see correct state
-        if !subscribed_channels.is_empty() {
+        // Remove channel memberships while the snapshot still corresponds to
+        // live namespace entries. Presence counting explicitly excludes this
+        // socket, so member_removed decisions remain correct without deleting
+        // the authoritative connection first.
+        let unsubscribe_result = if subscribed_channels.is_empty() {
+            Ok(())
+        } else {
             self.process_channel_unsubscriptions_on_disconnect(
                 socket_id,
                 &app_config,
@@ -617,8 +624,14 @@ impl ConnectionHandler {
                 &user_id,
                 presence_ungraceful_timeout_seconds,
             )
-            .await?;
-        }
+            .await
+        };
+
+        // Always finish comprehensive resource cleanup, even when channel or
+        // presence processing reports an error.
+        self.cleanup_connection_from_manager(socket_id, app_id)
+            .await;
+        unsubscribe_result?;
 
         // Update metrics
         if let Some(ref metrics) = self.metrics {

--- a/crates/sockudo-adapter/src/handler/signin_management.rs
+++ b/crates/sockudo-adapter/src/handler/signin_management.rs
@@ -68,9 +68,24 @@ impl ConnectionHandler {
         self.clear_user_authentication_timeout(&app_config.id, socket_id)
             .await?;
 
-        {
+        let previous_user_id = {
             let mut conn_locked = connection_arc.inner.lock().await;
+            if conn_locked.state.disconnecting {
+                return Err(Error::ConnectionClosed(
+                    "connection is disconnecting".to_string(),
+                ));
+            }
+            let previous = conn_locked.state.user_id.clone();
             conn_locked.set_user_info(user_info.clone());
+            previous
+        };
+
+        if previous_user_id.as_deref() != Some(user_info.id.as_str())
+            && let Some(ref prev_id) = previous_user_id
+        {
+            self.connection_manager
+                .remove_user_socket(prev_id, socket_id, &app_config.id)
+                .await?;
         }
 
         // Re-add user to adapter's tracking (this updates user associations)

--- a/crates/sockudo-adapter/src/local_adapter/connection_manager.rs
+++ b/crates/sockudo-adapter/src/local_adapter/connection_manager.rs
@@ -260,7 +260,7 @@ impl ConnectionManager for LocalAdapter {
         // Get target socket references based on channel type
         let (v1_all_sockets, v2_target_sockets) = if channel.starts_with("#server-to-user-") {
             let user_id = channel.trim_start_matches("#server-to-user-");
-            let socket_refs = namespace.get_user_sockets(user_id).await?;
+            let socket_refs = namespace.get_user_sockets(user_id)?;
 
             let mut target_refs = Vec::new();
             for socket_ref in socket_refs.iter() {
@@ -330,7 +330,7 @@ impl ConnectionManager for LocalAdapter {
         // Get target socket references based on channel type
         let (v1_all_sockets, v2_target_sockets) = if channel.starts_with("#server-to-user-") {
             let user_id = channel.trim_start_matches("#server-to-user-");
-            let socket_refs = namespace.get_user_sockets(user_id).await?;
+            let socket_refs = namespace.get_user_sockets(user_id)?;
 
             let mut target_refs = Vec::new();
             for socket_ref in socket_refs.iter() {
@@ -448,7 +448,7 @@ impl ConnectionManager for LocalAdapter {
 
     async fn get_user_sockets(&self, user_id: &str, app_id: &str) -> Result<Vec<WebSocketRef>> {
         match self.existing_namespace(app_id) {
-            Some(namespace) => namespace.get_user_sockets(user_id).await,
+            Some(namespace) => namespace.get_user_sockets(user_id),
             None => Ok(Vec::new()),
         }
     }
@@ -676,7 +676,7 @@ impl ConnectionManager for LocalAdapter {
         app_id: &str,
     ) -> Result<()> {
         match self.existing_namespace(app_id) {
-            Some(namespace) => namespace.remove_user_socket(user_id, socket_id).await,
+            Some(namespace) => namespace.remove_user_socket(user_id, socket_id),
             None => Ok(()),
         }
     }

--- a/crates/sockudo-adapter/tests/adapter/async_disconnect_cleanup_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/async_disconnect_cleanup_tests.rs
@@ -1,0 +1,296 @@
+use async_trait::async_trait;
+use crossfire::mpsc;
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::cleanup::{CleanupSender, DisconnectTask};
+use sockudo_adapter::handler::ConnectionHandler;
+use sockudo_adapter::local_adapter::LocalAdapter;
+use sockudo_app::memory_app_manager::MemoryAppManager;
+use sockudo_core::app::{App, AppLimitsPolicy, AppManager, AppPolicy};
+use sockudo_core::cache::CacheManager;
+use sockudo_core::error::Result;
+use sockudo_core::metrics::MetricsInterface;
+use sockudo_core::options::ServerOptions;
+use sockudo_core::websocket::{SocketId, WebSocketBufferConfig};
+use sockudo_protocol::{ProtocolVersion, WireFormat};
+use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, Stream as WsStream, WebSocketStream};
+use sonic_rs::Value;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+use tokio::net::{TcpListener, TcpStream};
+
+struct CountingMetrics {
+    disconnections: AtomicUsize,
+}
+
+impl CountingMetrics {
+    fn new() -> Self {
+        Self {
+            disconnections: AtomicUsize::new(0),
+        }
+    }
+
+    fn disconnections(&self) -> usize {
+        self.disconnections.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl MetricsInterface for CountingMetrics {
+    async fn init(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn mark_new_connection(&self, _app_id: &str, _socket_id: &SocketId) {}
+
+    fn mark_disconnection(&self, _app_id: &str, _socket_id: &SocketId) {
+        self.disconnections.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn mark_connection_error(&self, _: &str, _: &str) {}
+    fn mark_rate_limit_check(&self, _: &str, _: &str) {}
+    fn mark_rate_limit_check_with_context(&self, _: &str, _: &str, _: &str) {}
+    fn mark_rate_limit_triggered(&self, _: &str, _: &str) {}
+    fn mark_rate_limit_triggered_with_context(&self, _: &str, _: &str, _: &str) {}
+    fn mark_channel_subscription(&self, _: &str, _: &str) {}
+    fn mark_channel_unsubscription(&self, _: &str, _: &str) {}
+    fn mark_api_message(&self, _: &str, _: usize, _: usize) {}
+    fn mark_ws_message_sent(&self, _: &str, _: usize) {}
+    fn mark_ws_messages_sent_batch(&self, _: &str, _: usize, _: usize) {}
+    fn mark_ws_message_received(&self, _: &str, _: usize) {}
+    fn track_horizontal_adapter_resolve_time(&self, _: &str, _: f64) {}
+    fn track_horizontal_adapter_resolved_promises(&self, _: &str, _: bool) {}
+    fn mark_horizontal_adapter_request_sent(&self, _: &str) {}
+    fn mark_horizontal_adapter_request_received(&self, _: &str) {}
+    fn mark_horizontal_adapter_response_received(&self, _: &str) {}
+    fn track_broadcast_latency(&self, _: &str, _: &str, _: usize, _: f64) {}
+    fn track_horizontal_delta_compression(&self, _: &str, _: &str, _: bool) {}
+    fn track_delta_compression_bandwidth(&self, _: &str, _: &str, _: usize, _: usize) {}
+    fn track_delta_compression_full_message(&self, _: &str, _: &str) {}
+    fn track_delta_compression_delta_message(&self, _: &str, _: &str) {}
+
+    async fn get_metrics_as_plaintext(&self) -> String {
+        String::new()
+    }
+
+    async fn get_metrics_as_json(&self) -> Value {
+        sonic_rs::json!({})
+    }
+
+    async fn clear(&self) {}
+
+    fn mark_channel_activated(&self, _: &str, _: &str) {}
+    fn mark_channel_deactivated(&self, _: &str, _: &str) {}
+}
+
+struct NullCacheManager;
+
+#[async_trait]
+impl CacheManager for NullCacheManager {
+    async fn has(&self, _: &str) -> Result<bool> {
+        Ok(false)
+    }
+    async fn get(&self, _: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+    async fn set(&self, _: &str, _: &str, _: u64) -> Result<()> {
+        Ok(())
+    }
+    async fn remove(&self, _: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn disconnect(&self) -> Result<()> {
+        Ok(())
+    }
+    async fn ttl(&self, _: &str) -> Result<Option<Duration>> {
+        Ok(None)
+    }
+    async fn check_health(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+const APP_ID: &str = "async-disconnect-test-app";
+const APP_KEY: &str = "async-disconnect-test-key";
+
+fn make_app() -> App {
+    App::from_policy(
+        APP_ID.to_string(),
+        APP_KEY.to_string(),
+        "secret".to_string(),
+        true,
+        AppPolicy {
+            limits: AppLimitsPolicy {
+                max_connections: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+}
+
+async fn make_ws_pair() -> (WebSocketWriter, WebSocketStream<WsStream<Http1>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server_task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let ws = WebSocket::from_tcp(stream, WsConfig::default());
+        let (_reader, writer) = ws.split();
+        writer
+    });
+
+    let client_stream = TcpStream::connect(addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (client_ws, _): (WebSocketStream<WsStream<Http1>>, _) = client
+        .connect(client_stream, &addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    let server_writer = server_task.await.unwrap();
+    (server_writer, client_ws)
+}
+
+fn dummy_disconnect_task() -> DisconnectTask {
+    DisconnectTask {
+        socket_id: SocketId::new(),
+        app_id: APP_ID.to_string(),
+        subscribed_channels: vec![],
+        user_id: None,
+        timestamp: Instant::now(),
+        connection_info: None,
+        presence_ungraceful_timeout_seconds: 0,
+    }
+}
+
+#[tokio::test]
+async fn delayed_worker_cannot_delay_cancellation() {
+    let (tx, _rx) = mpsc::bounded_async::<DisconnectTask>(10);
+    let cleanup_sender = CleanupSender::Direct(tx);
+
+    let app = make_app();
+    let app_manager = Arc::new(MemoryAppManager::new());
+    app_manager.create_app(app).await.unwrap();
+
+    let adapter = Arc::new(LocalAdapter::new());
+    adapter.init().await;
+
+    let handler = ConnectionHandler::builder(
+        app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+        adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(NullCacheManager),
+        ServerOptions::default(),
+    )
+    .local_adapter(adapter.clone())
+    .cleanup_queue(cleanup_sender)
+    .build();
+
+    let socket_id = SocketId::new();
+    let (writer, _client) = make_ws_pair().await;
+    adapter
+        .add_socket(
+            socket_id,
+            writer,
+            APP_ID,
+            app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+            sockudo_protocol::AppendMode::Delta,
+        )
+        .await
+        .unwrap();
+
+    let token = adapter
+        .get_connection(&socket_id, APP_ID)
+        .await
+        .unwrap()
+        .cancellation_token();
+
+    assert!(
+        !token.is_cancelled(),
+        "token must be live before disconnect"
+    );
+
+    handler.handle_disconnect(APP_ID, &socket_id).await.unwrap();
+
+    assert!(
+        token.is_cancelled(),
+        "token must be cancelled immediately regardless of queue consumption"
+    );
+}
+
+#[tokio::test]
+async fn queue_fallback_remains_idempotent() {
+    let (tx, _rx) = mpsc::bounded_async::<DisconnectTask>(1);
+
+    tx.try_send(dummy_disconnect_task()).unwrap();
+
+    let cleanup_sender = CleanupSender::Direct(tx);
+
+    let metrics = Arc::new(CountingMetrics::new());
+    let app = make_app();
+    let app_manager = Arc::new(MemoryAppManager::new());
+    app_manager.create_app(app).await.unwrap();
+
+    let adapter = Arc::new(LocalAdapter::new());
+    adapter.init().await;
+
+    let handler = ConnectionHandler::builder(
+        app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+        adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(NullCacheManager),
+        ServerOptions::default(),
+    )
+    .local_adapter(adapter.clone())
+    .cleanup_queue(cleanup_sender)
+    .metrics(metrics.clone() as Arc<dyn MetricsInterface + Send + Sync>)
+    .build();
+
+    let socket_id = SocketId::new();
+    let (writer, _client) = make_ws_pair().await;
+    adapter
+        .add_socket(
+            socket_id,
+            writer,
+            APP_ID,
+            app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+            sockudo_protocol::AppendMode::Delta,
+        )
+        .await
+        .unwrap();
+
+    let token = adapter
+        .get_connection(&socket_id, APP_ID)
+        .await
+        .unwrap()
+        .cancellation_token();
+
+    assert!(
+        !token.is_cancelled(),
+        "token must be live before disconnect"
+    );
+
+    handler.handle_disconnect(APP_ID, &socket_id).await.unwrap();
+
+    assert!(
+        token.is_cancelled(),
+        "token must be cancelled even when queue is full (shutdown precedes try_send)"
+    );
+
+    assert_eq!(
+        metrics.disconnections(),
+        1,
+        "lifecycle metric must change exactly once regardless of fallback path"
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/handler/auth_token_user_index_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/auth_token_user_index_tests.rs
@@ -1,0 +1,194 @@
+/// Token-auth user-index routing audit (Task 6).
+///
+/// Confirms that `set_token_auth_context` / `apply_connection_token` never
+/// silently replace an already-indexed user identity:
+///   • initial token on a fresh connection is first-time assignment (user_id=None)
+///   • token refresh enforces the same client_id (idempotent re-index)
+///   • presence `is_none()` guard cannot overwrite a token-auth user_id
+///   • `validate_signin_token_boundary` blocks signin on token-auth connections
+use sockudo_core::capability_token::TokenAuthContext;
+use sockudo_core::websocket::{ConnectionCapabilities, SocketId, WebSocket, WebSocketRef};
+use sockudo_ws::axum_integration;
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, WebSocketStream};
+use tokio::net::{TcpListener, TcpStream};
+
+async fn create_test_writer() -> axum_integration::WebSocketWriter {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let _ = sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let ws = axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
+        let (_reader, writer) = ws.split();
+        writer
+    });
+
+    let client_stream = TcpStream::connect(addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+        .connect(client_stream, &addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    server.await.unwrap()
+}
+
+fn make_token_context(client_id: &str) -> TokenAuthContext {
+    TokenAuthContext {
+        client_id: client_id.to_string(),
+        capabilities: ConnectionCapabilities::default(),
+        jti: format!("jti-{client_id}"),
+        exp: i64::MAX,
+    }
+}
+
+async fn make_ws_ref(user_id: Option<&str>) -> WebSocketRef {
+    let writer = create_test_writer().await;
+    let mut ws = WebSocket::new(SocketId::new(), writer);
+    if let Some(uid) = user_id {
+        ws.state.user_id = Some(uid.to_string());
+    }
+    WebSocketRef::new(ws)
+}
+
+#[tokio::test]
+async fn token_auth_on_fresh_connection_is_first_time_assignment() {
+    let ws_ref = make_ws_ref(None).await;
+
+    let context = make_token_context("client-abc");
+
+    {
+        let mut conn = ws_ref.inner.lock().await;
+        let previous_user_id = conn.state.user_id.clone();
+        conn.set_token_auth_context(context.clone());
+
+        assert_eq!(
+            previous_user_id, None,
+            "user_id must be None before the first token auth"
+        );
+    }
+
+    let user_id = ws_ref.get_user_id().await;
+    assert_eq!(
+        user_id.as_deref(),
+        Some("client-abc"),
+        "user_id must be set to client_id after set_token_auth_context"
+    );
+}
+
+#[tokio::test]
+async fn token_auth_refresh_same_client_id_is_idempotent() {
+    let ws_ref = make_ws_ref(None).await;
+
+    let context_v1 = make_token_context("client-xyz");
+    {
+        let mut conn = ws_ref.inner.lock().await;
+        conn.set_token_auth_context(context_v1);
+    }
+
+    let context_v2 = TokenAuthContext {
+        client_id: "client-xyz".to_string(),
+        capabilities: ConnectionCapabilities::default(),
+        jti: "jti-refreshed".to_string(),
+        exp: i64::MAX,
+    };
+    {
+        let mut conn = ws_ref.inner.lock().await;
+        let previous_user_id = conn.state.user_id.clone();
+        conn.set_token_auth_context(context_v2.clone());
+
+        assert_eq!(
+            previous_user_id.as_deref(),
+            Some("client-xyz"),
+            "previous user_id before refresh must be client-xyz"
+        );
+    }
+
+    let user_id = ws_ref.get_user_id().await;
+    assert_eq!(
+        user_id.as_deref(),
+        Some("client-xyz"),
+        "user_id must remain client-xyz after same-id refresh"
+    );
+
+    let token_ctx = ws_ref.get_token_auth_context().await;
+    assert_eq!(
+        token_ctx.as_ref().map(|c| c.jti.as_str()),
+        Some("jti-refreshed"),
+        "token_auth_context must be updated to the refreshed token"
+    );
+}
+
+#[tokio::test]
+async fn presence_subscription_cannot_overwrite_token_auth_user_id() {
+    let ws_ref = make_ws_ref(None).await;
+
+    {
+        let mut conn = ws_ref.inner.lock().await;
+        conn.set_token_auth_context(make_token_context("token-client-1"));
+    }
+
+    {
+        let mut conn = ws_ref.inner.lock().await;
+        if conn.state.user_id.is_none() {
+            conn.state.user_id = Some("presence-user-99".to_string());
+        }
+    }
+
+    assert_eq!(
+        ws_ref.get_user_id().await.as_deref(),
+        Some("token-client-1")
+    );
+}
+
+#[tokio::test]
+async fn token_auth_sets_all_expected_state_fields() {
+    let ws_ref = make_ws_ref(None).await;
+    let context = make_token_context("state-fields-client");
+
+    {
+        let mut conn = ws_ref.inner.lock().await;
+        conn.set_token_auth_context(context.clone());
+    }
+
+    let conn = ws_ref.inner.lock().await;
+    assert_eq!(conn.state.user_id.as_deref(), Some("state-fields-client"));
+    assert!(conn.state.token_auth_context.is_some());
+    assert!(conn.state.connection_capabilities.is_some());
+    assert!(conn.state.user_info.is_some());
+    assert!(conn.state.user.is_some());
+    assert_eq!(conn.state.connection_meta, None);
+}
+
+#[tokio::test]
+async fn migration_detection_predicate_fires_for_differing_ids() {
+    let ws_ref = make_ws_ref(Some("old-user-identity")).await;
+
+    let ctx = make_token_context("new-token-client");
+    let previous_user_id = {
+        let mut conn = ws_ref.inner.lock().await;
+        let previous = conn.state.user_id.clone();
+        conn.set_token_auth_context(ctx.clone());
+        previous
+    };
+
+    let would_trigger_migration = previous_user_id.as_deref() != Some(ctx.client_id.as_str());
+    assert!(would_trigger_migration);
+}
+
+#[tokio::test]
+async fn token_auth_context_prevents_signin_overwrite() {
+    let ws_ref = make_ws_ref(None).await;
+
+    {
+        let mut conn = ws_ref.inner.lock().await;
+        conn.set_token_auth_context(make_token_context("token-user"));
+    }
+
+    assert!(ws_ref.get_token_auth_context().await.is_some());
+    assert_eq!(ws_ref.get_user_id().await.as_deref(), Some("token-user"));
+}

--- a/crates/sockudo-adapter/tests/adapter/handler/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/mod.rs
@@ -1,4 +1,5 @@
 pub mod annotations_test;
+pub mod auth_token_user_index_tests;
 pub mod authentication_test;
 pub mod clustered_runtime_rewind_recovery_redis_test;
 pub mod presence_user_id_guard_test;

--- a/crates/sockudo-adapter/tests/adapter/handler/presence_user_id_guard_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/presence_user_id_guard_test.rs
@@ -1,10 +1,25 @@
-use sockudo_core::websocket::{SocketId, WebSocket, WebSocketRef};
+use crate::mocks::connection_handler_mock::MockCacheManager;
+use futures_util::StreamExt;
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::handler::ConnectionHandler;
+use sockudo_adapter::handler::types::SubscriptionRequest;
+use sockudo_adapter::local_adapter::LocalAdapter;
+use sockudo_app::memory_app_manager::MemoryAppManager;
+use sockudo_core::app::{App, AppManager, AppPolicy};
+use sockudo_core::options::ServerOptions;
+use sockudo_core::token::Token;
+use sockudo_core::websocket::{SocketId, UserInfo, WebSocket, WebSocketBufferConfig, WebSocketRef};
+use sockudo_protocol::{ProtocolVersion, WireFormat};
 use sockudo_ws::axum_integration;
 use sockudo_ws::client::WebSocketClient;
-use sockudo_ws::{Config as WsConfig, Http1, WebSocketStream};
+use sockudo_ws::{Config as WsConfig, Http1, Message as WsMessage, WebSocketStream};
+use sonic_rs::JsonValueTrait;
+use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
 
-async fn create_test_writer() -> axum_integration::WebSocketWriter {
+type TestClient = WebSocketStream<sockudo_ws::Stream<Http1>>;
+
+async fn create_test_pair() -> (axum_integration::WebSocketWriter, TestClient) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
@@ -20,12 +35,16 @@ async fn create_test_writer() -> axum_integration::WebSocketWriter {
 
     let client_stream = TcpStream::connect(addr).await.unwrap();
     let client = WebSocketClient::<Http1>::new(WsConfig::default());
-    let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+    let (client_ws, _): (TestClient, _) = client
         .connect(client_stream, &addr.to_string(), "/", None)
         .await
         .unwrap();
 
-    server.await.unwrap()
+    (server.await.unwrap(), client_ws)
+}
+
+async fn create_test_writer() -> axum_integration::WebSocketWriter {
+    create_test_pair().await.0
 }
 
 async fn make_ws_ref(user_id: Option<&str>) -> WebSocketRef {
@@ -35,6 +54,176 @@ async fn make_ws_ref(user_id: Option<&str>) -> WebSocketRef {
         ws.state.user_id = Some(uid.to_string());
     }
     WebSocketRef::new(ws)
+}
+
+struct SigninHarness {
+    handler: ConnectionHandler,
+    adapter: Arc<LocalAdapter>,
+    app: App,
+    socket_id: SocketId,
+    ws_ref: WebSocketRef,
+}
+
+struct PresenceHarness {
+    handler: ConnectionHandler,
+    adapter: Arc<LocalAdapter>,
+    app_manager: Arc<MemoryAppManager>,
+    app: App,
+}
+
+async fn make_presence_harness() -> PresenceHarness {
+    let app = App::from_policy(
+        "presence-lifecycle-app".to_string(),
+        "presence-key".to_string(),
+        "presence-secret".to_string(),
+        true,
+        AppPolicy::default(),
+    );
+    let app_manager = Arc::new(MemoryAppManager::new());
+    app_manager.create_app(app.clone()).await.unwrap();
+    let adapter = Arc::new(LocalAdapter::new());
+    adapter.init().await;
+    let handler = ConnectionHandler::builder(
+        app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+        adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(MockCacheManager::new()),
+        ServerOptions::default(),
+    )
+    .local_adapter(adapter.clone())
+    .build();
+
+    PresenceHarness {
+        handler,
+        adapter,
+        app_manager,
+        app,
+    }
+}
+
+async fn add_presence_socket(harness: &PresenceHarness) -> (SocketId, TestClient) {
+    let socket_id = SocketId::new();
+    let (writer, client) = create_test_pair().await;
+    harness
+        .adapter
+        .add_socket(
+            socket_id,
+            writer,
+            &harness.app.id,
+            harness.app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+            sockudo_protocol::AppendMode::Delta,
+        )
+        .await
+        .unwrap();
+    (socket_id, client)
+}
+
+fn presence_request(
+    harness: &PresenceHarness,
+    socket_id: &SocketId,
+    channel: &str,
+    user_id: &str,
+) -> SubscriptionRequest {
+    let channel_data = sonic_rs::json!({
+        "user_id": user_id,
+        "user_info": {"name": user_id}
+    })
+    .to_string();
+    let signature = Token::new(harness.app.key.clone(), harness.app.secret.clone())
+        .sign(&format!("{socket_id}:{channel}:{channel_data}"));
+
+    SubscriptionRequest {
+        channel: channel.to_string(),
+        auth: Some(format!("{}:{signature}", harness.app.key)),
+        channel_data: Some(channel_data),
+        #[cfg(feature = "tag-filtering")]
+        tags_filter: None,
+        #[cfg(feature = "delta")]
+        delta: None,
+        rewind: None,
+        event_name_filter: None,
+        annotation_subscribe: false,
+    }
+}
+
+async fn recv_event(
+    client: &mut TestClient,
+    event: &str,
+) -> sockudo_protocol::messages::PusherMessage {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let frame = client
+                .next()
+                .await
+                .expect("websocket stream ended")
+                .expect("websocket receive failed");
+            let message: sockudo_protocol::messages::PusherMessage = match frame {
+                WsMessage::Text(bytes) => sonic_rs::from_slice(bytes.as_ref()).unwrap(),
+                WsMessage::Binary(bytes) => sonic_rs::from_slice(&bytes).unwrap(),
+                other => panic!("unexpected websocket frame: {other:?}"),
+            };
+            if message.event.as_deref() == Some(event) {
+                return message;
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {event}"))
+}
+
+async fn make_signin_harness(initial_user_id: Option<&str>) -> SigninHarness {
+    let app = App::from_policy(
+        "signin-migration-app".to_string(),
+        "signin-key".to_string(),
+        "signin-secret".to_string(),
+        true,
+        AppPolicy::default(),
+    );
+    let app_manager = Arc::new(MemoryAppManager::new());
+    app_manager.create_app(app.clone()).await.unwrap();
+
+    let adapter = Arc::new(LocalAdapter::new());
+    adapter.init().await;
+    let handler = ConnectionHandler::builder(
+        app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+        adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(MockCacheManager::new()),
+        ServerOptions::default(),
+    )
+    .local_adapter(adapter.clone())
+    .build();
+
+    let socket_id = SocketId::new();
+    adapter
+        .add_socket(
+            socket_id,
+            create_test_writer().await,
+            &app.id,
+            app_manager as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+            sockudo_protocol::AppendMode::Delta,
+        )
+        .await
+        .unwrap();
+    let ws_ref = adapter.get_connection(&socket_id, &app.id).await.unwrap();
+    if let Some(user_id) = initial_user_id {
+        ws_ref.inner.lock().await.state.user_id = Some(user_id.to_string());
+        adapter.add_user(ws_ref.clone()).await.unwrap();
+    }
+
+    SigninHarness {
+        handler,
+        adapter,
+        app,
+        socket_id,
+        ws_ref,
+    }
 }
 
 #[tokio::test]
@@ -74,5 +263,239 @@ async fn test_presence_subscription_guard_sets_user_id_when_none() {
         conn_locked.state.user_id.as_deref(),
         Some("presence-user-99"),
         "user_id should be set from presence member when no signin occurred"
+    );
+}
+
+#[tokio::test]
+async fn production_signin_migrates_composite_routing_identity() {
+    let harness = make_signin_harness(Some("alice:presence-socket")).await;
+
+    harness
+        .handler
+        .update_connection_with_user_info(
+            &harness.socket_id,
+            &harness.app,
+            &UserInfo {
+                id: "alice".to_string(),
+                watchlist: None,
+                info: Some(sonic_rs::json!({"name": "Alice"})),
+                capabilities: None,
+                meta: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        harness
+            .adapter
+            .get_user_sockets("alice:presence-socket", &harness.app.id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "production signin must remove the prior presence-derived route"
+    );
+    let current = harness
+        .adapter
+        .get_user_sockets("alice", &harness.app.id)
+        .await
+        .unwrap();
+    assert_eq!(current.len(), 1);
+    assert_eq!(*current[0].get_socket_id_sync(), harness.socket_id);
+    assert_eq!(
+        harness
+            .ws_ref
+            .inner
+            .lock()
+            .await
+            .state
+            .user_info
+            .as_ref()
+            .and_then(|info| info.info.as_ref())
+            .and_then(|info| info.get("name"))
+            .and_then(|name| name.as_str()),
+        Some("Alice")
+    );
+}
+
+#[tokio::test]
+async fn production_signin_rejects_disconnecting_socket_without_reindexing() {
+    let harness = make_signin_harness(Some("alice:presence-socket")).await;
+    harness.ws_ref.inner.lock().await.state.disconnecting = true;
+
+    let result = harness
+        .handler
+        .update_connection_with_user_info(
+            &harness.socket_id,
+            &harness.app,
+            &UserInfo {
+                id: "alice".to_string(),
+                watchlist: None,
+                info: None,
+                capabilities: None,
+                meta: None,
+            },
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(sockudo_core::error::Error::ConnectionClosed(_))),
+        "signin must return ConnectionClosed once teardown has started: {result:?}"
+    );
+    assert!(
+        harness
+            .adapter
+            .get_user_sockets("alice", &harness.app.id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "rejected signin must not create a new route"
+    );
+    assert_eq!(
+        harness
+            .adapter
+            .get_user_sockets("alice:presence-socket", &harness.app.id)
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "rejected signin must leave existing metadata for teardown to remove"
+    );
+}
+
+#[tokio::test]
+async fn production_same_id_signin_updates_user_info_without_duplicate_route() {
+    let harness = make_signin_harness(Some("alice")).await;
+
+    harness
+        .handler
+        .update_connection_with_user_info(
+            &harness.socket_id,
+            &harness.app,
+            &UserInfo {
+                id: "alice".to_string(),
+                watchlist: None,
+                info: Some(sonic_rs::json!({"role": "operator"})),
+                capabilities: None,
+                meta: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        harness
+            .adapter
+            .get_user_sockets("alice", &harness.app.id)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        harness
+            .ws_ref
+            .inner
+            .lock()
+            .await
+            .state
+            .user_info
+            .as_ref()
+            .and_then(|info| info.info.as_ref())
+            .and_then(|info| info.get("role"))
+            .and_then(|role| role.as_str()),
+        Some("operator")
+    );
+}
+
+#[tokio::test]
+async fn production_v1_presence_lifecycle_preserves_member_events_and_single_user_route() {
+    let harness = make_presence_harness().await;
+    let (alice_socket, mut alice_client) = add_presence_socket(&harness).await;
+    let (bob_socket, mut bob_client) = add_presence_socket(&harness).await;
+
+    harness
+        .handler
+        .handle_subscribe_request(
+            &alice_socket,
+            &harness.app,
+            presence_request(&harness, &alice_socket, "presence-room", "alice"),
+        )
+        .await
+        .unwrap();
+    let alice_ack = recv_event(&mut alice_client, "pusher_internal:subscription_succeeded").await;
+    assert_eq!(alice_ack.channel.as_deref(), Some("presence-room"));
+
+    harness
+        .handler
+        .handle_subscribe_request(
+            &alice_socket,
+            &harness.app,
+            presence_request(&harness, &alice_socket, "presence-room-two", "alice"),
+        )
+        .await
+        .unwrap();
+    recv_event(&mut alice_client, "pusher_internal:subscription_succeeded").await;
+    assert_eq!(
+        harness
+            .adapter
+            .get_user_sockets("alice", &harness.app.id)
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "multiple presence channels must retain one routing entry per socket"
+    );
+
+    harness
+        .handler
+        .handle_subscribe_request(
+            &bob_socket,
+            &harness.app,
+            presence_request(&harness, &bob_socket, "presence-room", "bob"),
+        )
+        .await
+        .unwrap();
+    recv_event(&mut bob_client, "pusher_internal:subscription_succeeded").await;
+    let added = recv_event(&mut alice_client, "pusher_internal:member_added").await;
+    assert_eq!(added.channel.as_deref(), Some("presence-room"));
+    assert!(
+        added
+            .data
+            .as_ref()
+            .is_some_and(|data| sonic_rs::to_string(data).unwrap().contains("bob")),
+        "member_added must identify bob: {:?}",
+        added.data
+    );
+
+    harness
+        .handler
+        .handle_disconnect(&harness.app.id, &bob_socket)
+        .await
+        .unwrap();
+    let removed = recv_event(&mut alice_client, "pusher_internal:member_removed").await;
+    assert_eq!(removed.channel.as_deref(), Some("presence-room"));
+    assert!(
+        removed
+            .data
+            .as_ref()
+            .is_some_and(|data| sonic_rs::to_string(data).unwrap().contains("bob")),
+        "member_removed must identify bob: {:?}",
+        removed.data
+    );
+
+    harness
+        .handler
+        .handle_disconnect(&harness.app.id, &alice_socket)
+        .await
+        .unwrap();
+    assert!(
+        harness
+            .adapter
+            .get_user_sockets("alice", &harness.app.id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "last disconnect must remove the presence user's routing entry"
     );
 }

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -90,3 +90,9 @@ mod connected_gauge_regression_tests;
 
 #[cfg(test)]
 mod server_capacity_tests;
+
+#[cfg(test)]
+mod async_disconnect_cleanup_tests;
+
+#[cfg(test)]
+mod user_socket_index_regression_tests;

--- a/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
@@ -67,7 +67,9 @@ async fn seed_local_user_connection(
         .users
         .entry(user_id.to_string())
         .or_default()
-        .insert(ws_ref.clone());
+        .insert(socket_id);
+
+    namespace.sockets.insert(socket_id, ws_ref.clone());
 
     namespace
         .presence_data

--- a/crates/sockudo-adapter/tests/adapter/user_socket_index_regression_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/user_socket_index_regression_tests.rs
@@ -1,0 +1,237 @@
+use bytes::Bytes;
+use futures_util::StreamExt;
+use sockudo_core::channel::PresenceMemberInfo;
+use sockudo_core::namespace::Namespace;
+use sockudo_core::websocket::{SocketId, WebSocket, WebSocketRef};
+use sockudo_ws::axum_integration;
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, Stream as WsStream, WebSocketStream};
+use std::time::Duration;
+use tokio::net::{TcpListener, TcpStream};
+
+type ClientWs = WebSocketStream<WsStream<Http1>>;
+
+async fn create_ws_pair() -> (axum_integration::WebSocketWriter, ClientWs) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server_task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let ws = axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
+        let (_reader, writer) = ws.split();
+        writer
+    });
+
+    let client_stream = TcpStream::connect(addr).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (client_ws, _): (ClientWs, _) = client
+        .connect(client_stream, &addr.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    let writer = server_task.await.unwrap();
+    (writer, client_ws)
+}
+
+fn insert_live_socket(
+    namespace: &Namespace,
+    socket_id: SocketId,
+    writer: axum_integration::WebSocketWriter,
+    user_id: &str,
+) -> WebSocketRef {
+    let mut ws = WebSocket::new(socket_id, writer);
+    ws.state.user_id = Some(user_id.to_string());
+    let ws_ref = WebSocketRef::new(ws);
+
+    namespace.sockets.insert(socket_id, ws_ref.clone());
+    namespace
+        .users
+        .entry(user_id.to_string())
+        .or_default()
+        .insert(socket_id);
+
+    ws_ref
+}
+
+fn insert_presence(namespace: &Namespace, socket_id: SocketId, channel: &str, user_id: &str) {
+    namespace
+        .presence_data
+        .entry(socket_id)
+        .or_default()
+        .insert(
+            channel.to_string(),
+            PresenceMemberInfo {
+                user_id: user_id.to_string(),
+                user_info: None,
+            },
+        );
+}
+
+async fn wait_for_close_frame(client: &mut ClientWs) -> Option<(u16, String)> {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            match client.next().await {
+                Some(Ok(sockudo_ws::Message::Close(Some(reason)))) => {
+                    return Some((reason.code, reason.reason.to_string()));
+                }
+                Some(Ok(sockudo_ws::Message::Close(None))) => return None,
+                Some(Ok(_)) => continue,
+                Some(Err(e)) => panic!("client read error: {e}"),
+                None => return None,
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for close frame")
+}
+
+#[tokio::test]
+async fn server_to_user_fanout_reaches_all_live_sockets() {
+    let namespace = Namespace::new("test-app".to_string());
+
+    let (writer_a1, mut client_a1) = create_ws_pair().await;
+    let (writer_a2, mut client_a2) = create_ws_pair().await;
+    let (writer_b, mut client_b) = create_ws_pair().await;
+
+    let sid_a1 = SocketId::new();
+    let sid_a2 = SocketId::new();
+    let sid_b = SocketId::new();
+
+    insert_live_socket(&namespace, sid_a1, writer_a1, "alice");
+    insert_live_socket(&namespace, sid_a2, writer_a2, "alice");
+    insert_live_socket(&namespace, sid_b, writer_b, "bob");
+
+    let alice_sockets = namespace.get_user_sockets("alice").unwrap();
+    assert_eq!(
+        alice_sockets.len(),
+        2,
+        "alice should have exactly 2 live sockets"
+    );
+
+    let payload = Bytes::from_static(b"{\"event\":\"test:fanout\",\"data\":{}}");
+    for ws_ref in &alice_sockets {
+        ws_ref.send_broadcast(payload.clone()).unwrap();
+    }
+
+    let frame_a1 = tokio::time::timeout(Duration::from_secs(2), client_a1.next())
+        .await
+        .expect("timed out waiting for alice socket 1")
+        .expect("alice socket 1 stream ended")
+        .expect("alice socket 1 read error");
+    assert!(
+        matches!(frame_a1, sockudo_ws::Message::Text(_)),
+        "alice socket 1 should receive a text frame, got: {frame_a1:?}"
+    );
+
+    let frame_a2 = tokio::time::timeout(Duration::from_secs(2), client_a2.next())
+        .await
+        .expect("timed out waiting for alice socket 2")
+        .expect("alice socket 2 stream ended")
+        .expect("alice socket 2 read error");
+    assert!(
+        matches!(frame_a2, sockudo_ws::Message::Text(_)),
+        "alice socket 2 should receive a text frame, got: {frame_a2:?}"
+    );
+
+    let bob_result = tokio::time::timeout(Duration::from_millis(80), client_b.next()).await;
+    assert!(
+        bob_result.is_err(),
+        "bob should not receive any frame from the alice-targeted fanout"
+    );
+}
+
+#[tokio::test]
+async fn stale_id_is_ignored_by_routing_and_counting() {
+    let namespace = Namespace::new("test-app".to_string());
+
+    let (writer, mut client) = create_ws_pair().await;
+    let live_sid = SocketId::new();
+    let stale_sid = SocketId::new();
+
+    let _ws_ref = insert_live_socket(&namespace, live_sid, writer, "alice");
+
+    namespace
+        .users
+        .entry("alice".to_string())
+        .or_default()
+        .insert(stale_sid);
+
+    assert_eq!(
+        namespace.users.get("alice").unwrap().len(),
+        2,
+        "users[alice] should contain 2 IDs (1 live + 1 stale)"
+    );
+
+    let resolved = namespace.get_user_sockets("alice").unwrap();
+    assert_eq!(
+        resolved.len(),
+        1,
+        "get_user_sockets must skip stale IDs; expected 1 live socket"
+    );
+    assert_eq!(
+        *resolved[0].get_socket_id_sync(),
+        live_sid,
+        "resolved socket must be the live one"
+    );
+
+    insert_presence(&namespace, live_sid, "presence-chat", "alice");
+
+    let count = namespace
+        .count_user_connections_in_channel("alice", "presence-chat", None)
+        .unwrap();
+    assert_eq!(
+        count, 1,
+        "count_user_connections_in_channel must return 1; stale ID has no presence_data"
+    );
+
+    namespace.terminate_user_connections("alice").await.unwrap();
+
+    let close = wait_for_close_frame(&mut client).await;
+    assert_eq!(
+        close,
+        Some((4009, "You got disconnected by the app.".to_string())),
+        "live socket must receive the exact terminate close frame"
+    );
+}
+
+#[tokio::test]
+async fn terminate_user_connections_closes_live_socket() {
+    let namespace = Namespace::new("test-app".to_string());
+
+    let (writer, mut client) = create_ws_pair().await;
+    let socket_id = SocketId::new();
+    insert_live_socket(&namespace, socket_id, writer, "alice");
+
+    namespace.terminate_user_connections("alice").await.unwrap();
+
+    let close = wait_for_close_frame(&mut client).await;
+    assert_eq!(
+        close,
+        Some((4009, "You got disconnected by the app.".to_string())),
+        "terminate_user_connections must preserve its exact close payload"
+    );
+}
+
+#[tokio::test]
+async fn force_reconnect_closes_live_socket() {
+    let namespace = Namespace::new("test-app".to_string());
+
+    let (writer, mut client) = create_ws_pair().await;
+    let socket_id = SocketId::new();
+    insert_live_socket(&namespace, socket_id, writer, "alice");
+
+    namespace
+        .force_reconnect_user_connections("alice")
+        .await
+        .unwrap();
+
+    let close = wait_for_close_frame(&mut client).await;
+    assert_eq!(
+        close,
+        Some((4200, "Force reconnect requested by the app.".to_string())),
+        "force_reconnect_user_connections must preserve its exact close payload"
+    );
+}

--- a/crates/sockudo-core/src/namespace.rs
+++ b/crates/sockudo-core/src/namespace.rs
@@ -18,10 +18,12 @@ pub struct Namespace {
     pub sockets: DashMap<SocketId, WebSocketRef>,
     pub channels: DashMap<String, DashSet<SocketId>>,
     wildcard_channels: DashSet<String>,
-    pub users: DashMap<String, DashSet<WebSocketRef>>,
+    pub users: DashMap<String, DashSet<SocketId>>,
     pub presence_data: DashMap<SocketId, HashMap<String, PresenceMemberInfo>>,
     // Reverse index of channels joined per socket, for O(channels-per-socket) disconnect cleanup.
     socket_channels: DashMap<SocketId, DashSet<String>>,
+    // Reverse index: socket → set of user IDs associated with that socket.
+    socket_users: DashMap<SocketId, DashSet<String>>,
 }
 
 pub struct SocketInitOptions {
@@ -42,6 +44,7 @@ impl Namespace {
             users: DashMap::new(),
             presence_data: DashMap::new(),
             socket_channels: DashMap::new(),
+            socket_users: DashMap::new(),
         }
     }
 
@@ -393,102 +396,66 @@ impl Namespace {
     }
 
     #[inline]
-    pub async fn get_user_sockets(&self, user_id: &str) -> Result<Vec<WebSocketRef>> {
-        match self.users.get(user_id) {
-            Some(user_sockets_ref) => Ok(user_sockets_ref.iter().map(|r| r.clone()).collect()),
-            None => Ok(Vec::new()),
-        }
+    pub fn get_user_sockets(&self, user_id: &str) -> Result<Vec<WebSocketRef>> {
+        let socket_ids: Vec<SocketId> = match self.users.get(user_id) {
+            Some(user_sockets_ref) => user_sockets_ref.iter().map(|r| *r.key()).collect(),
+            None => return Ok(Vec::new()),
+        };
+
+        Ok(socket_ids
+            .into_iter()
+            .filter_map(|sid| self.get_connection(&sid))
+            .collect())
     }
 
     pub async fn cleanup_connection(&self, ws_ref: WebSocketRef) {
         let socket_id = ws_ref.get_socket_id().await;
-
-        // Signal reader and writer tasks to stop
-        ws_ref.shutdown();
-
-        let channels_to_check: Vec<String> = self
-            .socket_channels
-            .remove(&socket_id)
-            .map(|(_, set)| set.iter().map(|c| c.key().clone()).collect())
-            .unwrap_or_default();
-
-        for channel_name in channels_to_check {
-            self.channels.remove_if(&channel_name, |_, set| {
-                set.remove(&socket_id);
-                set.is_empty()
-            });
-            if channel_name.contains('*') && !self.channels.contains_key(&channel_name) {
-                self.wildcard_channels.remove(&channel_name);
-            }
-        }
-
-        let user_id_option = ws_ref.get_user_id().await;
-
-        if let Some(user_id) = user_id_option
-            && let Some(user_sockets_ref) = self.users.get_mut(&user_id)
-        {
-            user_sockets_ref.remove(&ws_ref);
-            let is_empty = user_sockets_ref.is_empty();
-            drop(user_sockets_ref);
-            if is_empty {
-                self.users.remove(&user_id);
-                debug!("Removed empty user entry for: {}", user_id);
-            }
-        }
-
-        self.presence_data.remove(&socket_id);
-
-        if self.sockets.remove(&socket_id).is_some() {
-            debug!("Removed socket {} from main map.", socket_id);
-        } else {
-            warn!(
-                "Socket {} already removed from main map during cleanup.",
-                socket_id
-            );
-        }
+        self.remove_connection(&socket_id);
     }
 
     pub async fn terminate_user_connections(&self, user_id: &str) -> Result<()> {
-        if let Some(user_sockets_ref) = self.users.get(user_id) {
-            let user_sockets_snapshot = user_sockets_ref.clone();
-            drop(user_sockets_ref);
+        let socket_ids: Vec<SocketId> = match self.users.get(user_id) {
+            Some(user_sockets_ref) => user_sockets_ref.iter().map(|r| *r.key()).collect(),
+            None => return Ok(()),
+        };
 
-            let cleanup_tasks: Vec<_> = user_sockets_snapshot
-                .iter()
-                .map(|ws_ref| async move {
-                    if let Err(e) = ws_ref
-                        .close(4009, "You got disconnected by the app.".to_string())
-                        .await
-                    {
-                        warn!("Failed to close connection: {}", e);
-                    }
-                })
-                .collect();
+        let cleanup_tasks: Vec<_> = socket_ids
+            .into_iter()
+            .filter_map(|sid| self.get_connection(&sid))
+            .map(|ws_ref| async move {
+                if let Err(e) = ws_ref
+                    .close(4009, "You got disconnected by the app.".to_string())
+                    .await
+                {
+                    warn!(error = %e, "failed to close connection");
+                }
+            })
+            .collect();
 
-            join_all(cleanup_tasks).await;
-        }
+        join_all(cleanup_tasks).await;
         Ok(())
     }
 
     pub async fn force_reconnect_user_connections(&self, user_id: &str) -> Result<()> {
-        if let Some(user_sockets_ref) = self.users.get(user_id) {
-            let user_sockets_snapshot = user_sockets_ref.clone();
-            drop(user_sockets_ref);
+        let socket_ids: Vec<SocketId> = match self.users.get(user_id) {
+            Some(user_sockets_ref) => user_sockets_ref.iter().map(|r| *r.key()).collect(),
+            None => return Ok(()),
+        };
 
-            let cleanup_tasks: Vec<_> = user_sockets_snapshot
-                .iter()
-                .map(|ws_ref| async move {
-                    if let Err(e) = ws_ref
-                        .close(4200, "Force reconnect requested by the app.".to_string())
-                        .await
-                    {
-                        warn!(error = %e, "failed to close connection");
-                    }
-                })
-                .collect();
+        let cleanup_tasks: Vec<_> = socket_ids
+            .into_iter()
+            .filter_map(|sid| self.get_connection(&sid))
+            .map(|ws_ref| async move {
+                if let Err(e) = ws_ref
+                    .close(4200, "Force reconnect requested by the app.".to_string())
+                    .await
+                {
+                    warn!(error = %e, "failed to close connection");
+                }
+            })
+            .collect();
 
-            join_all(cleanup_tasks).await;
-        }
+        join_all(cleanup_tasks).await;
         Ok(())
     }
 
@@ -556,6 +523,19 @@ impl Namespace {
     }
 
     pub fn remove_connection(&self, socket_id: &SocketId) {
+        // 1. Linearization point: remove from authoritative map first.
+        let removed = self.sockets.remove(socket_id).map(|(_, ws_ref)| ws_ref);
+
+        // 2. Cancel the connection's reader/writer tasks.
+        if let Some(ws_ref) = removed.as_ref() {
+            ws_ref.shutdown();
+            debug!(socket_id = %socket_id, "removed socket from main map");
+        }
+
+        // 3. Exhaustive user cleanup via reverse index.
+        self.remove_socket_from_all_users(socket_id);
+
+        // 4. Exhaustive channel cleanup via reverse index.
         if let Some((_, channels)) = self.socket_channels.remove(socket_id) {
             for ch in channels.iter() {
                 let channel = ch.key();
@@ -568,9 +548,8 @@ impl Namespace {
                 }
             }
         }
-        if self.sockets.remove(socket_id).is_some() {
-            debug!("Explicitly removed socket: {}", socket_id);
-        }
+        // 5. Presence data cleanup.
+        self.presence_data.remove(socket_id);
     }
 
     pub fn get_channel(&self, channel: &str) -> Result<DashSet<SocketId>> {
@@ -617,40 +596,55 @@ impl Namespace {
     }
 
     pub async fn add_user(&self, ws_ref: WebSocketRef) -> Result<()> {
-        let user_id_option = ws_ref.get_user_id().await;
+        let socket_id = *ws_ref.get_socket_id_sync();
 
-        if let Some(user_id) = user_id_option {
-            let user_sockets_ref = self.users.entry(user_id.clone()).or_default();
-            user_sockets_ref.insert(ws_ref.clone());
-            let socket_id = ws_ref.get_socket_id().await;
-            debug!("Added socket {} to user {}", socket_id, user_id);
-        } else {
-            let socket_id = ws_ref.get_socket_id().await;
-            warn!(
-                "User data found for socket {} but missing user ID.",
-                socket_id
-            );
+        let user_id = {
+            let connection = ws_ref.inner.lock().await;
+            if connection.state.disconnecting {
+                return Ok(());
+            }
+            connection.state.user_id.clone()
+        };
+
+        let Some(user_id) = user_id else {
+            warn!(socket_id = %socket_id, "socket has no user id");
+            return Ok(());
+        };
+
+        if !self.sockets.contains_key(&socket_id) {
+            return Ok(());
         }
+
+        self.socket_users
+            .entry(socket_id)
+            .or_default()
+            .insert(user_id.clone());
+        self.users
+            .entry(user_id.clone())
+            .or_default()
+            .insert(socket_id);
+
+        let still_valid = self.sockets.contains_key(&socket_id) && {
+            let connection = ws_ref.inner.lock().await;
+            !connection.state.disconnecting
+        };
+
+        if !still_valid {
+            self.remove_user_socket_association(&user_id, &socket_id);
+        } else {
+            debug!(socket_id = %socket_id, user_id = %user_id, "added socket to user");
+        }
+
         Ok(())
     }
 
     pub async fn remove_user(&self, ws_ref: WebSocketRef) -> Result<()> {
+        let socket_id = *ws_ref.get_socket_id_sync();
         let user_id_option = ws_ref.get_user_id().await;
-        let socket_id = ws_ref.get_socket_id().await;
 
         if let Some(user_id) = user_id_option {
-            if let Some(user_sockets_ref) = self.users.get_mut(&user_id) {
-                let removed = user_sockets_ref.remove(&ws_ref);
-                let is_empty = user_sockets_ref.is_empty();
-                drop(user_sockets_ref);
-                if removed.is_some() {
-                    debug!("Removed socket {} from user {}", socket_id, user_id);
-                }
-                if is_empty {
-                    self.users.remove(&user_id);
-                    debug!("Removed empty user entry for: {}", user_id);
-                }
-            }
+            self.remove_user_socket_association(&user_id, &socket_id);
+            debug!(socket_id = %socket_id, user_id = %user_id, "removed socket from user");
         } else {
             warn!(
                 "User data found for socket {} during removal but missing user ID.",
@@ -660,37 +654,9 @@ impl Namespace {
         Ok(())
     }
 
-    pub async fn remove_user_socket(&self, user_id: &str, socket_id: &SocketId) -> Result<()> {
-        if let Some(user_sockets_ref) = self.users.get_mut(user_id) {
-            let mut found_socket = None;
-
-            for ws_ref in user_sockets_ref.iter() {
-                let ws_socket_id = ws_ref.get_socket_id().await;
-                if ws_socket_id == *socket_id {
-                    found_socket = Some(ws_ref.clone());
-                    break;
-                }
-            }
-
-            if let Some(ws_ref) = found_socket {
-                user_sockets_ref.remove(&ws_ref);
-            }
-
-            let is_empty = user_sockets_ref.is_empty();
-            drop(user_sockets_ref);
-
-            if is_empty {
-                self.users.remove(user_id);
-                debug!("Removed empty user entry for: {}", user_id);
-            }
-
-            debug!("Removed socket {} from user {}", socket_id, user_id);
-        } else {
-            debug!(
-                "User {} not found when removing socket {}",
-                user_id, socket_id
-            );
-        }
+    pub fn remove_user_socket(&self, user_id: &str, socket_id: &SocketId) -> Result<()> {
+        self.remove_user_socket_association(user_id, socket_id);
+        debug!(socket_id = %socket_id, user_id = %user_id, "removed socket from user");
         Ok(())
     }
 
@@ -703,8 +669,8 @@ impl Namespace {
         let mut count = 0;
 
         if let Some(user_sockets_ref) = self.users.get(user_id) {
-            for ws_ref in user_sockets_ref.iter() {
-                let socket_id = ws_ref.get_socket_id_sync();
+            for entry in user_sockets_ref.iter() {
+                let socket_id = entry.key();
                 if excluding_socket == Some(socket_id) {
                     continue;
                 }
@@ -739,6 +705,29 @@ impl Namespace {
             .iter()
             .map(|entry| (*entry.key(), entry.value().clone()))
             .collect())
+    }
+
+    fn remove_user_socket_association(&self, user_id: &str, socket_id: &SocketId) {
+        self.users.remove_if(user_id, |_, socket_ids| {
+            socket_ids.remove(socket_id);
+            socket_ids.is_empty()
+        });
+        self.socket_users.remove_if(socket_id, |_, user_ids| {
+            user_ids.remove(user_id);
+            user_ids.is_empty()
+        });
+    }
+
+    fn remove_socket_from_all_users(&self, socket_id: &SocketId) {
+        if let Some((_, user_ids)) = self.socket_users.remove(socket_id) {
+            for user_id_entry in user_ids.iter() {
+                let user_id = user_id_entry.key();
+                self.users.remove_if(user_id.as_str(), |_, socket_ids| {
+                    socket_ids.remove(socket_id);
+                    socket_ids.is_empty()
+                });
+            }
+        }
     }
 }
 
@@ -1003,5 +992,668 @@ mod tests {
             0,
             "channel must be empty after all sockets leave"
         );
+    }
+
+    fn assert_user_index_bidirectional(namespace: &Namespace) {
+        for entry in namespace.socket_users.iter() {
+            let socket_id = entry.key();
+            for user_id_entry in entry.value().iter() {
+                let user_id = user_id_entry.key();
+                assert!(
+                    namespace
+                        .users
+                        .get(user_id.as_str())
+                        .is_some_and(|s| s.contains(socket_id)),
+                    "socket_users[{socket_id}] contains {user_id} but users[{user_id}] does not contain {socket_id}"
+                );
+            }
+        }
+        for entry in namespace.users.iter() {
+            let user_id = entry.key();
+            for socket_id_entry in entry.value().iter() {
+                let socket_id = socket_id_entry.key();
+                assert!(
+                    namespace
+                        .socket_users
+                        .get(socket_id)
+                        .is_some_and(|u| u.contains(user_id.as_str())),
+                    "users[{user_id}] contains {socket_id} but socket_users[{socket_id}] does not contain {user_id}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn live_user_association_resolves_through_sockets() {
+        let namespace = Namespace::new("app".to_string());
+        let socket_id = SocketId::new();
+        let writer = create_server_writer().await;
+        let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(TestAppManager {
+            app: App::from_policy(
+                "app".to_string(),
+                "app-key".to_string(),
+                "app-secret".to_string(),
+                true,
+                AppPolicy::default(),
+            ),
+        });
+
+        let ws_ref = namespace
+            .add_socket(
+                socket_id,
+                writer,
+                app_manager,
+                SocketInitOptions {
+                    buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    append_mode: sockudo_protocol::AppendMode::Delta,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        {
+            let mut conn = ws_ref.inner.lock().await;
+            conn.state.user_id = Some("user-1".to_string());
+        }
+
+        namespace.add_user(ws_ref.clone()).await.unwrap();
+
+        assert!(namespace.users.get("user-1").is_some());
+        assert!(namespace.users.get("user-1").unwrap().contains(&socket_id));
+        assert!(namespace.socket_users.get(&socket_id).is_some());
+        assert!(
+            namespace
+                .socket_users
+                .get(&socket_id)
+                .unwrap()
+                .contains("user-1")
+        );
+
+        let resolved = namespace.get_user_sockets("user-1").unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(*resolved[0].get_socket_id_sync(), socket_id);
+
+        assert_user_index_bidirectional(&namespace);
+    }
+
+    #[tokio::test]
+    async fn late_user_association_rolls_back_when_socket_gone() {
+        let namespace = Namespace::new("app".to_string());
+        let socket_id = SocketId::new();
+        let writer = create_server_writer().await;
+        let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(TestAppManager {
+            app: App::from_policy(
+                "app".to_string(),
+                "app-key".to_string(),
+                "app-secret".to_string(),
+                true,
+                AppPolicy::default(),
+            ),
+        });
+
+        let ws_ref = namespace
+            .add_socket(
+                socket_id,
+                writer,
+                app_manager,
+                SocketInitOptions {
+                    buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    append_mode: sockudo_protocol::AppendMode::Delta,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        {
+            let mut conn = ws_ref.inner.lock().await;
+            conn.state.user_id = Some("user-late".to_string());
+        }
+
+        namespace.sockets.remove(&socket_id);
+
+        namespace.add_user(ws_ref.clone()).await.unwrap();
+
+        assert!(
+            namespace.users.get("user-late").is_none(),
+            "user entry should have been rolled back"
+        );
+        assert!(
+            namespace.socket_users.get(&socket_id).is_none(),
+            "socket_users entry should have been rolled back"
+        );
+
+        let resolved = namespace.get_user_sockets("user-late").unwrap();
+        assert!(resolved.is_empty());
+
+        assert_user_index_bidirectional(&namespace);
+    }
+
+    #[tokio::test]
+    async fn remove_user_socket_association_cleans_both_indexes() {
+        let namespace = Namespace::new("app".to_string());
+        let s1 = SocketId::new();
+        let s2 = SocketId::new();
+        let writer1 = create_server_writer().await;
+        let writer2 = create_server_writer().await;
+        let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(TestAppManager {
+            app: App::from_policy(
+                "app".to_string(),
+                "app-key".to_string(),
+                "app-secret".to_string(),
+                true,
+                AppPolicy::default(),
+            ),
+        });
+
+        let ws1 = namespace
+            .add_socket(
+                s1,
+                writer1,
+                app_manager.clone(),
+                SocketInitOptions {
+                    buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    append_mode: sockudo_protocol::AppendMode::Delta,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        let ws2 = namespace
+            .add_socket(
+                s2,
+                writer2,
+                app_manager,
+                SocketInitOptions {
+                    buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    append_mode: sockudo_protocol::AppendMode::Delta,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        {
+            let mut conn = ws1.inner.lock().await;
+            conn.state.user_id = Some("shared-user".to_string());
+        }
+        {
+            let mut conn = ws2.inner.lock().await;
+            conn.state.user_id = Some("shared-user".to_string());
+        }
+
+        namespace.add_user(ws1.clone()).await.unwrap();
+        namespace.add_user(ws2.clone()).await.unwrap();
+        assert_user_index_bidirectional(&namespace);
+
+        assert_eq!(namespace.users.get("shared-user").unwrap().len(), 2);
+
+        namespace.remove_user_socket_association("shared-user", &s1);
+
+        assert_eq!(namespace.users.get("shared-user").unwrap().len(), 1);
+        assert!(namespace.users.get("shared-user").unwrap().contains(&s2));
+        assert!(namespace.socket_users.get(&s1).is_none());
+        assert_user_index_bidirectional(&namespace);
+
+        namespace.remove_user_socket_association("shared-user", &s2);
+
+        assert!(namespace.users.get("shared-user").is_none());
+        assert!(namespace.socket_users.get(&s2).is_none());
+        assert_user_index_bidirectional(&namespace);
+    }
+
+    #[tokio::test]
+    async fn remove_socket_from_all_users_cleans_all_associations() {
+        let namespace = Namespace::new("app".to_string());
+        let socket_id = SocketId::new();
+        let writer = create_server_writer().await;
+        let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(TestAppManager {
+            app: App::from_policy(
+                "app".to_string(),
+                "app-key".to_string(),
+                "app-secret".to_string(),
+                true,
+                AppPolicy::default(),
+            ),
+        });
+
+        let ws_ref = namespace
+            .add_socket(
+                socket_id,
+                writer,
+                app_manager,
+                SocketInitOptions {
+                    buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    append_mode: sockudo_protocol::AppendMode::Delta,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        {
+            let mut conn = ws_ref.inner.lock().await;
+            conn.state.user_id = Some("user-a".to_string());
+        }
+        namespace.add_user(ws_ref.clone()).await.unwrap();
+
+        namespace
+            .socket_users
+            .entry(socket_id)
+            .or_default()
+            .insert("user-b".to_string());
+        namespace
+            .users
+            .entry("user-b".to_string())
+            .or_default()
+            .insert(socket_id);
+
+        assert_user_index_bidirectional(&namespace);
+
+        namespace.remove_socket_from_all_users(&socket_id);
+
+        assert!(namespace.socket_users.get(&socket_id).is_none());
+        assert!(namespace.users.get("user-a").is_none());
+        assert!(namespace.users.get("user-b").is_none());
+        assert_user_index_bidirectional(&namespace);
+    }
+
+    #[tokio::test]
+    async fn exhaustive_teardown_removes_all_state() {
+        use crate::channel::PresenceMemberInfo;
+
+        let namespace = Namespace::new("app".to_string());
+        let socket_id = SocketId::new();
+        let writer = create_server_writer().await;
+        let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(TestAppManager {
+            app: App::from_policy(
+                "app".to_string(),
+                "app-key".to_string(),
+                "app-secret".to_string(),
+                true,
+                AppPolicy::default(),
+            ),
+        });
+
+        let ws_ref = namespace
+            .add_socket(
+                socket_id,
+                writer,
+                app_manager,
+                SocketInitOptions {
+                    buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    append_mode: sockudo_protocol::AppendMode::Delta,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Two user IDs
+        {
+            let mut conn = ws_ref.inner.lock().await;
+            conn.state.user_id = Some("user-alpha".to_string());
+        }
+        namespace.add_user(ws_ref.clone()).await.unwrap();
+        namespace
+            .socket_users
+            .entry(socket_id)
+            .or_default()
+            .insert("user-beta".to_string());
+        namespace
+            .users
+            .entry("user-beta".to_string())
+            .or_default()
+            .insert(socket_id);
+
+        // Two channels (one wildcard)
+        namespace.add_channel_to_socket("presence-room", &socket_id);
+        namespace.add_channel_to_socket("events-*", &socket_id);
+
+        // Presence data
+        let mut per_socket = ahash::AHashMap::new();
+        per_socket.insert(
+            "presence-room".to_string(),
+            PresenceMemberInfo {
+                user_id: "user-alpha".to_string(),
+                user_info: None,
+            },
+        );
+        namespace.presence_data.insert(socket_id, per_socket);
+
+        let token = ws_ref.shutdown_token.clone();
+
+        // Act
+        namespace.remove_connection(&socket_id);
+
+        // Assert: authoritative map
+        assert!(namespace.sockets.get(&socket_id).is_none());
+
+        // Assert: token cancelled
+        assert!(token.is_cancelled());
+
+        // Assert: user indexes
+        assert!(namespace.users.get("user-alpha").is_none());
+        assert!(namespace.users.get("user-beta").is_none());
+        assert!(namespace.socket_users.get(&socket_id).is_none());
+
+        // Assert: channel indexes
+        assert!(!namespace.is_in_channel("presence-room", &socket_id));
+        assert!(!namespace.is_in_channel("events-*", &socket_id));
+        assert!(namespace.socket_channels.get(&socket_id).is_none());
+        assert!(!namespace.wildcard_channels.contains("events-*"));
+
+        // Assert: presence data
+        assert!(namespace.presence_data.get(&socket_id).is_none());
+
+        assert_user_index_bidirectional(&namespace);
+    }
+
+    #[tokio::test]
+    async fn duplicate_removal_is_harmless() {
+        let namespace = Namespace::new("app".to_string());
+        let socket_id = SocketId::new();
+        let writer = create_server_writer().await;
+        let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(TestAppManager {
+            app: App::from_policy(
+                "app".to_string(),
+                "app-key".to_string(),
+                "app-secret".to_string(),
+                true,
+                AppPolicy::default(),
+            ),
+        });
+
+        let ws_ref = namespace
+            .add_socket(
+                socket_id,
+                writer,
+                app_manager,
+                SocketInitOptions {
+                    buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    append_mode: sockudo_protocol::AppendMode::Delta,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        {
+            let mut conn = ws_ref.inner.lock().await;
+            conn.state.user_id = Some("user-dup".to_string());
+        }
+        namespace.add_user(ws_ref.clone()).await.unwrap();
+        namespace.add_channel_to_socket("ch-1", &socket_id);
+
+        // First removal: comprehensive teardown
+        namespace.remove_connection(&socket_id);
+
+        // Second removal: must be a no-op, no panic
+        namespace.remove_connection(&socket_id);
+
+        assert!(namespace.sockets.get(&socket_id).is_none());
+        assert!(namespace.users.get("user-dup").is_none());
+        assert!(namespace.socket_users.get(&socket_id).is_none());
+        assert!(namespace.socket_channels.get(&socket_id).is_none());
+        assert!(namespace.presence_data.get(&socket_id).is_none());
+        assert!(!namespace.is_in_channel("ch-1", &socket_id));
+    }
+
+    /// Covers the ordering where association completes before authoritative
+    /// removal. Teardown must drain both user indexes without retaining the
+    /// connection.
+    #[tokio::test]
+    async fn add_user_before_remove_connection_drains_indexes() {
+        let namespace = Namespace::new("app".to_string());
+        let socket_id = SocketId::new();
+        let writer = create_server_writer().await;
+        let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(TestAppManager {
+            app: App::from_policy(
+                "app".to_string(),
+                "app-key".to_string(),
+                "app-secret".to_string(),
+                true,
+                AppPolicy::default(),
+            ),
+        });
+
+        let ws_ref = namespace
+            .add_socket(
+                socket_id,
+                writer,
+                app_manager,
+                SocketInitOptions {
+                    buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    append_mode: sockudo_protocol::AppendMode::Delta,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        {
+            let mut conn = ws_ref.inner.lock().await;
+            conn.state.user_id = Some("alice".to_string());
+        }
+        let token = ws_ref.shutdown_token.clone();
+
+        namespace.add_user(ws_ref.clone()).await.unwrap();
+        assert!(namespace.users.get("alice").unwrap().contains(&socket_id));
+        assert!(
+            namespace
+                .socket_users
+                .get(&socket_id)
+                .unwrap()
+                .contains("alice")
+        );
+
+        namespace.remove_connection(&socket_id);
+
+        assert!(
+            namespace.users.is_empty(),
+            "users must be empty after removal"
+        );
+        assert!(
+            namespace.socket_users.is_empty(),
+            "socket_users must be empty after removal"
+        );
+        assert!(
+            namespace.sockets.is_empty(),
+            "sockets must be empty after removal"
+        );
+        assert!(token.is_cancelled(), "shutdown token must be cancelled");
+        assert_user_index_bidirectional(&namespace);
+    }
+
+    /// Race scenario 2: `remove_connection` completes first (removes socket from
+    /// the authoritative map), and only then `add_user` runs. `add_user` sees
+    /// `sockets.contains_key` = false at its pre-check and returns early without
+    /// inserting anything.
+    ///
+    /// Uses a oneshot channel to enforce strict ordering: `remove_connection`
+    /// signals completion, then `add_user` proceeds.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn remove_connection_before_add_user_prevents_insertion() {
+        use std::time::Duration;
+
+        let namespace = Arc::new(Namespace::new("app".to_string()));
+        let socket_id = SocketId::new();
+        let writer = create_server_writer().await;
+        let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(TestAppManager {
+            app: App::from_policy(
+                "app".to_string(),
+                "app-key".to_string(),
+                "app-secret".to_string(),
+                true,
+                AppPolicy::default(),
+            ),
+        });
+
+        let ws_ref = namespace
+            .add_socket(
+                socket_id,
+                writer,
+                app_manager,
+                SocketInitOptions {
+                    buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                    protocol_version: ProtocolVersion::V2,
+                    wire_format: WireFormat::Json,
+                    append_mode: sockudo_protocol::AppendMode::Delta,
+                    echo_messages: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        {
+            let mut conn = ws_ref.inner.lock().await;
+            conn.state.user_id = Some("alice".to_string());
+        }
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+
+        let ns_rm = Arc::clone(&namespace);
+        let remove_task = tokio::spawn(async move {
+            ns_rm.remove_connection(&socket_id);
+            tx.send(()).expect("signal send failed");
+        });
+
+        let ns_add = Arc::clone(&namespace);
+        let ws_add = ws_ref.clone();
+        let add_task = tokio::spawn(async move {
+            rx.await.expect("signal recv failed");
+            ns_add.add_user(ws_add).await.unwrap();
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let (rr, ra) = tokio::join!(remove_task, add_task);
+            rr.expect("remove_connection task panicked");
+            ra.expect("add_user task panicked");
+        })
+        .await
+        .expect("test timed out after 5s");
+
+        assert!(
+            namespace.users.is_empty(),
+            "users must be empty when remove_connection runs first"
+        );
+        assert!(
+            namespace.socket_users.is_empty(),
+            "socket_users must be empty when remove_connection runs first"
+        );
+        assert!(
+            namespace.sockets.is_empty(),
+            "sockets must be empty after remove_connection"
+        );
+        assert_user_index_bidirectional(&namespace);
+    }
+
+    /// Churn test: N sockets all associated with user "alice", each concurrently
+    /// added via `add_user` then removed via `remove_connection`. Final state must
+    /// be completely clean: no user entries, no socket_users entries, no sockets,
+    /// and all shutdown tokens cancelled.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_add_remove_churn_leaves_empty_indexes() {
+        use std::time::Duration;
+        use tokio::task::JoinSet;
+
+        let n: usize = 16;
+        let namespace = Arc::new(Namespace::new("app".to_string()));
+        let app_manager: Arc<dyn AppManager + Send + Sync> = Arc::new(TestAppManager {
+            app: App::from_policy(
+                "app".to_string(),
+                "app-key".to_string(),
+                "app-secret".to_string(),
+                true,
+                AppPolicy::default(),
+            ),
+        });
+
+        let mut socket_pairs = Vec::with_capacity(n);
+        for _ in 0..n {
+            let socket_id = SocketId::new();
+            let writer = create_server_writer().await;
+            let ws_ref = namespace
+                .add_socket(
+                    socket_id,
+                    writer,
+                    app_manager.clone(),
+                    SocketInitOptions {
+                        buffer_config: crate::websocket::WebSocketBufferConfig::default(),
+                        protocol_version: ProtocolVersion::V2,
+                        wire_format: WireFormat::Json,
+                        append_mode: sockudo_protocol::AppendMode::Delta,
+                        echo_messages: true,
+                    },
+                )
+                .await
+                .unwrap();
+            {
+                let mut conn = ws_ref.inner.lock().await;
+                conn.state.user_id = Some("alice".to_string());
+            }
+            socket_pairs.push((socket_id, ws_ref));
+        }
+
+        let tokens: Vec<_> = socket_pairs
+            .iter()
+            .map(|(_, ws)| ws.shutdown_token.clone())
+            .collect();
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(n));
+        let mut join_set = JoinSet::new();
+
+        for (socket_id, ws_ref) in socket_pairs {
+            let ns = Arc::clone(&namespace);
+            let bar = Arc::clone(&barrier);
+            join_set.spawn(async move {
+                bar.wait().await;
+                ns.add_user(ws_ref).await.unwrap();
+                ns.remove_connection(&socket_id);
+            });
+        }
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some(res) = join_set.join_next().await {
+                res.expect("churn task panicked");
+            }
+        })
+        .await
+        .expect("churn test timed out after 5s");
+
+        assert!(
+            namespace.users.is_empty(),
+            "users must be empty after churn"
+        );
+        assert!(
+            namespace.socket_users.is_empty(),
+            "socket_users must be empty after churn"
+        );
+        assert!(
+            namespace.sockets.is_empty(),
+            "sockets must be empty after churn"
+        );
+        for (i, token) in tokens.iter().enumerate() {
+            assert!(token.is_cancelled(), "shutdown token {i} must be cancelled");
+        }
+        assert_user_index_bidirectional(&namespace);
     }
 }

--- a/crates/sockudo-core/src/websocket/connection.rs
+++ b/crates/sockudo-core/src/websocket/connection.rs
@@ -97,7 +97,7 @@ impl WebSocket {
         }
 
         self.state.status = ConnectionStatus::Closing;
-        self.message_sender.send_close(code, &reason)?;
+        self.message_sender.send_close(code, &reason).await?;
         self.state.clear_timeouts();
         self.state.status = ConnectionStatus::Closed;
 

--- a/crates/sockudo-core/src/websocket/sender.rs
+++ b/crates/sockudo-core/src/websocket/sender.rs
@@ -4,6 +4,7 @@ use crossfire::{TrySendError, mpsc};
 use sockudo_ws::Message;
 use sockudo_ws::axum_integration::WebSocketWriter;
 use std::sync::Arc;
+use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, warn};
@@ -12,6 +13,7 @@ use tracing::{debug, error, warn};
 #[derive(Debug)]
 pub struct MessageSender {
     sender: MessageSenderHandle,
+    close_flushed: Arc<Notify>,
     receiver_handle: Option<JoinHandle<()>>,
 }
 
@@ -53,6 +55,8 @@ impl MessageSender {
         shutdown_token: CancellationToken,
     ) -> Self {
         let (sender, receiver) = mpsc::bounded_async::<Message>(buffer_capacity);
+        let close_flushed = Arc::new(Notify::new());
+        let writer_close_flushed = Arc::clone(&close_flushed);
 
         let receiver_handle = tokio::spawn(async move {
             let mut msg_count = 0;
@@ -99,17 +103,25 @@ impl MessageSender {
                             Ok(message) => {
                                 msg_count += 1;
 
-                                if matches!(message, Message::Close(_)) {
+                                let is_close = matches!(message, Message::Close(_));
+                                if is_close {
                                     is_shutting_down = true;
                                 }
 
-                                if let Err(e) = socket.send(message).await {
+                                let send_result = socket.send(message).await;
+                                if is_close {
+                                    writer_close_flushed.notify_one();
+                                }
+                                if let Err(e) = send_result {
                                     Self::log_connection_error(
                                         &e,
                                         SocketOperation::WriteFrame,
                                         msg_count,
                                         is_shutting_down,
                                     );
+                                    break;
+                                }
+                                if is_close {
                                     break;
                                 }
                             }
@@ -122,13 +134,14 @@ impl MessageSender {
                 }
             }
 
-            if let Err(e) = socket.close(1000, "Normal closure").await {
+            if !is_shutting_down && let Err(e) = socket.close(1000, "Normal closure").await {
                 Self::log_connection_error(&e, SocketOperation::SendCloseFrame, msg_count, true);
             }
         });
 
         Self {
             sender,
+            close_flushed,
             receiver_handle: Some(receiver_handle),
         }
     }
@@ -172,6 +185,8 @@ impl MessageSender {
 
     pub fn new(mut socket: WebSocketWriter, buffer_capacity: usize) -> Self {
         let (sender, receiver) = mpsc::bounded_async::<Message>(buffer_capacity);
+        let close_flushed = Arc::new(Notify::new());
+        let writer_close_flushed = Arc::clone(&close_flushed);
 
         let receiver_handle = tokio::spawn(async move {
             let mut msg_count = 0;
@@ -180,11 +195,16 @@ impl MessageSender {
             while let Ok(message) = receiver.recv().await {
                 msg_count += 1;
 
-                if matches!(message, Message::Close(_)) {
+                let is_close = matches!(message, Message::Close(_));
+                if is_close {
                     is_shutting_down = true;
                 }
 
-                if let Err(e) = socket.send(message).await {
+                let send_result = socket.send(message).await;
+                if is_close {
+                    writer_close_flushed.notify_one();
+                }
+                if let Err(e) = send_result {
                     Self::log_connection_error(
                         &e,
                         SocketOperation::WriteFrame,
@@ -193,15 +213,19 @@ impl MessageSender {
                     );
                     break;
                 }
+                if is_close {
+                    break;
+                }
             }
 
-            if let Err(e) = socket.close(1000, "Normal closure").await {
+            if !is_shutting_down && let Err(e) = socket.close(1000, "Normal closure").await {
                 Self::log_connection_error(&e, SocketOperation::SendCloseFrame, msg_count, true);
             }
         });
 
         Self {
             sender,
+            close_flushed,
             receiver_handle: Some(receiver_handle),
         }
     }
@@ -234,9 +258,12 @@ impl MessageSender {
         self.send(Message::text(text))
     }
 
-    pub fn send_close(&self, code: u16, reason: &str) -> Result<()> {
+    pub async fn send_close(&self, code: u16, reason: &str) -> Result<()> {
+        let flushed = self.close_flushed.notified();
         self.send(Message::Close(Some(sockudo_ws::error::CloseReason::new(
             code, reason,
-        ))))
+        ))))?;
+        flushed.await;
+        Ok(())
     }
 }

--- a/crates/sockudo-core/src/websocket/sender.rs
+++ b/crates/sockudo-core/src/websocket/sender.rs
@@ -14,6 +14,7 @@ use tracing::{debug, error, warn};
 pub struct MessageSender {
     sender: MessageSenderHandle,
     close_flushed: Arc<Notify>,
+    shutdown_token: Option<CancellationToken>,
     receiver_handle: Option<JoinHandle<()>>,
 }
 
@@ -57,6 +58,7 @@ impl MessageSender {
         let (sender, receiver) = mpsc::bounded_async::<Message>(buffer_capacity);
         let close_flushed = Arc::new(Notify::new());
         let writer_close_flushed = Arc::clone(&close_flushed);
+        let close_shutdown_token = shutdown_token.clone();
 
         let receiver_handle = tokio::spawn(async move {
             let mut msg_count = 0;
@@ -142,6 +144,7 @@ impl MessageSender {
         Self {
             sender,
             close_flushed,
+            shutdown_token: Some(close_shutdown_token),
             receiver_handle: Some(receiver_handle),
         }
     }
@@ -226,6 +229,7 @@ impl MessageSender {
         Self {
             sender,
             close_flushed,
+            shutdown_token: None,
             receiver_handle: Some(receiver_handle),
         }
     }
@@ -263,7 +267,18 @@ impl MessageSender {
         self.send(Message::Close(Some(sockudo_ws::error::CloseReason::new(
             code, reason,
         ))))?;
-        flushed.await;
-        Ok(())
+
+        if let Some(shutdown_token) = &self.shutdown_token {
+            tokio::select! {
+                biased;
+                _ = flushed => Ok(()),
+                _ = shutdown_token.cancelled() => Err(Error::ConnectionClosed(
+                    "WebSocket writer stopped before flushing close frame".into(),
+                )),
+            }
+        } else {
+            flushed.await;
+            Ok(())
+        }
     }
 }

--- a/crates/sockudo-core/src/websocket/tests/mod.rs
+++ b/crates/sockudo-core/src/websocket/tests/mod.rs
@@ -839,6 +839,33 @@ async fn close_frame_delivered_before_cancellation() {
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn close_wait_returns_error_when_writer_is_cancelled_before_flush() {
+    let socket_id = SocketId::new();
+    let (writer, _client) = create_server_writer_with_client().await;
+    let ws = WebSocket::new(socket_id, writer);
+    let ws_ref = WebSocketRef::new(ws);
+
+    ws_ref.shutdown();
+
+    let close_result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        ws_ref
+            .inner
+            .lock()
+            .await
+            .message_sender
+            .send_close(4009, "user connection terminated")
+            .await
+    })
+    .await
+    .expect("send_close() must not wait forever after writer cancellation");
+
+    assert!(
+        matches!(close_result, Err(crate::error::Error::ConnectionClosed(_))),
+        "cancelled writer must report that the close frame was not flushed: {close_result:?}"
+    );
+}
+
 #[tokio::test]
 async fn shutdown_cancels_task_while_handle_retained() {
     use sockudo_ws::Message;

--- a/crates/sockudo-core/src/websocket/tests/mod.rs
+++ b/crates/sockudo-core/src/websocket/tests/mod.rs
@@ -779,3 +779,106 @@ async fn test_shutdown_token_cancels_receiver() {
         "shutdown() must cancel the CancellationToken so the receiver task exits"
     );
 }
+
+#[tokio::test]
+async fn close_frame_delivered_before_cancellation() {
+    use sockudo_ws::Message;
+
+    let socket_id = SocketId::new();
+    let (writer, mut client) = create_server_writer_with_client().await;
+    let ws = WebSocket::new(socket_id, writer);
+    let ws_ref = WebSocketRef::new(ws);
+    let token = ws_ref.cancellation_token();
+
+    assert!(
+        !token.is_cancelled(),
+        "precondition: shutdown token must not be pre-cancelled"
+    );
+
+    let close_result = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        ws_ref.close(4009, "user connection terminated".to_string()),
+    )
+    .await
+    .expect("close() must complete within 2 s");
+
+    assert!(
+        close_result.is_ok(),
+        "close() returned Err — the close frame was not enqueued before cancellation \
+         (channel was already disconnected, meaning token fired before enqueue): {close_result:?}"
+    );
+
+    assert!(
+        token.is_cancelled(),
+        "shutdown token must be cancelled by the time close() returns"
+    );
+
+    let close_frame_received = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            match client.next().await {
+                Some(Ok(Message::Close(Some(frame)))) => {
+                    assert_eq!(frame.code, 4009);
+                    assert_eq!(frame.reason.as_str(), "user connection terminated");
+                    return true;
+                }
+                Some(Ok(Message::Close(None))) => {
+                    panic!("close frame must include the requested code and reason")
+                }
+                Some(Ok(_)) => continue,
+                Some(Err(e)) => panic!("client read error: {e}"),
+                None => return false,
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for close frame at client");
+
+    assert!(
+        close_frame_received,
+        "client stream ended without delivering a close frame"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_cancels_task_while_handle_retained() {
+    use sockudo_ws::Message;
+
+    let socket_id = SocketId::new();
+    let (writer, client) = create_server_writer_with_client().await;
+    let ws = WebSocket::new(socket_id, writer);
+    let ws_ref = WebSocketRef::new(ws);
+
+    let _retained_sender = ws_ref.message_sender.clone();
+
+    ws_ref.shutdown();
+
+    assert!(
+        ws_ref.cancellation_token().is_cancelled(),
+        "shutdown() must cancel the token synchronously"
+    );
+
+    let (task_done_tx, task_done_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let mut client = client;
+        loop {
+            match client.next().await {
+                Some(Ok(Message::Close(_))) => {
+                    let _ = task_done_tx.send(());
+                    break;
+                }
+                Some(Ok(_)) => continue,
+                _ => break,
+            }
+        }
+    });
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), task_done_rx)
+        .await
+        .expect(
+            "writer task did not terminate within 2 s — \
+             cancellation must drive task exit even with retained sender handle",
+        )
+        .expect("completion oneshot closed without firing");
+
+    drop(_retained_sender);
+}

--- a/crates/sockudo-server/src/cleanup/worker.rs
+++ b/crates/sockudo-server/src/cleanup/worker.rs
@@ -236,27 +236,12 @@ impl CleanupWorker {
 
         debug!("Removing {} connections", connections.len());
 
-        for (socket_id, app_id, user_id) in connections.into_iter() {
-            let result = {
-                let remove_result = self
-                    .connection_manager
-                    .remove_connection(&socket_id, &app_id)
-                    .await;
-
-                if let Some(uid) = &user_id
-                    && let Err(e) = self
-                        .connection_manager
-                        .remove_user_socket(uid, &socket_id, &app_id)
-                        .await
-                {
-                    warn!(
-                        "Failed to remove user socket mapping for {}: {}",
-                        socket_id, e
-                    );
-                }
-
-                remove_result
-            };
+        for (socket_id, app_id, _user_id) in connections {
+            // Comprehensive: handles shutdown, user-socket mappings, channels, and presence.
+            let result = self
+                .connection_manager
+                .remove_connection(&socket_id, &app_id)
+                .await;
 
             if let Err(e) = result {
                 warn!("Failed to remove connection {}: {}", socket_id, e);
@@ -434,5 +419,311 @@ impl CleanupWorker {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossfire::mpsc;
+    use sockudo_adapter::cleanup::{CleanupSender, DisconnectTask};
+    use sockudo_adapter::handler::ConnectionHandler;
+    use sockudo_adapter::local_adapter::LocalAdapter;
+    use sockudo_app::memory_app_manager::MemoryAppManager;
+    use sockudo_cache::MemoryCacheManager;
+    use sockudo_core::app::{App, AppManager, AppPolicy};
+    use sockudo_core::channel::PresenceMemberInfo;
+    use sockudo_core::options::{MemoryCacheOptions, PresenceHistoryConfig, ServerOptions};
+    use sockudo_core::presence_history::NoopPresenceHistoryStore;
+    use sockudo_core::websocket::{SocketId, WebSocketBufferConfig};
+    use sockudo_protocol::{ProtocolVersion, WireFormat};
+    use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
+    use sockudo_ws::client::WebSocketClient;
+    use sockudo_ws::{Config as WsConfig, Http1, Stream as WsStream, WebSocketStream};
+    use std::time::{Duration, Instant};
+    use tokio::net::{TcpListener, TcpStream};
+
+    const APP_ID: &str = "cleanup-worker-test";
+
+    fn make_app() -> App {
+        App::from_policy(
+            APP_ID.to_string(),
+            "test-key".to_string(),
+            "test-secret".to_string(),
+            true,
+            AppPolicy::default(),
+        )
+    }
+
+    async fn make_ws_pair() -> (WebSocketWriter, WebSocketStream<WsStream<Http1>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            sockudo_ws::handshake::server_handshake(&mut stream)
+                .await
+                .unwrap();
+            let ws = WebSocket::from_tcp(stream, WsConfig::default());
+            let (_reader, writer) = ws.split();
+            writer
+        });
+
+        let client_stream = TcpStream::connect(addr).await.unwrap();
+        let client = WebSocketClient::<Http1>::new(WsConfig::default());
+        let (client_ws, _): (WebSocketStream<WsStream<Http1>>, _) = client
+            .connect(client_stream, &addr.to_string(), "/", None)
+            .await
+            .unwrap();
+
+        let server_writer = server_task.await.unwrap();
+        (server_writer, client_ws)
+    }
+
+    fn make_worker(adapter: Arc<dyn ConnectionManager + Send + Sync>) -> CleanupWorker {
+        let app_manager = Arc::new(MemoryAppManager::new()) as Arc<dyn AppManager + Send + Sync>;
+        CleanupWorker::new(
+            adapter,
+            app_manager,
+            None,
+            Arc::new(NoopPresenceHistoryStore),
+            PresenceHistoryConfig::default(),
+            CleanupConfig {
+                batch_size: 64,
+                batch_timeout_ms: 50,
+                ..Default::default()
+            },
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn deferred_worker_completes_exhaustive_cleanup() {
+        // Arrange: socket with user identity and two channels
+        let adapter = Arc::new(LocalAdapter::new());
+        adapter.init().await;
+
+        let app_manager = Arc::new(MemoryAppManager::new());
+        app_manager.create_app(make_app()).await.unwrap();
+
+        let socket_id = SocketId::new();
+        let (writer, _client) = make_ws_pair().await;
+        adapter
+            .add_socket(
+                socket_id,
+                writer,
+                APP_ID,
+                app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+                WebSocketBufferConfig::default(),
+                ProtocolVersion::V1,
+                WireFormat::Json,
+                true,
+                sockudo_protocol::AppendMode::Delta,
+            )
+            .await
+            .unwrap();
+
+        // Associate the same socket with two identities, as happens when a
+        // presence-derived identity is replaced by signin metadata.
+        let ws_ref = adapter.get_connection(&socket_id, APP_ID).await.unwrap();
+        {
+            let mut guard = ws_ref.inner.lock().await;
+            guard.set_user_info(sockudo_core::websocket::UserInfo {
+                id: "user-alpha".to_string(),
+                watchlist: None,
+                info: None,
+                capabilities: None,
+                meta: None,
+            });
+        }
+        adapter.add_user(ws_ref.clone()).await.unwrap();
+        {
+            let mut guard = ws_ref.inner.lock().await;
+            guard.state.user_id = Some("user-beta".to_string());
+        }
+        adapter.add_user(ws_ref.clone()).await.unwrap();
+
+        // Subscribe to two channels
+        adapter
+            .add_to_channel(APP_ID, "public-feed", &socket_id)
+            .await
+            .unwrap();
+        adapter
+            .add_to_channel(APP_ID, "presence-room", &socket_id)
+            .await
+            .unwrap();
+
+        // Confirm indexes are populated
+        assert!(adapter.get_connection(&socket_id, APP_ID).await.is_some());
+        assert!(
+            adapter
+                .is_in_channel(APP_ID, "public-feed", &socket_id)
+                .await
+                .unwrap()
+        );
+        assert!(
+            adapter
+                .is_in_channel(APP_ID, "presence-room", &socket_id)
+                .await
+                .unwrap()
+        );
+        let user_sockets = adapter
+            .get_user_sockets("user-alpha", APP_ID)
+            .await
+            .unwrap();
+        assert!(!user_sockets.is_empty());
+        assert_eq!(
+            adapter
+                .get_user_sockets("user-beta", APP_ID)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let namespace = adapter.get_namespace(APP_ID).await.unwrap();
+        namespace
+            .presence_data
+            .entry(socket_id)
+            .or_default()
+            .insert(
+                "presence-room".to_string(),
+                PresenceMemberInfo {
+                    user_id: "user-beta".to_string(),
+                    user_info: None,
+                },
+            );
+
+        // The real async handler must cancel before the task is consumed.
+        let token = ws_ref.cancellation_token();
+        let (tx, rx) = mpsc::bounded_async::<DisconnectTask>(8);
+        let cache = Arc::new(MemoryCacheManager::new(
+            "cleanup-worker-test".to_string(),
+            MemoryCacheOptions::default(),
+        ));
+        let handler = ConnectionHandler::builder(
+            app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+            cache,
+            ServerOptions::default(),
+        )
+        .local_adapter(adapter.clone())
+        .cleanup_queue(CleanupSender::Direct(tx))
+        .build();
+
+        handler.handle_disconnect(APP_ID, &socket_id).await.unwrap();
+        assert!(token.is_cancelled());
+
+        let task = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("disconnect task must be queued")
+            .expect("cleanup queue must remain open");
+        let worker = make_worker(adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>);
+        let mut batch = vec![task];
+        worker.process_batch(&mut batch).await;
+
+        // Assert: all indexes cleaned by the comprehensive remove_connection path
+        assert!(
+            adapter.get_connection(&socket_id, APP_ID).await.is_none(),
+            "connection must be removed"
+        );
+        assert!(
+            !adapter
+                .is_in_channel(APP_ID, "public-feed", &socket_id)
+                .await
+                .unwrap(),
+            "socket must be removed from public-feed"
+        );
+        assert!(
+            !adapter
+                .is_in_channel(APP_ID, "presence-room", &socket_id)
+                .await
+                .unwrap(),
+            "socket must be removed from presence-room"
+        );
+        let user_sockets = adapter
+            .get_user_sockets("user-alpha", APP_ID)
+            .await
+            .unwrap();
+        assert!(
+            user_sockets.is_empty(),
+            "first user socket mapping must be empty after comprehensive removal"
+        );
+        assert!(
+            adapter
+                .get_user_sockets("user-beta", APP_ID)
+                .await
+                .unwrap()
+                .is_empty(),
+            "second user socket mapping must be empty after comprehensive removal"
+        );
+        assert!(
+            namespace.presence_data.get(&socket_id).is_none(),
+            "presence data must be removed by comprehensive cleanup"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_task_after_sync_fallback_is_harmless() {
+        // Arrange: socket already removed (sync fallback ran first)
+        let adapter = Arc::new(LocalAdapter::new());
+        adapter.init().await;
+
+        let app_manager = Arc::new(MemoryAppManager::new());
+        app_manager.create_app(make_app()).await.unwrap();
+
+        let socket_id = SocketId::new();
+        let (writer, _client) = make_ws_pair().await;
+        adapter
+            .add_socket(
+                socket_id,
+                writer,
+                APP_ID,
+                app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+                WebSocketBufferConfig::default(),
+                ProtocolVersion::V1,
+                WireFormat::Json,
+                true,
+                sockudo_protocol::AppendMode::Delta,
+            )
+            .await
+            .unwrap();
+
+        // Remove connection synchronously (simulating the fallback path ran first)
+        adapter.remove_connection(&socket_id, APP_ID).await.unwrap();
+        assert!(adapter.get_connection(&socket_id, APP_ID).await.is_none());
+
+        // Build a stale task referencing the already-removed socket
+        let stale_task = DisconnectTask {
+            socket_id,
+            app_id: APP_ID.to_string(),
+            subscribed_channels: vec!["public-channel".to_string()],
+            user_id: Some("stale-user".to_string()),
+            timestamp: Instant::now(),
+            connection_info: None,
+            presence_ungraceful_timeout_seconds: 0,
+        };
+
+        let (tx, rx) = mpsc::bounded_async::<DisconnectTask>(8);
+        tx.try_send(stale_task).unwrap();
+        drop(tx);
+
+        let worker = make_worker(adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>);
+
+        // Act: worker processes the stale task — must not panic
+        tokio::time::timeout(Duration::from_secs(5), worker.run(rx))
+            .await
+            .expect("worker must not hang on stale tasks");
+
+        // Assert: no entries recreated
+        assert!(
+            adapter.get_connection(&socket_id, APP_ID).await.is_none(),
+            "stale task must not recreate connection"
+        );
+        let sockets_count = adapter.get_sockets_count(APP_ID).await.unwrap();
+        assert_eq!(
+            sockets_count, 0,
+            "no sockets should exist after stale task processing"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- make the authoritative sockets map the sole long-lived WebSocketRef owner by indexing users with SocketIds and maintaining a reverse socket-to-user index
- cancel reader/writer tasks before deferred cleanup and make teardown comprehensive and idempotent while preserving Protocol V1 presence events
- preserve terminate and force-reconnect close frames, signin identity migration, capacity behavior, and add cancellation-aware close flushing
- add regression coverage for cleanup ordering, queue fallback, user indexes, presence lifecycle, exact close payloads, and concurrent teardown