### PR TITLE
fix(adapter): enable server-side activity timeout for V2 connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser",
  "html5ever",
@@ -3234,7 +3234,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 

--- a/crates/sockudo-adapter/src/handler/timeout_management.rs
+++ b/crates/sockudo-adapter/src/handler/timeout_management.rs
@@ -2,7 +2,6 @@ use super::ConnectionHandler;
 use bytes::Bytes;
 use sockudo_core::error::Result;
 use sockudo_core::websocket::SocketId;
-use sockudo_protocol::ProtocolVersion;
 use sockudo_protocol::constants::PONG_TIMEOUT;
 use sockudo_protocol::messages::PusherMessage;
 use sockudo_ws::Message;
@@ -34,21 +33,13 @@ impl ConnectionHandler {
         // Clear any existing timeout
         self.clear_activity_timeout(app_id, socket_id).await?;
 
-        let Some(connection) = self
+        let Some(_connection) = self
             .connection_manager
             .get_connection(socket_id, app_id)
             .await
         else {
             return Ok(());
         };
-
-        if connection.protocol_version == ProtocolVersion::V2 {
-            debug!(
-                "Skipping app-level activity timeout loop for V2 socket {} (native WebSocket ping/pong handles heartbeats)",
-                socket_id
-            );
-            return Ok(());
-        }
 
         let socket_id_clone = *socket_id;
         let app_id_clone = app_id.to_string();


### PR DESCRIPTION
V2 connections were skipping the server-initiated ping/pong keepalive loop, relying on sockudo-ws native auto_ping — which is not implemented (dead config). This left V2 with zero server-side keepalive, causing silent TCP deaths (1006 ABNORMAL CLOSURE on clients, transport_eof on server) instead of clean closes with code 4201.

Remove the V2 early return so both protocol versions get the same app-level activity timeout loop. The server now sends sockudo:ping after activity_timeout seconds of inactivity and closes with 4201 if no pong is received within PONG_TIMEOUT.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
