### PR TITLE
fix: use native V2 heartbeat with sockudo-ws 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- Protocol V2 now uses the native nonce-based Ping/Pong heartbeat in `sockudo-ws` 2.0.1 and
+  closes missed Pong deadlines with code 4201, without running a duplicate application-level
+  heartbeat. Protocol V1 and Ably compatibility keep their existing heartbeat behavior.
+
 ## [4.6.0] - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8334,9 +8334,9 @@ dependencies = [
 
 [[package]]
 name = "sockudo-ws"
-version = "1.7.4"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acad755d1e9548ba9f2a32efeb83e18eefd25f61907cf66e7653364a40ec990"
+checksum = "d332a6a163a2386c9785dccb61e69c4addd69e591de1d7c8ad32680c96efd217"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ serde_json = "1"
 serde_json_path = "0.7.2"
 serde_urlencoded = "0.7"
 sha2 = "0.11.0-rc.3"
-sockudo-ws = { version = "1.7.4", features = ["axum-integration"] }
+sockudo-ws = { version = "2.0.1", features = ["axum-integration"] }
 sonic-rs = "0.5.6"
 surrealdb = { version = "3.0.4", default-features = false, features = [
   "protocol-ws",

--- a/crates/sockudo-ably-compat/src/runtime/realtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime/realtime.rs
@@ -128,10 +128,14 @@ pub async fn handle_ably_realtime_upgrade(
             if error.status != StatusCode::UNAUTHORIZED {
                 return ably_error_response_format(error.status, error.code, error.message, format);
             }
-            let ws_cfg = handler.server_options().websocket.to_sockudo_ws_config(
-                handler.server_options().websocket_max_payload_kb,
-                handler.server_options().activity_timeout,
-            );
+            let ws_cfg = handler
+                .server_options()
+                .websocket
+                .to_sockudo_ws_config_with_native_heartbeat(
+                    handler.server_options().websocket_max_payload_kb,
+                    handler.server_options().activity_timeout,
+                    false,
+                );
             return ws
                 .config(ws_cfg)
                 .on_upgrade(move |socket| send_fatal_ably_socket_error(socket, format, error))
@@ -155,10 +159,14 @@ pub async fn handle_ably_realtime_upgrade(
         }
     }
 
-    let ws_cfg = handler.server_options().websocket.to_sockudo_ws_config(
-        handler.server_options().websocket_max_payload_kb,
-        handler.server_options().activity_timeout,
-    );
+    let ws_cfg = handler
+        .server_options()
+        .websocket
+        .to_sockudo_ws_config_with_native_heartbeat(
+            handler.server_options().websocket_max_payload_kb,
+            handler.server_options().activity_timeout,
+            false,
+        );
     if runtime.hub.config.realtime_admission == AblyRealtimeAdmission::PlacementConstraint {
         return ws
             .config(ws_cfg)
@@ -268,7 +276,10 @@ pub(super) async fn send_ably_socket_failure(
         Ok(Some(Ok(Message::Close(_))))
     );
     if peer_started_close {
-        let _ = writer.flush().await;
+        // Keep the split halves alive until the connection-scoped writer
+        // driver flushes the queued peer-Close response and reports terminal
+        // state. Dropping either half earlier cancels the driver.
+        let _ = tokio::time::timeout(Duration::from_millis(250), reader.next()).await;
     } else {
         let _ = writer.close(1000, "Ably protocol error").await;
     }

--- a/crates/sockudo-adapter/src/handler/mod.rs
+++ b/crates/sockudo-adapter/src/handler/mod.rs
@@ -43,7 +43,7 @@ use sockudo_core::presence_history::{NoopPresenceHistoryStore, PresenceHistorySt
 use sockudo_core::presence_registry::{PresenceRegistry, PresenceReplication};
 use sockudo_core::rate_limiter::RateLimiter;
 use sockudo_core::version_store::{NoopVersionStore, VersionStore};
-use sockudo_core::websocket::SocketId;
+use sockudo_core::websocket::{DisconnectCause, SocketId};
 use sockudo_protocol::constants::CLIENT_EVENT_PREFIX;
 use sockudo_protocol::messages::{MessageData, PusherMessage, is_ai_event};
 use sockudo_protocol::{AppendMode, ProtocolVersion, WireFormat};
@@ -57,7 +57,7 @@ use sonic_rs::Value;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 type FastDashMap<K, V> = DashMap<K, V, ahash::RandomState>;
 type SharedRateLimiter = Arc<dyn RateLimiter + Send + Sync>;
@@ -905,6 +905,29 @@ impl ConnectionHandler {
 
             let message = match next {
                 Ok(m) => m,
+                Err(e)
+                    if matches!(
+                        &e,
+                        sockudo_ws::Error::HeartbeatTimeout | sockudo_ws::Error::IdleTimeout
+                    ) =>
+                {
+                    if let Some(connection) = self
+                        .connection_manager
+                        .get_connection(socket_id, &app_config.id)
+                        .await
+                    {
+                        let mut connection = connection.inner.lock().await;
+                        connection
+                            .state
+                            .record_disconnect_cause(DisconnectCause::ActivityTimeout);
+                    }
+                    warn!(
+                        socket_id = %socket_id,
+                        error = %e,
+                        "native websocket activity timeout reached"
+                    );
+                    break;
+                }
                 Err(e) => return Err(Error::WebSocket(e)),
             };
             match message {
@@ -936,8 +959,8 @@ impl ConnectionHandler {
                         }
                     }
                 }
-                _ => {
-                    warn!(socket_id = %socket_id, "unsupported socket message type");
+                Message::Ping(_) | Message::Pong(_) => {
+                    trace!(socket_id = %socket_id, "websocket control frame handled");
                 }
             }
         }

--- a/crates/sockudo-adapter/src/handler/timeout_management.rs
+++ b/crates/sockudo-adapter/src/handler/timeout_management.rs
@@ -2,6 +2,7 @@ use super::ConnectionHandler;
 use bytes::Bytes;
 use sockudo_core::error::Result;
 use sockudo_core::websocket::SocketId;
+use sockudo_protocol::ProtocolVersion;
 use sockudo_protocol::constants::PONG_TIMEOUT;
 use sockudo_protocol::messages::PusherMessage;
 use sockudo_ws::Message;
@@ -33,13 +34,21 @@ impl ConnectionHandler {
         // Clear any existing timeout
         self.clear_activity_timeout(app_id, socket_id).await?;
 
-        let Some(_connection) = self
+        let Some(connection) = self
             .connection_manager
             .get_connection(socket_id, app_id)
             .await
         else {
             return Ok(());
         };
+
+        if connection.protocol_version == ProtocolVersion::V2 {
+            debug!(
+                socket_id = %socket_id,
+                "native websocket heartbeat handles v2 activity timeout"
+            );
+            return Ok(());
+        }
 
         let socket_id_clone = *socket_id;
         let app_id_clone = app_id.to_string();

--- a/crates/sockudo-adapter/tests/adapter/active_channels_gauge_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/active_channels_gauge_tests.rs
@@ -22,7 +22,14 @@ async fn make_writer() -> WebSocketWriter {
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 

--- a/crates/sockudo-adapter/tests/adapter/async_disconnect_cleanup_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/async_disconnect_cleanup_tests.rs
@@ -141,7 +141,14 @@ async fn make_ws_pair() -> (WebSocketWriter, WebSocketStream<WsStream<Http1>>) {
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 

--- a/crates/sockudo-adapter/tests/adapter/connected_gauge_regression_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/connected_gauge_regression_tests.rs
@@ -305,7 +305,14 @@ async fn make_ws_pair() -> (WebSocketWriter, WebSocketStream<WsStream<Http1>>) {
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 

--- a/crates/sockudo-adapter/tests/adapter/handler/activity_timeout_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/activity_timeout_test.rs
@@ -1,0 +1,169 @@
+use crate::mocks::connection_handler_mock::MockCacheManager;
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::handler::ConnectionHandler;
+use sockudo_adapter::local_adapter::LocalAdapter;
+use sockudo_app::memory_app_manager::MemoryAppManager;
+use sockudo_core::app::{App, AppManager, AppPolicy};
+use sockudo_core::options::ServerOptions;
+use sockudo_core::websocket::{SocketId, WebSocketBufferConfig};
+use sockudo_protocol::{AppendMode, ProtocolVersion, WireFormat};
+use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
+use sockudo_ws::client::WebSocketClient;
+use sockudo_ws::{Config as WsConfig, Http1, Stream as WsStream, WebSocketStream};
+use std::sync::Arc;
+use tokio::net::{TcpListener, TcpStream};
+
+const APP_ID: &str = "activity-timeout-test";
+type TestClient = WebSocketStream<WsStream<Http1>>;
+
+struct Harness {
+    handler: ConnectionHandler,
+    adapter: Arc<LocalAdapter>,
+    app_manager: Arc<MemoryAppManager>,
+    app: App,
+}
+
+async fn create_test_pair() -> (WebSocketWriter, TestClient) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        sockudo_ws::handshake::server_handshake(&mut stream)
+            .await
+            .unwrap();
+        let socket = WebSocket::from_tcp(stream, WsConfig::default());
+        let (mut reader, writer) = socket.split();
+        tokio::spawn(async move {
+            while let Some(message) = reader.next().await {
+                if message.is_err() {
+                    break;
+                }
+            }
+        });
+        writer
+    });
+
+    let stream = TcpStream::connect(address).await.unwrap();
+    let client = WebSocketClient::<Http1>::new(WsConfig::default());
+    let (client, _): (TestClient, _) = client
+        .connect(stream, &address.to_string(), "/", None)
+        .await
+        .unwrap();
+
+    (server.await.unwrap(), client)
+}
+
+async fn build_harness() -> Harness {
+    let app = App::from_policy(
+        APP_ID.to_string(),
+        "activity-timeout-key".to_string(),
+        "activity-timeout-secret".to_string(),
+        true,
+        AppPolicy::default(),
+    );
+    let app_manager = Arc::new(MemoryAppManager::new());
+    app_manager.create_app(app.clone()).await.unwrap();
+
+    let adapter = Arc::new(LocalAdapter::new());
+    adapter.init().await;
+    let handler = ConnectionHandler::builder(
+        app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+        adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(MockCacheManager::new()),
+        ServerOptions::default(),
+    )
+    .local_adapter(adapter.clone())
+    .build();
+
+    Harness {
+        handler,
+        adapter,
+        app_manager,
+        app,
+    }
+}
+
+async fn add_socket(
+    harness: &Harness,
+    protocol_version: ProtocolVersion,
+) -> (SocketId, TestClient) {
+    let socket_id = SocketId::new();
+    let (writer, client) = create_test_pair().await;
+    harness
+        .adapter
+        .add_socket(
+            socket_id,
+            writer,
+            &harness.app.id,
+            harness.app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            protocol_version,
+            WireFormat::Json,
+            true,
+            AppendMode::Delta,
+        )
+        .await
+        .unwrap();
+    (socket_id, client)
+}
+
+#[tokio::test]
+async fn initial_activity_timeout_task_is_installed_only_for_v1() {
+    let harness = build_harness().await;
+    let (v2_socket_id, _v2_client) = add_socket(&harness, ProtocolVersion::V2).await;
+    let (v1_socket_id, _v1_client) = add_socket(&harness, ProtocolVersion::V1).await;
+
+    harness
+        .handler
+        .setup_initial_timeouts(&v2_socket_id, &harness.app)
+        .await
+        .unwrap();
+    harness
+        .handler
+        .setup_initial_timeouts(&v1_socket_id, &harness.app)
+        .await
+        .unwrap();
+
+    let v2_connection = harness
+        .adapter
+        .get_connection(&v2_socket_id, APP_ID)
+        .await
+        .unwrap();
+    let v2_has_legacy_timeout = v2_connection
+        .inner
+        .lock()
+        .await
+        .state
+        .timeouts
+        .activity_timeout_handle
+        .is_some();
+    assert!(
+        !v2_has_legacy_timeout,
+        "V2 must not spawn the application-level timeout task"
+    );
+
+    let v1_connection = harness
+        .adapter
+        .get_connection(&v1_socket_id, APP_ID)
+        .await
+        .unwrap();
+    let v1_timeout_is_running = v1_connection
+        .inner
+        .lock()
+        .await
+        .state
+        .timeouts
+        .activity_timeout_handle
+        .as_ref()
+        .is_some_and(|handle| !handle.is_finished());
+    assert!(
+        v1_timeout_is_running,
+        "V1 must retain the Pusher-compatible application timeout task"
+    );
+
+    harness
+        .handler
+        .clear_activity_timeout(APP_ID, &v1_socket_id)
+        .await
+        .unwrap();
+}

--- a/crates/sockudo-adapter/tests/adapter/handler/annotations_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/annotations_test.rs
@@ -27,7 +27,7 @@ use sockudo_protocol::{ProtocolVersion, WireFormat};
 use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
 use sockudo_ws::client::WebSocketClient;
 use sockudo_ws::{
-    Config as WsConfig, Http1, Message as WsMessage, SplitReader, Stream as WsStream,
+    Config as WsConfig, Http1, Message as WsMessage, SplitReader, SplitWriter, Stream as WsStream,
     WebSocketStream,
 };
 use sonic_rs::{JsonValueTrait, Value, json};
@@ -36,7 +36,26 @@ use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::{Duration, timeout};
 
-type ClientReader = SplitReader<WsStream<Http1>>;
+struct ClientReader {
+    reader: SplitReader<WsStream<Http1>>,
+    _writer_guard: SplitWriter<WsStream<Http1>>,
+}
+
+impl ClientReader {
+    fn new(
+        reader: SplitReader<WsStream<Http1>>,
+        writer_guard: SplitWriter<WsStream<Http1>>,
+    ) -> Self {
+        Self {
+            reader,
+            _writer_guard: writer_guard,
+        }
+    }
+
+    async fn next(&mut self) -> Option<sockudo_ws::Result<WsMessage>> {
+        self.reader.next().await
+    }
+}
 
 const APP_ID: &str = "app";
 const CHANNEL: &str = "chat";
@@ -301,7 +320,14 @@ async fn connect_socket(
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 
@@ -311,7 +337,8 @@ async fn connect_socket(
         .connect(client_stream, &addr.to_string(), "/", None)
         .await
         .unwrap();
-    let (reader, _writer) = client_ws.split();
+    let (reader, writer_guard) = client_ws.split();
+    let reader = ClientReader::new(reader, writer_guard);
     let server_writer: WebSocketWriter = server_task.await.unwrap();
 
     let socket_id = SocketId::new();

--- a/crates/sockudo-adapter/tests/adapter/handler/auth_token_user_index_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/auth_token_user_index_tests.rs
@@ -23,7 +23,14 @@ async fn create_test_writer() -> axum_integration::WebSocketWriter {
             .await
             .unwrap();
         let ws = axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 

--- a/crates/sockudo-adapter/tests/adapter/handler/clustered_runtime_rewind_recovery_redis_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/clustered_runtime_rewind_recovery_redis_test.rs
@@ -33,7 +33,7 @@ use sockudo_protocol::{ProtocolVersion, WireFormat};
 use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
 use sockudo_ws::client::WebSocketClient;
 use sockudo_ws::{
-    Config as WsConfig, Http1, Message as WsMessage, SplitReader, Stream as WsStream,
+    Config as WsConfig, Http1, Message as WsMessage, SplitReader, SplitWriter, Stream as WsStream,
     WebSocketStream,
 };
 use sonic_rs::{JsonValueTrait, Value, json};
@@ -47,7 +47,26 @@ use tokio::sync::{Mutex, RwLock, oneshot};
 use tokio::time::timeout;
 use uuid::Uuid;
 
-type ClientReader = SplitReader<WsStream<Http1>>;
+struct ClientReader {
+    reader: SplitReader<WsStream<Http1>>,
+    _writer_guard: SplitWriter<WsStream<Http1>>,
+}
+
+impl ClientReader {
+    fn new(
+        reader: SplitReader<WsStream<Http1>>,
+        writer_guard: SplitWriter<WsStream<Http1>>,
+    ) -> Self {
+        Self {
+            reader,
+            _writer_guard: writer_guard,
+        }
+    }
+
+    async fn next(&mut self) -> Option<sockudo_ws::Result<WsMessage>> {
+        self.reader.next().await
+    }
+}
 
 struct ReadGate {
     started_tx: Option<oneshot::Sender<()>>,
@@ -448,7 +467,14 @@ async fn connect_v2_socket(node: &ClusterNode, app: &App) -> (SocketId, ClientRe
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 
@@ -458,7 +484,8 @@ async fn connect_v2_socket(node: &ClusterNode, app: &App) -> (SocketId, ClientRe
         .connect(client_stream, &addr.to_string(), "/", None)
         .await
         .unwrap();
-    let (reader, _writer) = client_ws.split();
+    let (reader, writer_guard) = client_ws.split();
+    let reader = ClientReader::new(reader, writer_guard);
     let server_writer: WebSocketWriter = server_task.await.unwrap();
 
     let socket_id = SocketId::new();

--- a/crates/sockudo-adapter/tests/adapter/handler/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/mod.rs
@@ -1,3 +1,4 @@
+pub mod activity_timeout_test;
 pub mod annotations_test;
 pub mod auth_token_user_index_tests;
 pub mod authentication_test;

--- a/crates/sockudo-adapter/tests/adapter/handler/presence_user_id_guard_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/presence_user_id_guard_test.rs
@@ -29,7 +29,14 @@ async fn create_test_pair() -> (axum_integration::WebSocketWriter, TestClient) {
             .await
             .unwrap();
         let ws = axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 

--- a/crates/sockudo-adapter/tests/adapter/handler/runtime_rewind_recovery_e2e_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/runtime_rewind_recovery_e2e_test.rs
@@ -27,7 +27,7 @@ use sockudo_protocol::{ProtocolVersion, WireFormat};
 use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
 use sockudo_ws::client::WebSocketClient;
 use sockudo_ws::{
-    Config as WsConfig, Http1, Message as WsMessage, SplitReader, Stream as WsStream,
+    Config as WsConfig, Http1, Message as WsMessage, SplitReader, SplitWriter, Stream as WsStream,
     WebSocketStream,
 };
 use sonic_rs::{JsonContainerTrait, JsonValueTrait};
@@ -37,7 +37,26 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex, oneshot};
 use tokio::time::{Duration, timeout};
 
-type ClientReader = SplitReader<WsStream<Http1>>;
+struct ClientReader {
+    reader: SplitReader<WsStream<Http1>>,
+    _writer_guard: SplitWriter<WsStream<Http1>>,
+}
+
+impl ClientReader {
+    fn new(
+        reader: SplitReader<WsStream<Http1>>,
+        writer_guard: SplitWriter<WsStream<Http1>>,
+    ) -> Self {
+        Self {
+            reader,
+            _writer_guard: writer_guard,
+        }
+    }
+
+    async fn next(&mut self) -> Option<sockudo_ws::Result<WsMessage>> {
+        self.reader.next().await
+    }
+}
 
 #[derive(Clone)]
 struct GateHistoryStore {
@@ -266,7 +285,14 @@ async fn connect_v2_socket_with_append_mode(
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 
@@ -276,7 +302,8 @@ async fn connect_v2_socket_with_append_mode(
         .connect(client_stream, &addr.to_string(), "/", None)
         .await
         .unwrap();
-    let (reader, _writer) = client_ws.split();
+    let (reader, writer_guard) = client_ws.split();
+    let reader = ClientReader::new(reader, writer_guard);
     let server_writer: WebSocketWriter = server_task.await.unwrap();
 
     let socket_id = SocketId::new();
@@ -1601,7 +1628,14 @@ async fn cold_recovery_replays_real_deliveries_e2e() {
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
     let client_stream = TcpStream::connect(addr).await.unwrap();
@@ -1610,7 +1644,8 @@ async fn cold_recovery_replays_real_deliveries_e2e() {
         .connect(client_stream, &addr.to_string(), "/", None)
         .await
         .unwrap();
-    let (mut resume_reader, _writer) = client_ws.split();
+    let (reader, writer_guard) = client_ws.split();
+    let mut resume_reader = ClientReader::new(reader, writer_guard);
     let resume_socket_id = SocketId::new();
     adapter
         .add_socket(
@@ -1813,7 +1848,14 @@ async fn writer_queue_full_fault_rejects_publish_without_live_delivery() {
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
     let client_stream = TcpStream::connect(addr).await.unwrap();
@@ -1822,7 +1864,8 @@ async fn writer_queue_full_fault_rejects_publish_without_live_delivery() {
         .connect(client_stream, &addr.to_string(), "/", None)
         .await
         .unwrap();
-    let (mut reader, _writer) = client_ws.split();
+    let (reader, writer_guard) = client_ws.split();
+    let mut reader = ClientReader::new(reader, writer_guard);
     let socket_id = SocketId::new();
     adapter
         .add_socket(

--- a/crates/sockudo-adapter/tests/adapter/horizontal_adapter_base_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/horizontal_adapter_base_test.rs
@@ -27,7 +27,14 @@ async fn create_test_writer() -> axum_integration::WebSocketWriter {
             .await
             .unwrap();
         let ws = axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 

--- a/crates/sockudo-adapter/tests/adapter/server_capacity_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/server_capacity_tests.rs
@@ -142,7 +142,14 @@ async fn make_ws_pair() -> (WebSocketWriter, WebSocketStream<WsStream<Http1>>) {
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 

--- a/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
@@ -26,7 +26,14 @@ async fn create_test_writer() -> axum_integration::WebSocketWriter {
             .await
             .unwrap();
         let ws = axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 

--- a/crates/sockudo-adapter/tests/adapter/user_socket_index_regression_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/user_socket_index_regression_tests.rs
@@ -21,7 +21,14 @@ async fn create_ws_pair() -> (axum_integration::WebSocketWriter, ClientWs) {
             .await
             .unwrap();
         let ws = axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 

--- a/crates/sockudo-core/benches/namespace_bench.rs
+++ b/crates/sockudo-core/benches/namespace_bench.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use criterion::{Criterion, criterion_group, criterion_main};
+use futures_util::StreamExt;
 use sockudo_core::app::{App, AppManager, AppPolicy};
 use sockudo_core::namespace::Namespace;
 use sockudo_core::websocket::{SocketId, WebSocketBufferConfig};
@@ -85,16 +86,30 @@ async fn create_server_writer(addr: std::net::SocketAddr) -> WebSocketWriter {
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 
     let client_stream = TcpStream::connect(local_addr).await.unwrap();
     let client = WebSocketClient::<Http1>::new(WsConfig::default());
-    let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+    let (mut client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
         .connect(client_stream, &local_addr.to_string(), "/", None)
         .await
         .unwrap();
+    tokio::spawn(async move {
+        while let Some(result) = client_ws.next().await {
+            if result.is_err() {
+                break;
+            }
+        }
+    });
 
     server_task.await.unwrap()
 }

--- a/crates/sockudo-core/examples/profile_namespace_ref_allocs.rs
+++ b/crates/sockudo-core/examples/profile_namespace_ref_allocs.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::StreamExt;
 use sockudo_core::app::{App, AppManager, AppPolicy};
 use sockudo_core::namespace::Namespace;
 use sockudo_core::websocket::{SocketId, WebSocketBufferConfig};
@@ -86,16 +87,30 @@ async fn create_server_writer() -> WebSocketWriter {
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 
     let client_stream = TcpStream::connect(local_addr).await.unwrap();
     let client = WebSocketClient::<Http1>::new(WsConfig::default());
-    let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+    let (mut client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
         .connect(client_stream, &local_addr.to_string(), "/", None)
         .await
         .unwrap();
+    tokio::spawn(async move {
+        while let Some(result) = client_ws.next().await {
+            if result.is_err() {
+                break;
+            }
+        }
+    });
 
     server_task.await.unwrap()
 }

--- a/crates/sockudo-core/src/namespace.rs
+++ b/crates/sockudo-core/src/namespace.rs
@@ -729,6 +729,7 @@ mod tests {
     use crate::namespace::SocketInitOptions;
     use crate::websocket::SocketId;
     use async_trait::async_trait;
+    use futures_util::StreamExt;
     use sockudo_protocol::{ProtocolVersion, WireFormat};
     use sockudo_ws::Config as WsConfig;
     use sockudo_ws::Http1;
@@ -788,16 +789,30 @@ mod tests {
                 .await
                 .unwrap();
             let ws = WebSocket::from_tcp(stream, WsConfig::default());
-            let (_reader, writer) = ws.split();
+            let (mut reader, writer) = ws.split();
+            tokio::spawn(async move {
+                while let Some(result) = reader.next().await {
+                    if result.is_err() {
+                        break;
+                    }
+                }
+            });
             writer
         });
 
         let client_stream = TcpStream::connect(local_addr).await.unwrap();
         let client = WebSocketClient::<Http1>::new(WsConfig::default());
-        let (_client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
+        let (mut client_ws, _): (WebSocketStream<sockudo_ws::Stream<Http1>>, _) = client
             .connect(client_stream, &local_addr.to_string(), "/", None)
             .await
             .unwrap();
+        tokio::spawn(async move {
+            while let Some(result) = client_ws.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
 
         server_task.await.unwrap()
     }

--- a/crates/sockudo-core/src/options/runtime.rs
+++ b/crates/sockudo-core/src/options/runtime.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
+use sockudo_protocol::constants::PONG_TIMEOUT;
 
 use super::{CacheDriver, MetricsDriver, RedisConfig};
+
+const PONG_TIMEOUT_CLOSE_REASON: &str = "Pong reply not received in time";
 
 // Custom deserializer for octal permission mode (string format only, like chmod)
 fn deserialize_octal_permission<'de, D>(deserializer: D) -> Result<u32, D::Error>
@@ -141,11 +144,34 @@ impl WebSocketConfig {
         }
     }
 
-    /// Convert to native sockudo-ws runtime configuration.
+    /// Convert to native sockudo-ws runtime configuration with native
+    /// heartbeat settings enabled.
+    ///
+    /// This keeps the existing two-argument API available. Protocol-aware
+    /// server call sites should use
+    /// [`Self::to_sockudo_ws_config_with_native_heartbeat`] instead.
     pub fn to_sockudo_ws_config(
         &self,
         websocket_max_payload_kb: u32,
         activity_timeout: u64,
+    ) -> sockudo_ws::Config {
+        self.to_sockudo_ws_config_with_native_heartbeat(
+            websocket_max_payload_kb,
+            activity_timeout,
+            true,
+        )
+    }
+
+    /// Convert to native sockudo-ws runtime configuration with explicit
+    /// heartbeat ownership.
+    ///
+    /// `use_native_heartbeat` is enabled for Protocol V2. Protocol V1 and
+    /// compatibility protocols keep their application-level heartbeat loops.
+    pub fn to_sockudo_ws_config_with_native_heartbeat(
+        &self,
+        websocket_max_payload_kb: u32,
+        activity_timeout: u64,
+        use_native_heartbeat: bool,
     ) -> sockudo_ws::Config {
         use sockudo_ws::Compression;
 
@@ -161,6 +187,13 @@ impl WebSocketConfig {
             "window32kb" => Compression::Window32KB,
             _ => Compression::Disabled,
         };
+        let minimum_ping_interval =
+            u32::try_from((activity_timeout / 2).max(5)).unwrap_or(u32::MAX);
+        let ping_interval = if self.ping_interval == 0 {
+            0
+        } else {
+            self.ping_interval.max(minimum_ping_interval)
+        };
 
         sockudo_ws::Config::builder()
             .max_payload_length(
@@ -171,11 +204,60 @@ impl WebSocketConfig {
             .max_frame_size(self.max_frame_size)
             .write_buffer_size(self.write_buffer_size)
             .max_backpressure(self.max_backpressure)
-            .idle_timeout(self.idle_timeout)
-            .auto_ping(self.auto_ping)
-            .ping_interval(self.ping_interval.max((activity_timeout / 2).max(5) as u32))
+            .idle_timeout(if use_native_heartbeat {
+                self.idle_timeout
+            } else {
+                0
+            })
+            .auto_ping(use_native_heartbeat && self.auto_ping)
+            .ping_interval(ping_interval)
+            .pong_timeout(PONG_TIMEOUT as u32)
+            .pong_timeout_close(
+                crate::error::Error::PongNotReceived.close_code(),
+                PONG_TIMEOUT_CLOSE_REASON,
+            )
             .compression(compression)
             .build()
+    }
+}
+
+#[cfg(test)]
+mod websocket_config_tests {
+    use super::*;
+
+    #[test]
+    fn native_heartbeat_uses_sockudo_timeout_contract() {
+        let config = WebSocketConfig::default().to_sockudo_ws_config(64, 120);
+
+        assert!(config.auto_ping);
+        assert_eq!(config.ping_interval, 60);
+        assert_eq!(config.idle_timeout, 120);
+        assert_eq!(config.pong_timeout, PONG_TIMEOUT as u32);
+        assert_eq!(
+            config.pong_timeout_close_code,
+            crate::error::Error::PongNotReceived.close_code()
+        );
+        assert_eq!(config.pong_timeout_close_reason, PONG_TIMEOUT_CLOSE_REASON);
+    }
+
+    #[test]
+    fn application_heartbeat_disables_native_deadlines() {
+        let config =
+            WebSocketConfig::default().to_sockudo_ws_config_with_native_heartbeat(64, 120, false);
+
+        assert!(!config.auto_ping);
+        assert_eq!(config.idle_timeout, 0);
+    }
+
+    #[test]
+    fn zero_ping_interval_remains_disabled() {
+        let websocket = WebSocketConfig {
+            ping_interval: 0,
+            ..WebSocketConfig::default()
+        };
+        let config = websocket.to_sockudo_ws_config(64, 120);
+
+        assert_eq!(config.ping_interval, 0);
     }
 }
 

--- a/crates/sockudo-core/src/websocket/sender.rs
+++ b/crates/sockudo-core/src/websocket/sender.rs
@@ -155,6 +155,8 @@ impl MessageSender {
             sockudo_ws::Error::ConnectionClosed
                 | sockudo_ws::Error::ConnectionReset
                 | sockudo_ws::Error::Closed(_)
+                | sockudo_ws::Error::HeartbeatTimeout
+                | sockudo_ws::Error::IdleTimeout
                 | sockudo_ws::Error::Io(_)
         )
     }

--- a/crates/sockudo-core/src/websocket/tests/mod.rs
+++ b/crates/sockudo-core/src/websocket/tests/mod.rs
@@ -381,7 +381,14 @@ async fn create_server_writer_with_client() -> (WebSocketWriter, ClientWs) {
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 

--- a/crates/sockudo-server/src/cleanup/worker.rs
+++ b/crates/sockudo-server/src/cleanup/worker.rs
@@ -493,7 +493,14 @@ mod tests {
                 .await
                 .unwrap();
             let ws = WebSocket::from_tcp(stream, WsConfig::default());
-            let (_reader, writer) = ws.split();
+            let (mut reader, writer) = ws.split();
+            tokio::spawn(async move {
+                while let Some(result) = reader.next().await {
+                    if result.is_err() {
+                        break;
+                    }
+                }
+            });
             writer
         });
 

--- a/crates/sockudo-server/src/http_handler/test_support.rs
+++ b/crates/sockudo-server/src/http_handler/test_support.rs
@@ -5,6 +5,7 @@ use axum::{
     http::{HeaderMap, HeaderValue, StatusCode, Uri, header},
     response::IntoResponse,
 };
+use futures_util::StreamExt;
 use sockudo_adapter::ConnectionHandler;
 use sockudo_adapter::ConnectionHandlerBuilder;
 use sockudo_adapter::local_adapter::LocalAdapter;
@@ -458,17 +459,30 @@ pub(crate) async fn test_websocket_writer() -> WebSocketWriter {
             .await
             .unwrap();
         let ws = sockudo_ws::axum_integration::WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 
     let client_stream = TcpStream::connect(addr).await.unwrap();
     let client = WebSocketClient::<Http1>::new(WsConfig::default());
-    let (client_ws, _): (WebSocketStream<WsStream<Http1>>, _) = client
+    let (mut client_ws, _): (WebSocketStream<WsStream<Http1>>, _) = client
         .connect(client_stream, &addr.to_string(), "/", None)
         .await
         .unwrap();
-    let (_reader, _writer) = client_ws.split();
+    tokio::spawn(async move {
+        while let Some(result) = client_ws.next().await {
+            if result.is_err() {
+                break;
+            }
+        }
+    });
 
     server_task.await.unwrap()
 }

--- a/crates/sockudo-server/src/ws_handler.rs
+++ b/crates/sockudo-server/src/ws_handler.rs
@@ -83,10 +83,13 @@ pub async fn handle_ws_upgrade(
     } else {
         AppendMode::Full
     };
-    let ws_cfg = server_options.websocket.to_sockudo_ws_config(
-        server_options.websocket_max_payload_kb,
-        server_options.activity_timeout,
-    );
+    let ws_cfg = server_options
+        .websocket
+        .to_sockudo_ws_config_with_native_heartbeat(
+            server_options.websocket_max_payload_kb,
+            server_options.activity_timeout,
+            protocol_version == ProtocolVersion::V2,
+        );
 
     ws.config(ws_cfg)
         .on_upgrade(move |socket| async move {

--- a/crates/sockudo-server/src/ws_handler.rs
+++ b/crates/sockudo-server/src/ws_handler.rs
@@ -29,6 +29,19 @@ pub struct ConnectionQuery {
     token: Option<String>,
 }
 
+fn websocket_config_for_protocol(
+    server_options: &sockudo_core::options::ServerOptions,
+    protocol_version: ProtocolVersion,
+) -> sockudo_ws::Config {
+    server_options
+        .websocket
+        .to_sockudo_ws_config_with_native_heartbeat(
+            server_options.websocket_max_payload_kb,
+            server_options.activity_timeout,
+            protocol_version == ProtocolVersion::V2,
+        )
+}
+
 // WebSocket upgrade handler
 pub async fn handle_ws_upgrade(
     Path(app_key): Path<String>,
@@ -83,13 +96,7 @@ pub async fn handle_ws_upgrade(
     } else {
         AppendMode::Full
     };
-    let ws_cfg = server_options
-        .websocket
-        .to_sockudo_ws_config_with_native_heartbeat(
-            server_options.websocket_max_payload_kb,
-            server_options.activity_timeout,
-            protocol_version == ProtocolVersion::V2,
-        );
+    let ws_cfg = websocket_config_for_protocol(server_options, protocol_version);
 
     ws.config(ws_cfg)
         .on_upgrade(move |socket| async move {
@@ -145,6 +152,19 @@ mod tests {
         };
 
         assert_eq!(wire_format, WireFormat::Json);
+    }
+
+    #[test]
+    fn websocket_heartbeat_ownership_follows_protocol_version() {
+        let server_options = sockudo_core::options::ServerOptions::default();
+
+        let v2 = websocket_config_for_protocol(&server_options, ProtocolVersion::V2);
+        assert!(v2.auto_ping);
+        assert_eq!(v2.pong_timeout_close_code, 4201);
+
+        let v1 = websocket_config_for_protocol(&server_options, ProtocolVersion::V1);
+        assert!(!v1.auto_ping);
+        assert_eq!(v1.idle_timeout, 0);
     }
 
     #[test]

--- a/crates/sockudo-server/tests/clustered_durable_history_redis_test.rs
+++ b/crates/sockudo-server/tests/clustered_durable_history_redis_test.rs
@@ -28,7 +28,7 @@ use sockudo_protocol::{ProtocolVersion, WireFormat};
 use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
 use sockudo_ws::client::WebSocketClient;
 use sockudo_ws::{
-    Config as WsConfig, Http1, Message as WsMessage, SplitReader, Stream as WsStream,
+    Config as WsConfig, Http1, Message as WsMessage, SplitReader, SplitWriter, Stream as WsStream,
     WebSocketStream,
 };
 use sonic_rs::{JsonValueTrait, Value, json};
@@ -42,6 +42,7 @@ use tokio::time::timeout;
 use uuid::Uuid;
 
 type ClientReader = SplitReader<WsStream<Http1>>;
+type ClientWriter = SplitWriter<WsStream<Http1>>;
 
 struct ReadGate {
     started_tx: Option<oneshot::Sender<()>>,
@@ -278,7 +279,10 @@ async fn wait_for_cluster_ready(nodes: &[&Arc<RedisAdapter>], expected_nodes: us
     }
 }
 
-async fn connect_v2_socket(node: &ClusterNode, app: &App) -> (SocketId, ClientReader) {
+async fn connect_v2_socket(
+    node: &ClusterNode,
+    app: &App,
+) -> (SocketId, ClientReader, ClientWriter) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
@@ -288,7 +292,14 @@ async fn connect_v2_socket(node: &ClusterNode, app: &App) -> (SocketId, ClientRe
             .await
             .unwrap();
         let ws = WebSocket::from_tcp(stream, WsConfig::default());
-        let (_reader, writer) = ws.split();
+        let (mut reader, writer) = ws.split();
+        tokio::spawn(async move {
+            while let Some(result) = reader.next().await {
+                if result.is_err() {
+                    break;
+                }
+            }
+        });
         writer
     });
 
@@ -298,7 +309,7 @@ async fn connect_v2_socket(node: &ClusterNode, app: &App) -> (SocketId, ClientRe
         .connect(client_stream, &addr.to_string(), "/", None)
         .await
         .unwrap();
-    let (reader, _writer) = client_ws.split();
+    let (reader, writer) = client_ws.split();
     let server_writer: WebSocketWriter = server_task.await.unwrap();
 
     let socket_id = SocketId::new();
@@ -317,7 +328,7 @@ async fn connect_v2_socket(node: &ClusterNode, app: &App) -> (SocketId, ClientRe
         .await
         .unwrap();
 
-    (socket_id, reader)
+    (socket_id, reader, writer)
 }
 
 fn live_message(channel: &str, event: &str, message_id: &str) -> PusherMessage {
@@ -492,7 +503,8 @@ async fn run_cross_node_cold_recovery_test(history_store: Arc<dyn HistoryStore +
     .await;
     wait_for_cluster_ready(&[&node_a.adapter, &node_b.adapter], 2).await;
 
-    let (source_socket_id, mut source_reader) = connect_v2_socket(&node_b, &app).await;
+    let (source_socket_id, mut source_reader, _source_writer) =
+        connect_v2_socket(&node_b, &app).await;
     node_b
         .handler
         .handle_subscribe_request(
@@ -542,7 +554,8 @@ async fn run_cross_node_cold_recovery_test(history_store: Arc<dyn HistoryStore +
     .await;
     wait_for_cluster_ready(&[&node_a.adapter, &restarted_node_b.adapter], 2).await;
 
-    let (resume_socket_id, mut resume_reader) = connect_v2_socket(&restarted_node_b, &app).await;
+    let (resume_socket_id, mut resume_reader, _resume_writer) =
+        connect_v2_socket(&restarted_node_b, &app).await;
     let resume_payload = json!({
         "channel_positions": {
             "cold": {

--- a/crates/sockudo-server/tests/native_v2_heartbeat_test.rs
+++ b/crates/sockudo-server/tests/native_v2_heartbeat_test.rs
@@ -1,0 +1,270 @@
+use axum::Router;
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use sockudo_core::options::WebSocketConfig;
+use sockudo_ws::axum_integration::WebSocketUpgrade;
+use sockudo_ws::{Error as WebSocketError, Message};
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+const PONG_TIMEOUT_CLOSE_CODE: u16 = 4201;
+const PONG_TIMEOUT_CLOSE_REASON: &[u8] = b"Pong reply not received in time";
+const FRAME_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Clone)]
+struct HeartbeatState {
+    events: mpsc::UnboundedSender<ServerEvent>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ServerEvent {
+    Pong(Vec<u8>),
+    HeartbeatTimeout,
+    UnexpectedError(String),
+}
+
+struct TestServer {
+    address: SocketAddr,
+    task: JoinHandle<()>,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[derive(Debug)]
+struct ServerFrame {
+    opcode: u8,
+    payload: Vec<u8>,
+}
+
+fn v2_heartbeat_test_config() -> sockudo_ws::Config {
+    let websocket = WebSocketConfig {
+        ping_interval: 1,
+        idle_timeout: 0,
+        ..WebSocketConfig::default()
+    };
+    let mut config = websocket.to_sockudo_ws_config_with_native_heartbeat(64, 2, true);
+
+    assert!(config.auto_ping, "Protocol V2 must enable native auto-ping");
+    assert_eq!(config.pong_timeout_close_code, PONG_TIMEOUT_CLOSE_CODE);
+    assert_eq!(
+        config.pong_timeout_close_reason.as_bytes(),
+        PONG_TIMEOUT_CLOSE_REASON
+    );
+
+    // Runtime values are deliberately shortened for this integration test.
+    // The production Pong deadline and close contract remain asserted above.
+    config.ping_interval = 1;
+    config.pong_timeout = 1;
+    config.close_timeout = 1;
+    config
+}
+
+async fn heartbeat_handler(
+    State(state): State<HeartbeatState>,
+    upgrade: WebSocketUpgrade,
+) -> impl IntoResponse {
+    upgrade
+        .config(v2_heartbeat_test_config())
+        .on_upgrade(move |socket| async move {
+            let (mut reader, _writer) = socket.split();
+            while let Some(result) = reader.next().await {
+                let event = match result {
+                    Ok(Message::Pong(payload)) => Some(ServerEvent::Pong(payload.to_vec())),
+                    Err(WebSocketError::HeartbeatTimeout) => Some(ServerEvent::HeartbeatTimeout),
+                    Err(error) => Some(ServerEvent::UnexpectedError(error.to_string())),
+                    Ok(_) => None,
+                };
+                if let Some(event) = event
+                    && state.events.send(event).is_err()
+                {
+                    break;
+                }
+            }
+        })
+}
+
+async fn spawn_test_server() -> (TestServer, mpsc::UnboundedReceiver<ServerEvent>) {
+    let (events, event_receiver) = mpsc::unbounded_channel();
+    let state = HeartbeatState { events };
+    let app = Router::new()
+        .route("/app/test", get(heartbeat_handler))
+        .with_state(state);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test server should bind");
+    let address = listener
+        .local_addr()
+        .expect("test server should have a local address");
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("test server should run");
+    });
+
+    (TestServer { address, task }, event_receiver)
+}
+
+async fn connect_raw_websocket(address: SocketAddr) -> TcpStream {
+    let mut stream = TcpStream::connect(address)
+        .await
+        .expect("test client should connect");
+    let request = format!(
+        "GET /app/test?protocol=2 HTTP/1.1\r\n\
+         Host: {address}\r\n\
+         Upgrade: websocket\r\n\
+         Connection: Upgrade\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+         \r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("WebSocket handshake should be written");
+    stream
+        .flush()
+        .await
+        .expect("WebSocket handshake should be flushed");
+
+    let response = timeout(FRAME_TIMEOUT, async {
+        let mut response = Vec::new();
+        let mut byte = [0_u8; 1];
+        while !response.ends_with(b"\r\n\r\n") {
+            stream
+                .read_exact(&mut byte)
+                .await
+                .expect("WebSocket handshake response should be readable");
+            response.push(byte[0]);
+        }
+        response
+    })
+    .await
+    .expect("timed out waiting for WebSocket handshake");
+    let response = String::from_utf8(response).expect("handshake response should be UTF-8");
+    assert!(
+        response.starts_with("HTTP/1.1 101"),
+        "expected switching protocols response, got: {response}"
+    );
+
+    stream
+}
+
+async fn read_server_frame(stream: &mut TcpStream) -> ServerFrame {
+    timeout(FRAME_TIMEOUT, async {
+        let mut header = [0_u8; 2];
+        stream
+            .read_exact(&mut header)
+            .await
+            .expect("server frame header should be readable");
+        assert_ne!(header[0] & 0x80, 0, "server control frame must be final");
+        assert_eq!(header[1] & 0x80, 0, "server frames must not be masked");
+
+        let payload_length = usize::from(header[1] & 0x7f);
+        assert!(
+            payload_length <= 125,
+            "control frame payload must fit in one byte"
+        );
+        let mut payload = vec![0; payload_length];
+        stream
+            .read_exact(&mut payload)
+            .await
+            .expect("server frame payload should be readable");
+
+        ServerFrame {
+            opcode: header[0] & 0x0f,
+            payload,
+        }
+    })
+    .await
+    .expect("timed out waiting for server frame")
+}
+
+async fn send_masked_pong(stream: &mut TcpStream, payload: &[u8]) {
+    let mask = [0x11, 0x22, 0x33, 0x44];
+    let mut frame = Vec::with_capacity(6 + payload.len());
+    frame.push(0x8a);
+    frame.push(0x80 | payload.len() as u8);
+    frame.extend_from_slice(&mask);
+    frame.extend(
+        payload
+            .iter()
+            .enumerate()
+            .map(|(index, byte)| byte ^ mask[index % mask.len()]),
+    );
+    stream
+        .write_all(&frame)
+        .await
+        .expect("Pong frame should be written");
+    stream.flush().await.expect("Pong frame should be flushed");
+}
+
+async fn next_server_event(events: &mut mpsc::UnboundedReceiver<ServerEvent>) -> ServerEvent {
+    timeout(FRAME_TIMEOUT, events.recv())
+        .await
+        .expect("timed out waiting for server heartbeat event")
+        .expect("server heartbeat event channel closed")
+}
+
+#[tokio::test]
+async fn native_v2_heartbeat_accepts_matching_pong_and_keeps_connection_open() {
+    let (server, mut events) = spawn_test_server().await;
+    let mut client = connect_raw_websocket(server.address).await;
+
+    let first_ping = read_server_frame(&mut client).await;
+    assert_eq!(first_ping.opcode, 0x09);
+    assert_eq!(first_ping.payload.len(), 8, "Ping must contain a nonce");
+    send_masked_pong(&mut client, &first_ping.payload).await;
+    assert_eq!(
+        next_server_event(&mut events).await,
+        ServerEvent::Pong(first_ping.payload.clone())
+    );
+
+    let second_ping = read_server_frame(&mut client).await;
+    assert_eq!(
+        second_ping.opcode, 0x09,
+        "a matching Pong must keep the connection alive for the next Ping"
+    );
+    assert_eq!(second_ping.payload.len(), 8, "Ping must contain a nonce");
+    assert_ne!(
+        second_ping.payload, first_ping.payload,
+        "each Ping must use a fresh nonce"
+    );
+    send_masked_pong(&mut client, &second_ping.payload).await;
+    assert_eq!(
+        next_server_event(&mut events).await,
+        ServerEvent::Pong(second_ping.payload)
+    );
+}
+
+#[tokio::test]
+async fn native_v2_heartbeat_closes_nonresponsive_peer_with_4201() {
+    let (server, mut events) = spawn_test_server().await;
+    let mut client = connect_raw_websocket(server.address).await;
+
+    let ping = read_server_frame(&mut client).await;
+    assert_eq!(ping.opcode, 0x09);
+    assert_eq!(ping.payload.len(), 8, "Ping must contain a nonce");
+
+    let close = read_server_frame(&mut client).await;
+    assert_eq!(close.opcode, 0x08);
+    assert!(close.payload.len() >= 2, "Close frame must include a code");
+    assert_eq!(
+        u16::from_be_bytes([close.payload[0], close.payload[1]]),
+        PONG_TIMEOUT_CLOSE_CODE
+    );
+    assert_eq!(&close.payload[2..], PONG_TIMEOUT_CLOSE_REASON);
+    assert_eq!(
+        next_server_event(&mut events).await,
+        ServerEvent::HeartbeatTimeout
+    );
+}

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -334,9 +334,9 @@ See [Logging](/docs/reference/logging) for level policy, stable lifecycle fields
 | `WEBSOCKET_MAX_FRAME_SIZE` | WebSocket frame size limit. |
 | `WEBSOCKET_WRITE_BUFFER_SIZE` | WebSocket write buffer size. |
 | `WEBSOCKET_MAX_BACKPRESSURE` | WebSocket backpressure limit. |
-| `WEBSOCKET_AUTO_PING` | Enables automatic WebSocket ping frames. |
-| `WEBSOCKET_PING_INTERVAL` | WebSocket ping interval. |
-| `WEBSOCKET_IDLE_TIMEOUT` | WebSocket idle timeout. |
+| `WEBSOCKET_AUTO_PING` | Enables native WebSocket Ping/Pong keepalive for Protocol V2. Protocol V1 retains its Pusher-compatible application heartbeat. |
+| `WEBSOCKET_PING_INTERVAL` | Inbound inactivity in seconds before a Protocol V2 native Ping. `0` disables proactive native Ping frames; nonzero values are bounded to at least half of `ACTIVITY_TIMEOUT` (and at least 5 seconds). |
+| `WEBSOCKET_IDLE_TIMEOUT` | Hard inbound-idle timeout in seconds for Protocol V2 native connections. `0` disables the hard idle deadline. |
 | `WEBSOCKET_COMPRESSION` | WebSocket compression mode. |
 | `CONNECTION_RECOVERY_ENABLED` | Enables Protocol V2 connection recovery. |
 | `CONNECTION_RECOVERY_BUFFER_TTL` | Recovery buffer TTL. |


### PR DESCRIPTION
## Summary

- upgrade `sockudo-ws` from 1.7.4 to 2.0.1
- use the native nonce-based WebSocket Ping/Pong heartbeat for Protocol V2
- close missed native Pong deadlines with code 4201 and preserve activity-timeout cleanup attribution
- keep Protocol V1 on the Pusher-compatible application heartbeat and Ably compatibility on `ACTION_HEARTBEAT`
- migrate split WebSocket fixtures and the Ably fatal-close path to the 2.0.1 split-driver lifetime contract
- document the protocol-specific heartbeat configuration

## Root cause

PR #352 enabled Sockudo's application-level V2 activity loop because `sockudo-ws` 1.7.4 exposed `auto_ping` configuration without implementing it. `sockudo-ws` 2.0.1 now implements native heartbeat handling. Leaving the application loop enabled would run two competing V2 keepalive mechanisms and could produce duplicate pings, conflicting timeout state, and unexpected closes.

The 2.0.1 split implementation also uses a connection-scoped writer driver that is cancelled when either split half is dropped, so writer-only test helpers needed to retain and poll their reader half.

## Behavior

- Protocol V2 sends native Ping frames after configured inbound inactivity.
- A matching nonce Pong must arrive within `PONG_TIMEOUT`; otherwise the transport sends close code 4201 with `Pong reply not received in time`.
- Native heartbeat and idle terminal errors are recorded as `activity_timeout`, not `transport_eof`.
- Protocol V1 and Ably heartbeat behavior remains unchanged.

## Regression proof

- an adapter integration test verifies that V2 never installs the legacy application timeout task that emits `pong timeout reached, forcing cleanup`, while V1 still installs it
- a real WebSocket integration test verifies that matching native nonce Pongs keep V2 connected across successive Ping intervals
- the same transport test verifies that an ignored native Ping produces close code 4201 and a typed `HeartbeatTimeout`
- a manual 20-client V2 soak ran beyond the old `activity_timeout + PONG_TIMEOUT` failure window with 20/20 connections open, no application Ping messages, and no legacy timeout warnings
- a deliberately nonresponsive raw V2 client received one native Ping followed by close code 4201, with the native timeout warning and no legacy warning

## Validation

- `cargo test --locked --workspace --quiet -- --skip redis`
- `cargo test --locked --workspace --no-run`
- `cargo test --locked -p sockudo --test native_v2_heartbeat_test`
- `cargo test --locked -p sockudo-adapter --test integration adapter::handler::activity_timeout_test::initial_activity_timeout_task_is_installed_only_for_v1 -- --exact`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --locked -p sockudo-core -p sockudo-adapter -p sockudo-ably-compat -p sockudo`
- `cd docs && npm run types:check`
- `cd docs && npm run build`

Redis-named runtime tests were skipped because no Redis service was available; all workspace test targets, including Redis-gated targets, compiled successfully.
