### PR TITLE
perf: reduce clone allocations in hot paths

### DIFF
--- a/benches/ai/benches/ai_hot_paths.rs
+++ b/benches/ai/benches/ai_hot_paths.rs
@@ -16,18 +16,73 @@ use sockudo_protocol::messages::{
     AI_EVENT_INPUT, AiExtras, MessageData, MessageExtras, PusherMessage, is_ai_event,
 };
 use sockudo_protocol::versioned_messages::{
-    MessageAction, MessageVersionMetadata, apply_runtime_metadata,
+    MessageAction, MessageVersionMetadata, apply_runtime_metadata, set_runtime_append_fragment,
 };
 use sonic_rs::json;
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::collections::HashMap;
 use std::hint::black_box;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Once;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 const APP_ID: &str = "app";
 const CHANNEL: &str = "ai:bench";
 const MESSAGE_SERIAL: &str = "msg:bench";
+const ROLLUP_ALLOCATION_FRAGMENTS: usize = 256;
+
+struct CountingAllocator;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+static ROLLUP_ALLOCATION_REPORT: Once = Once::new();
+
+// SAFETY: every allocation operation delegates to the process system allocator.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the caller provided a valid allocation layout.
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        let pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn measure_allocations<T>(operation: impl FnOnce() -> T) -> (T, u64, u64) {
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    ALLOCATION_COUNT.store(0, Ordering::SeqCst);
+    ALLOCATED_BYTES.store(0, Ordering::SeqCst);
+    TRACK_ALLOCATIONS.store(true, Ordering::SeqCst);
+    let result = operation();
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    (
+        result,
+        ALLOCATION_COUNT.load(Ordering::SeqCst),
+        ALLOCATED_BYTES.load(Ordering::SeqCst),
+    )
+}
 
 struct CountingBlockVersionStore {
     inner: MemoryVersionStore,
@@ -194,6 +249,12 @@ fn append_wire_message(serial: &str, data: String, now: i64, terminal: bool) -> 
     message
 }
 
+fn append_rollup_fragment_message(serial: &str, fragment: String, now: i64) -> PusherMessage {
+    let mut message = append_wire_message(serial, "latest".to_string(), now, false);
+    set_runtime_append_fragment(&mut message, fragment);
+    message
+}
+
 fn rollup_engine() -> RollupEngine {
     RollupEngine::new(RollupConfig {
         max_active_streams_per_channel: 50_000,
@@ -351,6 +412,58 @@ fn bench_rollup(c: &mut Criterion) {
             let message = append_wire_message(MESSAGE_SERIAL, "x".repeat(64), serial, false);
             serial = serial.wrapping_add(1);
             black_box(engine.ingest(APP_ID, CHANNEL, message, 1));
+        });
+    });
+
+    ROLLUP_ALLOCATION_REPORT.call_once(|| {
+        let (deliveries, allocations, allocated_bytes) = measure_allocations(|| {
+            let engine = RollupEngine::new(RollupConfig::default());
+            let _ = engine.ingest(
+                APP_ID,
+                CHANNEL,
+                append_rollup_fragment_message(MESSAGE_SERIAL, "x".repeat(256), 0),
+                0,
+            );
+            for index in 1..=ROLLUP_ALLOCATION_FRAGMENTS {
+                let _ = engine.ingest(
+                    APP_ID,
+                    CHANNEL,
+                    append_rollup_fragment_message(
+                        MESSAGE_SERIAL,
+                        "x".repeat(256),
+                        index as i64,
+                    ),
+                    1,
+                );
+            }
+            engine.flush_due(40)
+        });
+        assert_eq!(deliveries.len(), 1);
+        eprintln!(
+            "allocation_profile name=ai_rollup_256x256b allocations={allocations} allocated_bytes={allocated_bytes}"
+        );
+        black_box(deliveries);
+    });
+
+    group.throughput(Throughput::Elements(ROLLUP_ALLOCATION_FRAGMENTS as u64));
+    group.bench_function("rollup_coalesce_256x256b", |b| {
+        b.iter(|| {
+            let engine = RollupEngine::new(RollupConfig::default());
+            let _ = engine.ingest(
+                APP_ID,
+                CHANNEL,
+                append_rollup_fragment_message(MESSAGE_SERIAL, "x".repeat(256), 0),
+                0,
+            );
+            for index in 1..=ROLLUP_ALLOCATION_FRAGMENTS {
+                let _ = engine.ingest(
+                    APP_ID,
+                    CHANNEL,
+                    append_rollup_fragment_message(MESSAGE_SERIAL, "x".repeat(256), index as i64),
+                    1,
+                );
+            }
+            black_box(engine.flush_due(40))
         });
     });
 

--- a/client-sdks/sockudo-python/README.md
+++ b/client-sdks/sockudo-python/README.md
@@ -97,7 +97,9 @@ from sockudo_python import (
 )
 
 
-async def my_auth_handler(request: ChannelAuthorizationRequest) -> ChannelAuthorizationData:
+async def my_auth_handler(
+    request: ChannelAuthorizationRequest,
+) -> ChannelAuthorizationData:
     # Call your own backend to produce a signed auth token.
     return ChannelAuthorizationData(
         auth="app-key:hmac-sha256-signature",
@@ -177,7 +179,11 @@ await channel.update({"status": "editing"})
 Client-side presence history is proxy-backed. The Python client does not sign the server REST API directly; configure a backend endpoint that accepts `{channel, params, action}` and proxies the request with server credentials.
 
 ```python
-from sockudo_python import PresenceHistoryOptions, PresenceHistoryParams, PresenceSnapshotParams
+from sockudo_python import (
+    PresenceHistoryOptions,
+    PresenceHistoryParams,
+    PresenceSnapshotParams,
+)
 
 client = SockudoClient(
     "app-key",
@@ -193,9 +199,7 @@ client = SockudoClient(
 
 channel = client.subscribe("presence-lobby")
 
-page = await channel.history(
-    PresenceHistoryParams(limit=50, direction="newest_first")
-)
+page = await channel.history(PresenceHistoryParams(limit=50, direction="newest_first"))
 if page.has_next():
     next_page = await page.next()
 
@@ -322,7 +326,9 @@ channel.bind("doc-updated", lambda data, meta: print(data))  # data is already d
 Your auth handler must populate `shared_secret` in `ChannelAuthorizationData`:
 
 ```python
-async def encrypted_auth(request: ChannelAuthorizationRequest) -> ChannelAuthorizationData:
+async def encrypted_auth(
+    request: ChannelAuthorizationRequest,
+) -> ChannelAuthorizationData:
     return ChannelAuthorizationData(
         auth="app-key:hmac-sha256-signature",
         shared_secret="base64-encoded-32-byte-secret",
@@ -359,8 +365,11 @@ Bind to connection state changes to react to connect, disconnect, and reconnect 
 def on_state_change(change) -> None:
     print(f"connection: {change.previous} -> {change.current}")
 
+
 client.connection.bind("state_change", on_state_change)
-client.connection.bind("connected", lambda data, _: print("socket id:", data.get("socket_id")))
+client.connection.bind(
+    "connected", lambda data, _: print("socket id:", data.get("socket_id"))
+)
 client.connection.bind("disconnected", lambda data, _: print("disconnected"))
 client.connection.bind("error", lambda data, _: print("error:", data))
 

--- a/client-sdks/sockudo-python/pyproject.toml
+++ b/client-sdks/sockudo-python/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
   "build>=1.2.2",
   "pytest>=8.0.0",
   "pytest-asyncio>=0.23.0",
-  "ruff>=0.9.0",
+  "ruff==0.16.0",
   "twine>=6.0.0",
 ]
 
@@ -41,3 +41,9 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/crates/sockudo-ably-compat/src/runtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime.rs
@@ -1499,7 +1499,7 @@ impl RealtimeEgressTap for AblyCompatHub {
                     action: ACTION_ANNOTATION,
                     timestamp: Some(event.timestamp),
                     channel: Some(channel.to_string()),
-                    channel_serial,
+                    channel_serial: channel_serial.clone(),
                     annotations: Some(vec![ably_annotation_from_native_event(event)]),
                     ..empty_protocol_message(ACTION_ANNOTATION)
                 },
@@ -1527,7 +1527,7 @@ impl RealtimeEgressTap for AblyCompatHub {
                     action: ACTION_MESSAGE,
                     timestamp: Some(now_ms()),
                     channel: Some(channel.to_string()),
-                    channel_serial,
+                    channel_serial: channel_serial.clone(),
                     messages: Some(vec![AblyMessage {
                         serial: Some(serial.to_string()),
                         action: Some(MESSAGE_SUMMARY),
@@ -1555,15 +1555,6 @@ impl RealtimeEgressTap for AblyCompatHub {
                     return Ok(());
                 }
             };
-        let aggregate = (envelope.action
-            == Some(sockudo_core::versioned_messages::MessageAction::Append))
-        .then(|| envelope_to_ably_message(envelope, message, AblyMessageProjection::Aggregate))
-        .transpose()
-        .ok()
-        .flatten();
-        let aggregate_channel_serial = aggregate
-            .as_ref()
-            .and_then(|_| channel_serial.as_ref().cloned());
         self.broadcast(
             app_id,
             channel,
@@ -1571,14 +1562,17 @@ impl RealtimeEgressTap for AblyCompatHub {
                 action: ACTION_MESSAGE,
                 timestamp: Some(now_ms()),
                 channel: Some(channel.to_string()),
-                channel_serial,
+                channel_serial: channel_serial.clone(),
                 messages: Some(vec![ably_message]),
                 ..empty_protocol_message(ACTION_MESSAGE)
             },
             envelope.publisher_connection_id.as_deref(),
             envelope.extras.as_ref().and_then(|extras| extras.echo),
         );
-        if let Some(aggregate) = aggregate {
+        if envelope.action == Some(sockudo_core::versioned_messages::MessageAction::Append)
+            && let Ok(aggregate) =
+                envelope_to_ably_message(envelope, message, AblyMessageProjection::Aggregate)
+        {
             self.broadcast(
                 app_id,
                 channel,
@@ -1586,7 +1580,7 @@ impl RealtimeEgressTap for AblyCompatHub {
                     action: ACTION_MESSAGE,
                     timestamp: Some(now_ms()),
                     channel: Some(channel.to_string()),
-                    channel_serial: aggregate_channel_serial,
+                    channel_serial,
                     messages: Some(vec![aggregate]),
                     ..empty_protocol_message(ACTION_MESSAGE)
                 },

--- a/crates/sockudo-ably-compat/src/runtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime.rs
@@ -1478,7 +1478,7 @@ impl RealtimeEgressTap for AblyCompatHub {
             );
             return Ok(());
         }
-        let channel_serial = envelope
+        let mut channel_serial = envelope
             .stream_id
             .as_deref()
             .zip(envelope.delivery_serial)
@@ -1499,7 +1499,7 @@ impl RealtimeEgressTap for AblyCompatHub {
                     action: ACTION_ANNOTATION,
                     timestamp: Some(event.timestamp),
                     channel: Some(channel.to_string()),
-                    channel_serial: channel_serial.clone(),
+                    channel_serial,
                     annotations: Some(vec![ably_annotation_from_native_event(event)]),
                     ..empty_protocol_message(ACTION_ANNOTATION)
                 },
@@ -1527,7 +1527,7 @@ impl RealtimeEgressTap for AblyCompatHub {
                     action: ACTION_MESSAGE,
                     timestamp: Some(now_ms()),
                     channel: Some(channel.to_string()),
-                    channel_serial: channel_serial.clone(),
+                    channel_serial,
                     messages: Some(vec![AblyMessage {
                         serial: Some(serial.to_string()),
                         action: Some(MESSAGE_SUMMARY),
@@ -1555,6 +1555,13 @@ impl RealtimeEgressTap for AblyCompatHub {
                     return Ok(());
                 }
             };
+        let is_append =
+            envelope.action == Some(sockudo_core::versioned_messages::MessageAction::Append);
+        let primary_channel_serial = if is_append {
+            channel_serial.clone()
+        } else {
+            channel_serial.take()
+        };
         self.broadcast(
             app_id,
             channel,
@@ -1562,14 +1569,14 @@ impl RealtimeEgressTap for AblyCompatHub {
                 action: ACTION_MESSAGE,
                 timestamp: Some(now_ms()),
                 channel: Some(channel.to_string()),
-                channel_serial: channel_serial.clone(),
+                channel_serial: primary_channel_serial,
                 messages: Some(vec![ably_message]),
                 ..empty_protocol_message(ACTION_MESSAGE)
             },
             envelope.publisher_connection_id.as_deref(),
             envelope.extras.as_ref().and_then(|extras| extras.echo),
         );
-        if envelope.action == Some(sockudo_core::versioned_messages::MessageAction::Append)
+        if is_append
             && let Ok(aggregate) =
                 envelope_to_ably_message(envelope, message, AblyMessageProjection::Aggregate)
         {

--- a/crates/sockudo-ably-compat/src/runtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime.rs
@@ -1499,7 +1499,7 @@ impl RealtimeEgressTap for AblyCompatHub {
                     action: ACTION_ANNOTATION,
                     timestamp: Some(event.timestamp),
                     channel: Some(channel.to_string()),
-                    channel_serial: channel_serial.clone(),
+                    channel_serial,
                     annotations: Some(vec![ably_annotation_from_native_event(event)]),
                     ..empty_protocol_message(ACTION_ANNOTATION)
                 },
@@ -1527,7 +1527,7 @@ impl RealtimeEgressTap for AblyCompatHub {
                     action: ACTION_MESSAGE,
                     timestamp: Some(now_ms()),
                     channel: Some(channel.to_string()),
-                    channel_serial: channel_serial.clone(),
+                    channel_serial,
                     messages: Some(vec![AblyMessage {
                         serial: Some(serial.to_string()),
                         action: Some(MESSAGE_SUMMARY),
@@ -1555,6 +1555,15 @@ impl RealtimeEgressTap for AblyCompatHub {
                     return Ok(());
                 }
             };
+        let aggregate = (envelope.action
+            == Some(sockudo_core::versioned_messages::MessageAction::Append))
+        .then(|| envelope_to_ably_message(envelope, message, AblyMessageProjection::Aggregate))
+        .transpose()
+        .ok()
+        .flatten();
+        let aggregate_channel_serial = aggregate
+            .as_ref()
+            .and_then(|_| channel_serial.as_ref().cloned());
         self.broadcast(
             app_id,
             channel,
@@ -1562,17 +1571,14 @@ impl RealtimeEgressTap for AblyCompatHub {
                 action: ACTION_MESSAGE,
                 timestamp: Some(now_ms()),
                 channel: Some(channel.to_string()),
-                channel_serial: channel_serial.clone(),
+                channel_serial,
                 messages: Some(vec![ably_message]),
                 ..empty_protocol_message(ACTION_MESSAGE)
             },
             envelope.publisher_connection_id.as_deref(),
             envelope.extras.as_ref().and_then(|extras| extras.echo),
         );
-        if envelope.action == Some(sockudo_core::versioned_messages::MessageAction::Append)
-            && let Ok(aggregate) =
-                envelope_to_ably_message(envelope, message, AblyMessageProjection::Aggregate)
-        {
+        if let Some(aggregate) = aggregate {
             self.broadcast(
                 app_id,
                 channel,
@@ -1580,7 +1586,7 @@ impl RealtimeEgressTap for AblyCompatHub {
                     action: ACTION_MESSAGE,
                     timestamp: Some(now_ms()),
                     channel: Some(channel.to_string()),
-                    channel_serial,
+                    channel_serial: aggregate_channel_serial,
                     messages: Some(vec![aggregate]),
                     ..empty_protocol_message(ACTION_MESSAGE)
                 },

--- a/crates/sockudo-ably-compat/src/runtime/auth_runtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime/auth_runtime.rs
@@ -325,9 +325,8 @@ pub(super) fn intersect_ably_capability(
         for (resource, operations) in &key {
             capability_operations(resource, operations)?;
         }
-        let capabilities =
-            ably_capability_value_to_sockudo(&serde_json::Value::Object(key.clone()))
-                .map_err(|error| CapabilityIntersectionError::Invalid(error.to_string()))?;
+        let capabilities = ably_capability_value_to_sockudo(&serde_json::Value::Object(key))
+            .map_err(|error| CapabilityIntersectionError::Invalid(error.to_string()))?;
         return Ok((key_capability.to_string(), Some(capabilities)));
     };
     let requested = parse_ably_capability_object(requested_raw)?;

--- a/crates/sockudo-ably-compat/src/runtime/realtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime/realtime.rs
@@ -1007,9 +1007,10 @@ pub(super) async fn handle_ably_protocol_message(
                 client_id.map(str::to_string),
             )
             .await;
-            *active_connection_key
+            active_connection_key
                 .write()
-                .unwrap_or_else(|poisoned| poisoned.into_inner()) = connection_key.clone();
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone_from(&connection_key);
             send_protocol(
                 sender,
                 connected_message(

--- a/crates/sockudo-ably-compat/src/runtime/tests.rs
+++ b/crates/sockudo-ably-compat/src/runtime/tests.rs
@@ -3,7 +3,9 @@
 use super::*;
 use base64::engine::general_purpose;
 use sockudo_cache::{MemoryCacheManager, RedisCacheManager};
-use sockudo_core::{app::AppPolicy, options::MemoryCacheOptions};
+use sockudo_core::{
+    app::AppPolicy, options::MemoryCacheOptions, versioned_messages::MessageAction,
+};
 use sockudo_protocol::messages::{AiExtras, MessageExtras};
 use sockudo_protocol::versioned_messages::apply_runtime_metadata;
 use sockudo_ws::{
@@ -1456,6 +1458,89 @@ async fn duplicate_remote_delivery_position_reaches_local_ably_subscriber_once()
     assert_eq!(hub.metrics.snapshot().fanout, 1);
     assert_eq!(hub.metrics.snapshot().data_encoded, 1);
     assert_eq!(hub.metrics.snapshot().duplicate_suppression, 1);
+}
+
+#[tokio::test]
+async fn append_delivery_preserves_channel_serial_across_both_projections() {
+    let hub = AblyCompatHub::default();
+    let (sender, mut receiver) = AblyOutbound::channel(
+        AblyFormat::Json,
+        OutboundLimits::default(),
+        Arc::clone(&hub.metrics),
+    );
+    let channel = AblyChannelName::parse("append-room".to_string()).unwrap();
+    hub.attach_clean(
+        "app",
+        &channel,
+        AblyAttachment {
+            connection_id: "subscriber-connection",
+            session_id: "subscriber-session",
+            sender,
+            filter: None,
+            params: HashMap::new(),
+            mode_flags: ABLY_DEFAULT_MODE_FLAGS,
+            echo: true,
+            presence: Vec::new(),
+        },
+        None,
+        Vec::new(),
+    );
+    let attached = receiver.recv().await.expect("ATTACHED frame");
+    assert_eq!(
+        decode_protocol_bytes(attached.bytes.as_ref(), AblyFormat::Json)
+            .unwrap()
+            .action,
+        ACTION_ATTACHED
+    );
+
+    let message = PusherMessage {
+        event: Some("sockudo:message.append".to_string()),
+        channel: Some(channel.base().to_string()),
+        data: Some(MessageData::String("hello".to_string())),
+        name: Some("ai-output".to_string()),
+        user_id: None,
+        tags: None,
+        sequence: None,
+        conflation_key: None,
+        message_id: Some("message-1".to_string()),
+        stream_id: Some("stream-1".to_string()),
+        serial: Some(7),
+        idempotency_key: None,
+        extras: None,
+        delta_sequence: None,
+        delta_conflation_key: None,
+    };
+    let mut envelope = MessageEnvelope::from_message(&message, None, None, 1).unwrap();
+    envelope.set_commit_positions(Some("stream-1".to_string()), Some(7), Some(7));
+    envelope.action = Some(MessageAction::Append);
+
+    RealtimeEgressTap::deliver(&hub, "app", channel.base(), &message, &envelope).unwrap();
+
+    let mutation = receiver.recv().await.expect("append mutation");
+    let mutation = decode_protocol_bytes(mutation.bytes.as_ref(), AblyFormat::Json).unwrap();
+    let aggregate = receiver.recv().await.expect("append aggregate");
+    let aggregate = decode_protocol_bytes(aggregate.bytes.as_ref(), AblyFormat::Json).unwrap();
+    assert_eq!(mutation.channel_serial.as_deref(), Some("stream-1:7"));
+    assert_eq!(
+        aggregate.channel_serial.as_deref(),
+        mutation.channel_serial.as_deref()
+    );
+    assert_eq!(
+        mutation
+            .messages
+            .as_ref()
+            .and_then(|messages| messages.first())
+            .and_then(|message| message.action),
+        Some(MESSAGE_APPEND)
+    );
+    assert_eq!(
+        aggregate
+            .messages
+            .as_ref()
+            .and_then(|messages| messages.first())
+            .and_then(|message| message.action),
+        Some(MESSAGE_UPDATE)
+    );
 }
 
 #[test]

--- a/crates/sockudo-adapter/benches/hot_path_replacements.rs
+++ b/crates/sockudo-adapter/benches/hot_path_replacements.rs
@@ -1,15 +1,147 @@
 use ahash::{AHashMap, AHasher, RandomState as AHashRandomState};
+use bytes::Bytes;
 use compact_str::{CompactString, format_compact};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use dashmap::DashMap;
 use papaya::HashMap as PapayaHashMap;
 use parking_lot::Mutex as ParkingMutex;
 use scc::{HashIndex as SccHashIndex, HashMap as SccHashMap};
+use sockudo_protocol::messages::PusherMessage;
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::collections::VecDeque;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::hint::black_box;
-use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Mutex as StdMutex, Once};
 use std::thread;
+
+struct CountingAllocator;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+static FANOUT_ALLOCATION_REPORT: Once = Once::new();
+
+// SAFETY: every allocation operation delegates to the process system allocator.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the caller provided a valid allocation layout.
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        let pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn measure_allocations<T>(operation: impl FnOnce() -> T) -> (T, u64, u64) {
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    ALLOCATION_COUNT.store(0, Ordering::SeqCst);
+    ALLOCATED_BYTES.store(0, Ordering::SeqCst);
+    TRACK_ALLOCATIONS.store(true, Ordering::SeqCst);
+    let result = operation();
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    (
+        result,
+        ALLOCATION_COUNT.load(Ordering::SeqCst),
+        ALLOCATED_BYTES.load(Ordering::SeqCst),
+    )
+}
+
+fn fanout_message(payload_bytes: usize) -> PusherMessage {
+    PusherMessage::channel_event(
+        "message",
+        "bench-channel",
+        sonic_rs::json!({"payload": "x".repeat(payload_bytes)}),
+    )
+}
+
+fn legacy_protocol_fanout(message: &PusherMessage, sockets: usize) -> usize {
+    (0..sockets)
+        .map(|_| {
+            let socket_message = message.clone();
+            sonic_rs::to_vec(&socket_message).unwrap().len()
+        })
+        .sum()
+}
+
+fn serialized_bytes_fanout(message: &PusherMessage, sockets: usize) -> usize {
+    let bytes = Bytes::from(sonic_rs::to_vec(message).unwrap());
+    (0..sockets)
+        .map(|_| {
+            let socket_bytes = bytes.clone();
+            socket_bytes.len()
+        })
+        .sum()
+}
+
+fn bench_serialized_fanout(c: &mut Criterion) {
+    FANOUT_ALLOCATION_REPORT.call_once(|| {
+        let message = fanout_message(64 * 1024);
+        let (_, legacy_allocations, legacy_bytes) =
+            measure_allocations(|| legacy_protocol_fanout(&message, 1_000));
+        let (_, shared_allocations, shared_bytes) =
+            measure_allocations(|| serialized_bytes_fanout(&message, 1_000));
+        eprintln!(
+            "allocation_profile name=adapter_v2_fanout_1000x64k variant=legacy allocations={legacy_allocations} allocated_bytes={legacy_bytes}"
+        );
+        eprintln!(
+            "allocation_profile name=adapter_v2_fanout_1000x64k variant=shared_bytes allocations={shared_allocations} allocated_bytes={shared_bytes}"
+        );
+    });
+
+    let mut group = c.benchmark_group("adapter_v2_serialized_fanout");
+    for payload_bytes in [1_024_usize, 64 * 1_024] {
+        let message = fanout_message(payload_bytes);
+        for sockets in [1_usize, 100, 1_000] {
+            group.throughput(Throughput::Elements(sockets as u64));
+            group.bench_with_input(
+                BenchmarkId::new(format!("legacy_{payload_bytes}b"), sockets),
+                &sockets,
+                |b, &sockets| {
+                    b.iter(|| {
+                        black_box(legacy_protocol_fanout(
+                            black_box(&message),
+                            black_box(sockets),
+                        ))
+                    })
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new(format!("shared_bytes_{payload_bytes}b"), sockets),
+                &sockets,
+                |b, &sockets| {
+                    b.iter(|| {
+                        black_box(serialized_bytes_fanout(
+                            black_box(&message),
+                            black_box(sockets),
+                        ))
+                    })
+                },
+            );
+        }
+    }
+    group.finish();
+}
 
 fn hash_with_default(payload: &[u8]) -> u64 {
     let mut hasher = DefaultHasher::new();
@@ -850,6 +982,7 @@ criterion_group!(
     bench_replay_lock_store,
     bench_compact_string_candidates,
     bench_concurrent_map_candidates,
-    bench_subscription_count_notification_plans
+    bench_subscription_count_notification_plans,
+    bench_serialized_fanout
 );
 criterion_main!(benches);

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -1464,7 +1464,7 @@ mod tests {
                 presence_member.user_id.clone(),
                 PresenceMemberInfo {
                     user_id: presence_member.user_id.clone(),
-                    user_info: Some(presence_member.user_info.clone()),
+                    user_info: Some(presence_member.user_info),
                 },
             );
         }
@@ -1504,7 +1504,7 @@ mod tests {
                 presence_member.user_id.clone(),
                 PresenceMemberInfo {
                     user_id: presence_member.user_id.clone(),
-                    user_info: Some(presence_member.user_info.clone()),
+                    user_info: Some(presence_member.user_info),
                 },
             );
         }

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
@@ -119,10 +119,13 @@ where
         // Fall back to regular sending without delta compression
         // Send locally first (tracked in connection manager for metrics)
         let node_id = self.horizontal.node_id.clone();
+        let message_json = sonic_rs::to_string(&message)?;
+        let idempotency_key = message.idempotency_key.clone();
+        let ephemeral = message.is_ephemeral();
 
         let local_result = self
             .local_adapter
-            .send(channel, message.clone(), except, app_id, start_time_ms)
+            .send(channel, message, except, app_id, start_time_ms)
             .await;
 
         if let Err(e) = local_result {
@@ -130,7 +133,6 @@ where
         }
 
         // Broadcast to other nodes
-        let message_json = sonic_rs::to_string(&message)?;
         let broadcast = BroadcastMessage {
             node_id,
             app_id: app_id.to_string(),
@@ -149,8 +151,8 @@ where
                 )
             }),
             compression_metadata: None,
-            idempotency_key: message.idempotency_key.clone(),
-            ephemeral: message.is_ephemeral(),
+            idempotency_key,
+            ephemeral,
         };
 
         // Skip broadcasting to other nodes if we're in single-node mode
@@ -171,9 +173,12 @@ where
         envelope: Option<sockudo_core::message_envelope::MessageEnvelope>,
     ) -> Result<()> {
         let node_id = self.horizontal.node_id.clone();
+        let message_json = sonic_rs::to_string(&message)?;
+        let idempotency_key = message.idempotency_key.clone();
+        let ephemeral = message.is_ephemeral();
         let local_result = self
             .local_adapter
-            .send(channel, message.clone(), except, app_id, start_time_ms)
+            .send(channel, message, except, app_id, start_time_ms)
             .await;
         if let Err(error) = local_result {
             warn!(channel, %error, "Local send failed");
@@ -183,7 +188,7 @@ where
             node_id,
             app_id: app_id.to_string(),
             channel: channel.to_string(),
-            message: sonic_rs::to_string(&message)?,
+            message: message_json,
             presence_replication: None,
             envelope,
             except_socket_id: except.map(ToString::to_string),
@@ -197,8 +202,8 @@ where
                 )
             }),
             compression_metadata: None,
-            idempotency_key: message.idempotency_key.clone(),
-            ephemeral: message.is_ephemeral(),
+            idempotency_key,
+            ephemeral,
         };
         if !self.should_skip_horizontal_communication().await {
             self.transport.publish_broadcast(&broadcast).await?;
@@ -275,6 +280,10 @@ where
         start_time_ms: Option<f64>,
         compression: crate::connection_manager::CompressionParams<'_>,
     ) -> Result<()> {
+        let message_json = sonic_rs::to_string(&message)?;
+        let event_name = message.event.clone();
+        let idempotency_key = message.idempotency_key.clone();
+        let ephemeral = message.is_ephemeral();
         // Send locally first with delta compression support
         let (node_id, local_result) = {
             let result = self
@@ -282,7 +291,7 @@ where
                 .local_adapter
                 .send_with_compression(
                     channel,
-                    message.clone(),
+                    message,
                     except,
                     app_id,
                     start_time_ms,
@@ -302,16 +311,12 @@ where
 
         // Broadcast to other nodes with compression metadata
         // Other nodes will apply their own delta compression using this metadata
-        let message_json = sonic_rs::to_string(&message)?;
-
         // Extract conflation key from channel settings
         let conflation_key = compression
             .channel_settings
             .and_then(|s| s.conflation_key.clone());
 
         // Extract event name from message for tracking
-        let event_name = message.event.as_deref().map(|s| s.to_string());
-
         // Check cluster coordination for synchronized full message intervals
         let (cluster_should_send_full, cluster_delta_count) = if compression
             .delta_compression
@@ -376,8 +381,8 @@ where
                 is_full_message, // Determined by cluster coordination or defaults to true
                 event_name,
             }),
-            idempotency_key: message.idempotency_key.clone(),
-            ephemeral: message.is_ephemeral(),
+            idempotency_key,
+            ephemeral,
         };
 
         // Skip broadcasting to other nodes if we're in single-node mode

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
@@ -565,8 +565,9 @@ where
                                                     // Use the conflation key from compression metadata
                                                     let mut settings = settings.clone();
                                                     if compression_meta.conflation_key.is_some() {
-                                                        settings.conflation_key =
-                                                            compression_meta.conflation_key.clone();
+                                                        settings.conflation_key.clone_from(
+                                                            &compression_meta.conflation_key,
+                                                        );
                                                     }
                                                     Some(settings)
                                                 }

--- a/crates/sockudo-adapter/src/local_adapter/broadcast.rs
+++ b/crates/sockudo-adapter/src/local_adapter/broadcast.rs
@@ -26,84 +26,37 @@ fn hash_cached_base_message(base: &[u8]) -> u64 {
 #[cfg(feature = "delta")]
 /// Parameters for sending a message to a socket with compression
 #[allow(dead_code)]
-struct SocketMessageParams<'a> {
+struct SocketMessageParams {
     socket_ref: WebSocketRef,
-    base_message: PusherMessage,
-    base_message_bytes: Vec<u8>,
-    channel: &'a str,
-    event_name: &'a str,
+    base_message: Arc<PusherMessage>,
+    base_message_bytes: Arc<Vec<u8>>,
+    channel: Arc<str>,
+    event_name: Arc<str>,
     delta_compression: Arc<sockudo_delta::DeltaCompressionManager>,
-    channel_settings: Option<&'a sockudo_delta::ChannelDeltaSettings>,
+    channel_settings: Option<Arc<sockudo_delta::ChannelDeltaSettings>>,
     tag_filtering_enabled: bool,
 }
 
 #[cfg(feature = "delta")]
 /// Parameters for sending a message with pre-computed delta
 #[allow(dead_code)]
-struct PrecomputedDeltaParams<'a> {
+struct PrecomputedDeltaParams {
     socket_ref: WebSocketRef,
-    base_message: PusherMessage,
-    base_message_bytes: Vec<u8>,
-    channel: &'a str,
-    event_name: &'a str,
+    base_message: Arc<PusherMessage>,
+    base_message_bytes: Arc<Vec<u8>>,
+    channel: Arc<str>,
+    event_name: Arc<str>,
     delta_compression: Arc<sockudo_delta::DeltaCompressionManager>,
-    channel_settings: Option<&'a sockudo_delta::ChannelDeltaSettings>,
+    channel_settings: Option<Arc<sockudo_delta::ChannelDeltaSettings>>,
     tag_filtering_enabled: bool,
     /// Pre-computed delta bytes and the sequence number of the base message used to compute it
     precomputed_delta: Option<(Arc<Vec<u8>>, u32)>,
-    conflation_key: String,
+    conflation_key: Arc<str>,
     /// Hash of the base message used to compute the precomputed delta (for verification)
     base_hash: u64,
 }
 
 impl LocalAdapter {
-    pub(super) async fn send_protocol_messages_concurrent(
-        &self,
-        target_socket_refs: Vec<WebSocketRef>,
-        message: PusherMessage,
-    ) -> Vec<Result<()>> {
-        use futures::stream::{self, StreamExt};
-
-        let socket_count = target_socket_refs.len();
-        let target_chunks = socket_count.div_ceil(self.max_concurrent).clamp(1, 8);
-        let socket_chunk_size = (socket_count / target_chunks)
-            .min(self.max_concurrent)
-            .max(1);
-
-        let mut results = Vec::with_capacity(socket_count);
-
-        for socket_chunk in target_socket_refs.chunks(socket_chunk_size) {
-            let chunk_size = socket_chunk.len();
-            match self
-                .broadcast_semaphore
-                .acquire_many(chunk_size as u32)
-                .await
-            {
-                Ok(_permits) => {
-                    let chunk_vec: Vec<_> = socket_chunk.to_vec();
-                    let chunk_results: Vec<Result<()>> = stream::iter(chunk_vec)
-                        .map(|socket_ref| {
-                            let msg = message.clone();
-                            async move { socket_ref.send_message(&msg) }
-                        })
-                        .buffer_unordered(chunk_size)
-                        .collect()
-                        .await;
-                    results.extend(chunk_results);
-                }
-                Err(_) => {
-                    for _ in 0..chunk_size {
-                        results.push(Err(Error::Connection(
-                            "Broadcast semaphore unavailable".to_string(),
-                        )));
-                    }
-                }
-            }
-        }
-
-        results
-    }
-
     /// Send messages using chunked processing with semaphore-controlled concurrency
     pub(super) async fn send_messages_concurrent(
         &self,
@@ -372,6 +325,12 @@ impl LocalAdapter {
             }
         }
 
+        let base_message = Arc::new(base_message);
+        let base_message_bytes = Arc::new(base_message_bytes);
+        let channel: Arc<str> = Arc::from(channel);
+        let event_name: Arc<str> = Arc::from(event_name);
+        let channel_settings = channel_settings.cloned().map(Arc::new);
+
         // Determine target number of chunks (1-8 based on socket count vs max concurrency)
         let target_chunks = socket_count.div_ceil(self.max_concurrent).clamp(1, 8);
 
@@ -402,25 +361,25 @@ impl LocalAdapter {
                     Ok(_permits) => {
                         // Process sockets in this chunk using buffered unordered streaming
                         let chunk_vec: Vec<_> = socket_chunk.to_vec();
-                        let base_msg = base_message.clone();
-                        let base_bytes = base_message_bytes.clone();
-                        let channel_str = channel.to_string();
-                        let event_str = event_name.to_string();
+                        let base_msg = Arc::clone(&base_message);
+                        let base_bytes = Arc::clone(&base_message_bytes);
+                        let channel_str = Arc::clone(&channel);
+                        let event_str = Arc::clone(&event_name);
                         let delta_comp = Arc::clone(&delta_compression);
-                        let ch_settings = channel_settings.cloned();
+                        let ch_settings = channel_settings.clone();
                         let precomp_delta = precomputed_delta.clone();
-                        let conf_key = conflation_key.clone();
+                        let conf_key: Arc<str> = Arc::from(conflation_key.as_str());
 
                         let chunk_results: Vec<Result<()>> = stream::iter(chunk_vec)
                             .map(|socket_ref| {
-                                let msg = base_msg.clone();
-                                let bytes = base_bytes.clone();
-                                let ch = channel_str.clone();
-                                let ev = event_str.clone();
+                                let msg = Arc::clone(&base_msg);
+                                let bytes = Arc::clone(&base_bytes);
+                                let ch = Arc::clone(&channel_str);
+                                let ev = Arc::clone(&event_str);
                                 let dc = Arc::clone(&delta_comp);
                                 let settings = ch_settings.clone();
                                 let delta = precomp_delta.clone();
-                                let ck = conf_key.clone();
+                                let ck = Arc::clone(&conf_key);
 
                                 async move {
                                     Self::send_to_socket_with_precomputed_delta(
@@ -428,10 +387,10 @@ impl LocalAdapter {
                                             socket_ref,
                                             base_message: msg,
                                             base_message_bytes: bytes,
-                                            channel: &ch,
-                                            event_name: &ev,
+                                            channel: ch,
+                                            event_name: ev,
                                             delta_compression: dc,
-                                            channel_settings: settings.as_ref(),
+                                            channel_settings: settings,
                                             tag_filtering_enabled: tag_filtering,
                                             precomputed_delta: delta,
                                             conflation_key: ck,
@@ -470,19 +429,19 @@ impl LocalAdapter {
             {
                 Ok(_permits) => {
                     let chunk_vec: Vec<_> = socket_chunk.to_vec();
-                    let base_msg = base_message.clone();
-                    let base_bytes = base_message_bytes.clone();
-                    let channel_str = channel.to_string();
-                    let event_str = event_name.to_string();
+                    let base_msg = Arc::clone(&base_message);
+                    let base_bytes = Arc::clone(&base_message_bytes);
+                    let channel_str = Arc::clone(&channel);
+                    let event_str = Arc::clone(&event_name);
                     let delta_comp = Arc::clone(&delta_compression);
-                    let ch_settings = channel_settings.cloned();
+                    let ch_settings = channel_settings.clone();
 
                     let chunk_results: Vec<Result<()>> = stream::iter(chunk_vec)
                         .map(|socket_ref| {
-                            let msg = base_msg.clone();
-                            let bytes = base_bytes.clone();
-                            let ch = channel_str.clone();
-                            let ev = event_str.clone();
+                            let msg = Arc::clone(&base_msg);
+                            let bytes = Arc::clone(&base_bytes);
+                            let ch = Arc::clone(&channel_str);
+                            let ev = Arc::clone(&event_str);
                             let dc = Arc::clone(&delta_comp);
                             let settings = ch_settings.clone();
 
@@ -491,10 +450,10 @@ impl LocalAdapter {
                                     socket_ref,
                                     base_message: msg,
                                     base_message_bytes: bytes,
-                                    channel: &ch,
-                                    event_name: &ev,
+                                    channel: ch,
+                                    event_name: ev,
                                     delta_compression: dc,
-                                    channel_settings: settings.as_ref(),
+                                    channel_settings: settings,
                                     tag_filtering_enabled: tag_filtering,
                                 })
                                 .await
@@ -524,7 +483,7 @@ impl LocalAdapter {
     ///
     /// # Arguments
     /// * `params` - Parameters for sending the message
-    async fn send_to_socket_with_compression(params: SocketMessageParams<'_>) -> Result<()> {
+    async fn send_to_socket_with_compression(params: SocketMessageParams) -> Result<()> {
         use sockudo_delta::CompressionResult;
 
         let SocketMessageParams {
@@ -537,6 +496,9 @@ impl LocalAdapter {
             channel_settings,
             tag_filtering_enabled: _,
         } = params;
+        let channel = channel.as_ref();
+        let event_name = event_name.as_ref();
+        let channel_settings = channel_settings.as_deref();
 
         // Get socket ID and filter for this channel subscription (lock-free)
         let socket_id = socket_ref.get_socket_id_sync();
@@ -544,77 +506,25 @@ impl LocalAdapter {
         // NOTE: Tag filtering already applied at broadcast level - no redundant check needed
 
         // Only process delta compression if it's enabled for this socket
-        let (compression_result, message_with_sequence) = if !delta_compression
-            .is_enabled_for_socket_channel(socket_id, channel)
-        {
-            (CompressionResult::Uncompressed, base_message_bytes.clone())
-        } else {
-            // First, we need to determine what sequence number this message will have
-            // and add it to the message BEFORE computing delta compression
-            let conflation_key_path = channel_settings
-                .and_then(|s| s.conflation_key.as_ref())
-                .or(delta_compression.get_conflation_key_path());
-            let conflation_key = if let Some(path) = conflation_key_path {
-                delta_compression.extract_conflation_key_from_path(&base_message_bytes, path)
+        let compression_result =
+            if !delta_compression.is_enabled_for_socket_channel(socket_id, channel) {
+                CompressionResult::Uncompressed
             } else {
-                String::new()
+                // Compute compression WITHOUT sequence metadata
+                // Sequence changes every message and should not be part of delta base
+                delta_compression
+                    .compress_message(
+                        socket_id,
+                        channel,
+                        event_name,
+                        base_message_bytes.as_slice(),
+                        channel_settings,
+                    )
+                    .await?
             };
-
-            // Create composite cache key: event_name:conflation_key
-            let cache_key = if conflation_key.is_empty() {
-                event_name.to_string()
-            } else {
-                format!("{}:{}", event_name, conflation_key)
-            };
-
-            // Compute compression WITHOUT sequence metadata
-            // Sequence changes every message and should not be part of delta base
-            let result = delta_compression
-                .compress_message(
-                    socket_id,
-                    channel,
-                    event_name,
-                    &base_message_bytes,
-                    channel_settings,
-                )
-                .await?;
-
-            // Get the sequence number that will be used for this message
-            let next_sequence = delta_compression.get_next_sequence(socket_id, channel, &cache_key);
-
-            // Add sequence metadata to the message AFTER delta compression for sending to client
-            // IMPORTANT: Use string manipulation instead of JSON parse/re-serialize
-            // to preserve exact byte ordering. JSON re-serialization can change key order,
-            // causing checksum mismatches when computing deltas.
-            let msg_with_seq = if let Ok(base_str) = std::str::from_utf8(&base_message_bytes) {
-                if let Some(last_brace) = base_str.rfind('}') {
-                    let mut result = String::with_capacity(base_str.len() + 100);
-                    result.push_str(&base_str[..last_brace]);
-                    if last_brace > 1
-                        && base_str[..last_brace]
-                            .trim_end()
-                            .ends_with(|c| c != '{' && c != ',')
-                    {
-                        result.push(',');
-                    }
-                    result.push_str(&format!("\"__delta_seq\":{}", next_sequence));
-                    if !conflation_key.is_empty() {
-                        result.push_str(&format!(",\"__conflation_key\":\"{}\"", conflation_key));
-                    }
-                    result.push('}');
-                    result.into_bytes()
-                } else {
-                    base_message_bytes.clone()
-                }
-            } else {
-                base_message_bytes.clone()
-            };
-
-            (result, msg_with_seq)
-        };
 
         match compression_result {
-            CompressionResult::Uncompressed => socket_ref.send_message(&base_message),
+            CompressionResult::Uncompressed => socket_ref.send_message(base_message.as_ref()),
             CompressionResult::FullMessage {
                 sequence,
                 conflation_key,
@@ -627,16 +537,12 @@ impl LocalAdapter {
                     len_bytes = base_message_bytes.len(),
                     "storing full base message"
                 );
-                info!(
-                    len_bytes = message_with_sequence.len(),
-                    "sending full message"
-                );
                 if let Err(e) = delta_compression
-                    .store_sent_message(
+                    .store_shared_sent_message(
                         socket_id,
                         channel,
                         event_name,
-                        base_message_bytes.clone(),
+                        Arc::clone(&base_message_bytes),
                         true,
                         channel_settings,
                     )
@@ -645,7 +551,7 @@ impl LocalAdapter {
                     warn!(error = %e, "failed to store full message for delta state");
                 }
 
-                let mut full_message = base_message;
+                let mut full_message = base_message.as_ref().clone();
                 full_message.delta_sequence = Some(sequence.into());
                 full_message.delta_conflation_key = conflation_key;
                 socket_ref.send_message(&full_message)
@@ -715,11 +621,11 @@ impl LocalAdapter {
                 // Store the ORIGINAL message bytes (without sequence/conflation_key metadata) for future delta computation
                 // The sequence changes every message, so it should not be part of the delta base
                 if let Err(e) = delta_compression
-                    .store_sent_message(
+                    .store_shared_sent_message(
                         socket_id,
                         channel,
                         event_name,
-                        base_message_bytes.clone(),
+                        Arc::clone(&base_message_bytes),
                         false,
                         channel_settings,
                     )
@@ -737,9 +643,7 @@ impl LocalAdapter {
     ///
     /// This is used when delta has been computed once at the broadcast level and can be
     /// reused for multiple sockets with the same base message.
-    async fn send_to_socket_with_precomputed_delta(
-        params: PrecomputedDeltaParams<'_>,
-    ) -> Result<()> {
+    async fn send_to_socket_with_precomputed_delta(params: PrecomputedDeltaParams) -> Result<()> {
         let PrecomputedDeltaParams {
             socket_ref,
             base_message,
@@ -753,6 +657,9 @@ impl LocalAdapter {
             conflation_key,
             base_hash,
         } = params;
+        let channel = channel.as_ref();
+        let event_name = event_name.as_ref();
+        let channel_settings = channel_settings.as_deref();
 
         // Get socket ID (lock-free sync access)
         let socket_id = socket_ref.get_socket_id_sync();
@@ -845,7 +752,7 @@ impl LocalAdapter {
 
             // Add conflation key and base index
             if !conflation_key.is_empty() {
-                delta_data["conflation_key"] = sonic_rs::Value::from(&conflation_key);
+                delta_data["conflation_key"] = sonic_rs::Value::from(conflation_key.as_ref());
             }
             delta_data["base_index"] = sonic_rs::Value::from(base_index as u64);
 
@@ -876,11 +783,11 @@ impl LocalAdapter {
             // store the same sanitized version for consistent delta computation.
             // base_message_bytes IS the new message - no reconstruction needed.
             let _ = delta_compression
-                .store_sent_message(
+                .store_shared_sent_message(
                     socket_id,
                     channel,
                     event_name,
-                    base_message_bytes.clone(),
+                    Arc::clone(&base_message_bytes),
                     false,
                     channel_settings,
                 )
@@ -895,36 +802,6 @@ impl LocalAdapter {
                 size_bytes = base_message_bytes.len(),
                 "sending full message to socket"
             );
-            // Create message with metadata for sending to client
-            // IMPORTANT: Use string manipulation instead of JSON parse/re-serialize
-            // to preserve exact byte ordering. JSON re-serialization can change key order,
-            // causing checksum mismatches when computing deltas.
-            let _msg_with_seq = if let Ok(base_str) = std::str::from_utf8(&base_message_bytes) {
-                // Find the last '}' and inject metadata before it
-                if let Some(last_brace) = base_str.rfind('}') {
-                    let mut result = String::with_capacity(base_str.len() + 100);
-                    result.push_str(&base_str[..last_brace]);
-                    // Add comma if there's content before the brace
-                    if last_brace > 1
-                        && base_str[..last_brace]
-                            .trim_end()
-                            .ends_with(|c| c != '{' && c != ',')
-                    {
-                        result.push(',');
-                    }
-                    result.push_str(&format!("\"__delta_seq\":{}", sequence));
-                    if !conflation_key.is_empty() {
-                        result.push_str(&format!(",\"__conflation_key\":\"{}\"", conflation_key));
-                    }
-                    result.push('}');
-                    result.into_bytes()
-                } else {
-                    base_message_bytes.clone()
-                }
-            } else {
-                base_message_bytes.clone()
-            };
-
             // CRITICAL: Store the message WITHOUT metadata (base_message_bytes).
             // The client strips __delta_seq and __conflation_key before storing, creating a
             // "sanitized" base. We must store the same sanitized version so that when we
@@ -932,11 +809,11 @@ impl LocalAdapter {
             // Previously we stored msg_with_seq (with metadata), causing delta decode failures
             // because the server's base had metadata but the client's base did not.
             match delta_compression
-                .store_sent_message(
+                .store_shared_sent_message(
                     socket_id,
                     channel,
                     event_name,
-                    base_message_bytes.clone(),
+                    Arc::clone(&base_message_bytes),
                     true,
                     channel_settings,
                 )
@@ -960,10 +837,10 @@ impl LocalAdapter {
                 }
             }
 
-            let mut full_message = base_message;
+            let mut full_message = base_message.as_ref().clone();
             full_message.delta_sequence = Some(sequence.into());
             if !conflation_key.is_empty() {
-                full_message.delta_conflation_key = Some(conflation_key);
+                full_message.delta_conflation_key = Some(conflation_key.to_string());
             }
             socket_ref.send_message(&full_message)
         }

--- a/crates/sockudo-adapter/src/local_adapter/connection_manager.rs
+++ b/crates/sockudo-adapter/src/local_adapter/connection_manager.rs
@@ -34,12 +34,8 @@ async fn send_v2_append_mode_groups(
             continue;
         }
         let mode_message = crate::v2_broadcast::apply_append_mode(message.clone(), append_mode);
-        let (v2_message, _v2_bytes) = crate::v2_broadcast::prepare_v2_message(mode_message)?;
-        LocalAdapter::log_send_errors(
-            adapter
-                .send_protocol_messages_concurrent(sockets, v2_message)
-                .await,
-        );
+        let (_, v2_bytes) = crate::v2_broadcast::prepare_v2_message(mode_message)?;
+        LocalAdapter::log_send_errors(adapter.send_messages_concurrent(sockets, v2_bytes).await);
     }
     Ok(())
 }

--- a/crates/sockudo-adapter/src/replay_buffer.rs
+++ b/crates/sockudo-adapter/src/replay_buffer.rs
@@ -279,7 +279,7 @@ impl ReplayBuffer {
         if state.current_stream_id != incoming_stream_id {
             state.messages.clear();
         }
-        state.current_stream_id = incoming_stream_id.clone();
+        state.current_stream_id.clone_from(&incoming_stream_id);
         state.last_touched = now;
         Self::raise_next_serial(entry.value(), serial.saturating_add(1));
         // Evict oldest if at capacity

--- a/crates/sockudo-adapter/src/services.rs
+++ b/crates/sockudo-adapter/src/services.rs
@@ -833,7 +833,7 @@ mod tests {
         let envelope = MessageEnvelope::from_message(&message, None, None, 100).unwrap();
         let first = canonical_publish_fingerprint("channel", &message, &envelope).unwrap();
 
-        let mut changed = message.clone();
+        let mut changed = message;
         changed.user_id = Some("publisher-b".to_string());
         let changed_envelope = MessageEnvelope::from_message(&changed, None, None, 100).unwrap();
         assert_ne!(

--- a/crates/sockudo-adapter/src/watchlist.rs
+++ b/crates/sockudo-adapter/src/watchlist.rs
@@ -118,7 +118,7 @@ impl WatchlistManager {
                         watchers: HashSet::new(),
                         watching: watching_set.clone(),
                     });
-                user_entry.watching = watching_set.clone();
+                user_entry.watching.clone_from(&watching_set);
                 user_entry.watchers.clone()
             };
 

--- a/crates/sockudo-adapter/tests/adapter/dead_node_detection_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/dead_node_detection_tests.rs
@@ -154,7 +154,7 @@ async fn test_cleanup_leader_election_excludes_dead_nodes() {
         let before_node = format!("aaa-before-{}", our_node_id);
         let after_node = format!("zzz-after-{}", our_node_id);
 
-        heartbeats.insert(before_node.clone(), std::time::Instant::now());
+        heartbeats.insert(before_node, std::time::Instant::now());
         heartbeats.insert(after_node, std::time::Instant::now());
     }
 

--- a/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
@@ -248,7 +248,7 @@ pub fn create_test_handlers(
 
     let broadcast_collector = collector.clone();
     let request_collector = collector.clone();
-    let response_collector = collector.clone();
+    let response_collector = collector;
 
     sockudo_adapter::horizontal_transport::TransportHandlers {
         node_id: "test-node".to_string(),

--- a/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/user_has_connections_tests.rs
@@ -76,7 +76,7 @@ async fn seed_local_user_connection(
         .or_default()
         .insert(socket_id);
 
-    namespace.sockets.insert(socket_id, ws_ref.clone());
+    namespace.sockets.insert(socket_id, ws_ref);
 
     namespace
         .presence_data

--- a/crates/sockudo-adapter/tests/adapter/user_socket_index_regression_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/user_socket_index_regression_tests.rs
@@ -82,7 +82,7 @@ async fn wait_for_close_frame(client: &mut ClientWs) -> Option<(u16, String)> {
         loop {
             match client.next().await {
                 Some(Ok(sockudo_ws::Message::Close(Some(reason)))) => {
-                    return Some((reason.code, reason.reason.to_string()));
+                    return Some((reason.code, reason.reason));
                 }
                 Some(Ok(sockudo_ws::Message::Close(None))) => return None,
                 Some(Ok(_)) => continue,

--- a/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
+++ b/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
@@ -469,7 +469,7 @@ pub fn create_test_connection_handler_with_app_manager(
     app_manager: MockAppManager,
 ) -> ConnectionHandler {
     let builder = ConnectionHandler::builder(
-        Arc::new(app_manager.clone()) as Arc<dyn AppManager + Send + Sync>,
+        Arc::new(app_manager) as Arc<dyn AppManager + Send + Sync>,
         Arc::new(MockAdapter::new()) as Arc<dyn ConnectionManager + Send + Sync>,
         Arc::new(MockCacheManager::new()),
         ServerOptions::default(),

--- a/crates/sockudo-ai-transport/src/lib.rs
+++ b/crates/sockudo-ai-transport/src/lib.rs
@@ -186,31 +186,29 @@ impl PendingBatch {
     }
 
     fn capture_fragment(&mut self) {
-        let next_fragment =
-            extract_runtime_append_fragment(&self.latest_message).map(str::to_string);
-        if let Some(next_fragment) = next_fragment {
+        if let Some(next_fragment) = extract_runtime_append_fragment(&self.latest_message) {
             match self.pending_fragment.as_mut() {
-                Some(pending) => pending.push_str(&next_fragment),
-                None => self.pending_fragment = Some(next_fragment),
-            }
-            if let Some(pending) = self.pending_fragment.as_ref() {
-                set_runtime_append_fragment(&mut self.latest_message, pending.clone());
+                Some(pending) => pending.push_str(next_fragment),
+                None => self.pending_fragment = Some(next_fragment.to_owned()),
             }
         } else {
             self.pending_fragment = None;
         }
         self.appended_count += 1;
-        if let Some(envelope) = self.context.envelope.as_mut() {
-            envelope.extras = self.latest_message.extras.clone();
-        }
     }
 
     fn into_delivery(
-        self,
+        mut self,
         reason: RollupDeliveryReason,
         app_id: &str,
         channel: &str,
     ) -> RollupDelivery {
+        if let Some(pending_fragment) = self.pending_fragment.take() {
+            set_runtime_append_fragment(&mut self.latest_message, pending_fragment);
+        }
+        if let Some(envelope) = self.context.envelope.as_mut() {
+            envelope.extras.clone_from(&self.latest_message.extras);
+        }
         let coalesced = self.appended_count.max(1);
         RollupDelivery {
             app_id: app_id.to_string(),

--- a/crates/sockudo-ai-transport/tests/ait_s_conformance.rs
+++ b/crates/sockudo-ai-transport/tests/ait_s_conformance.rs
@@ -305,7 +305,7 @@ fn ait_s026_to_s030_history_cursor_and_bounds_validation_are_strict() {
         direction: HistoryDirection::NewestFirst,
         limit: 10,
         cursor: Some(cursor.clone()),
-        bounds: cursor.bounds.clone(),
+        bounds: cursor.bounds,
     };
     valid.validate().unwrap();
 

--- a/crates/sockudo-app/src/memory_app_manager.rs
+++ b/crates/sockudo-app/src/memory_app_manager.rs
@@ -36,23 +36,23 @@ impl AppManager for MemoryAppManager {
 
     async fn create_app(&self, config: App) -> Result<()> {
         let mut state = self.state.write().unwrap();
-        if let Some(previous) = state.apps_by_id.insert(config.id.clone(), config.clone()) {
+        let id = config.id.clone();
+        let key = config.key.clone();
+        if let Some(previous) = state.apps_by_id.insert(id.clone(), config) {
             state.app_id_by_key.remove(&previous.key);
         }
-        state
-            .app_id_by_key
-            .insert(config.key.clone(), config.id.clone());
+        state.app_id_by_key.insert(key, id);
         Ok(())
     }
 
     async fn update_app(&self, config: App) -> Result<()> {
         let mut state = self.state.write().unwrap();
-        if let Some(previous) = state.apps_by_id.insert(config.id.clone(), config.clone()) {
+        let id = config.id.clone();
+        let key = config.key.clone();
+        if let Some(previous) = state.apps_by_id.insert(id.clone(), config) {
             state.app_id_by_key.remove(&previous.key);
         }
-        state
-            .app_id_by_key
-            .insert(config.key.clone(), config.id.clone());
+        state.app_id_by_key.insert(key, id);
         Ok(())
     }
 

--- a/crates/sockudo-core/benches/annotation_replay.rs
+++ b/crates/sockudo-core/benches/annotation_replay.rs
@@ -4,13 +4,68 @@ use sockudo_core::annotations::{
     MemoryAnnotationStore, RawAnnotationReplayRequest, StoredAnnotationEvent,
 };
 use sockudo_core::versioned_messages::MessageSerial;
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::hint::black_box;
+use std::sync::Once;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 const APP_ID: &str = "bench-app";
 const CHANNEL: &str = "bench-channel";
 const NOISY_EVENTS: usize = 2_000;
 const TARGET_EVENTS: usize = 100;
 const PAGE_SIZE: usize = 50;
+
+struct CountingAllocator;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+static ANNOTATION_ALLOCATION_REPORT: Once = Once::new();
+
+// SAFETY: every allocation operation delegates to the process system allocator.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the caller provided a valid allocation layout.
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        let pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn measure_allocations<T>(operation: impl FnOnce() -> T) -> (T, u64, u64) {
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    ALLOCATION_COUNT.store(0, Ordering::SeqCst);
+    ALLOCATED_BYTES.store(0, Ordering::SeqCst);
+    TRACK_ALLOCATIONS.store(true, Ordering::SeqCst);
+    let result = operation();
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    (
+        result,
+        ALLOCATION_COUNT.load(Ordering::SeqCst),
+        ALLOCATED_BYTES.load(Ordering::SeqCst),
+    )
+}
 
 fn stored_event(index: usize, message_serial: MessageSerial) -> StoredAnnotationEvent {
     StoredAnnotationEvent {
@@ -56,6 +111,28 @@ fn annotation_replay(c: &mut Criterion) {
                 .await
                 .unwrap();
         }
+    });
+
+    ANNOTATION_ALLOCATION_REPORT.call_once(|| {
+        let allocation_store = MemoryAnnotationStore::new();
+        let allocation_target = MessageSerial::new("msg:allocation").unwrap();
+        runtime.block_on(async {
+            for index in 0..100 {
+                allocation_store
+                    .append_event(stored_event(index, allocation_target.clone()))
+                    .await
+                    .unwrap();
+            }
+        });
+        let (projection, allocations, allocated_bytes) = measure_allocations(|| {
+            runtime.block_on(
+                allocation_store.append_event(stored_event(100, allocation_target.clone())),
+            )
+        });
+        black_box(projection.unwrap());
+        eprintln!(
+            "allocation_profile name=memory_annotation_append_projection100 allocations={allocations} allocated_bytes={allocated_bytes}"
+        );
     });
 
     let mut group = c.benchmark_group("annotation_rest_page");

--- a/crates/sockudo-core/benches/versioned_message_streaming.rs
+++ b/crates/sockudo-core/benches/versioned_message_streaming.rs
@@ -11,8 +11,62 @@ use sockudo_core::versioned_messages::{
     MessageAppend, MessageSerial, VersionMetadata, VersionSerial, VersionedMessage,
 };
 use sockudo_protocol::messages::MessageData;
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Once;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+struct CountingAllocator;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+static VERSION_STORE_ALLOCATION_REPORT: Once = Once::new();
+
+// SAFETY: every allocation operation delegates to the process system allocator.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the caller provided a valid allocation layout.
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        let pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn measure_allocations<T>(operation: impl FnOnce() -> T) -> (T, u64, u64) {
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    ALLOCATION_COUNT.store(0, Ordering::SeqCst);
+    ALLOCATED_BYTES.store(0, Ordering::SeqCst);
+    TRACK_ALLOCATIONS.store(true, Ordering::SeqCst);
+    let result = operation();
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    (
+        result,
+        ALLOCATION_COUNT.load(Ordering::SeqCst),
+        ALLOCATED_BYTES.load(Ordering::SeqCst),
+    )
+}
 
 struct CountingBlockVersionStore {
     inner: MemoryVersionStore,
@@ -236,7 +290,59 @@ fn bench_atomic_compare_and_append_64b_to_100k(c: &mut Criterion) {
     });
 }
 
+fn report_version_store_allocations() {
+    VERSION_STORE_ALLOCATION_REPORT.call_once(|| {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let store = MemoryVersionStore::new();
+        let mut current = record_with_data(String::new());
+        runtime
+            .block_on(store.append_version(current.clone()))
+            .unwrap();
+        for index in 0..32 {
+            let next = StoredVersionRecord {
+                message: current
+                    .message
+                    .apply_append(
+                        version(index + 2),
+                        index + 2,
+                        MessageAppend {
+                            data_fragment: "x".repeat(1024),
+                            extras: None,
+                        },
+                    )
+                    .unwrap(),
+                ..current.clone()
+            };
+            runtime
+                .block_on(store.append_version(next.clone()))
+                .unwrap();
+            current = next;
+        }
+        let next = StoredVersionRecord {
+            message: current
+                .message
+                .apply_append(
+                    version(34),
+                    34,
+                    MessageAppend {
+                        data_fragment: "x".repeat(1024),
+                        extras: None,
+                    },
+                )
+                .unwrap(),
+            ..current
+        };
+        let (result, allocations, allocated_bytes) =
+            measure_allocations(|| runtime.block_on(store.append_version(next)));
+        result.unwrap();
+        eprintln!(
+            "allocation_profile name=memory_version_store_append_chain32_1k allocations={allocations} allocated_bytes={allocated_bytes}"
+        );
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
+    report_version_store_allocations();
     bench_append_64b_to_100k(c);
     bench_warm_get_latest_2000_appends(c);
     bench_leased_delivery_reservations(c);

--- a/crates/sockudo-core/src/annotations/memory.rs
+++ b/crates/sockudo-core/src/annotations/memory.rs
@@ -15,8 +15,9 @@ pub struct MemoryAnnotationStore {
 #[derive(Default)]
 pub(super) struct MemoryAnnotationState {
     pub(super) events_by_projection:
-        BTreeMap<String, BTreeMap<AnnotationSerial, StoredAnnotationEvent>>,
-    pub(super) raw_by_channel: BTreeMap<String, BTreeMap<AnnotationSerial, StoredAnnotationEvent>>,
+        BTreeMap<String, BTreeMap<AnnotationSerial, Arc<StoredAnnotationEvent>>>,
+    pub(super) raw_by_channel:
+        BTreeMap<String, BTreeMap<AnnotationSerial, Arc<StoredAnnotationEvent>>>,
     pub(super) projections: BTreeMap<String, StoredAnnotationProjection>,
 }
 
@@ -74,7 +75,7 @@ impl MemoryAnnotationStore {
     fn projection_events(
         state: &MemoryAnnotationState,
         projection_key: &str,
-    ) -> Vec<StoredAnnotationEvent> {
+    ) -> Vec<Arc<StoredAnnotationEvent>> {
         state
             .events_by_projection
             .get(projection_key)
@@ -84,14 +85,14 @@ impl MemoryAnnotationStore {
 
     fn build_projection(
         request: &AnnotationProjectionRequest,
-        events: Vec<StoredAnnotationEvent>,
+        events: Vec<Arc<StoredAnnotationEvent>>,
         options: AnnotationProjectionOptions,
     ) -> Result<StoredAnnotationProjection> {
-        let projection = AnnotationProjection::rebuild_with_options(
+        let projection = AnnotationProjection::rebuild_from_refs_with_options(
             request.channel_id.clone(),
             request.message_serial.clone(),
             request.annotation_type.clone(),
-            events.into_iter().map(|record| record.annotation),
+            events.iter().map(|record| &record.annotation),
             options,
         )?;
         Ok(StoredAnnotationProjection::from_projection(
@@ -161,6 +162,7 @@ impl AnnotationStore for MemoryAnnotationStore {
         };
         let projection_key = Self::event_projection_key(&record);
         let channel_key = Self::channel_key(&record.app_id, &record.channel_id);
+        let record = Arc::new(record);
 
         {
             let mut state = self.state.write().await;
@@ -170,7 +172,7 @@ impl AnnotationStore for MemoryAnnotationStore {
                 .or_default();
             events
                 .entry(record.annotation_serial().clone())
-                .or_insert_with(|| record.clone());
+                .or_insert_with(|| Arc::clone(&record));
             state
                 .raw_by_channel
                 .entry(channel_key)
@@ -212,6 +214,7 @@ impl AnnotationStore for MemoryAnnotationStore {
         };
         let projection_key = Self::event_projection_key(&record);
         let channel_key = Self::channel_key(&record.app_id, &record.channel_id);
+        let record = Arc::new(record);
         let canonical_serial = {
             let mut state = self.state.write().await;
             if let Some(existing) =
@@ -242,12 +245,12 @@ impl AnnotationStore for MemoryAnnotationStore {
                     .events_by_projection
                     .entry(projection_key.clone())
                     .or_default()
-                    .insert(record.annotation_serial().clone(), record.clone());
+                    .insert(record.annotation_serial().clone(), Arc::clone(&record));
                 state
                     .raw_by_channel
                     .entry(channel_key)
                     .or_default()
-                    .insert(record.annotation_serial().clone(), record.clone());
+                    .insert(record.annotation_serial().clone(), Arc::clone(&record));
                 None
             }
         };
@@ -282,7 +285,12 @@ impl AnnotationStore for MemoryAnnotationStore {
         Ok(state
             .events_by_projection
             .get(&key)
-            .map(|events| events.values().cloned().collect())
+            .map(|events| {
+                events
+                    .values()
+                    .map(|record| record.as_ref().clone())
+                    .collect()
+            })
             .unwrap_or_default())
     }
 
@@ -311,7 +319,7 @@ impl AnnotationStore for MemoryAnnotationStore {
                     .as_ref()
                     .is_none_or(|message_serial| record.message_serial() == message_serial)
             })
-            .map(|(_, record)| record.clone())
+            .map(|(_, record)| record.as_ref().clone())
             .take(request.limit)
             .collect();
         Ok(items)
@@ -327,7 +335,8 @@ impl AnnotationStore for MemoryAnnotationStore {
         Ok(state
             .raw_by_channel
             .get(&key)
-            .and_then(|events| events.get(&request.annotation_serial).cloned()))
+            .and_then(|events| events.get(&request.annotation_serial))
+            .map(|record| record.as_ref().clone()))
     }
 
     async fn get_projection(

--- a/crates/sockudo-core/src/annotations/tests/mod.rs
+++ b/crates/sockudo-core/src/annotations/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::versioned_messages::MessageSerial;
 use sonic_rs::json;
+use std::sync::Arc;
 
 fn annotation_type(value: &str) -> AnnotationType {
     AnnotationType::new(value).unwrap()
@@ -763,13 +764,17 @@ async fn memory_store_get_projection_repairs_stale_watermark() {
     let projection_key = MemoryAnnotationStore::event_projection_key(&late_event);
     let channel_key =
         MemoryAnnotationStore::channel_key(&late_event.app_id, &late_event.channel_id);
+    let late_event = Arc::new(late_event);
     {
         let mut state = store.state.write().await;
         state
             .events_by_projection
             .entry(projection_key)
             .or_default()
-            .insert(late_event.annotation_serial().clone(), late_event.clone());
+            .insert(
+                late_event.annotation_serial().clone(),
+                Arc::clone(&late_event),
+            );
         state
             .raw_by_channel
             .entry(channel_key)
@@ -804,13 +809,14 @@ async fn memory_store_list_projections_rebuilds_cold_projection_cache() {
     );
     let projection_key = MemoryAnnotationStore::event_projection_key(&event);
     let channel_key = MemoryAnnotationStore::channel_key(&event.app_id, &event.channel_id);
+    let event = Arc::new(event);
     {
         let mut state = store.state.write().await;
         state
             .events_by_projection
             .entry(projection_key)
             .or_default()
-            .insert(event.annotation_serial().clone(), event.clone());
+            .insert(event.annotation_serial().clone(), Arc::clone(&event));
         state
             .raw_by_channel
             .entry(channel_key)
@@ -848,13 +854,14 @@ async fn memory_store_reports_cold_projection_cache_rebuild_count() {
     );
     let projection_key = MemoryAnnotationStore::event_projection_key(&event);
     let channel_key = MemoryAnnotationStore::channel_key(&event.app_id, &event.channel_id);
+    let event = Arc::new(event);
     {
         let mut state = store.state.write().await;
         state
             .events_by_projection
             .entry(projection_key)
             .or_default()
-            .insert(event.annotation_serial().clone(), event.clone());
+            .insert(event.annotation_serial().clone(), Arc::clone(&event));
         state
             .raw_by_channel
             .entry(channel_key)

--- a/crates/sockudo-core/src/annotations/types.rs
+++ b/crates/sockudo-core/src/annotations/types.rs
@@ -4,6 +4,7 @@ use crate::versioned_messages::{MAX_VERSIONED_SERIAL_LENGTH, MessageSerial};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use sonic_rs::Value;
+use std::borrow::Borrow;
 use std::collections::{BTreeMap, HashSet};
 
 pub const MAX_ANNOTATION_TYPE_LENGTH: usize = 256;
@@ -259,15 +260,56 @@ impl AnnotationProjection {
     where
         I: IntoIterator<Item = Annotation>,
     {
-        let summarizer = annotation_type.summarizer()?;
-        let mut engine = crate::annotation_summarizers::new_engine(summarizer, options);
         let mut sorted_events: Vec<_> = events.into_iter().collect();
         sorted_events.sort_by(|left, right| left.serial.cmp(&right.serial));
+        Self::rebuild_sorted(
+            channel_id.into(),
+            message_serial,
+            annotation_type,
+            &sorted_events,
+            options,
+        )
+    }
+
+    pub(crate) fn rebuild_from_refs_with_options<'a, I>(
+        channel_id: impl Into<String>,
+        message_serial: MessageSerial,
+        annotation_type: AnnotationType,
+        events: I,
+        options: AnnotationProjectionOptions,
+    ) -> Result<Self>
+    where
+        I: IntoIterator<Item = &'a Annotation>,
+    {
+        let mut sorted_events = events.into_iter().collect::<Vec<_>>();
+        sorted_events.sort_by(|left, right| left.serial.cmp(&right.serial));
+        Self::rebuild_sorted(
+            channel_id.into(),
+            message_serial,
+            annotation_type,
+            &sorted_events,
+            options,
+        )
+    }
+
+    fn rebuild_sorted<E>(
+        channel_id: String,
+        message_serial: MessageSerial,
+        annotation_type: AnnotationType,
+        sorted_events: &[E],
+        options: AnnotationProjectionOptions,
+    ) -> Result<Self>
+    where
+        E: Borrow<Annotation>,
+    {
+        let summarizer = annotation_type.summarizer()?;
+        let mut engine = crate::annotation_summarizers::new_engine(summarizer, options);
 
         let create_ids = sorted_events
             .iter()
+            .map(Borrow::borrow)
             .filter(|event| event.action == AnnotationAction::Create)
-            .map(|event| event.id.clone())
+            .map(|event| &event.id)
             .collect::<HashSet<_>>();
         let mut seen_serials = HashSet::new();
         let mut seen_create_ids = HashSet::new();
@@ -276,39 +318,40 @@ impl AnnotationProjection {
         let mut applied_events = 0;
 
         for event in sorted_events {
-            validate_event_key(&event, &message_serial, &annotation_type)?;
-            if !seen_serials.insert(event.serial.as_str().to_string()) {
+            let event = event.borrow();
+            validate_event_key(event, &message_serial, &annotation_type)?;
+            if !seen_serials.insert(event.serial.as_str()) {
                 continue;
             }
 
-            last_serial = Some(event.serial.clone());
+            last_serial = Some(&event.serial);
             match event.action {
                 AnnotationAction::Create => {
                     if deleted_create_ids.contains(&event.id) {
                         continue;
                     }
-                    seen_create_ids.insert(event.id.clone());
+                    seen_create_ids.insert(&event.id);
                 }
                 AnnotationAction::Delete if create_ids.contains(&event.id) => {
-                    deleted_create_ids.insert(event.id.clone());
+                    deleted_create_ids.insert(&event.id);
                     if !seen_create_ids.contains(&event.id) {
                         continue;
                     }
                 }
                 AnnotationAction::Delete => {}
             }
-            engine.apply(&event)?;
+            engine.apply(event)?;
             applied_events += 1;
         }
 
         Ok(Self {
             key: AnnotationProjectionKey {
-                channel_id: channel_id.into(),
+                channel_id,
                 message_serial,
                 annotation_type,
             },
             summary: engine.finish(),
-            last_serial,
+            last_serial: last_serial.cloned(),
             applied_events,
         })
     }

--- a/crates/sockudo-core/src/app.rs
+++ b/crates/sockudo-core/src/app.rs
@@ -1061,7 +1061,7 @@ mod tests {
             "key".to_string(),
             "secret".to_string(),
             true,
-            policy.clone(),
+            policy,
         );
 
         assert_eq!(app.policy().limits.max_connections, 250);

--- a/crates/sockudo-core/src/history/memory.rs
+++ b/crates/sockudo-core/src/history/memory.rs
@@ -151,7 +151,7 @@ impl HistoryStore for MemoryHistoryStore {
         let mut channels = self.channels.write().await;
         let channel_state = channels.entry(key).or_default();
         if channel_state.stream_id != record.stream_id {
-            channel_state.stream_id = record.stream_id.clone();
+            channel_state.stream_id.clone_from(&record.stream_id);
         }
         channel_state.next_serial = channel_state
             .next_serial

--- a/crates/sockudo-core/src/options/env/adapters.rs
+++ b/crates/sockudo-core/src/options/env/adapters.rs
@@ -134,30 +134,38 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
 
     // --- Apache Iggy Adapter / Queue ---
     if let Ok(connection_string) = std::env::var("IGGY_CONNECTION_STRING") {
-        options.adapter.iggy.connection_string = connection_string.clone();
+        options
+            .adapter
+            .iggy
+            .connection_string
+            .clone_from(&connection_string);
         options.queue.iggy.connection_string = connection_string;
     }
     if let Ok(username) = std::env::var("IGGY_USERNAME") {
         let username = (!username.is_empty()).then_some(username);
-        options.adapter.iggy.username = username.clone();
+        options.adapter.iggy.username.clone_from(&username);
         options.queue.iggy.username = username;
     }
     if let Ok(password) = std::env::var("IGGY_PASSWORD") {
         let password = (!password.is_empty()).then_some(password);
-        options.adapter.iggy.password = password.clone();
+        options.adapter.iggy.password.clone_from(&password);
         options.queue.iggy.password = password;
     }
     if let Ok(consumer_name) = std::env::var("IGGY_CONSUMER_NAME") {
         let consumer_name = (!consumer_name.is_empty()).then_some(consumer_name);
-        options.adapter.iggy.consumer_name = consumer_name.clone();
+        options
+            .adapter
+            .iggy
+            .consumer_name
+            .clone_from(&consumer_name);
         options.queue.iggy.consumer_name = consumer_name;
     } else if let Ok(process_id) = std::env::var("INSTANCE_PROCESS_ID") {
         let process_id = (!process_id.is_empty()).then_some(process_id);
-        options.adapter.iggy.consumer_name = process_id.clone();
+        options.adapter.iggy.consumer_name.clone_from(&process_id);
         options.queue.iggy.consumer_name = process_id;
     }
     if let Ok(stream) = std::env::var("IGGY_STREAM") {
-        options.adapter.iggy.stream = stream.clone();
+        options.adapter.iggy.stream.clone_from(&stream);
         options.queue.iggy.stream = stream;
     }
     if let Ok(prefix) = std::env::var("IGGY_TOPIC_PREFIX") {

--- a/crates/sockudo-core/src/options/env/databases.rs
+++ b/crates/sockudo-core/src/options/env/databases.rs
@@ -143,14 +143,19 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
             .map(ToString::to_string)
             .collect();
 
-        options.adapter.cluster.nodes = node_list.clone();
-        options.queue.redis_cluster.nodes = node_list.clone();
+        options.adapter.cluster.nodes.clone_from(&node_list);
+        options.queue.redis_cluster.nodes.clone_from(&node_list);
 
         let parsed_nodes: Vec<ClusterNode> = node_list
             .iter()
             .filter_map(|seed| ClusterNode::from_seed(seed))
             .collect();
-        options.database.redis.cluster.nodes = parsed_nodes.clone();
+        options
+            .database
+            .redis
+            .cluster
+            .nodes
+            .clone_from(&parsed_nodes);
         options.database.redis.cluster_nodes = parsed_nodes;
     };
 

--- a/crates/sockudo-core/src/version_store/memory.rs
+++ b/crates/sockudo-core/src/version_store/memory.rs
@@ -3,7 +3,8 @@ use super::types::*;
 use crate::error::{Error, Result};
 use crate::history::now_ms;
 use crate::versioned_messages::{
-    MessageAction, MessageSerial, validate_replay_continuity, validate_version_chain,
+    MessageAction, MessageSerial, validate_replay_continuity_iter, validate_version_chain,
+    validate_version_chain_iter,
 };
 use async_trait::async_trait;
 use std::collections::{BTreeMap, BTreeSet};
@@ -19,8 +20,8 @@ pub struct MemoryVersionStore {
 struct MemoryVersionChannel {
     stream_id: String,
     next_delivery_serial: u64,
-    messages: BTreeMap<String, Vec<StoredVersionRecord>>,
-    replay: BTreeMap<u64, StoredVersionRecord>,
+    messages: BTreeMap<String, Vec<Arc<StoredVersionRecord>>>,
+    replay: BTreeMap<u64, Arc<StoredVersionRecord>>,
     // Parallel map: `delivery_serial -> server-side append time (ms)`.
     // Used by `purge_before` for TTL eviction without touching read paths.
     created_at: BTreeMap<u64, i64>,
@@ -115,30 +116,30 @@ impl VersionStore for MemoryVersionStore {
             )));
         }
 
-        let tentative_chain = channel_state
-            .messages
-            .get(record.message_serial().as_str())
-            .cloned()
-            .unwrap_or_default();
-        let mut validated_chain = tentative_chain;
-        validated_chain.push(record.clone());
-        validate_version_chain(
-            &validated_chain
-                .iter()
-                .map(|entry| entry.message.clone())
-                .collect::<Vec<_>>(),
-        )?;
+        let message_serial = record.message_serial().as_str().to_owned();
+        if let Some(chain) = channel_state.messages.get(&message_serial) {
+            validate_version_chain_iter(
+                chain
+                    .iter()
+                    .map(|entry| &entry.message)
+                    .chain(std::iter::once(&record.message)),
+            )?;
+        } else {
+            validate_version_chain(std::slice::from_ref(&record.message))?;
+        }
 
-        channel_state.messages.insert(
-            record.message_serial().as_str().to_string(),
-            validated_chain,
-        );
+        let record = Arc::new(record);
+        channel_state
+            .messages
+            .entry(message_serial)
+            .or_default()
+            .push(Arc::clone(&record));
         channel_state
             .created_at
             .insert(record.delivery_serial(), now_ms());
         channel_state
             .replay
-            .insert(record.delivery_serial(), record.clone());
+            .insert(record.delivery_serial(), Arc::clone(&record));
         channel_state.next_delivery_serial = channel_state
             .next_delivery_serial
             .max(record.delivery_serial().saturating_add(1));
@@ -161,7 +162,7 @@ impl VersionStore for MemoryVersionStore {
             })
         {
             return Ok(VersionCreateResult::Conflict {
-                current: Some(current.clone()),
+                current: Some(current.as_ref().clone()),
             });
         }
         if let Some(limit) = request.limits.max_accumulated_message_bytes
@@ -201,12 +202,13 @@ impl VersionStore for MemoryVersionStore {
                 "duplicate delivery_serial {delivery_serial} in version replay log"
             )));
         }
+        let stored_record = Arc::new(record.clone());
         channel_state.messages.insert(
             record.message_serial().as_str().to_string(),
-            vec![record.clone()],
+            vec![Arc::clone(&stored_record)],
         );
         channel_state.created_at.insert(delivery_serial, now_ms());
-        channel_state.replay.insert(delivery_serial, record.clone());
+        channel_state.replay.insert(delivery_serial, stored_record);
         channel_state.next_delivery_serial = delivery_serial.saturating_add(1);
 
         Ok(VersionCreateResult::Applied {
@@ -250,7 +252,7 @@ impl VersionStore for MemoryVersionStore {
                 return Err(Error::IdempotencyConflict);
             }
             return Ok(VersionMutationResult::Duplicate {
-                record: existing.clone(),
+                record: existing.as_ref().clone(),
                 stream_id: channel_state.stream_id.clone(),
             });
         }
@@ -258,18 +260,17 @@ impl VersionStore for MemoryVersionStore {
         let current = chain
             .iter()
             .max_by(|left, right| left.version_serial().cmp(right.version_serial()))
-            .cloned()
             .ok_or_else(|| {
                 Error::InvalidMessageFormat("version chain must not be empty".to_string())
             })?;
-        if !request.expected.matches(&current) {
+        if !request.expected.matches(current) {
             return Ok(VersionMutationResult::Conflict {
-                current: Some(current),
+                current: Some(current.as_ref().clone()),
             });
         }
 
         if matches!(request.mutation, VersionMutation::Append(_)) {
-            if request.limits.reject_append_after_terminal && Self::is_terminal(&current) {
+            if request.limits.reject_append_after_terminal && Self::is_terminal(current) {
                 return Ok(VersionMutationResult::Rejected(
                     VersionMutationRejection::TerminalMessage,
                 ));
@@ -319,13 +320,11 @@ impl VersionStore for MemoryVersionStore {
             }
         }
 
-        let mut validated_chain = chain.clone();
-        validated_chain.push(record.clone());
-        validate_version_chain(
-            &validated_chain
+        validate_version_chain_iter(
+            chain
                 .iter()
-                .map(|entry| entry.message.clone())
-                .collect::<Vec<_>>(),
+                .map(|entry| &entry.message)
+                .chain(std::iter::once(&record.message)),
         )?;
         if channel_state.replay.contains_key(&delivery_serial) {
             return Err(Error::InvalidMessageFormat(format!(
@@ -333,11 +332,16 @@ impl VersionStore for MemoryVersionStore {
             )));
         }
 
+        let stored_record = Arc::new(record.clone());
         channel_state
             .messages
-            .insert(request.message_serial.as_str().to_string(), validated_chain);
+            .get_mut(request.message_serial.as_str())
+            .ok_or_else(|| {
+                Error::Internal("version chain disappeared during mutation".to_string())
+            })?
+            .push(Arc::clone(&stored_record));
         channel_state.created_at.insert(delivery_serial, now_ms());
-        channel_state.replay.insert(delivery_serial, record.clone());
+        channel_state.replay.insert(delivery_serial, stored_record);
         channel_state.next_delivery_serial = delivery_serial.saturating_add(1);
 
         Ok(VersionMutationResult::Applied {
@@ -364,10 +368,9 @@ impl VersionStore for MemoryVersionStore {
         let latest = chain
             .iter()
             .max_by(|left, right| left.version_serial().cmp(right.version_serial()))
-            .cloned()
             .ok_or_else(|| Error::InvalidMessageFormat("version chain must not be empty".into()))?;
 
-        Ok(Some(latest))
+        Ok(Some(latest.as_ref().clone()))
     }
 
     async fn get_latest_batch(
@@ -398,8 +401,7 @@ impl VersionStore for MemoryVersionStore {
                 chain
                     .iter()
                     .max_by(|left, right| left.version_serial().cmp(right.version_serial()))
-                    .cloned()
-                    .map(|record| (message_serial.clone(), record))
+                    .map(|record| (message_serial.clone(), record.as_ref().clone()))
                     .ok_or_else(|| {
                         Error::InvalidMessageFormat("version chain must not be empty".into())
                     })
@@ -426,13 +428,13 @@ impl VersionStore for MemoryVersionStore {
             });
         };
 
-        let mut items = chain.clone();
+        let mut items = chain.iter().collect::<Vec<_>>();
         items.sort_by(|left, right| left.version_serial().cmp(right.version_serial()));
         if matches!(request.direction, VersionStoreDirection::NewestFirst) {
             items.reverse();
         }
 
-        let filtered: Vec<StoredVersionRecord> = items
+        let filtered = items
             .into_iter()
             .filter(|item| {
                 request
@@ -448,10 +450,14 @@ impl VersionStore for MemoryVersionStore {
                     })
             })
             .take(request.limit + 1)
-            .collect();
+            .collect::<Vec<_>>();
 
         let has_more = filtered.len() > request.limit;
-        let items: Vec<StoredVersionRecord> = filtered.into_iter().take(request.limit).collect();
+        let items = filtered
+            .into_iter()
+            .take(request.limit)
+            .map(|item| item.as_ref().clone())
+            .collect::<Vec<_>>();
         let next_cursor = if has_more {
             items.last().map(|item| VersionStoreCursor {
                 version: 1,
@@ -480,22 +486,22 @@ impl VersionStore for MemoryVersionStore {
             return Ok(Vec::new());
         };
 
-        let items: Vec<StoredVersionRecord> = channel_state
+        let stored_items = channel_state
             .replay
             .range((request.after_delivery_serial.saturating_add(1))..)
-            .map(|(_, value)| value.clone())
+            .map(|(_, value)| value)
             .take(request.limit)
-            .collect();
+            .collect::<Vec<_>>();
 
-        validate_replay_continuity(
-            &items
-                .iter()
-                .map(|entry| entry.message.clone())
-                .collect::<Vec<_>>(),
+        validate_replay_continuity_iter(
+            stored_items.iter().map(|entry| &entry.message),
             request.after_delivery_serial,
         )?;
 
-        Ok(items)
+        Ok(stored_items
+            .into_iter()
+            .map(|item| item.as_ref().clone())
+            .collect())
     }
 
     async fn latest_by_history(
@@ -516,7 +522,7 @@ impl VersionStore for MemoryVersionStore {
                 chain
                     .iter()
                     .max_by(|left, right| left.version_serial().cmp(right.version_serial()))
-                    .cloned()
+                    .map(|record| record.as_ref().clone())
             })
             .collect::<Vec<_>>();
 

--- a/crates/sockudo-core/src/versioned_messages.rs
+++ b/crates/sockudo-core/src/versioned_messages.rs
@@ -264,7 +264,14 @@ impl VersionedMessage {
 }
 
 pub fn validate_version_chain(versions: &[VersionedMessage]) -> Result<()> {
-    let Some(first) = versions.first() else {
+    validate_version_chain_iter(versions)
+}
+
+pub(crate) fn validate_version_chain_iter<'a>(
+    versions: impl IntoIterator<Item = &'a VersionedMessage>,
+) -> Result<()> {
+    let mut versions = versions.into_iter();
+    let Some(first) = versions.next() else {
         return Err(Error::InvalidMessageFormat(
             "version chain must not be empty".to_string(),
         ));
@@ -272,11 +279,13 @@ pub fn validate_version_chain(versions: &[VersionedMessage]) -> Result<()> {
 
     let mut version_serials = HashSet::new();
     let mut delivery_serials = HashSet::new();
+    version_serials.insert(first.version.serial.as_str());
+    delivery_serials.insert(first.replay_position.delivery_serial);
 
     for version in versions {
         ensure_same_chain(first, version)?;
 
-        if !version_serials.insert(version.version.serial.as_str().to_string()) {
+        if !version_serials.insert(version.version.serial.as_str()) {
             return Err(Error::InvalidMessageFormat(format!(
                 "duplicate version_serial {} in version chain",
                 version.version.serial.as_str()
@@ -296,6 +305,13 @@ pub fn validate_version_chain(versions: &[VersionedMessage]) -> Result<()> {
 
 pub fn validate_replay_continuity(
     replay: &[VersionedMessage],
+    requested_after_serial: u64,
+) -> Result<()> {
+    validate_replay_continuity_iter(replay, requested_after_serial)
+}
+
+pub(crate) fn validate_replay_continuity_iter<'a>(
+    replay: impl IntoIterator<Item = &'a VersionedMessage>,
     requested_after_serial: u64,
 ) -> Result<()> {
     let mut expected = requested_after_serial.saturating_add(1);

--- a/crates/sockudo-core/src/websocket/connection.rs
+++ b/crates/sockudo-core/src/websocket/connection.rs
@@ -141,8 +141,10 @@ impl WebSocket {
 
     pub fn set_user_info(&mut self, user_info: UserInfo) {
         self.state.user_id = Some(user_info.id.clone());
-        self.state.connection_capabilities = user_info.capabilities.clone();
-        self.state.connection_meta = user_info.meta.clone();
+        self.state
+            .connection_capabilities
+            .clone_from(&user_info.capabilities);
+        self.state.connection_meta.clone_from(&user_info.meta);
         self.state.user_info = Some(user_info.clone());
 
         if let Some(info) = &user_info.info {
@@ -162,7 +164,7 @@ impl WebSocket {
             meta: None,
         });
         self.state.user = Some(sonic_rs::json!({
-            "id": context.client_id.clone(),
+            "id": context.client_id,
         }));
         self.state.token_auth_context = Some(context);
     }

--- a/crates/sockudo-delta/benches/delta_compression_bench.rs
+++ b/crates/sockudo-delta/benches/delta_compression_bench.rs
@@ -1,6 +1,122 @@
-use std::hint::black_box;
-
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use sockudo_core::delta_types::DeltaCompressionConfig;
+use sockudo_core::websocket::SocketId;
+use sockudo_delta::DeltaCompressionManager;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::Once;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+struct CountingAllocator;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+static DELTA_STATE_ALLOCATION_REPORT: Once = Once::new();
+
+// SAFETY: every allocation operation delegates to the process system allocator.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the caller provided a valid allocation layout.
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        let pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !pointer.is_null() && TRACK_ALLOCATIONS.load(Ordering::Relaxed) {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn measure_allocations<T>(operation: impl FnOnce() -> T) -> (T, u64, u64) {
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    ALLOCATION_COUNT.store(0, Ordering::SeqCst);
+    ALLOCATED_BYTES.store(0, Ordering::SeqCst);
+    TRACK_ALLOCATIONS.store(true, Ordering::SeqCst);
+    let result = operation();
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    (
+        result,
+        ALLOCATION_COUNT.load(Ordering::SeqCst),
+        ALLOCATED_BYTES.load(Ordering::SeqCst),
+    )
+}
+
+fn delta_state_fixture(socket_count: usize) -> (DeltaCompressionManager, Vec<SocketId>) {
+    let manager = DeltaCompressionManager::new(DeltaCompressionConfig::default());
+    let sockets = (0..socket_count)
+        .map(|_| {
+            let socket_id = SocketId::new();
+            manager.enable_for_socket(&socket_id);
+            socket_id
+        })
+        .collect();
+    (manager, sockets)
+}
+
+fn store_legacy_copies(
+    runtime: &tokio::runtime::Runtime,
+    manager: &DeltaCompressionManager,
+    sockets: &[SocketId],
+    payload: &Arc<Vec<u8>>,
+) {
+    runtime.block_on(async {
+        for socket_id in sockets {
+            manager
+                .store_sent_message(
+                    socket_id,
+                    "bench-channel",
+                    "bench-event",
+                    payload.as_ref().clone(),
+                    true,
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+    });
+}
+
+fn store_shared_bytes(
+    runtime: &tokio::runtime::Runtime,
+    manager: &DeltaCompressionManager,
+    sockets: &[SocketId],
+    payload: &Arc<Vec<u8>>,
+) {
+    runtime.block_on(async {
+        for socket_id in sockets {
+            manager
+                .store_shared_sent_message(
+                    socket_id,
+                    "bench-channel",
+                    "bench-event",
+                    Arc::clone(payload),
+                    true,
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+    });
+}
 
 fn make_payload(symbol: &str, seq: u32, price: f64, volume: f64) -> String {
     format!(
@@ -59,5 +175,53 @@ fn bench_fossil_delta(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_fossil_delta);
+fn bench_shared_delta_state(c: &mut Criterion) {
+    const SOCKETS: usize = 256;
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let payload = Arc::new(vec![42_u8; 64 * 1024]);
+
+    DELTA_STATE_ALLOCATION_REPORT.call_once(|| {
+        let (legacy_manager, legacy_sockets) = delta_state_fixture(SOCKETS);
+        let (_, legacy_allocations, legacy_bytes) = measure_allocations(|| {
+            store_legacy_copies(&runtime, &legacy_manager, &legacy_sockets, &payload)
+        });
+        let (shared_manager, shared_sockets) = delta_state_fixture(SOCKETS);
+        let (_, shared_allocations, shared_bytes) = measure_allocations(|| {
+            store_shared_bytes(&runtime, &shared_manager, &shared_sockets, &payload)
+        });
+        eprintln!(
+            "allocation_profile name=delta_state_256x64k variant=legacy allocations={legacy_allocations} allocated_bytes={legacy_bytes}"
+        );
+        eprintln!(
+            "allocation_profile name=delta_state_256x64k variant=shared allocations={shared_allocations} allocated_bytes={shared_bytes}"
+        );
+    });
+
+    let (legacy_manager, legacy_sockets) = delta_state_fixture(SOCKETS);
+    let (shared_manager, shared_sockets) = delta_state_fixture(SOCKETS);
+    let mut group = c.benchmark_group("delta_state_fanout");
+    group.bench_function("legacy_vec_copy_256x64k", |b| {
+        b.iter(|| {
+            store_legacy_copies(
+                &runtime,
+                black_box(&legacy_manager),
+                black_box(&legacy_sockets),
+                black_box(&payload),
+            )
+        })
+    });
+    group.bench_function("shared_arc_256x64k", |b| {
+        b.iter(|| {
+            store_shared_bytes(
+                &runtime,
+                black_box(&shared_manager),
+                black_box(&shared_sockets),
+                black_box(&payload),
+            )
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_fossil_delta, bench_shared_delta_state);
 criterion_main!(benches);

--- a/crates/sockudo-delta/src/compression.rs
+++ b/crates/sockudo-delta/src/compression.rs
@@ -322,6 +322,27 @@ impl DeltaCompressionManager {
         is_full_message: bool,
         channel_settings: Option<&ChannelDeltaSettings>,
     ) -> Result<()> {
+        self.store_shared_sent_message(
+            socket_id,
+            channel,
+            event_name,
+            Arc::new(sent_message_bytes),
+            is_full_message,
+            channel_settings,
+        )
+        .await
+    }
+
+    /// Store immutable message bytes already shared by a broadcast fanout.
+    pub async fn store_shared_sent_message(
+        &self,
+        socket_id: &SocketId,
+        channel: &str,
+        event_name: &str,
+        sent_message_bytes: Arc<Vec<u8>>,
+        is_full_message: bool,
+        channel_settings: Option<&ChannelDeltaSettings>,
+    ) -> Result<()> {
         let socket_state = match self.socket_states.get(socket_id) {
             Some(state) => state,
             None => return Ok(()),
@@ -374,7 +395,7 @@ impl DeltaCompressionManager {
             }
         };
 
-        cache.add_message(sent_message_bytes).await?;
+        cache.add_shared_message(sent_message_bytes).await?;
         tracing::trace!(socket_id = %socket_id, channel, cache_existed, "store_sent_message: added message to cache");
 
         if is_full_message {
@@ -482,7 +503,7 @@ impl DeltaCompressionManager {
                         .entry(key)
                         .and_modify(|existing| {
                             if messages.len() > existing.len() {
-                                *existing = messages.clone();
+                                existing.clone_from(&messages);
                             }
                         })
                         .or_insert(messages);

--- a/crates/sockudo-delta/src/messages.rs
+++ b/crates/sockudo-delta/src/messages.rs
@@ -53,9 +53,9 @@ where
 }
 
 impl CachedMessage {
-    pub(crate) fn new(content: Vec<u8>, sequence: u32) -> Self {
+    pub(crate) fn new_shared(content: Arc<Vec<u8>>, sequence: u32) -> Self {
         Self {
-            content: Arc::new(content),
+            content,
             sequence,
             timestamp: Instant::now(),
         }

--- a/crates/sockudo-delta/src/state.rs
+++ b/crates/sockudo-delta/src/state.rs
@@ -29,11 +29,16 @@ impl ConflationKeyCache {
         }
     }
 
+    #[cfg(test)]
     pub(crate) async fn add_message(&self, content: Vec<u8>) -> Result<()> {
+        self.add_shared_message(Arc::new(content)).await
+    }
+
+    pub(crate) async fn add_shared_message(&self, content: Arc<Vec<u8>>) -> Result<()> {
         use std::sync::atomic::Ordering;
 
         let sequence = self.next_sequence.fetch_add(1, Ordering::Relaxed);
-        let msg = Arc::new(CachedMessage::new(content, sequence));
+        let msg = Arc::new(CachedMessage::new_shared(content, sequence));
 
         *self.last_message.write().await = Some(msg);
         Ok(())

--- a/crates/sockudo-protocol/tests/protocol_compliance.rs
+++ b/crates/sockudo-protocol/tests/protocol_compliance.rs
@@ -809,11 +809,8 @@ fn test_encrypted_channel_event_format() {
         "nonce": "random_nonce_value"
     });
 
-    let message = PusherMessage::channel_event(
-        "my-event",
-        "private-encrypted-channel",
-        encrypted_data.clone(),
-    );
+    let message =
+        PusherMessage::channel_event("my-event", "private-encrypted-channel", encrypted_data);
     let json = message_to_json(&message);
 
     // Assert event and channel fields exist and have correct values

--- a/crates/sockudo-push/benches/push_pipeline_bench.rs
+++ b/crates/sockudo-push/benches/push_pipeline_bench.rs
@@ -1,6 +1,8 @@
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::hint::black_box;
 use std::num::NonZeroU32;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use aws_lc_rs::pbkdf2 as aws_lc_pbkdf2;
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
@@ -25,6 +27,56 @@ const BENCH_NOW_MS: u64 = 1_778_070_000_000;
 const PBKDF2_BENCH_ITERATIONS: u32 = 120_000;
 
 type HmacSha256 = Hmac<Sha256>;
+
+struct CountingAllocator;
+
+static COUNT_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+// SAFETY: every allocation operation delegates to the process system allocator.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the caller provided a valid allocation layout.
+        let pointer = unsafe { System.alloc(layout) };
+        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) && !pointer.is_null() {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: the pointer and layout came from the delegated system allocator.
+        let pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if COUNT_ALLOCATIONS.load(Ordering::Relaxed) && !pointer.is_null() {
+            ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+            ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
+        pointer
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn measure_allocations<T>(operation: impl FnOnce() -> T) -> (T, u64, u64) {
+    ALLOCATION_COUNT.store(0, Ordering::Relaxed);
+    ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+    COUNT_ALLOCATIONS.store(true, Ordering::SeqCst);
+    let output = operation();
+    COUNT_ALLOCATIONS.store(false, Ordering::SeqCst);
+    (
+        output,
+        ALLOCATION_COUNT.load(Ordering::Relaxed),
+        ALLOCATED_BYTES.load(Ordering::Relaxed),
+    )
+}
 
 fn bench_admission(c: &mut Criterion) {
     let mut group = c.benchmark_group("push_admission");
@@ -247,6 +299,28 @@ fn bench_queue(c: &mut Criterion) {
 }
 
 fn bench_provider_dispatch(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("tokio runtime");
+    let queue = Arc::new(MemoryPushQueue::new());
+    runtime.block_on(async {
+        let batch = sample_delivery_batch("dispatch-allocation-profile".to_owned(), 500);
+        queue
+            .produce(
+                PushQueueStage::DeliveryJobs(PushProviderKind::Fcm),
+                batch.queue_key(),
+                PushQueuePayload::DeliveryBatch(Box::new(batch)),
+            )
+            .await
+            .unwrap();
+    });
+    let dispatcher = Arc::new(AcceptAllDispatcher::new(PushProviderKind::Fcm));
+    let mut worker = ProviderDispatchWorker::new(PushProviderKind::Fcm, queue, dispatcher);
+    let (processed, allocations, allocated_bytes) =
+        measure_allocations(|| runtime.block_on(worker.run_once("bench-provider")));
+    assert_eq!(processed.unwrap(), 1);
+    eprintln!(
+        "allocation_profile name=push_provider_dispatch_500 allocations={allocations} allocated_bytes={allocated_bytes}"
+    );
+
     let mut group = c.benchmark_group("push_provider_dispatch");
     group.throughput(Throughput::Elements(500));
     group.bench_function("mock_accept_all_dispatch_500_jobs", |b| {

--- a/crates/sockudo-push/src/dispatch/auth.rs
+++ b/crates/sockudo-push/src/dispatch/auth.rs
@@ -81,19 +81,25 @@ impl CachedTokenProvider {
     }
 
     pub async fn access_token(&self, now_ms: u64) -> Result<SecretString, ProviderAuthError> {
-        let cached = self.cache.read().await.clone();
-        if let Some(cached) = cached
-            && cached.expires_at_ms > now_ms.saturating_add(self.refresh_skew_ms)
-        {
-            return Ok(cached.token.clone());
+        if let Some(token) = {
+            let cached = self.cache.read().await;
+            cached
+                .as_ref()
+                .filter(|cached| cached.expires_at_ms > now_ms.saturating_add(self.refresh_skew_ms))
+                .map(|cached| cached.token.clone())
+        } {
+            return Ok(token);
         }
 
         let _refresh = self.refresh_lock.lock().await;
-        let cached = self.cache.read().await.clone();
-        if let Some(cached) = cached
-            && cached.expires_at_ms > now_ms.saturating_add(self.refresh_skew_ms)
-        {
-            return Ok(cached.token.clone());
+        if let Some(token) = {
+            let cached = self.cache.read().await;
+            cached
+                .as_ref()
+                .filter(|cached| cached.expires_at_ms > now_ms.saturating_add(self.refresh_skew_ms))
+                .map(|cached| cached.token.clone())
+        } {
+            return Ok(token);
         }
         let refreshed = CachedProviderAccessToken::new(self.source.fetch_token(now_ms).await?)?;
         let token = refreshed.token.clone();
@@ -102,19 +108,25 @@ impl CachedTokenProvider {
     }
 
     pub async fn bearer_token(&self, now_ms: u64) -> Result<SecretString, ProviderAuthError> {
-        let cached = self.cache.read().await.clone();
-        if let Some(cached) = cached
-            && cached.expires_at_ms > now_ms.saturating_add(self.refresh_skew_ms)
-        {
-            return Ok(cached.bearer_token.clone());
+        if let Some(bearer_token) = {
+            let cached = self.cache.read().await;
+            cached
+                .as_ref()
+                .filter(|cached| cached.expires_at_ms > now_ms.saturating_add(self.refresh_skew_ms))
+                .map(|cached| cached.bearer_token.clone())
+        } {
+            return Ok(bearer_token);
         }
 
         let _refresh = self.refresh_lock.lock().await;
-        let cached = self.cache.read().await.clone();
-        if let Some(cached) = cached
-            && cached.expires_at_ms > now_ms.saturating_add(self.refresh_skew_ms)
-        {
-            return Ok(cached.bearer_token.clone());
+        if let Some(bearer_token) = {
+            let cached = self.cache.read().await;
+            cached
+                .as_ref()
+                .filter(|cached| cached.expires_at_ms > now_ms.saturating_add(self.refresh_skew_ms))
+                .map(|cached| cached.bearer_token.clone())
+        } {
+            return Ok(bearer_token);
         }
         let refreshed = CachedProviderAccessToken::new(self.source.fetch_token(now_ms).await?)?;
         let bearer_token = refreshed.bearer_token.clone();

--- a/crates/sockudo-push/src/dispatch/worker.rs
+++ b/crates/sockudo-push/src/dispatch/worker.rs
@@ -109,17 +109,15 @@ impl ProviderDispatchWorker {
     }
 
     async fn handle_message(&mut self, message: QueueMessage) -> PushPipelineResult<()> {
-        let PushQueuePayload::DeliveryBatch(batch) = message.payload.clone() else {
+        let QueueMessage { payload, ack, .. } = message;
+        let PushQueuePayload::DeliveryBatch(batch) = payload else {
             self.queue
-                .dead_letter(
-                    message.ack,
-                    "unexpected payload for provider worker".to_owned(),
-                )
+                .dead_letter(ack, "unexpected payload for provider worker".to_owned())
                 .await?;
             return Ok(());
         };
         let batch = *batch;
-        let Some(batch) = self.preflight_batch(message.ack.clone(), batch).await? else {
+        let Some(batch) = self.preflight_batch(ack.clone(), batch).await? else {
             return Ok(());
         };
         let app_id = batch.app_id.clone();
@@ -138,10 +136,7 @@ impl ProviderDispatchWorker {
             self.metrics
                 .circuit_breaker_state(self.provider, &app_id, true);
             self.queue
-                .nack(
-                    message.ack,
-                    Some(self.circuit_breaker.retry_after_ms(now_ms())),
-                )
+                .nack(ack, Some(self.circuit_breaker.retry_after_ms(now_ms())))
                 .await?;
             return Ok(());
         }
@@ -149,7 +144,7 @@ impl ProviderDispatchWorker {
         if !self.rate_limiter.acquire(&app_id, self.provider) {
             self.metrics.rate_limiter_throttled(self.provider, &app_id);
             self.queue
-                .nack(message.ack, Some(now_ms().saturating_add(1_000)))
+                .nack(ack, Some(now_ms().saturating_add(1_000)))
                 .await?;
             return Ok(());
         }
@@ -166,8 +161,15 @@ impl ProviderDispatchWorker {
             batch_id,
             jobs,
         } = batch;
-        for chunk in jobs.chunks(self.max_outbound_requests) {
-            let chunk_jobs = chunk.to_vec();
+        let mut jobs = jobs.into_iter();
+        loop {
+            let chunk_jobs = jobs
+                .by_ref()
+                .take(self.max_outbound_requests)
+                .collect::<Vec<_>>();
+            if chunk_jobs.is_empty() {
+                break;
+            }
             self.metrics
                 .worker_pool(self.provider, self.max_outbound_requests, chunk_jobs.len());
             let mut original_jobs = chunk_jobs.clone().into_iter();
@@ -257,7 +259,7 @@ impl ProviderDispatchWorker {
         self.rate_limiter.release(&app_id, self.provider);
         self.metrics
             .worker_pool(self.provider, self.max_outbound_requests, 0);
-        self.queue.ack(message.ack).await?;
+        self.queue.ack(ack).await?;
         Ok(())
     }
 
@@ -353,7 +355,7 @@ impl ProviderDispatchWorker {
         }
         let batch_id = format!("{original_batch_id}-deferred-{not_before_ms}");
         for job in &mut jobs {
-            job.batch_id = batch_id.clone();
+            job.batch_id.clone_from(&batch_id);
         }
         let batch = DeliveryBatch {
             app_id: app_id.to_owned(),

--- a/crates/sockudo-push/src/domain.rs
+++ b/crates/sockudo-push/src/domain.rs
@@ -2125,7 +2125,7 @@ mod tests {
             "{:?}",
             DevicePushDetails {
                 error_reason: Some("provider leaked token fcm-token-secret".to_owned()),
-                ..device.push.clone()
+                ..device.push
             }
         );
         assert!(push_debug.contains("[REDACTED]"));
@@ -2334,7 +2334,7 @@ mod tests {
             not_before_ms: None,
             expires_at_ms: Some(1000),
         };
-        assert_eq!(intent.idempotency_key(), intent.clone().idempotency_key());
+        assert_eq!(intent.idempotency_key(), intent.idempotency_key());
     }
 
     #[test]

--- a/crates/sockudo-push/src/feedback.rs
+++ b/crates/sockudo-push/src/feedback.rs
@@ -81,19 +81,20 @@ impl PushFeedbackProcessor {
     }
 
     async fn handle_message(&self, message: QueueMessage) -> PushPipelineResult<()> {
-        let feedback = match message.payload.clone() {
+        let QueueMessage { payload, ack, .. } = message;
+        let feedback = match payload {
             PushQueuePayload::DeliveryResult(result) => DeliveryFeedback::from_result(*result),
             PushQueuePayload::DeliveryFeedback(feedback) => *feedback,
             _ => {
                 self.queue
-                    .dead_letter(message.ack, "unexpected payload for feedback".to_owned())
+                    .dead_letter(ack, "unexpected payload for feedback".to_owned())
                     .await?;
                 return Ok(());
             }
         };
 
         self.apply_feedback(feedback).await?;
-        self.queue.ack(message.ack).await?;
+        self.queue.ack(ack).await?;
         Ok(())
     }
 

--- a/crates/sockudo-push/src/pipeline.rs
+++ b/crates/sockudo-push/src/pipeline.rs
@@ -502,7 +502,7 @@ struct MemoryQueueState {
     next_id: u64,
     ready: BTreeMap<PushQueueStage, VecDeque<StoredMessage>>,
     inflight: BTreeMap<(PushQueueStage, String), StoredMessage>,
-    produced_keys: BTreeMap<(PushQueueStage, String), String>,
+    produced_keys: BTreeMap<PushQueueStage, BTreeMap<String, String>>,
     dead_letters: Vec<StoredDeadLetter>,
 }
 
@@ -644,7 +644,7 @@ impl PushQueue for MemoryPushQueue {
     async fn ack(&self, token: QueueAckToken) -> PushQueueResult<()> {
         let mut inner = self.lock()?;
         if let Some(stored) = inner.inflight.remove(&(token.stage, token.message_id)) {
-            inner.produced_keys.remove(&(token.stage, stored.key));
+            remove_produced_key(&mut inner, token.stage, &stored.key);
         }
         Ok(())
     }
@@ -667,9 +667,7 @@ impl PushQueue for MemoryPushQueue {
     async fn dead_letter(&self, token: QueueAckToken, reason: String) -> PushQueueResult<()> {
         let mut inner = self.lock()?;
         if let Some(stored) = inner.inflight.remove(&(token.stage, token.message_id)) {
-            inner
-                .produced_keys
-                .remove(&(token.stage, stored.key.clone()));
+            remove_produced_key(&mut inner, token.stage, &stored.key);
             let dead_letter = dead_letter_from_message(token.stage, &stored, reason);
             inner.dead_letters.push(StoredDeadLetter {
                 dead_letter_id: dead_letter_entry_id(&dead_letter, &stored.message_id),
@@ -816,7 +814,11 @@ impl MemoryPushQueue {
         not_before_ms: Option<u64>,
     ) -> PushQueueResult<String> {
         let mut inner = self.lock()?;
-        if let Some(existing) = inner.produced_keys.get(&(stage, key.clone())) {
+        if let Some(existing) = inner
+            .produced_keys
+            .get(&stage)
+            .and_then(|stage_keys| stage_keys.get(&key))
+        {
             return Ok(existing.clone());
         }
 
@@ -825,7 +827,9 @@ impl MemoryPushQueue {
         let route = QueueRoute::for_message(stage, &key, &payload);
         inner
             .produced_keys
-            .insert((stage, key.clone()), message_id.clone());
+            .entry(stage)
+            .or_default()
+            .insert(key.clone(), message_id.clone());
         if let (PushQueueStage::DeadLetters, PushQueuePayload::DeadLetter(dead_letter)) =
             (stage, &payload)
         {
@@ -859,6 +863,19 @@ impl MemoryPushQueue {
         self.inner
             .lock()
             .map_err(|_| PushQueueError::Backend("memory queue lock poisoned".to_owned()))
+    }
+}
+
+fn remove_produced_key(inner: &mut MemoryQueueState, stage: PushQueueStage, key: &str) {
+    let remove_stage = inner
+        .produced_keys
+        .get_mut(&stage)
+        .is_some_and(|stage_keys| {
+            stage_keys.remove(key);
+            stage_keys.is_empty()
+        });
+    if remove_stage {
+        inner.produced_keys.remove(&stage);
     }
 }
 

--- a/crates/sockudo-push/src/planner.rs
+++ b/crates/sockudo-push/src/planner.rs
@@ -71,9 +71,10 @@ impl PushPlanner {
         consumer_group: &str,
     ) -> PushPipelineResult<()> {
         let started = Instant::now();
-        let PushQueuePayload::PublishLog(event) = message.payload.clone() else {
+        let QueueMessage { payload, ack, .. } = message;
+        let PushQueuePayload::PublishLog(event) = payload else {
             self.queue
-                .dead_letter(message.ack, "unexpected payload for publish log".to_owned())
+                .dead_letter(ack, "unexpected payload for publish log".to_owned())
                 .await?;
             return Ok(());
         };
@@ -81,11 +82,11 @@ impl PushPlanner {
         let lock_id = match self.begin_planning(&event, consumer_group).await? {
             PlanningStart::Started { lock_id } => lock_id,
             PlanningStart::AlreadyHandled => {
-                self.queue.ack(message.ack).await?;
+                self.queue.ack(ack).await?;
                 return Ok(());
             }
             PlanningStart::Locked { retry_at_ms } => {
-                self.queue.nack(message.ack, Some(retry_at_ms)).await?;
+                self.queue.nack(ack, Some(retry_at_ms)).await?;
                 return Ok(());
             }
         };
@@ -97,7 +98,7 @@ impl PushPlanner {
             self.mark_failed(&event, reason.clone()).await?;
             self.release_planner_lock(&event, &lock_id, consumer_group)
                 .await;
-            self.queue.dead_letter(message.ack, reason).await?;
+            self.queue.dead_letter(ack, reason).await?;
             return Ok(());
         }
         if let Err(error) = plan_result {
@@ -110,7 +111,7 @@ impl PushPlanner {
             .await?;
         self.release_planner_lock(&event, &lock_id, consumer_group)
             .await;
-        self.queue.ack(message.ack).await?;
+        self.queue.ack(ack).await?;
         Ok(())
     }
 
@@ -480,12 +481,10 @@ impl PushShardWorker {
     }
 
     async fn handle_shard_message(&self, message: QueueMessage) -> PushPipelineResult<()> {
-        let PushQueuePayload::ShardJob(shard) = message.payload.clone() else {
+        let QueueMessage { payload, ack, .. } = message;
+        let PushQueuePayload::ShardJob(shard) = payload else {
             self.queue
-                .dead_letter(
-                    message.ack,
-                    "unexpected payload for shard worker".to_owned(),
-                )
+                .dead_letter(ack, "unexpected payload for shard worker".to_owned())
                 .await?;
             return Ok(());
         };
@@ -500,7 +499,7 @@ impl PushShardWorker {
                 Err(PushPipelineError::InvalidPayload(reason)) => {
                     shard.status = ShardJobStatus::Failed;
                     self.store.put_fanout_shard(shard).await?;
-                    self.queue.dead_letter(message.ack, reason).await?;
+                    self.queue.dead_letter(ack, reason).await?;
                     return Ok(());
                 }
                 Err(error) => return Err(error),
@@ -546,7 +545,7 @@ impl PushShardWorker {
                 .await?;
         }
 
-        self.queue.ack(message.ack).await?;
+        self.queue.ack(ack).await?;
         Ok(())
     }
 
@@ -770,7 +769,7 @@ impl ProviderBatcher {
             *index
         );
         for job in &mut jobs {
-            job.batch_id = batch_id.clone();
+            job.batch_id.clone_from(&batch_id);
         }
         let jobs_len = jobs.len();
         let batch = DeliveryBatch {

--- a/crates/sockudo-push/src/retry.rs
+++ b/crates/sockudo-push/src/retry.rs
@@ -8,7 +8,7 @@ use crate::domain::{
 use crate::meta::{PushMetaEvent, emit_push_meta_event};
 use crate::metrics::PushMetrics;
 use crate::pipeline::{
-    PushPipelineResult, PushQueuePayload, PushQueueStage, QueueMessage,
+    PushPipelineResult, PushQueuePayload, PushQueueStage, QueueAckToken, QueueMessage,
     guard_publish_status_transition, mutate_publish_status_with_cas, now_ms,
 };
 use crate::storage::{DynPushStore, IdempotencyRecord, SchedulerLock};
@@ -200,12 +200,10 @@ impl PushRetryScheduler {
     }
 
     async fn handle_message(&self, message: QueueMessage) -> PushPipelineResult<bool> {
-        let PushQueuePayload::RetrySchedule(entry) = message.payload.clone() else {
+        let QueueMessage { payload, ack, .. } = message;
+        let PushQueuePayload::RetrySchedule(entry) = payload else {
             self.queue
-                .dead_letter(
-                    message.ack,
-                    "unexpected payload for retry scheduler".to_owned(),
-                )
+                .dead_letter(ack, "unexpected payload for retry scheduler".to_owned())
                 .await?;
             self.metrics
                 .retry_malformed("unknown", "unexpected_payload");
@@ -216,19 +214,19 @@ impl PushRetryScheduler {
         let now = now_ms();
         let Some(provider) = entry.provider else {
             return self
-                .dead_letter_malformed(message, &entry, "missing retry provider")
+                .dead_letter_malformed(ack, &entry, "missing retry provider")
                 .await
                 .map(|_| false);
         };
         let Some(job) = entry.job.as_deref().cloned() else {
             return self
-                .dead_letter_malformed(message, &entry, "missing retry job")
+                .dead_letter_malformed(ack, &entry, "missing retry job")
                 .await
                 .map(|_| false);
         };
         if entry.retry_idempotency_key.trim().is_empty() {
             return self
-                .dead_letter_malformed(message, &entry, "missing retry idempotency key")
+                .dead_letter_malformed(ack, &entry, "missing retry idempotency key")
                 .await
                 .map(|_| false);
         }
@@ -238,14 +236,12 @@ impl PushRetryScheduler {
                 &entry.app_id,
                 entry.next_attempt_at_ms.saturating_sub(now),
             );
-            self.queue
-                .nack(message.ack, Some(entry.next_attempt_at_ms))
-                .await?;
+            self.queue.nack(ack, Some(entry.next_attempt_at_ms)).await?;
             return Ok(false);
         }
 
         if self.retry_already_completed(&entry).await? {
-            self.queue.ack(message.ack).await?;
+            self.queue.ack(ack).await?;
             return Ok(false);
         }
 
@@ -264,14 +260,14 @@ impl PushRetryScheduler {
             .await?;
         if !lock_acquired {
             self.queue
-                .nack(message.ack, Some(now.saturating_add(1_000)))
+                .nack(ack, Some(now.saturating_add(1_000)))
                 .await?;
             return Ok(false);
         }
 
         let app_id = entry.app_id.clone();
         let result = self
-            .handle_locked_retry(message, entry, provider, job, now)
+            .handle_locked_retry(ack, entry, provider, job, now)
             .await;
         let release = self
             .store
@@ -284,7 +280,7 @@ impl PushRetryScheduler {
 
     async fn handle_locked_retry(
         &self,
-        message: QueueMessage,
+        ack: QueueAckToken,
         entry: RetryScheduleEntry,
         provider: PushProviderKind,
         job: DeliveryJob,
@@ -295,7 +291,7 @@ impl PushRetryScheduler {
             .is_some_and(|expires_at_ms| expires_at_ms <= now)
         {
             self.complete_terminal_retry(
-                message,
+                ack,
                 &entry,
                 RetryTerminalKind::Expired,
                 "delivery expired before retry",
@@ -305,7 +301,7 @@ impl PushRetryScheduler {
         }
         if entry.attempt > entry.max_attempts || entry.max_attempts == 0 {
             self.complete_terminal_retry(
-                message,
+                ack,
                 &entry,
                 RetryTerminalKind::DeadLettered,
                 "retry attempts exhausted",
@@ -315,7 +311,7 @@ impl PushRetryScheduler {
         }
         if entry.expires_at_ms <= now {
             self.complete_terminal_retry(
-                message,
+                ack,
                 &entry,
                 RetryTerminalKind::DeadLettered,
                 "retry age expired",
@@ -358,7 +354,7 @@ impl PushRetryScheduler {
                 )
             {
                 self.put_retry_idempotency(&entry).await?;
-                self.queue.ack(message.ack).await?;
+                self.queue.ack(ack).await?;
                 return Ok(());
             }
         }
@@ -412,13 +408,13 @@ impl PushRetryScheduler {
             &entry.publish_id,
             "retry-dispatched",
         ));
-        self.queue.ack(message.ack).await?;
+        self.queue.ack(ack).await?;
         Ok(())
     }
 
     async fn dead_letter_malformed(
         &self,
-        message: QueueMessage,
+        ack: QueueAckToken,
         entry: &RetryScheduleEntry,
         reason: &'static str,
     ) -> PushPipelineResult<()> {
@@ -426,9 +422,7 @@ impl PushRetryScheduler {
             .retry_malformed(provider_for_metrics(entry.provider), reason);
         self.mark_terminal_status(entry, RetryTerminalKind::DeadLettered, reason)
             .await?;
-        self.queue
-            .dead_letter(message.ack, reason.to_owned())
-            .await?;
+        self.queue.dead_letter(ack, reason.to_owned()).await?;
         emit_push_meta_event(PushMetaEvent::dead_letter(
             &entry.app_id,
             &entry.publish_id,
@@ -440,7 +434,7 @@ impl PushRetryScheduler {
 
     async fn complete_terminal_retry(
         &self,
-        message: QueueMessage,
+        ack: QueueAckToken,
         entry: &RetryScheduleEntry,
         kind: RetryTerminalKind,
         reason: &'static str,
@@ -463,9 +457,7 @@ impl PushRetryScheduler {
             "retry_schedule",
             reason,
         ));
-        self.queue
-            .dead_letter(message.ack, reason.to_owned())
-            .await?;
+        self.queue.dead_letter(ack, reason.to_owned()).await?;
         Ok(())
     }
 

--- a/crates/sockudo-queue/src/iggy_queue_manager.rs
+++ b/crates/sockudo-queue/src/iggy_queue_manager.rs
@@ -498,7 +498,7 @@ async fn cached_queue_producer(
     topic: &str,
 ) -> Result<Arc<IggyProducer>> {
     if let Some(producer) = producers.lock().await.get(topic).cloned() {
-        return Ok(producer.clone());
+        return Ok(producer);
     }
 
     let producer = Arc::new(build_queue_producer(client, config, stream, topic).await?);

--- a/crates/sockudo-queue/src/nats_queue_manager.rs
+++ b/crates/sockudo-queue/src/nats_queue_manager.rs
@@ -124,7 +124,7 @@ impl NatsJetStreamQueueManager {
             return Ok(());
         }
         self.ensure_stream_once(queue_name).await?;
-        let subject = self.subject_name(queue_name);
+        let subject = async_nats::Subject::from(self.subject_name(queue_name));
 
         for chunk in jobs.chunks(self.reliability.max_batch_size) {
             let mut acknowledgements = Vec::with_capacity(chunk.len());

--- a/crates/sockudo-server/src/http_handler/history/mod.rs
+++ b/crates/sockudo-server/src/http_handler/history/mod.rs
@@ -251,7 +251,7 @@ pub async fn channel_history(
                         }
                         let latest_message = build_versioned_realtime_message(latest);
                         let latest_bytes = sonic_rs::to_vec(&latest_message)?;
-                        event_name = latest_message.message.event.clone();
+                        event_name.clone_from(&latest_message.message.event);
                         operation_kind = latest_message.action.as_str().to_string();
                         payload_size_bytes = latest_bytes.len();
                         sonic_rs::to_value(&latest_message)?

--- a/crates/sockudo-server/src/http_handler/test_support.rs
+++ b/crates/sockudo-server/src/http_handler/test_support.rs
@@ -501,7 +501,7 @@ pub(crate) fn test_realtime_handler_harness() -> (Arc<ConnectionHandler>, Arc<Me
     let app_manager = Arc::new(MemoryAppManager::new());
     let adapter = Arc::new(LocalAdapter::new());
     let app_manager_dyn = app_manager.clone() as Arc<dyn AppManager + Send + Sync>;
-    let adapter_dyn = adapter.clone() as Arc<dyn sockudo_adapter::ConnectionManager + Send + Sync>;
+    let adapter_dyn = adapter as Arc<dyn sockudo_adapter::ConnectionManager + Send + Sync>;
     let cache = Arc::new(MemoryCacheManager::new(
         "test".to_string(),
         MemoryCacheOptions::default(),

--- a/crates/sockudo-simulator/src/real_subsystems.rs
+++ b/crates/sockudo-simulator/src/real_subsystems.rs
@@ -61,7 +61,7 @@ impl RealPushHarness {
     pub(crate) fn new() -> Self {
         let store = Arc::new(MemoryPushStore::new());
         let queue = Arc::new(MemoryPushQueue::new());
-        let pipeline = PushPipeline::new(store.clone(), queue.clone(), FanoutConfig::default())
+        let pipeline = PushPipeline::new(store.clone(), queue, FanoutConfig::default())
             .with_max_publish_log_lag(u64::MAX);
         Self {
             store,

--- a/crates/sockudo-simulator/src/simulator.rs
+++ b/crates/sockudo-simulator/src/simulator.rs
@@ -853,7 +853,7 @@ impl DeterministicSimulator {
             .await?;
         self.shadow
             .channel_mut(&channel)
-            .reset_history(history.new_stream_id.clone());
+            .reset_history(history.new_stream_id);
         self.storage_visibility.reset_history(&channel);
 
         let presence = self
@@ -868,7 +868,7 @@ impl DeterministicSimulator {
             .await?;
         self.shadow
             .channel_mut(&channel)
-            .reset_presence(presence.new_stream_id.clone());
+            .reset_presence(presence.new_stream_id);
         self.storage_visibility.reset_presence(&channel);
 
         for client in &mut self.clients {

--- a/crates/sockudo-webhook/src/sender.rs
+++ b/crates/sockudo-webhook/src/sender.rs
@@ -830,7 +830,7 @@ mod tests {
             request_timeout_ms: None,
         };
 
-        let webhooks = [prefixed.clone(), catch_all.clone()];
+        let webhooks = [prefixed, catch_all];
         let relevant = webhook_sender.find_relevant_webhooks(
             &[
                 sonic_rs::json!({

--- a/scripts/ably-compat-release-guard.py
+++ b/scripts/ably-compat-release-guard.py
@@ -19,7 +19,9 @@ def arguments() -> argparse.Namespace:
     parser.add_argument("--confirmation-criterion-root", type=Path)
     parser.add_argument("--require-criterion-comparison", action="store_true")
     parser.add_argument("--load-result", action="append", default=[], type=Path)
-    parser.add_argument("--baseline-load-result", action="append", default=[], type=Path)
+    parser.add_argument(
+        "--baseline-load-result", action="append", default=[], type=Path
+    )
     parser.add_argument("--require-independent-runs", action="store_true")
     return parser.parse_args()
 
@@ -44,7 +46,9 @@ def main() -> int:
     baseline = [read_json(path) for path in args.baseline_load_result]
     minimum_runs = int(budgets["load"]["minimumIndependentRuns"])
     if args.require_independent_runs and len(current) < minimum_runs:
-        failures.append(f"release evidence requires {minimum_runs} independent load runs; found {len(current)}")
+        failures.append(
+            f"release evidence requires {minimum_runs} independent load runs; found {len(current)}"
+        )
     for path, result in zip(args.load_result, current):
         check_load_result(path, result, budgets["load"], failures, checked)
 
@@ -54,7 +58,9 @@ def main() -> int:
                 f"statistical comparison requires at least {minimum_runs} current and baseline runs"
             )
         else:
-            check_statistical_regressions(current, baseline, budgets["load"], failures, checked)
+            check_statistical_regressions(
+                current, baseline, budgets["load"], failures, checked
+            )
 
     if failures:
         print("Ably compatibility release guard failed:")
@@ -82,25 +88,34 @@ def check_criterion(
     ]
     for required in budget.get("requiredBenchmarks", []):
         if not any(required in estimate for estimate in estimates):
-            failures.append(f"missing required Criterion estimate matching {required!r}")
+            failures.append(
+                f"missing required Criterion estimate matching {required!r}"
+            )
     if estimates:
         checked.append(f"{len(estimates)} Criterion estimates discovered")
     changes = criterion_changes(root)
     threshold = float(budget["maxSignificantRegressionPercent"]) / 100.0
     if not changes:
-        message = "Criterion estimates present; no saved-baseline change intervals to gate"
+        message = (
+            "Criterion estimates present; no saved-baseline change intervals to gate"
+        )
         if require_comparison:
             failures.append(message)
         else:
             checked.append(message)
         return
     confirmation_changes = (
-        {bench_id(path, confirmation_root): path for path in criterion_changes(confirmation_root)}
+        {
+            bench_id(path, confirmation_root): path
+            for path in criterion_changes(confirmation_root)
+        }
         if confirmation_root
         else {}
     )
     if confirmation_root and not confirmation_changes:
-        failures.append("confirmation Criterion evidence has no saved-baseline change intervals")
+        failures.append(
+            "confirmation Criterion evidence has no saved-baseline change intervals"
+        )
         return
     for path in changes:
         data = read_json(path)
@@ -109,14 +124,18 @@ def check_criterion(
         lower = confidence.get("lower_bound")
         upper = confidence.get("upper_bound")
         if lower is None or upper is None:
-            failures.append(f"{path}: missing Criterion mean change confidence interval")
+            failures.append(
+                f"{path}: missing Criterion mean change confidence interval"
+            )
             continue
         bench = bench_id(path, root)
         if float(lower) > threshold:
             if confirmation_root:
                 confirmation_path = confirmation_changes.get(bench)
                 if confirmation_path is None:
-                    failures.append(f"{bench}: missing confirmation Criterion change interval")
+                    failures.append(
+                        f"{bench}: missing confirmation Criterion change interval"
+                    )
                     continue
                 confirmation_data = read_json(confirmation_path)
                 confirmation_lower = (
@@ -160,7 +179,13 @@ def criterion_changes(root: Path) -> list[Path]:
     ]
 
 
-def check_load_result(path: Path, result: dict[str, Any], budget: dict[str, Any], failures: list[str], checked: list[str]) -> None:
+def check_load_result(
+    path: Path,
+    result: dict[str, Any],
+    budget: dict[str, Any],
+    failures: list[str],
+    checked: list[str],
+) -> None:
     if result.get("schema") != "sockudo.ably-compat.capacity-result.v1":
         failures.append(f"{path}: not an executable compatibility capacity result")
         return
@@ -180,7 +205,9 @@ def check_load_result(path: Path, result: dict[str, Any], budget: dict[str, Any]
     present_topologies = {topology.get("topology") for topology in topologies}
     missing_topologies = set(budget.get("requiredTopologies", [])) - present_topologies
     if missing_topologies:
-        failures.append(f"{path}: missing required topologies {sorted(missing_topologies)}")
+        failures.append(
+            f"{path}: missing required topologies {sorted(missing_topologies)}"
+        )
     for topology in topologies:
         label = f"{path}:{topology.get('topology')}"
         if topology.get("status") != "passed":
@@ -189,7 +216,9 @@ def check_load_result(path: Path, result: dict[str, Any], budget: dict[str, Any]
             readiness = topology.get("readiness", {})
             if readiness.get("crossNodeFanout") != "ready":
                 failures.append(f"{label}: cross-node fanout did not become ready")
-            elif float(readiness.get("durationMs", math.inf)) > float(budget["maxCrossNodeReadyMs"]):
+            elif float(readiness.get("durationMs", math.inf)) > float(
+                budget["maxCrossNodeReadyMs"]
+            ):
                 failures.append(f"{label}: cross-node fanout readiness exceeded budget")
         plateau = topology.get("resources", {}).get("plateau", {})
         if not plateau.get("stalledPeersExercised"):
@@ -199,22 +228,40 @@ def check_load_result(path: Path, result: dict[str, Any], budget: dict[str, Any]
         if not plateau.get("postDisconnectPlateau"):
             failures.append(f"{label}: RSS did not plateau after disconnect")
         for node in plateau.get("nodes", []):
-            if float(node.get("stalledSlopeBytesPerSecond", math.inf)) > float(budget["maxRssPlateauSlopeBytesPerSecond"]):
-                failures.append(f"{label}: node {node.get('node')} stalled-peer RSS slope exceeded budget")
-            if float(node.get("postDisconnectSlopeBytesPerSecond", math.inf)) > float(budget["maxRssPlateauSlopeBytesPerSecond"]):
-                failures.append(f"{label}: node {node.get('node')} post-disconnect RSS slope exceeded budget")
-            if float(node.get("postDisconnectRatio", math.inf)) > float(budget["maxPostDisconnectRssRatio"]):
-                failures.append(f"{label}: node {node.get('node')} post-disconnect RSS ratio exceeded budget")
+            if float(node.get("stalledSlopeBytesPerSecond", math.inf)) > float(
+                budget["maxRssPlateauSlopeBytesPerSecond"]
+            ):
+                failures.append(
+                    f"{label}: node {node.get('node')} stalled-peer RSS slope exceeded budget"
+                )
+            if float(node.get("postDisconnectSlopeBytesPerSecond", math.inf)) > float(
+                budget["maxRssPlateauSlopeBytesPerSecond"]
+            ):
+                failures.append(
+                    f"{label}: node {node.get('node')} post-disconnect RSS slope exceeded budget"
+                )
+            if float(node.get("postDisconnectRatio", math.inf)) > float(
+                budget["maxPostDisconnectRssRatio"]
+            ):
+                failures.append(
+                    f"{label}: node {node.get('node')} post-disconnect RSS ratio exceeded budget"
+                )
         for shutdown in topology.get("shutdown", []):
             if not shutdown.get("continuityExplicit"):
-                failures.append(f"{label}: node {shutdown.get('node')} shutdown neither drained nor marked continuity")
+                failures.append(
+                    f"{label}: node {shutdown.get('node')} shutdown neither drained nor marked continuity"
+                )
             if shutdown.get("sensitiveDataLogged") is not False:
-                failures.append(f"{label}: node {shutdown.get('node')} did not prove secret/raw-payload log safety")
+                failures.append(
+                    f"{label}: node {shutdown.get('node')} did not prove secret/raw-payload log safety"
+                )
         scenarios = topology.get("scenarios", [])
         present_scenarios = {scenario.get("name") for scenario in scenarios}
         missing_scenarios = set(budget.get("requiredScenarios", [])) - present_scenarios
         if missing_scenarios:
-            failures.append(f"{label}: missing required scenarios {sorted(missing_scenarios)}")
+            failures.append(
+                f"{label}: missing required scenarios {sorted(missing_scenarios)}"
+            )
         for scenario in scenarios:
             scenario_label = f"{label}:{scenario.get('name')}"
             if scenario.get("status") != "passed":
@@ -224,41 +271,81 @@ def check_load_result(path: Path, result: dict[str, Any], budget: dict[str, Any]
                 if int(correctness.get(key, 0)) != 0:
                     failures.append(f"{scenario_label}: {key}={correctness[key]}")
             encoding = scenario.get("encoding")
-            if scenario.get("name") in {
-                "steady_publish",
-                "burst",
-                "payload_64k",
-                "encrypted_binary",
-                "fanout_1000",
-                "slow_consumers",
-            } and not encoding:
-                failures.append(f"{scenario_label}: missing active-format encode evidence")
+            if (
+                scenario.get("name")
+                in {
+                    "steady_publish",
+                    "burst",
+                    "payload_64k",
+                    "encrypted_binary",
+                    "fanout_1000",
+                    "slow_consumers",
+                }
+                and not encoding
+            ):
+                failures.append(
+                    f"{scenario_label}: missing active-format encode evidence"
+                )
             if encoding and not encoding.get("exactlyOncePerFormat"):
-                failures.append(f"{scenario_label}: encode count was not exactly once per active format")
+                failures.append(
+                    f"{scenario_label}: encode count was not exactly once per active format"
+                )
             for snapshot in scenario.get("runtimeAfter", []):
                 aggregation = snapshot.get("aggregation")
                 if aggregation:
                     backlog = int(aggregation.get("backlog", -1))
                     capacity = int(aggregation.get("queueCapacity", -1))
                     if backlog < 0 or capacity <= 0 or backlog > capacity:
-                        failures.append(f"{scenario_label}: stats backlog was missing or exceeded its bounded queue")
+                        failures.append(
+                            f"{scenario_label}: stats backlog was missing or exceeded its bounded queue"
+                        )
                     if int(aggregation.get("dropped", 0)) != 0:
-                        failures.append(f"{scenario_label}: stats observations were dropped")
+                        failures.append(
+                            f"{scenario_label}: stats observations were dropped"
+                        )
             if scenario.get("name") == "recovery_storm":
-                if int(scenario.get("resumed", -1)) != int(scenario.get("attempted", 0)):
+                if int(scenario.get("resumed", -1)) != int(
+                    scenario.get("attempted", 0)
+                ):
                     failures.append(f"{scenario_label}: not every connection recovered")
                 if int(scenario.get("replaySource", 0)) <= 0:
-                    failures.append(f"{scenario_label}: no canonical replay source was observed")
+                    failures.append(
+                        f"{scenario_label}: no canonical replay source was observed"
+                    )
                 if int(scenario.get("backendCalls", 0)) <= 0:
-                    failures.append(f"{scenario_label}: no recovery backend boundary was observed")
-                if int(scenario.get("backendCalls", 0)) > int(scenario.get("backendCallBudget", -1)):
-                    failures.append(f"{scenario_label}: recovery backend calls exceeded the constant budget")
-            check_latency(scenario_label, scenario, "publishLatencyMs", budget["maxPublishP99Ms"], failures)
-            check_latency(scenario_label, scenario, "deliveryLatencyMs", budget["maxDeliveryP99Ms"], failures)
+                    failures.append(
+                        f"{scenario_label}: no recovery backend boundary was observed"
+                    )
+                if int(scenario.get("backendCalls", 0)) > int(
+                    scenario.get("backendCallBudget", -1)
+                ):
+                    failures.append(
+                        f"{scenario_label}: recovery backend calls exceeded the constant budget"
+                    )
+            check_latency(
+                scenario_label,
+                scenario,
+                "publishLatencyMs",
+                budget["maxPublishP99Ms"],
+                failures,
+            )
+            check_latency(
+                scenario_label,
+                scenario,
+                "deliveryLatencyMs",
+                budget["maxDeliveryP99Ms"],
+                failures,
+            )
         checked.append(f"{label}: real topology and correctness invariants")
 
 
-def check_latency(label: str, scenario: dict[str, Any], field: str, maximum: float, failures: list[str]) -> None:
+def check_latency(
+    label: str,
+    scenario: dict[str, Any],
+    field: str,
+    maximum: float,
+    failures: list[str],
+) -> None:
     summary = scenario.get(field, {})
     p99 = summary.get("p99")
     if p99 is not None and float(p99) > float(maximum):
@@ -277,7 +364,13 @@ def bench_id(path: Path, root: Path) -> str:
     return path.relative_to(root).parent.parent.as_posix()
 
 
-def check_statistical_regressions(current: list[dict[str, Any]], baseline: list[dict[str, Any]], budget: dict[str, Any], failures: list[str], checked: list[str]) -> None:
+def check_statistical_regressions(
+    current: list[dict[str, Any]],
+    baseline: list[dict[str, Any]],
+    budget: dict[str, Any],
+    failures: list[str],
+    checked: list[str],
+) -> None:
     current_samples = collect_samples(current)
     baseline_samples = collect_samples(baseline)
     z_limit = float(budget["significanceZ"])
@@ -308,7 +401,9 @@ def check_statistical_regressions(current: list[dict[str, Any]], baseline: list[
                     f"(z={z_score:.3f}) exceeds {limits[metric]:.2f}%"
                 )
             else:
-                checked.append(f"{key}:{metric}: regression={regression:.2f}% z={z_score:.3f}")
+                checked.append(
+                    f"{key}:{metric}: regression={regression:.2f}% z={z_score:.3f}"
+                )
 
 
 def collect_samples(results: list[dict[str, Any]]) -> dict[str, dict[str, list[float]]]:
@@ -317,15 +412,36 @@ def collect_samples(results: list[dict[str, Any]]) -> dict[str, dict[str, list[f
         for topology in result.get("topologies", []):
             topology_name = topology.get("topology")
             peak_rss = max(
-                (float(node.get("peakRssBytes", 0)) for node in topology.get("resources", {}).get("plateau", {}).get("nodes", [])),
+                (
+                    float(node.get("peakRssBytes", 0))
+                    for node in topology.get("resources", {})
+                    .get("plateau", {})
+                    .get("nodes", [])
+                ),
                 default=0,
             )
             for scenario in topology.get("scenarios", []):
                 key = f"{topology_name}:{scenario.get('name')}"
-                target = samples.setdefault(key, {"publish_p99": [], "delivery_p99": [], "throughput": [], "peak_rss": []})
-                append_if_number(target["publish_p99"], scenario.get("publishLatencyMs", {}).get("p99"))
-                append_if_number(target["delivery_p99"], scenario.get("deliveryLatencyMs", {}).get("p99"))
-                append_if_number(target["throughput"], scenario.get("throughputPerSecond"))
+                target = samples.setdefault(
+                    key,
+                    {
+                        "publish_p99": [],
+                        "delivery_p99": [],
+                        "throughput": [],
+                        "peak_rss": [],
+                    },
+                )
+                append_if_number(
+                    target["publish_p99"],
+                    scenario.get("publishLatencyMs", {}).get("p99"),
+                )
+                append_if_number(
+                    target["delivery_p99"],
+                    scenario.get("deliveryLatencyMs", {}).get("p99"),
+                )
+                append_if_number(
+                    target["throughput"], scenario.get("throughputPerSecond")
+                )
                 append_if_number(target["peak_rss"], peak_rss)
     return samples
 
@@ -336,8 +452,14 @@ def append_if_number(target: list[float], value: Any) -> None:
 
 
 def welch_z(current: list[float], baseline: list[float], throughput: bool) -> float:
-    difference = statistics.mean(baseline) - statistics.mean(current) if throughput else statistics.mean(current) - statistics.mean(baseline)
-    variance = statistics.variance(current) / len(current) + statistics.variance(baseline) / len(baseline)
+    difference = (
+        statistics.mean(baseline) - statistics.mean(current)
+        if throughput
+        else statistics.mean(current) - statistics.mean(baseline)
+    )
+    variance = statistics.variance(current) / len(current) + statistics.variance(
+        baseline
+    ) / len(baseline)
     return 0.0 if variance <= 0 else difference / math.sqrt(variance)
 
 

--- a/server-sdks/sockudo-http-java/scripts/get_staging_repository_id.py
+++ b/server-sdks/sockudo-http-java/scripts/get_staging_repository_id.py
@@ -4,26 +4,35 @@ import os
 import sys
 import urllib.request
 
-username = os.environ.get('NEXUS_USERNAME')
-password = os.environ.get('NEXUS_PASSWORD')
+username = os.environ.get("NEXUS_USERNAME")
+password = os.environ.get("NEXUS_PASSWORD")
+
 
 def get(url, username, password):
     req = urllib.request.Request(url)
-    base64_auth = base64.b64encode(bytes('{}:{}'.format(username, password),'ascii'))
-    req.add_header("Authorization", "Basic {}".format(base64_auth.decode('utf-8')))
-    req.add_header('Accept', 'application/json')
+    base64_auth = base64.b64encode(bytes("{}:{}".format(username, password), "ascii"))
+    req.add_header("Authorization", "Basic {}".format(base64_auth.decode("utf-8")))
+    req.add_header("Accept", "application/json")
     with urllib.request.urlopen(req) as response:
         return response.read()
 
+
 def getRepositories(username, password):
-    return json.loads(get("https://oss.sonatype.org/service/local/staging/profile_repositories", username, password))
+    return json.loads(
+        get(
+            "https://oss.sonatype.org/service/local/staging/profile_repositories",
+            username,
+            password,
+        )
+    )
+
 
 repositories = getRepositories(username, password).get("data")
 if len(repositories) != 1:
-    sys.stderr.write("Zero or more than one staging repository. Exiting. Please execute the process manually.")
+    sys.stderr.write(
+        "Zero or more than one staging repository. Exiting. Please execute the process manually."
+    )
     exit(1)
 
 repositoryId = repositories[0].get("repositoryId")
 print(repositoryId)
-
-

--- a/server-sdks/sockudo-http-python/README.md
+++ b/server-sdks/sockudo-http-python/README.md
@@ -35,7 +35,11 @@ pip install -e server-sdks/sockudo-http-python[dev]
 ```python
 from sockudo_http import Config, Sockudo
 
-sockudo = Sockudo(Config(app_id="app-id", key="app-key", secret="app-secret", host="127.0.0.1", port=6001))
+sockudo = Sockudo(
+    Config(
+        app_id="app-id", key="app-key", secret="app-secret", host="127.0.0.1", port=6001
+    )
+)
 
 result = sockudo.trigger("orders", "order.created", {"id": "ord_123"})
 assert result.ok
@@ -68,7 +72,9 @@ sockudo.trigger(
     TriggerOptions(idempotency_key="order-created-ord_123"),
 )
 
-sockudo.trigger("orders", "order.created", {"id": "ord_124"}, TriggerOptions(idempotency_key=True))
+sockudo.trigger(
+    "orders", "order.created", {"id": "ord_124"}, TriggerOptions(idempotency_key=True)
+)
 ```
 
 Set `SockudoOptions(auto_idempotency=True)` to generate keys for publish and batch publish calls that omit one.
@@ -113,7 +119,11 @@ body = encrypted.authenticate("123.456", "private-encrypted-room")
 ```python
 from sockudo_http_python import ChannelsParams, HistoryParams, PresenceHistoryParams
 
-sockudo.list_channels(ChannelsParams(filter_by_prefix="presence-", info=["subscription_count", "user_count"]))
+sockudo.list_channels(
+    ChannelsParams(
+        filter_by_prefix="presence-", info=["subscription_count", "user_count"]
+    )
+)
 sockudo.get_channel_users("presence-room")
 sockudo.get_channel_history("orders", HistoryParams(limit=50, direction="newest_first"))
 sockudo.get_channel_presence_history("presence-room", PresenceHistoryParams(limit=50))
@@ -157,7 +167,9 @@ sockudo.delete_message("orders", "msg:1", MessageMutation(description="moderated
 sockudo.publish_annotation(
     "orders",
     "msg:1",
-    PublishAnnotationRequest(type="reactions:distinct.v1", name="like", client_id="user-1", count=1),
+    PublishAnnotationRequest(
+        type="reactions:distinct.v1", name="like", client_id="user-1", count=1
+    ),
 )
 sockudo.list_annotations("orders", "msg:1")
 ```
@@ -165,7 +177,9 @@ sockudo.list_annotations("orders", "msg:1")
 ## Webhooks
 
 ```python
-validity = sockudo.validate_webhook_signature(x_pusher_key, x_pusher_signature, raw_body)
+validity = sockudo.validate_webhook_signature(
+    x_pusher_key, x_pusher_signature, raw_body
+)
 webhook = sockudo.parse_webhook(x_pusher_key, x_pusher_signature, raw_body)
 ```
 
@@ -174,7 +188,9 @@ If a webhook contains encrypted channel events and the client has an encryption 
 ## Signed URIs
 
 ```python
-uri = sockudo.signed_uri("GET", "/apps/app-id/channels", parameters={"filter_by_prefix": "presence-"})
+uri = sockudo.signed_uri(
+    "GET", "/apps/app-id/channels", parameters={"filter_by_prefix": "presence-"}
+)
 ```
 
 The signing format matches Sockudo/Pusher REST auth: `auth_key`, `auth_timestamp`, `auth_version`, optional `body_md5`, and `auth_signature` over `{METHOD}\n{PATH}\n{SORTED_QUERY}`.

--- a/server-sdks/sockudo-http-python/pyproject.toml
+++ b/server-sdks/sockudo-http-python/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
   "build>=1.2.2",
   "pytest>=8.0.0",
   "pytest-asyncio>=0.23.0",
-  "ruff>=0.9.0",
+  "ruff==0.16.0",
   "twine>=6.0.0",
 ]
 
@@ -39,3 +39,9 @@ where = ["src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+[tool.ruff]
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/server-sdks/sockudo-http-rust/README.md
+++ b/server-sdks/sockudo-http-rust/README.md
@@ -528,7 +528,7 @@ async fn fetch_history(sockudo: &Sockudo) -> Result<(), sockudo_http::SockudoErr
         )
         .await?;
 
-    if let Some(cursor) = page.next_cursor.clone() {
+    if let Some(cursor) = page.next_cursor {
         let _next_page = sockudo
             .channel_history_with_name(
                 "my-channel",


### PR DESCRIPTION
## Summary

This PR implements a workspace-wide audit of Rust `.clone()` and `::clone()` usage, focusing on deep-copy amplification in realtime hot paths while preserving Protocol V1 behavior, Protocol V2 feature gating, public APIs, and owned return-value contracts.

The audit started from `dbb58421` on `master`. It changes 55 tracked files and leaves unrelated/untracked workspace content out of the commit.

## Why

Several high-volume paths cloned complete payloads, version chains, annotation events, or serialized buffers even when the data was identical for every consumer. The largest costs came from:

- rebuilding the accumulated AI append payload on every fragment;
- cloning entire in-memory version and annotation chains before validation or mutation;
- serializing/cloning the same V2 fanout payload independently for each socket;
- copying 64 KiB delta bases for every subscriber cache entry;
- cloning push queue payloads at every worker boundary and cloning delivery jobs twice per outbound chunk;
- cloning cached token containers, queue subjects, and other values where borrowed access, moves, `Arc`, `Bytes`, or `clone_from` are sufficient.

Not every clone is removable: owned public return values, retry snapshots, per-recipient mutations, and cheap `Arc`/`Bytes` handle increments remain intentional.

## Implementation

### AI rollup

- Accumulate append fragments in one `String`.
- Stop cloning the growing aggregate into `latest_message` on every append.
- Install the aggregate once when the pending batch becomes a delivery.

### Version and annotation stores

- Store shared internal version records and annotation events as `Arc` values.
- Validate chains and replay continuity through borrowed iterators.
- Mutate chains in place and clone owned records only at public API boundaries.
- Rebuild annotation projections from borrowed event references rather than cloned/sorted event values.

### Adapter and delta fanout

- Serialize common V2 payloads once and fan out shared `Bytes` handles.
- Move the original horizontal message into local delivery after extracting transport metadata.
- Share base messages, serialized bytes, settings, and metadata across socket tasks.
- Add an additive shared-buffer delta-cache entry point while retaining the existing owned API as a compatibility wrapper.
- Remove per-socket buffers that were constructed but never sent.

### Push and queue ownership

- Move queue payloads into planner, shard, feedback, retry, and provider handlers instead of cloning them.
- Consume delivery-job vectors in bounded chunks and retain only the copy required for retry/error correlation.
- Avoid cloning the complete cached provider-token object when only one returned token is needed.
- Reshape the in-memory idempotency index to support borrowed key lookup.
- Reuse `String` allocations with `clone_from` where values are repeatedly reassigned.
- Use an `async_nats::Subject` for publish fanout so per-message subject clones are cheap shared handles.
- Remove a redundant Iggy producer `Arc` clone.

### Workspace cleanup and benchmarks

- Remove every clone that Clippy can prove redundant across production, test, example, and benchmark targets.
- Resolve every `clippy::assigning_clones` finding with moves or `clone_from`.
- Add allocation counters and focused Criterion cases for AI rollup, version storage, annotation replay, V2 fanout, delta state, and push dispatch.
- Update the Rust SDK README example to move a terminal pagination cursor rather than clone it.

The raw number of Rust source lines matching `.clone()` or `::clone()` falls from 4,663 to 4,616. The smaller net reduction reflects the new legacy-vs-shared benchmark fixtures and intentional cheap handle clones; the meaningful improvement is removal of deep copies from hot loops.

## Benchmark results

Allocation figures are total allocation operations and total allocated bytes inside the measured operation, not peak RSS. Timings are Criterion quick-run centers/ranges on the same local machine and should primarily be read as relative comparisons.

| Path | Allocation operations | Allocated bytes | Runtime |
|---|---:|---:|---:|
| AI rollup, 256 × 256 B fragments | 10,302 → 9,536 (-7.4%) | 9,112,064 → 619,543 (-93.2%) | ~356 µs → ~228 µs (-35.9%) |
| Version append to a 32-record, 1 KiB chain | 566 → 15 (-97.3%) | 1,414,817 → 7,757 (-99.45%) | 28.24 µs → 13.14 µs (-53.5%) |
| Annotation append/projection, 100 events | 1,082 → 67 (-93.8%) | 120,279 → 13,321 (-88.9%) | message replay 9.52 µs → 8.22 µs (-13.7%) |
| V2 serialization/fanout prep, 1,000 sockets × 64 KiB | 6,000 → 4 (-99.93%) | 459,341,000 → 393,795 (-99.91%) | 3.35 ms → 5.87 µs (~570× faster) |
| Delta cache fanout, 256 sockets × 64 KiB | 3,329 → 2,816 (-15.4%) | 21,156,648 → 4,369,152 (-79.3%) | 270.1 µs → 114.7 µs (-57.5%) |
| Push provider dispatch, 500 jobs | 49,554 → 44,052 (-11.1%) | 2,403,685 → 2,156,984 (-10.3%) | 1.64 ms → 1.47 ms (-10.5%) |

## Behavior and compatibility

- Protocol V1 serialization and extras stripping remain unchanged.
- V2-only fields and append modes remain gated.
- Public owned-return APIs still return independent values.
- The existing owned delta-cache API remains available.
- Queue retry behavior still retains the original payload in inflight storage; eliminating that final copy would require a breaking owned-callback API change.
- No new dependencies were added.

## Validation

Passed:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D clippy::redundant_clone -D clippy::assigning_clones`
- `cargo test -p sockudo-ai-transport`
- `cargo test -p sockudo-core`
- `cargo test -p sockudo-delta`
- `cargo test -p sockudo-adapter --features 'delta,tag-filtering'`
- `cargo test -p sockudo-push`
- `cargo test -p sockudo-queue`
- `cargo check -p sockudo-queue --features nats`
- `cargo build -p sockudo --features 'v2,ai-transport,redis,postgres,push'`
- `cargo test --workspace -- --skip runtime::tests::two_redis_backed_nodes_share_tokens_revocation_and_session_ownership --skip stats::tests::redis_store_merges_independent_nodes_and_survives_rolling_restart`

The unfiltered workspace run reached the Ably compatibility suite and passed all locally runnable tests, but two Redis-backed tests failed to connect because no Redis service was listening on the development machine. Both were rerun only as explicit skips in the successful workspace pass.

## Follow-up observation

The existing `memory_drain_100k_due_retry_entries_budget_lt_5s` benchmark took approximately 51.5 seconds before sampling and then could not complete Criterion's quick sampling. That is outside this clone-removal change and likely deserves a separate retry-scheduler scalability investigation.


## Ably fanout CI follow-up

The initial clone-removal commit prepared append aggregate projection before primary fanout. The release guard reproduced 10,000-subscriber regressions: JSON lower bounds of 16.67% and 12.81%, and MsgPack lower bounds of 17.72% and 12.26%. No benchmark threshold was changed.

Commit `4e144468` first restored the complete delivery method to `master`; the replacement guard passed. Commit `42906205` then applied a narrower ownership change: non-append deliveries move the channel serial with `Option::take`, while append retains one clone because mutation and aggregate frames each require owned serials. Aggregate projection remains lazy and occurs only after primary fanout. A wire-level regression test verifies that both append frames retain the same channel serial and the expected append/update actions.

This removes exactly one short-string allocation and copy per non-append Ably event, independent of subscriber count. The authoritative ordered GitHub base/head guard passed the conditional-move candidate on its first comparison run, including JSON, MsgPack, and mixed 10,000-subscriber fanout. Local Criterion timing was too variable for release evidence (an identical binary ranged roughly 4.4–6.6 ms at 10k), so the GitHub guard is the accepted performance result.