### PR TITLE
docs: expand deployment and SDK guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,11 @@ Major runtime sections:
 
 Reference docs:
 
+- [Deployment guide](docs/content/docs/deployment/index.mdx)
+- [Static configuration](docs/content/docs/deployment/static-configuration.mdx)
+- [Kubernetes and Helm](docs/content/docs/deployment/kubernetes.mdx)
+- [Cloud platforms](docs/content/docs/deployment/cloud-platforms.mdx)
+- [Capacity planning](docs/content/docs/deployment/capacity-planning.mdx)
 - [Configuration](docs/content/docs/reference/configuration.mdx)
 - [Environment variables](docs/content/docs/reference/environment-variables.mdx)
 - [HTTP endpoints](docs/content/docs/reference/http-endpoints.mdx)

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -2345,6 +2345,15 @@ body {
   box-shadow: 0 22px 52px -40px color-mix(in srgb, var(--color-fd-primary) 55%, transparent);
 }
 
+.prose :where(figure.shiki) :where(pre),
+.prose [data-rehype-pretty-code-figure] :where(pre) {
+  overflow-x: auto;
+  overflow-y: hidden;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
 .prose :where(table) {
   border-color: color-mix(in srgb, var(--color-fd-primary) 18%, var(--color-fd-border));
   background: color-mix(in srgb, var(--color-fd-card) 94%, transparent);

--- a/docs/content/docs/clients/dotnet.mdx
+++ b/docs/content/docs/clients/dotnet.mdx
@@ -6,6 +6,10 @@ icon: MonitorSmartphone
 
 `Sockudo.Client` is the official .NET realtime SDK. It defaults to Protocol V2 and supports V1 compatibility, public, private, presence, encrypted channels, recovery, filters, MessagePack, Protobuf, and delta reconstruction.
 
+The current monorepo package targets .NET 10. Choose
+[`SockudoServer`](/docs/server-sdks/dotnet) instead when the process needs app
+credentials to publish or authorize clients over HTTP.
+
 ## Install
 
 Install the published NuGet package:
@@ -44,6 +48,40 @@ channel.Bind("price-updated", (data, meta) => Console.WriteLine(data));
 await client.ConnectAsync();
 ```
 
+For production, use the public ingress or load-balancer hostname with
+`ForceTls = true`. Reuse one client for the application lifetime rather than
+opening a WebSocket per operation.
+
+## Connection lifecycle
+
+```csharp
+var stateToken = client.Bind("state_change", (value, _) =>
+{
+    var change = (StateChange)value!;
+    Console.WriteLine($"connection: {change.Previous} -> {change.Current}");
+});
+client.Bind("connected", (_, _) =>
+    Console.WriteLine($"socket id: {client.SocketId}"));
+client.Bind("connecting", (_, _) =>
+    Console.WriteLine("connecting"));
+client.Bind("error", (error, _) =>
+    Console.Error.WriteLine(error));
+
+await client.ConnectAsync();
+```
+
+A connected socket can still have a pending or rejected channel. Wait for the
+subscription-success event before treating channel data as live. Clean up
+bindings and subscriptions with `Unbind`, `UnsubscribeAsync`, and
+`DisconnectAsync`:
+
+```csharp
+channel.Unbind("price-updated");
+client.Unbind("state_change", stateToken);
+await client.UnsubscribeAsync("public-updates");
+await client.DisconnectAsync();
+```
+
 ## Auth
 
 ```csharp
@@ -61,17 +99,54 @@ var client = new SockudoClient(
 );
 ```
 
+The endpoint authenticates the caller, authorizes the exact requested channel,
+and signs with the app secret. Derive presence identity from the backend
+session; never trust a user ID supplied by the client.
+
+Protocol V2 can use scoped capability tokens with refresh:
+
+```csharp
+var client = new SockudoClient(
+    "app-key",
+    new SockudoOptions(
+        Cluster: "local",
+        WsHost: "realtime.example.com",
+        ForceTls: true,
+        TokenAuthentication: new TokenAuthenticationOptions(
+            TokenProvider: cancellationToken =>
+                FetchSockudoTokenAsync(cancellationToken)
+        )
+    )
+);
+```
+
+JWT expiry metadata enables proactive refresh. Token expiration and revocation
+are also exposed as typed errors.
+
 ## Presence
 
 ```csharp
 var channel = client.Subscribe("presence-lobby");
 
-channel.Bind("pusher:subscription_succeeded", (data, meta) =>
+channel.Bind("sockudo:subscription_succeeded", (data, meta) =>
     Console.WriteLine($"members: {data}"));
-channel.Bind("pusher:member_added", (data, meta) =>
+channel.Bind("sockudo:member_added", (data, meta) =>
     Console.WriteLine($"joined: {data}"));
-channel.Bind("pusher:member_removed", (data, meta) =>
+channel.Bind("sockudo:member_removed", (data, meta) =>
     Console.WriteLine($"left: {data}"));
+```
+
+Protocol V2 presence data can change without a leave/rejoin:
+
+```csharp
+var presence = (PresenceChannel)channel;
+presence.Bind("sockudo:presence_update", (member, _) =>
+    Console.WriteLine(member));
+
+await presence.UpdateAsync(new Dictionary<string, object?>
+{
+    ["status"] = "editing",
+});
 ```
 
 ## Filters
@@ -89,6 +164,28 @@ var channel = client.Subscribe(
     )
 );
 ```
+
+Combine filters with delta compression and bounded rewind for high-volume
+state feeds:
+
+```csharp
+var orderBook = client.Subscribe(
+    "orderbook:btc-usd",
+    new SubscriptionOptions(
+        Delta: new ChannelDeltaSettings(
+            Enabled: true,
+            Algorithm: DeltaAlgorithm.Xdelta3
+        ),
+        Rewind: new SubscriptionRewind.Seconds(30)
+    )
+);
+
+client.Bind("sockudo:resume_failed", (data, _) =>
+    Console.WriteLine($"reload authoritative state: {data}"));
+```
+
+On a failed resume or missing delta base, discard derived state and load a
+fresh snapshot.
 
 ## Presence history proxy
 
@@ -109,6 +206,46 @@ var channel = (PresenceChannel)client.Subscribe("presence-lobby");
 var page = await channel.HistoryAsync(
     new PresenceHistoryParams(Limit: 50, Direction: "newest_first")
 );
+```
+
+Proxy endpoints keep the app secret server-side. They must authenticate the
+caller, check channel access, bound page sizes, and forward opaque cursors.
+Channel history with `UntilAttach: true` provides a gap-free late join.
+
+## Versioned and encrypted messages
+
+Configure `VersionedMessages.Endpoint` to create and mutate messages through a
+trusted backend:
+
+```csharp
+var chat = client.Subscribe("chat:room-1");
+var created = await chat.CreateVersionedMessageAsync(
+    "chat.message",
+    "Hello",
+    new VersionedMessageCreateOptions(MessageId: "message-1")
+);
+await chat.AppendVersionedMessageAsync(created.MessageSerial, " world");
+await chat.UpdateVersionedMessageAsync(
+    created.MessageSerial,
+    new VersionedMessageMutationOptions(Data: "Hello world!")
+);
+```
+
+Apply V2 update, delete, and append actions in serial order. If an append
+arrives without a known base, fetch the latest visible version first.
+
+`private-encrypted-*` payloads decrypt automatically when channel auth returns
+the derived `SharedSecret`. Keep the encryption master key on the backend and
+continue to use TLS.
+
+## User sign-in
+
+Configure `UserAuthenticationOptions` and sign in after connecting when the
+application uses user-targeted events or watchlists:
+
+```csharp
+await client.ConnectAsync();
+await client.User.SignInAsync();
 ```
 
 ## Push proxy helper
@@ -141,3 +278,16 @@ var publish = await push.PublishAsync(
 ```
 
 The helper points at your backend proxy. Keep Sockudo app secrets on the backend.
+
+## Production checklist
+
+- Register the client as a singleton or hosted-service dependency and dispose
+  it during shutdown.
+- Pass cancellation tokens through long-running application operations.
+- Keep callbacks short and move blocking work away from the receive path.
+- Handle auth failure, token expiry, rate limiting, and transport failure as
+  different cases.
+- Make event processing idempotent and reload state after failed recovery.
+- Protect history, mutation, and push proxy endpoints with the application's
+  normal authorization.
+- Test reconnects, service restarts, token rotation, and graceful host shutdown.

--- a/docs/content/docs/clients/flutter.mdx
+++ b/docs/content/docs/clients/flutter.mdx
@@ -6,6 +6,10 @@ icon: Smartphone
 
 `sockudo_flutter` is the official Flutter and Dart realtime SDK. It supports public, private, presence, encrypted channels, auth, V2 recovery, rewind, filters, deltas, mutable messages, presence history proxies, and push registration workflows.
 
+The current package requires Dart 3.11.3+ and Flutter 3.35+ when used in a
+Flutter application. Protocol V1 compatibility is the default; opt into
+Protocol V2 for Sockudo-native features.
+
 ## Install
 
 Install the published package from `pub.dev`:
@@ -45,6 +49,34 @@ channel.bind('price-updated', (data, _) {
 client.connect();
 ```
 
+Use a public load-balancer or ingress hostname with `forceTls: true` in
+production. Create the client in an application-scoped service rather than in a
+widget's `build` method.
+
+## Lifecycle and cleanup
+
+Keep binding tokens when a widget or controller needs to remove a specific
+handler:
+
+```dart
+final stateToken = client.bind('state_change', (change, _) {
+  print('connection: $change');
+});
+final orderToken = channel.bind('order.created', (data, _) {
+  print(data);
+});
+
+channel.unbind(eventName: 'order.created', token: orderToken);
+client.unbind(eventName: 'state_change', token: stateToken);
+client.unsubscribe('public-updates');
+client.disconnect();
+```
+
+Wait for the channel subscription-success event before treating its data as
+live. Unsubscribe in the owning service or controller's disposal path, and
+disconnect on explicit sign-out or process shutdown. Let the SDK handle
+temporary transport failures and resubscription.
+
 ## Auth
 
 ```dart
@@ -61,6 +93,43 @@ final client = SockudoClient(
   ),
 );
 ```
+
+The endpoint must authenticate the user and authorize the exact requested
+channel. Presence identity comes from the backend session, not from an
+untrusted request field.
+
+Protocol V2 can use a scoped capability token and async refresh callback:
+
+```dart
+final client = SockudoClient(
+  'app-key',
+  SockudoOptions(
+    cluster: 'local',
+    protocolVersion: 2,
+    wsHost: 'realtime.example.com',
+    forceTls: true,
+    token: initialToken,
+    authCallback: () async => fetchFreshSockudoToken(),
+  ),
+);
+```
+
+JWTs with expiry metadata refresh proactively. Opaque tokens depend on the
+server's expiration event.
+
+## Presence
+
+```dart
+final presence = client.subscribe('presence-lobby') as PresenceChannel;
+
+presence.bind('sockudo:member_added', (member, _) => print('joined: $member'));
+presence.bind('sockudo:member_removed', (member, _) => print('left: $member'));
+presence.bind('sockudo:presence_update', (member, _) => print('updated: $member'));
+
+presence.update(<String, Object?>{'status': 'editing'});
+```
+
+V2 presence updates modify member data without a leave and rejoin cycle.
 
 ## Filters and deltas
 
@@ -110,6 +179,24 @@ channel.bindGlobal((eventName, data) {
 });
 ```
 
+Configure `versionedMessages` with a trusted backend endpoint to create,
+append, update, or delete messages:
+
+```dart
+final created = await channel.createMessage(
+  const VersionedMessageCreateRequest(data: 'hello'),
+);
+await channel.appendMessage(created.messageSerial, ' world');
+await channel.updateMessage(
+  created.messageSerial,
+  const VersionedMessageMutation(data: <String, Object?>{'text': 'edited'}),
+);
+await channel.deleteMessage(created.messageSerial);
+```
+
+Apply mutation events in serial order. If an append arrives before its base,
+fetch the latest visible message through the proxy first.
+
 ## Presence history proxy
 
 ```dart
@@ -132,6 +219,23 @@ final page = await channel.history(
 );
 ```
 
+The history proxy owns the app secret, authenticates the caller, checks channel
+access, and forwards opaque pagination cursors. Use channel history with
+`untilAttach: true` for a gap-free late join.
+
+## Encrypted channels
+
+`private-encrypted-*` channels decrypt automatically when protected-channel
+authorization returns the derived `sharedSecret`:
+
+```dart
+final encrypted = client.subscribe('private-encrypted-documents');
+encrypted.bind('doc-updated', (payload, _) => print(payload));
+```
+
+Keep the encryption master key on the backend. End-to-end encryption does not
+replace TLS or channel authorization.
+
 ## Push registration
 
 Use a platform push plugin to get the provider token, then send the token to your backend.
@@ -151,3 +255,18 @@ await http.post(
 ```
 
 The backend registers the device with Sockudo and enforces user ownership.
+
+## Production checklist
+
+- Scope the client above individual widgets and avoid reconnecting on rebuild.
+- Remove bindings and subscriptions when their lifecycle owner is disposed.
+- Keep event callbacks fast and move blocking work to an isolate or async
+  service.
+- On `sockudo:resume_failed`, discard derived state and load an authoritative
+  snapshot.
+- Protect and rate-limit auth, history, mutable-message, and push proxy
+  endpoints.
+- Refresh provider tokens through the backend and associate them with the
+  authenticated user.
+- Test background/foreground transitions, offline recovery, token expiry, and
+  application process recreation.

--- a/docs/content/docs/clients/index.mdx
+++ b/docs/content/docs/clients/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Realtime clients
-description: Choose the official Sockudo realtime client SDK for web, mobile, desktop, Flutter, Kotlin, Swift, JavaScript, or .NET.
+description: Choose and operate an official Sockudo realtime client for web, mobile, desktop, Python, and backend WebSocket consumers.
 icon: Smartphone
 ---
 
@@ -15,11 +15,25 @@ archived/legacy mirrors.
 | --- | --- | --- | --- |
 | JavaScript / TypeScript | `@sockudo/client` | Web, Node, worker, React, Vue, React Native, NativeScript | Protocol V1 compatibility |
 | Swift | `SockudoSwift` via SwiftPM | iOS, macOS, tvOS, watchOS, visionOS | Protocol V1 compatibility |
-| Kotlin | `io.sockudo:sockudo-kotlin` | Android and JVM | Protocol V1 compatibility |
+| Kotlin | `io.sockudo:sockudo-kotlin` | Android and JVM | Protocol V2 by default |
 | Flutter / Dart | `sockudo_flutter` | Flutter and Dart | Protocol V1 compatibility |
 | .NET realtime | `Sockudo.Client` | .NET apps | Protocol V2 by default |
+| Python realtime | `sockudo-python` | Python 3.10+ and asyncio | Protocol V2 by default |
 
 Use Protocol V1 when migrating existing Pusher clients. Use Protocol V2 for recovery, rewind, delta compression, tag filters, mutable messages, annotations, and native Sockudo metadata.
+
+The realtime and HTTP SDKs have different trust boundaries. Realtime clients
+hold only the public app key and maintain WebSocket subscriptions. Server SDKs
+hold the app secret, publish over HTTP, authorize protected subscriptions, and
+validate webhooks. For Python and .NET in particular, make sure you choose the
+package whose role matches your process.
+
+| Language | Realtime package | Trusted HTTP package |
+| --- | --- | --- |
+| JavaScript / TypeScript | `@sockudo/client` | `sockudo` |
+| Python | `sockudo-python` | `sockudo-http-python` |
+| .NET | `Sockudo.Client` | `SockudoServer` |
+| Swift | `SockudoSwift` | `Sockudo` server package |
 
 ## Client responsibilities
 
@@ -31,6 +45,9 @@ Client SDKs should:
 - bind events and update UI state
 - store recovery positions when V2 recovery is enabled
 - register devices for push through trusted backend endpoints
+
+They should never contain the app secret, provider credentials, an encryption
+master key, or an unrestricted capability token.
 
 ## Server responsibilities
 
@@ -52,6 +69,68 @@ const client = new Sockudo("app-key", {
   connectionRecovery: true,
 });
 ```
+
+Use this sequence in every client:
+
+1. Construct one long-lived client with your public key and public WebSocket
+   endpoint.
+2. Bind connection diagnostics and event handlers.
+3. Subscribe to channels, using a backend auth endpoint for protected names.
+4. Connect and let the SDK resubscribe after transient failures.
+5. If recovery fails, replace derived state from an authoritative snapshot.
+6. Unbind or unsubscribe when a screen or worker no longer needs a channel.
+7. Disconnect during application shutdown.
+
+## Choosing features
+
+| Requirement | Client setting or API | Backend requirement |
+| --- | --- | --- |
+| Pusher migration | Protocol V1 | Pusher-compatible app config |
+| Resume after a short outage | Protocol V2 recovery | Durable or hot recovery configured |
+| Initial backlog | Subscription rewind | History enabled with suitable retention |
+| Gap-free late join | History with `until_attach` | Authorized history proxy |
+| Lower high-volume bandwidth | Tag filters and delta compression | V2 filtering/delta enabled |
+| Private data | Private channel auth | Session-aware auth endpoint |
+| End-to-end content encryption | `private-encrypted-*` | Shared-secret auth and key management |
+| User-targeted events | User sign-in | User auth endpoint |
+| Mobile notifications | Provider token collection | Push registration and publish backend |
+
+## Connection and state model
+
+A successful WebSocket connection does not mean every channel is subscribed.
+Wait for each channel's subscription-success event before treating its state as
+live. During reconnect, keep the last rendered state but mark it stale. After a
+successful resume, continue from the recovered serial; after a failed resume,
+discard derived state and fetch a fresh snapshot.
+
+Event handlers should be idempotent. Network reconnects, application retries,
+and upstream publishing workflows can all repeat logical work even when the
+client deduplicates messages by `message_id`.
+
+## Protected-channel auth flow
+
+```text
+client -> your backend: socket_id + requested channel
+your backend: authenticate session and authorize that exact channel
+your backend -> client: short-lived signed auth response
+client -> Sockudo: subscribe with auth response
+```
+
+Do not implement an auth endpoint that signs every requested channel. Validate
+tenant ownership, resource access, and presence identity before signing. For
+encrypted channels, return only the derived channel shared secret—not the
+encryption master key.
+
+## Production checklist
+
+- Terminate TLS at Sockudo or a load balancer and use `wss://`.
+- Keep a single client per app or process unless isolation is intentional.
+- Observe connected, unavailable, failed, and reconnecting states.
+- Set auth and proxy request timeouts; handle `401`, `403`, and `429`
+  separately from transport failures.
+- Bound rewind and history page sizes.
+- Test a rolling restart, network interruption, auth expiry, and resume failure.
+- Unsubscribe and unbind handlers when views or jobs end.
 
 ## Push from clients
 
@@ -77,4 +156,5 @@ await fetch("/api/push/devices", {
   <Card title="Kotlin" href="/docs/clients/kotlin" description="Android and JVM WebSocket client examples." />
   <Card title="Flutter" href="/docs/clients/flutter" description="Flutter and pure Dart client examples." />
   <Card title=".NET realtime" href="/docs/clients/dotnet" description="Protocol V2 by default for .NET applications." />
+  <Card title="Python realtime" href="/docs/clients/python" description="Asyncio client for services, agents, workers, and CLIs." />
 </Cards>

--- a/docs/content/docs/clients/javascript.mdx
+++ b/docs/content/docs/clients/javascript.mdx
@@ -6,6 +6,10 @@ icon: Braces
 
 `@sockudo/client` is the official JavaScript and TypeScript realtime SDK. It preserves the Pusher subscribe/bind model and adds runtime-specific entrypoints.
 
+The default is Protocol V1 compatibility. Set `protocolVersion: 2` for
+Sockudo-native recovery, rewind, filters, deltas, binary wire formats, and
+versioned-message metadata.
+
 ## Install
 
 Install the published package from npm:
@@ -50,6 +54,52 @@ channel.bind("price-updated", (payload) => {
 });
 ```
 
+For self-hosted production, `wsHost` should be the public ingress or load
+balancer name, `wssPort` is normally `443`, and `forceTLS` should be `true`.
+Specify `enabledTransports: ["ws"]` only when debugging a direct local
+connection; allowing both secure and fallback transports is safer across
+browser and mobile runtimes.
+
+## Connection lifecycle
+
+Observe the connection separately from channel subscription state:
+
+```ts
+client.connection.bind("state_change", ({ previous, current }) => {
+  console.log(`connection: ${previous} -> ${current}`);
+});
+client.connection.bind("error", (error) => {
+  console.error("Sockudo connection error", error);
+});
+
+const channel = client.subscribe("orders");
+channel.bind("sockudo:subscription_succeeded", () => {
+  console.log("orders is live");
+});
+channel.bind("sockudo:subscription_error", (error) => {
+  console.error("orders subscription failed", error);
+});
+```
+
+A connected socket can still have an unauthorized or pending channel. Gate
+channel-dependent UI on `subscription_succeeded`, not only the global
+`connected` event.
+
+Keep the binding callback when you need to remove one handler, or remove the
+whole subscription when its owning component or job ends:
+
+```ts
+const onOrder = (order: unknown) => console.log(order);
+channel.bind("order.created", onOrder);
+
+channel.unbind("order.created", onOrder);
+client.unsubscribe("orders");
+client.disconnect();
+```
+
+Framework hooks clean up their own bindings when components unmount. When using
+the core client directly, lifecycle cleanup is your responsibility.
+
 ## Binary wire formats
 
 Protocol V2 can negotiate JSON, MessagePack, or Protobuf with `wireFormat`.
@@ -90,6 +140,24 @@ const client = new Sockudo("app-key", {
 const presence = client.subscribe("presence-lobby");
 presence.bind("pusher:member_added", console.log);
 ```
+
+The auth endpoint must validate the current application session and authorize
+the exact `channel_name` sent by the SDK before signing. For presence channels,
+derive `user_id` on the server; do not trust a client-supplied identity. The
+client bundle contains only the public app key.
+
+```ts
+presence.bind("pusher:subscription_succeeded", (members) => {
+  console.log("initial members", members);
+});
+presence.bind("pusher:member_removed", (member) => {
+  console.log("left", member);
+});
+```
+
+Configure `userAuthentication.endpoint` and call `client.signin()` when using
+user-targeted events or watchlists. The backend signs the current `socket_id`
+and authenticated user data.
 
 ## React
 
@@ -190,6 +258,34 @@ const versions = await channel.getMessageVersions("42", {
 });
 ```
 
+The proxy endpoint must authenticate the caller, authorize access to the
+channel, and sign the upstream HTTP request with the app secret. Use
+`until_attach` channel history for a gap-free late join: first attach, then load
+history ending at the server-provided attach serial, then apply buffered live
+events.
+
+## Encrypted channels
+
+Use the encryption entrypoint for `private-encrypted-*` channels:
+
+```ts
+import SockudoEncrypted from "@sockudo/client/with-encryption";
+
+const encryptedClient = new SockudoEncrypted("app-key", {
+  wsHost: "realtime.example.com",
+  forceTLS: true,
+  channelAuthorization: { endpoint: "/sockudo/auth" },
+});
+
+encryptedClient
+  .subscribe("private-encrypted-documents")
+  .bind("doc.updated", (payload) => console.log(payload));
+```
+
+Your auth response supplies the derived channel `shared_secret`. Keep the
+encryption master key on the trusted backend. End-to-end encryption complements
+TLS and authorization; it does not replace either.
+
 ## Push proxy helpers
 
 Browser push registration should flow through your backend. Keep app secrets and provider credentials server-side.
@@ -207,3 +303,20 @@ await fetch("/sockudo/push/devices", {
 ```
 
 Use a server SDK to publish push after validating user and tenant policy.
+
+## Error handling and production guidance
+
+- Reuse one client per browser tab, worker, or native application runtime.
+- Create the client outside React render functions and Vue component setup.
+- Use the runtime-specific entrypoint so bundlers do not pull in incompatible
+  browser or Node transports.
+- Treat auth `401`/`403` as an application-permission problem, not a reconnect
+  loop.
+- On `sockudo:resume_failed`, clear derived state and fetch an authoritative
+  snapshot before applying new events.
+- Make handlers idempotent and validate unknown payloads at the application
+  boundary.
+- Unbind handlers, unsubscribe unused channels, and disconnect during
+  application shutdown.
+- Never expose the app secret, push credentials, or encryption master key in a
+  browser or mobile bundle.

--- a/docs/content/docs/clients/kotlin.mdx
+++ b/docs/content/docs/clients/kotlin.mdx
@@ -6,6 +6,10 @@ icon: Smartphone
 
 `sockudo-kotlin` is the official Android and JVM realtime SDK. It uses OkHttp for WebSockets and exposes the same channel model as other Sockudo clients.
 
+The current package targets JVM 23 and uses Protocol V2 by default. Set
+`protocolVersion = 1` only when strict Pusher Protocol V1 compatibility is
+required.
+
 ## Install
 
 Install the published package from Maven Central:
@@ -56,6 +60,36 @@ channel.bind("price-updated") { data, _ ->
 client.connect()
 ```
 
+For production, point `wsHost` at the public load balancer or ingress, set
+`forceTls = true`, and use the secure WebSocket port. Keep one long-lived
+client per application process or signed-in mobile session.
+
+## Lifecycle and cleanup
+
+Connection and channel events use the same binding model as application events:
+
+```kotlin
+val stateToken =
+    client.bind("state_change") { change, _ ->
+        println("connection: $change")
+    }
+
+val eventToken =
+    channel.bind("price-updated") { data, _ ->
+        println(data)
+    }
+
+channel.unbind("price-updated", eventToken)
+client.unbind("state_change", stateToken)
+client.unsubscribe("public-updates")
+client.disconnect()
+```
+
+Wait for the channel subscription-success event before treating channel state
+as live. Unsubscribe and unbind when an Android lifecycle owner no longer needs
+updates; disconnect on explicit sign-out. A temporary network loss should be
+left to the SDK's reconnect path.
+
 ## Auth
 
 ```kotlin
@@ -76,6 +110,47 @@ val client =
         ),
     )
 ```
+
+Your auth endpoint must validate the application session and authorize the
+exact requested channel. For presence, derive `user_id` from the server-side
+identity. Never ship the app secret or an encryption master key in the APK.
+
+Protocol V2 capability tokens can be supplied with a refresh provider:
+
+```kotlin
+val client =
+    SockudoClient(
+        "app-key",
+        SockudoOptions(
+            cluster = "local",
+            protocolVersion = 2,
+            authTokenProvider =
+                ClientAuthTokenProvider { request ->
+                    fetchCapabilityToken(
+                        reason = request.reason,
+                        socketId = request.socketId,
+                    )
+                },
+        ),
+    )
+```
+
+JWT expiry metadata enables proactive refresh. Opaque tokens refresh after the
+server reports expiration.
+
+## Presence
+
+```kotlin
+val presence = client.subscribe("presence-lobby") as PresenceChannel
+
+presence.bind("sockudo:member_added") { member, _ -> println("joined: $member") }
+presence.bind("sockudo:member_removed") { member, _ -> println("left: $member") }
+presence.bind("sockudo:presence_update") { member, _ -> println("updated: $member") }
+
+presence.update(mapOf("status" to "typing"))
+```
+
+The update method changes V2 presence member data without a leave/rejoin cycle.
 
 ## Filters and deltas
 
@@ -136,6 +211,41 @@ val page = channel.history(PresenceHistoryParams(limit = 50, direction = "newest
 val snapshot = channel.snapshot(PresenceSnapshotParams(atSerial = 4))
 ```
 
+History, snapshots, and versioned-message helpers call your trusted proxy. The
+proxy must authenticate the caller, authorize the channel, bound page sizes,
+and sign the upstream Sockudo request. Use channel history with
+`untilAttach = true` when building a gap-free late join.
+
+## Mutable messages
+
+Apply V2 message actions in serial order. An update replaces local data, a
+delete becomes the latest visible version, and an append concatenates to a
+known string base. Configure `VersionedMessagesOptions.endpoint` for
+proxy-backed writes:
+
+```kotlin
+val chat = client.subscribe("chat:room-1")
+val ack = chat.createMessage("chat.message", mapOf("text" to "hello"))
+chat.appendMessage(ack.messageSerial, " world")
+chat.updateMessage(ack.messageSerial, mapOf("text" to "edited"))
+chat.deleteMessage(ack.messageSerial)
+```
+
+If an append arrives before its base, fetch the latest message through the
+proxy before applying subsequent actions.
+
+## Encrypted channels
+
+`private-encrypted-*` subscriptions decrypt automatically when the auth
+response includes the derived channel shared secret:
+
+```kotlin
+val encrypted = client.subscribe("private-encrypted-documents")
+encrypted.bind("doc-updated") { payload, _ -> println(payload) }
+```
+
+Encrypted channels still require TLS and normal channel authorization.
+
 ## Android push registration
 
 Use Firebase Messaging or the platform provider to obtain a token, then register through your backend.
@@ -153,3 +263,15 @@ class PushTokenService : FirebaseMessagingService() {
 ```
 
 The backend should call Sockudo push registration APIs with app credentials. The Android app should not hold Sockudo secrets.
+
+## Production checklist
+
+- Tie subscriptions to an Android lifecycle owner and avoid duplicate bindings
+  after configuration changes.
+- Keep callbacks short; move blocking work off the WebSocket callback path.
+- Treat auth failures as permission failures instead of endlessly reconnecting.
+- On `sockudo:resume_failed`, reload authoritative application state.
+- Bound rewind and proxy history requests.
+- Refresh FCM tokens through the backend when `onNewToken` fires.
+- Test airplane-mode transitions, process recreation, capability-token expiry,
+  and rolling Sockudo restarts.

--- a/docs/content/docs/clients/meta.json
+++ b/docs/content/docs/clients/meta.json
@@ -8,6 +8,7 @@
     "kotlin",
     "flutter",
     "dotnet",
+    "python",
     "protocol-v2",
     "filters-delta",
     "presence-history"

--- a/docs/content/docs/clients/python.mdx
+++ b/docs/content/docs/clients/python.mdx
@@ -1,0 +1,401 @@
+---
+title: Python
+description: Use the async sockudo-python realtime client with Protocol V2, protected channels, recovery, filters, deltas, history, and encrypted payloads.
+icon: FileCode
+---
+
+`sockudo-python` is the official asynchronous realtime client for Python. It is
+intended for long-running services, agents, workers, CLIs, and other
+`asyncio` applications that need a WebSocket connection to Sockudo. It is
+different from [`sockudo-http-python`](/docs/server-sdks/python), which is the
+trusted server-side HTTP SDK used to publish and sign authorization responses.
+
+The client requires Python 3.10 or newer and uses Protocol V2 by default.
+
+## Install
+
+```bash
+python -m pip install sockudo-python
+```
+
+For development from this monorepo:
+
+```bash
+python -m pip install -e client-sdks/sockudo-python
+```
+
+## Connect and subscribe
+
+Create one client per application process, bind handlers before connecting, and
+close it during application shutdown:
+
+```python
+import asyncio
+
+from sockudo_python import SockudoClient, SockudoOptions
+
+
+async def main() -> None:
+    client = SockudoClient(
+        "app-key",
+        SockudoOptions(
+            cluster="local",
+            ws_host="127.0.0.1",
+            ws_port=6001,
+            force_tls=False,
+            protocol_version=2,
+            connection_recovery=True,
+        ),
+    )
+
+    channel = client.subscribe("public-updates")
+    channel.bind("price-updated", lambda payload, meta: print(payload))
+
+    try:
+        await client.connect()
+        await asyncio.Event().wait()
+    finally:
+        await client.disconnect()
+
+
+asyncio.run(main())
+```
+
+`connect()` returns after starting the connection; event callbacks run on the
+same asyncio event loop. Do not perform blocking file, database, or network work
+inside a callback. Schedule or await that work in an async task instead.
+
+### Self-hosted connection options
+
+| Option | Purpose | Production guidance |
+| --- | --- | --- |
+| `ws_host` | WebSocket host without a scheme | Use the public load balancer or ingress hostname |
+| `ws_port` / `wss_port` | Plaintext and TLS WebSocket ports | Usually `80` and `443` behind a proxy |
+| `force_tls` | Select `wss://` when true | Enable outside local development |
+| `protocol_version` | `2` for Sockudo-native features; `1` for Pusher compatibility | Prefer `2` for new applications |
+| `connection_recovery` | Resume from the last `stream_id` and `serial` | Enable when missed events matter |
+| `wire_format` | JSON, MessagePack, or Protobuf | Use a binary format only when every endpoint supports it |
+
+`cluster` remains required by the options type, but a custom `ws_host` is the
+important routing setting for self-hosted deployments.
+
+## Lifecycle and cleanup
+
+Bind connection events to make health and reconnect behavior visible:
+
+```python
+def on_state_change(change, _) -> None:
+    print(f"connection: {change['previous']} -> {change['current']}")
+
+
+client.bind("state_change", on_state_change)
+client.bind(
+    "connected",
+    lambda data, _: print("socket id:", data.get("socket_id")),
+)
+client.bind("connecting", lambda *_: print("connecting"))
+client.bind("error", lambda error, _: print("error:", error))
+```
+
+Remove a subscription when its consumer goes away. This also clears the
+channel's recovery and delta state:
+
+```python
+await client.unsubscribe("public-updates")
+```
+
+`await client.close()` is an alias for `disconnect()`. A manual disconnect
+stops reconnect timers; an unexpected transport failure uses the client's
+reconnect policy.
+
+## Private and presence authorization
+
+The client sends its `socket_id` and channel name to your backend. Your backend
+must authenticate the user, enforce access to the requested channel, and use a
+[server SDK](/docs/server-sdks) to sign the response. Never put the app secret
+in Python client code.
+
+```python
+from sockudo_python import ChannelAuthorizationOptions
+
+client = SockudoClient(
+    "app-key",
+    SockudoOptions(
+        cluster="local",
+        ws_host="realtime.example.com",
+        force_tls=True,
+        channel_authorization=ChannelAuthorizationOptions(
+            endpoint="https://api.example.com/sockudo/auth",
+            headers={"X-Client": "worker"},
+        ),
+    ),
+)
+
+private_orders = client.subscribe("private-orders")
+private_orders.bind("order-placed", lambda data, _: print(data))
+```
+
+Presence subscriptions receive the initial member set and subsequent joins and
+leaves:
+
+```python
+presence = client.subscribe("presence-lobby")
+presence.bind(
+    "sockudo:subscription_succeeded",
+    lambda members, _: print("members:", members),
+)
+presence.bind("sockudo:member_added", lambda member, _: print("joined:", member))
+presence.bind("sockudo:member_removed", lambda member, _: print("left:", member))
+
+await client.connect()
+await presence.update({"status": "editing"})
+```
+
+The `update()` call is a Protocol V2 presence update. It changes member data
+without a leave and rejoin cycle.
+
+## Capability-token authentication
+
+Protocol V2 can authorize the WebSocket itself with a scoped capability token.
+Use an async callback so the client can obtain fresh credentials:
+
+```python
+from sockudo_python import TokenAuthData
+
+
+async def fetch_token() -> TokenAuthData:
+    response = await call_your_backend()
+    return TokenAuthData(
+        token=response["token"],
+        expires_in=response["expires_in"],
+    )
+
+
+client = SockudoClient(
+    "app-key",
+    SockudoOptions(
+        cluster="local",
+        ws_host="realtime.example.com",
+        force_tls=True,
+        auth_callback=fetch_token,
+    ),
+)
+```
+
+Expiry metadata lets the SDK schedule a refresh before expiration. Opaque
+tokens without expiry metadata are refreshed after the server emits
+`sockudo:token_expired`.
+
+## Filters, event selection, and delta compression
+
+Protocol V2 subscriptions can combine event names, tag filters, and a bounded
+expression. All supplied conditions must match:
+
+```python
+from sockudo_python import (
+    ChannelDeltaSettings,
+    DeltaAlgorithm,
+    Filter,
+    SubscriptionOptions,
+)
+
+market = client.subscribe(
+    "price:btc",
+    options=SubscriptionOptions(
+        events=["price.updated"],
+        filter=Filter.and_(
+            Filter.eq("market", "spot"),
+            Filter.gt("spread", "0"),
+        ),
+        expression="data.price >= `100`",
+        delta=ChannelDeltaSettings(
+            enabled=True,
+            algorithm=DeltaAlgorithm.XDELTA3,
+        ),
+    ),
+)
+```
+
+Use delta compression for frequently changing, structurally similar payloads
+such as order books. The SDK reconstructs full payloads before invoking your
+handler. Monitor `client.get_delta_stats()` and fall back to full events if
+base continuity is lost. See [Filters and delta compression](/docs/clients/filters-delta).
+
+## Recovery, rewind, and late joins
+
+Recovery resumes a previously attached channel after a connection interruption.
+Rewind asks the server for a bounded amount of earlier history at subscription
+time:
+
+```python
+from sockudo_python import SubscriptionOptions, SubscriptionRewind
+
+market = client.subscribe(
+    "market:btc",
+    options=SubscriptionOptions(
+        rewind=SubscriptionRewind.seconds_back(30),
+    ),
+)
+
+client.bind("sockudo:resume_success", lambda data, _: print(data))
+client.bind("sockudo:resume_failed", lambda data, _: print(data))
+market.bind("sockudo:rewind_complete", lambda data, _: print(data))
+```
+
+Treat `resume_failed` as a continuity break: clear derived local state and fetch
+an authoritative snapshot before applying new events.
+
+For gap-free late joins, proxy channel history through your backend and request
+history only up to the subscription's attach point:
+
+```python
+from sockudo_python import ChannelHistoryOptions, ChannelHistoryParams
+
+client = SockudoClient(
+    "app-key",
+    SockudoOptions(
+        cluster="local",
+        channel_history=ChannelHistoryOptions(
+            endpoint="https://api.example.com/sockudo/channel-history",
+        ),
+    ),
+)
+
+channel = client.subscribe("orders")
+page = await channel.history(
+    ChannelHistoryParams(limit=50, until_attach=True),
+)
+```
+
+The proxy owns Sockudo credentials and validates which channels the requesting
+user may read.
+
+## Presence history and snapshots
+
+Presence history is also proxy-backed. The endpoint receives a channel, action,
+and parameters, then calls the signed server REST API:
+
+```python
+from sockudo_python.client import (
+    PresenceHistoryOptions,
+    PresenceHistoryParams,
+    PresenceSnapshotParams,
+)
+
+client = SockudoClient(
+    "app-key",
+    SockudoOptions(
+        cluster="local",
+        presence_history=PresenceHistoryOptions(
+            endpoint="https://api.example.com/sockudo/presence-history",
+        ),
+    ),
+)
+
+presence = client.subscribe("presence-lobby")
+page = await presence.history(
+    PresenceHistoryParams(limit=50, direction="newest_first"),
+)
+if page.has_next():
+    next_page = await page.next()
+
+snapshot = await presence.snapshot(PresenceSnapshotParams(at_serial=4))
+```
+
+Use current membership for live UI, history for audit or timelines, and a
+snapshot to reconstruct membership at a specific serial. See
+[Presence history](/docs/clients/presence-history).
+
+## Versioned messages
+
+Create and mutate versioned messages through a trusted proxy. These helpers do
+not expose app credentials or send mutation frames over the WebSocket:
+
+```python
+from sockudo_python import VersionedMessageOptions
+
+client = SockudoClient(
+    "app-key",
+    SockudoOptions(
+        cluster="local",
+        versioned_messages=VersionedMessageOptions(
+            endpoint="https://api.example.com/sockudo/versioned-messages",
+        ),
+    ),
+)
+
+ack = await client.versioned_messages.create(
+    "chat:room-1",
+    "message.created",
+    {"text": "hello"},
+)
+if ack.message_id is None:
+    raise RuntimeError("Sockudo did not return a message_id")
+
+await client.versioned_messages.append(
+    "chat:room-1",
+    ack.message_id,
+    {"text": " world"},
+)
+await client.versioned_messages.update(
+    "chat:room-1",
+    ack.message_id,
+    {"text": "hello world"},
+)
+```
+
+Apply mutations in serial order. If an append arrives before its base, fetch
+the latest visible message from the proxy before applying later appends.
+
+## Encrypted channels
+
+`private-encrypted-*` subscriptions are decrypted automatically. The
+authorization response must include a `shared_secret` derived by your trusted
+backend:
+
+```python
+encrypted = client.subscribe("private-encrypted-documents")
+encrypted.bind("doc-updated", lambda data, _: print(data))
+```
+
+Encryption protects event content end to end. It does not replace TLS,
+authorization, channel naming policy, or secret rotation.
+
+## User sign-in
+
+Configure a user-auth endpoint when using user-targeted events or watchlists:
+
+```python
+from sockudo_python import UserAuthenticationOptions
+
+client = SockudoClient(
+    "app-key",
+    SockudoOptions(
+        cluster="local",
+        user_authentication=UserAuthenticationOptions(
+            endpoint="https://api.example.com/sockudo/user-auth",
+        ),
+    ),
+)
+
+await client.connect()
+await client.user.sign_in()
+```
+
+The backend must bind the authenticated application user to the current
+`socket_id`; never accept a user ID supplied by the client without checking the
+session.
+
+## Error handling and production checklist
+
+- Catch `SockudoException` around explicit connect, auth, proxy, and mutation
+  operations; connection errors are also emitted through the connection.
+- Put timeouts and authentication on every proxy endpoint.
+- Use TLS and a public load-balancer hostname outside local development.
+- Keep callbacks fast and move blocking work off the asyncio event loop.
+- Make handlers idempotent because reconnect and application retries can repeat
+  work even when transport deduplication is enabled.
+- On a failed resume or unrecoverable delta, reload authoritative state.
+- Unsubscribe unused channels and disconnect cleanly during process shutdown.
+- Use the HTTP [Python server SDK](/docs/server-sdks/python) for publishing,
+  signing auth, webhooks, history administration, and push.

--- a/docs/content/docs/clients/swift.mdx
+++ b/docs/content/docs/clients/swift.mdx
@@ -6,6 +6,10 @@ icon: Smartphone
 
 `SockudoSwift` is the official realtime client for Apple platforms. It supports public, private, presence, encrypted channels, auth endpoints, V2 recovery, rewind, filters, deltas, mutable messages, and proxy-backed history helpers.
 
+Supported deployment targets are iOS 13+, macOS 10.15+, tvOS 13+, watchOS
+6+, and visionOS 1+. The package uses Swift 6.2 concurrency and isolates the
+client, channels, and callbacks on `@SockudoActor`.
+
 ## Install
 
 Install through Swift Package Manager from the SockudoSwift mirror. SwiftPM resolves this from
@@ -51,6 +55,46 @@ channel.bind("price-updated") { data, _ in
 client.connect()
 ```
 
+Protocol V1 compatibility is the default. Set `protocolVersion: 2` explicitly
+for new Sockudo applications that need continuity metadata and V2 features.
+Use the public ingress hostname with `forceTLS: true` in production.
+
+## Concurrency and lifecycle
+
+From code outside `@SockudoActor`, access client methods with `await`:
+
+```swift
+func startRealtime() async {
+    await client.connect()
+}
+
+func stopRealtime() async {
+    await client.unsubscribe("public-updates")
+    await client.disconnect()
+}
+```
+
+Event callbacks execute on the dedicated Sockudo actor, not the main thread.
+Hop to `MainActor` for UIKit or SwiftUI state:
+
+```swift
+channel.bind("price-updated") { data, _ in
+    Task { @MainActor in
+        viewModel.latestPrice = String(describing: data)
+    }
+}
+```
+
+Keep the `EventBindingToken` returned by `bind` when you want to remove one
+handler with `unbind(eventName:token:)`; call `unbindAll()` only when the
+channel owner is being torn down.
+
+Unexpected disconnects reconnect with bounded exponential backoff. Tune
+`maxReconnectAttempts` and `maxReconnectGapInSeconds` for the app's foreground
+and background policy. Client events emitted while disconnected are buffered
+up to 50 per channel and replayed after subscription; unsubscribing clears that
+buffer.
+
 ## Auth
 
 ```swift
@@ -67,6 +111,51 @@ let client = try SockudoClient(
     )
 )
 ```
+
+The backend must authenticate the current user and authorize the exact
+`channel_name` before signing. Presence identity must come from the server-side
+session, not a value supplied by the app.
+
+Protocol V2 also supports scoped capability tokens:
+
+```swift
+let client = try SockudoClient(
+    "app-key",
+    options: .init(
+        cluster: "local",
+        protocolVersion: 2,
+        forceTLS: true,
+        wsHost: "realtime.example.com",
+        capabilityToken: .init(asyncProvider: {
+            try await tokenService.fetchSockudoToken()
+        })
+    )
+)
+```
+
+JWTs with expiry metadata refresh proactively. Opaque tokens refresh when the
+server reports expiration, provided an async provider is configured.
+
+## Presence
+
+Subscribe as `PresenceChannel` to access members and V2 in-place presence
+updates:
+
+```swift
+let presence = client.subscribe("presence-agent:session-123") as! PresenceChannel
+
+presence.bind("sockudo:member_added") { member, _ in
+    print(member as Any)
+}
+presence.bind("sockudo:presence_update") { member, _ in
+    print(member as Any)
+}
+
+try presence.update(data: ["status": "thinking"])
+```
+
+Wait for the subscription-success event before treating the initial membership
+set as authoritative.
 
 ## Filters and deltas
 
@@ -137,6 +226,25 @@ channel.history(.init(limit: 50, direction: "newest_first")) { result in
 }
 ```
 
+History endpoints are backend proxies because a mobile client must not sign
+Sockudo REST requests. Authorize the caller and channel on every request, bound
+page sizes, and forward opaque cursors unchanged.
+
+## Encrypted channels
+
+`private-encrypted-*` channels decrypt automatically when the protected-channel
+auth response contains a derived `shared_secret`:
+
+```swift
+let encrypted = client.subscribe("private-encrypted-documents")
+encrypted.bind("doc-updated") { payload, _ in
+    print(payload as Any)
+}
+```
+
+Keep the encryption master key on the backend. Continue to use TLS and normal
+channel authorization.
+
 ## Push notifications on Apple platforms
 
 Use APNs to obtain a device token, then send it to your backend. Your backend registers the device with Sockudo and keeps APNs credentials server-side.
@@ -158,3 +266,18 @@ func application(
 ```
 
 Do not embed APNs private keys or Sockudo app secrets in the app.
+
+## Production checklist
+
+- Use one long-lived client for the app session and disconnect it on explicit
+  sign-out.
+- Select Protocol V2 deliberately; do not assume the default changed during a
+  Pusher migration.
+- Move UI mutations from `@SockudoActor` to `MainActor`.
+- Apply an app-specific reconnect limit for backgrounded mobile processes.
+- Treat failed recovery as a signal to reload authoritative application state.
+- Keep auth, history, versioned-message, and push proxy credentials on the
+  backend.
+- Unbind view-owned callbacks to prevent retained views and duplicate updates.
+- Test offline/online transitions, token expiry, app suspension, and a rolling
+  Sockudo restart.

--- a/docs/content/docs/deployment/capacity-planning.mdx
+++ b/docs/content/docs/deployment/capacity-planning.mdx
@@ -1,0 +1,350 @@
+---
+title: Capacity planning and benchmarks
+description: Size Sockudo from measured connection, fanout, memory, network, and failure budgets without benchmarking the load generator by accident.
+icon: Gauge
+---
+
+There is no single “connections per node” number. A quiet public-channel socket, a presence member,
+a filtered Protocol V2 subscriber, and a slow client receiving large payloads have different memory,
+CPU, and network costs. Capacity is the lowest limit across Sockudo, the process, the node, the load
+balancer, shared backends, and the client generator.
+
+## Name the workload
+
+Always report at least these independent dimensions:
+
+| Dimension | Example | Why it changes the result |
+| --- | ---: | --- |
+| Concurrent connected sockets | 100,000 | Drives file descriptors, memory, LB state, and heartbeat work. |
+| New connections per second | 2,000/s | Drives TCP/TLS handshake, auth, and reconnect CPU. |
+| Subscriptions per socket | 5 | Drives local channel state and adapter subscription behavior. |
+| Subscribe/unsubscribe cycles | 500/s | Drives churn and presence/count coordination. |
+| Backend publishes per second | 1,000/s | Measures ingest and adapter work. |
+| Average subscribers per publish | 100 | Converts publishes into 100,000 client deliveries/s. |
+| Payload size | 1 KiB | Drives serialization, buffers, broker traffic, and egress. |
+| Private/presence percentage | 30% / 10% | Adds auth and membership work. |
+| Protocol features | V2 recovery + deltas | Adds continuity, cache, compression, or storage work. |
+| Client RTT and TLS | 180 ms, TLS 1.3 | Changes ramp, handshake, ack, and reconnect timing. |
+
+Never publish “messages per second” without saying whether it means accepted publishes, adapter
+messages, or delivered client frames.
+
+## Capacity is the minimum budget
+
+For one Sockudo node:
+
+```text
+safe connections = min(
+  Sockudo admission limit,
+  process file-descriptor budget,
+  measured memory budget,
+  measured CPU/latency budget,
+  node and vNIC limits,
+  load-balancer target limits,
+  shared-backend budget
+) - operational headroom
+```
+
+Use 20–30% headroom after a stable test, more when traffic is bursty or failure of one node must be
+absorbed by the others.
+
+For an `N`-node cluster that must survive one node loss:
+
+```text
+normal per-node target <= cluster peak connections / (N - 1)
+```
+
+That is an availability constraint, not just a scaling calculation. The remaining nodes also need
+CPU, network, broker, and memory headroom for the reconnect burst.
+
+## File descriptor budget
+
+Estimate:
+
+```text
+nofile soft limit
+- backend sockets
+- listener, metrics, logging, and runtime descriptors
+- 10–20% descriptor reserve
+= maximum socket descriptor budget
+```
+
+Then set `SOCKUDO_MAX_CONNECTIONS` below that result. Verify the actual process:
+
+```bash
+pid="$(pidof sockudo)"
+cat "/proc/$pid/limits" | grep -i 'open files'
+find "/proc/$pid/fd" -maxdepth 1 -type l | wc -l
+```
+
+In a container or pod, run the check inside that container. Host login limits do not prove the
+container process limit.
+
+## Measure memory per workload
+
+Do not borrow a per-socket number from another server or another Sockudo feature set.
+
+1. Start the exact release build, allocator, config, and container limit.
+2. Hold the server idle and record steady resident memory.
+3. Ramp to a known socket and subscription count.
+4. Wait for allocations, buffers, and metrics to settle.
+5. Exercise the intended message, presence, filter, delta, and recovery workload.
+6. Record both steady and peak resident memory.
+7. Repeat at several counts; do not extrapolate from 100 sockets to 100,000.
+
+Approximate the marginal result:
+
+```text
+marginal bytes per socket =
+  (steady RSS at high count - baseline RSS) / active sockets
+```
+
+Use peak RSS, not only marginal steady memory, when setting a cgroup or pod memory limit. Include
+allocator fragmentation, slow-client buffers, adapter queues, recovery buffers, and rolling-deploy
+overlap.
+
+An OOM kill is a correlated disconnect event. Leave enough margin to avoid turning a transient
+fanout burst into a reconnect storm.
+
+## CPU and event throughput
+
+Separate tests for:
+
+- connection and TLS handshake rate
+- public subscribe/unsubscribe churn
+- private and presence authentication
+- presence first-join and last-leave transitions
+- backend publish admission
+- fanout deliveries
+- delta compression and tag filtering
+- durable history and version writes
+- replay and reconnect recovery
+- webhook and push queue work
+
+A workload at 1,000 publishes/s with one subscriber is not comparable to 1,000 publishes/s with
+10,000 subscribers.
+
+Approximate client delivery rate:
+
+```text
+deliveries/s = publishes/s × average matching subscribers per publish
+```
+
+Adapter and serialization cost may scale with publishes while egress and per-client write cost scale
+with deliveries.
+
+## Network budget
+
+Approximate payload egress before protocol, TLS, and TCP overhead:
+
+```text
+payload egress bytes/s =
+  publishes/s × matching subscribers × average delivered payload bytes
+```
+
+Also account for:
+
+- WebSocket frame and Sockudo/Pusher envelope size
+- TLS and TCP/IP overhead
+- heartbeat traffic for every quiet socket
+- retransmissions at the measured client RTT and loss
+- cross-zone or cross-node adapter traffic
+- metrics, webhook, history, and push traffic
+
+Cloud VM “up to” bandwidth and packets-per-second limits can produce a sharp knee. Inspect vNIC and
+load-balancer metrics while increasing load.
+
+## The load generator is often the first limit
+
+A remote benchmark can fail without Sockudo being saturated.
+
+Check every generator for:
+
+- CPU and scheduler saturation
+- memory and garbage collection
+- its own `nofile` limit
+- local ephemeral port exhaustion
+- `TIME_WAIT` accumulation between repeated runs
+- source NAT or gateway connection tracking
+- NIC bandwidth and packets per second
+- DNS and TLS handshake rate
+- dropped iterations or failure to maintain the requested arrival rate
+
+One source IP connecting to one target IP and port has a finite TCP 4-tuple space, commonly much
+less than a high-density Sockudo node can accept. To test beyond it, shard across generators, source
+IPs, or target addresses. Do not “solve” a generator's ephemeral ports by changing
+`ip_local_port_range` on the Sockudo server.
+
+Inspect a Linux generator:
+
+```bash
+ulimit -n
+sysctl net.ipv4.ip_local_port_range
+ss -s
+nstat -az | grep -E 'TCPSynRetrans|TCPAbort|ListenDrop'
+sar -n DEV,TCP,ETCP 1
+```
+
+If achieved request rate falls while Sockudo CPU, memory, network, queues, and latency remain flat,
+the server is probably not the limiting system.
+
+## Geography changes the benchmark
+
+Record both generator and server region. “Clients in Taiwan” is not a reproducible topology:
+document the cloud, city/region, ISP or cloud network, public or private path, RTT distribution, and
+packet loss.
+
+Long RTT changes:
+
+- how quickly sockets can be established during a fixed ramp
+- TLS handshake duration
+- subscribe/auth acknowledgement latency
+- retransmission recovery
+- reconnect convergence after a failure
+
+For geographically distributed users:
+
+1. run generators in the actual client regions
+2. synchronize their start time
+3. report each region separately as well as the aggregate
+4. keep server-side publish load independent from client-region socket generation
+5. compare public internet and private cloud paths only when clearly labeled
+
+A short test may end before a high-RTT generator reaches the intended connection count. Report
+achieved active sockets over time, not only configured virtual users.
+
+## Use distinct benchmark phases
+
+### 1. Connect ramp
+
+Measure connection success, TLS and WebSocket upgrade latency, admission rejections, and achieved
+connections per second. Add jitter so the default test is not an unrealistic simultaneous SYN
+flood, then run a separate reconnect-storm test intentionally.
+
+### 2. Quiet-socket soak
+
+Hold target connections long enough to observe memory stability, heartbeats, load-balancer idle
+behavior, NAT state, and unexpected platform timeouts.
+
+### 3. Subscription workload
+
+Apply the real channel cardinality, subscriptions per socket, private/presence mix, and room churn.
+
+### 4. Publish and fanout
+
+Ramp accepted publishes and matching subscribers independently. Track delivery correctness and
+end-to-end p50, p95, and p99 latency.
+
+### 5. Failure and recovery
+
+Remove a Sockudo node, interrupt the adapter, and slow a durable store. Measure reconnect time,
+recovery success, duplicates, gaps, readiness changes, and backlog drain.
+
+### 6. Cooldown
+
+Allow connections and `TIME_WAIT` state to clear, or start from a fresh generator fleet. Back-to-back
+runs without cooldown are not independent.
+
+## Repository benchmarks
+
+### Subscription churn
+
+`benches/subscription-churn.js` models room switching. Churn rate is approximately:
+
+```text
+cycles/s = VUS / (ROOM_SWITCH_INTERVAL_MS / 1000)
+```
+
+For 10,000 sockets and about 500 unsubscribe/subscribe cycles per second:
+
+```bash
+k6 run \
+  -e WS_HOSTS=wss://ws.example.com/app/app-key \
+  -e VUS=10000 \
+  -e CHANNEL_COUNT=4000 \
+  -e ROOM_SWITCH_INTERVAL_MS=20000 \
+  -e SOCKET_LIFETIME_MS=600000 \
+  -e DURATION=10m \
+  benches/subscription-churn.js
+```
+
+Shard `WS_HOSTS` or run several generators when one process or source IP approaches its limit.
+
+### Horizontal adapter fanout
+
+`benches/adapter-horizontal.js` records successful publishes, client deliveries, delivery ratio,
+and latency:
+
+```bash
+SUBSCRIBERS=900 \
+CHANNELS=100 \
+MESSAGES_PER_SECOND=1000 \
+WARMUP_SECONDS=30 \
+DURATION_SECONDS=120 \
+DRAIN_SECONDS=20 \
+RESULT_PATH=/tmp/sockudo-adapter.json \
+k6 run --quiet benches/adapter-horizontal.js
+```
+
+Use the same image, nodes, subscriber distribution, payload, warmup, and generator placement when
+comparing adapters.
+
+## Diagnose the first knee
+
+| Observation | Likely area | Next evidence |
+| --- | --- | --- |
+| Connect failures, Sockudo mostly idle | Generator, LB, firewall, NAT, SYN path | Generator ports/CPU, LB target errors, SYN retransmits, listen drops |
+| `ListenOverflows` rises | Host listen/accept path | CPU, `somaxconn`, SYN backlog, connection ramp shape |
+| High Sockudo CPU, low broker latency | Protocol, auth, compression, filtering, fanout | Flamegraph/profile and feature-isolated tests |
+| Low Sockudo CPU, broker latency/backlog rises | Adapter, queue, cache, or database | Backend CPU, connections, command latency, network |
+| Memory climbs after clients stabilize | Buffers, retained state, leak, slow clients | Heap/RSS profile, send queues, feature comparison |
+| P99 rises, throughput still correct | Queueing before saturation | Per-stage latency and utilization; reduce offered load |
+| Delivery ratio falls but publishes succeed | Fanout, slow clients, generator receive path | Per-node delivery counters, socket errors, client CPU |
+| Reconnect test collapses only after node loss | Insufficient failure headroom | Remaining-node admission, LB distribution, backend burst |
+
+Stop increasing the offered load at the first sustained latency or correctness failure. The
+maximum technically accepted rate beyond that point is not the production capacity.
+
+## Benchmark report template
+
+Publish enough information for another operator to reproduce the result:
+
+```text
+Sockudo version and commit:
+Build features and release profile:
+Allocator and container image:
+Server region, instance type, vCPU, RAM, NIC:
+Replica count and per-node max_connections:
+Load balancer and timeout:
+Adapter, cache, queue, app manager, history:
+Backend topology and region:
+Protocol version and enabled features:
+Generator version, count, regions, source IP count:
+RTT p50/p95 and packet loss:
+TLS termination path:
+Connection ramp and achieved sockets:
+Subscriptions, channels, presence/private mix, churn:
+Publish rate, matching subscribers, delivery rate:
+Payload and wire size:
+Duration, warmup, drain, and cooldown:
+Success/error/duplicate/gap counts:
+Latency p50/p95/p99:
+Sockudo, generator, LB, node, and backend utilization:
+```
+
+Without that context, benchmark numbers are anecdotes.
+
+## Set the production limit
+
+After the stable knee is known:
+
+1. choose a point below the first latency, error, or resource cliff
+2. subtract failure and rollout headroom
+3. set `SOCKUDO_MAX_CONNECTIONS` per node
+4. configure load-balancer and autoscaling thresholds to add capacity before admission rejects
+5. alert on connection utilization, rejection rate, memory, CPU throttling, network, adapter
+   latency, and recovery failures
+6. rerun after changing the binary, features, instance type, kernel, runtime, CNI, load balancer, or
+   shared backend
+
+Capacity belongs to the complete deployment, not the Sockudo process in isolation.

--- a/docs/content/docs/deployment/cloud-platforms.mdx
+++ b/docs/content/docs/deployment/cloud-platforms.mdx
@@ -1,0 +1,312 @@
+---
+title: Cloud platforms
+description: Deploy Sockudo on AWS, Google Cloud, and Azure with managed backends, WebSocket load balancing, and provider-supported node tuning.
+icon: Globe
+---
+
+Sockudo uses the same runtime model on every cloud: long-lived client connections at the edge,
+shared fanout and coordination between instances, and optional durable stores. Provider services
+change the failure modes and tuning controls, not those requirements.
+
+## Platform map
+
+| Need | AWS | Google Cloud | Azure |
+| --- | --- | --- | --- |
+| Direct VM control | EC2 Auto Scaling group | Compute Engine managed instance group | Virtual Machine Scale Sets |
+| Managed Kubernetes | EKS | GKE Standard or Autopilot | AKS |
+| Managed containers | ECS, including Fargate | Cloud Run | Azure Container Apps |
+| WebSocket ingress | ALB or NLB | External Application Load Balancer | Application Gateway, Load Balancer, or platform ingress |
+| Redis-compatible shared state | Managed Redis-compatible service | Memorystore for Redis | Managed Redis-compatible service |
+| Relational app/history store | RDS or Aurora | Cloud SQL or AlloyDB | Azure Database for PostgreSQL/MySQL |
+| Native fanout option | Redis, MSK, or self-managed NATS | Google Pub/Sub adapter | Redis, Kafka-compatible service, or self-managed NATS |
+
+The table is a starting map, not a requirement to use every managed service. Keep latency-sensitive
+dependencies in the same region as Sockudo and test cross-zone or cross-region traffic costs.
+
+## AWS
+
+### Recommended shapes
+
+| Shape | Use when | Notes |
+| --- | --- | --- |
+| EC2 + ALB/NLB | You need full kernel, `rlimit`, NIC, and process control. | Best match for very high connection density and stable workloads. |
+| EKS managed node group | You already operate Kubernetes and need pod-level rollout and placement. | Use a dedicated node pool when tuning or noisy neighbors matter. |
+| ECS on EC2 | You want task scheduling with host control. | Set task `ulimits`; tune the EC2 host separately. |
+| ECS Fargate | Moderate workloads and low node-operations overhead. | Validate supported `ulimits`, system controls, ENI, and per-task connection density. |
+
+For a regional cluster, put Sockudo targets in at least two Availability Zones. Use one shared
+adapter and cache across all replicas. Keep a minimum target count available during deployments.
+
+### Application Load Balancer
+
+Application Load Balancers support WebSockets natively. Their idle timeout defaults to 60 seconds,
+which is too close to many heartbeat configurations. Set it deliberately and test through every
+proxy layer:
+
+```bash
+aws elbv2 modify-load-balancer-attributes \
+  --load-balancer-arn "$SOCKUDO_ALB_ARN" \
+  --attributes Key=idle_timeout.timeout_seconds,Value=180
+```
+
+AWS documents the default, valid range, and keepalive interaction in
+[Application Load Balancer attributes](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/edit-load-balancer-attributes.html).
+ALB access logs identify `ws` and `wss` requests and are useful for separating target disconnects
+from client-side failures.
+
+Configure:
+
+- target health on `/up/<app-id>` and process monitoring on `/live`
+- deregistration delay and service termination grace as one drain budget
+- security groups that expose the Sockudo port only to the load balancer
+- metrics on target connection errors, rejected connections, and 5xx responses
+
+### EKS on Amazon Linux 2023
+
+Amazon EKS managed node groups that use launch templates require MIME multipart user data for
+Amazon Linux AMIs. Amazon Linux 2023 uses `nodeadm` and the `application/node.eks.aws` content type.
+AWS documents the merge behavior and required self-managed fields in
+[Customize managed nodes with launch templates](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html).
+
+This example applies a conservative node profile and allows a pod to request the otherwise unsafe
+`net.core.somaxconn` sysctl:
+
+```text
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="SOCKUDO"
+
+--SOCKUDO
+Content-Type: text/x-shellscript; charset="us-ascii"
+
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cat > /etc/sysctl.d/99-sockudo.conf <<'EOF'
+net.core.somaxconn = 65535
+net.core.netdev_max_backlog = 16384
+net.ipv4.tcp_max_syn_backlog = 65535
+net.ipv4.tcp_keepalive_time = 600
+net.ipv4.tcp_keepalive_intvl = 60
+net.ipv4.tcp_keepalive_probes = 5
+net.ipv4.tcp_slow_start_after_idle = 0
+EOF
+
+sysctl --system
+
+--SOCKUDO
+Content-Type: application/node.eks.aws
+
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  kubelet:
+    config:
+      allowedUnsafeSysctls:
+        - "net.core.somaxconn"
+
+--SOCKUDO--
+```
+
+For a managed node group, EKS merges its bootstrap data with the launch-template user data. For a
+self-managed AL2023 group or a custom AMI workflow, include the required `spec.cluster.name`,
+`apiServerEndpoint`, base64 certificate authority, and service CIDR described by AWS.
+
+The two parts do different jobs:
+
+- the shell script changes the node-wide baseline
+- `allowedUnsafeSysctls` only permits a pod to request that exact sysctl in its own security context
+
+If the pod does not request an unsafe sysctl, the allowlist alone changes nothing. Verify effective
+values inside the Sockudo pod.
+
+Do not add `/etc/security/limits.d` to EKS user data expecting it to raise a container's `nofile`.
+PAM limits do not control the existing container process. Check `/proc/1/limits` inside the pod and
+customize the node runtime only if the effective value is too low.
+
+Apply this profile to a dedicated, canary node group first. A launch-template or node configuration
+change replaces nodes and causes pod movement.
+
+### AWS service choices
+
+- a managed Redis-compatible service is the simplest shared adapter, cache, queue, and rate-limit
+  authority for most clusters
+- RDS or Aurora PostgreSQL/MySQL can hold dynamic apps and supported durable state
+- DynamoDB is available for supported app/history/version paths when the matching feature is built
+- use private subnets and security groups; broker and database ports should not be public
+- use workload identity or instance/task roles instead of long-lived AWS access keys
+
+## Google Cloud
+
+### Recommended shapes
+
+| Shape | Use when | Notes |
+| --- | --- | --- |
+| Compute Engine managed instance group | Maximum connection density and host control. | Pair with an external load balancer and health checks. |
+| GKE Standard | Kubernetes with node-pool and sysctl control. | Best GKE fit for dedicated realtime nodes. |
+| GKE Autopilot | Lower cluster operations overhead. | Node configuration is more constrained; verify all required controls. |
+| Cloud Run | Moderate connection count with forced reconnect tolerance. | WebSockets are requests with a finite timeout and per-instance concurrency. |
+
+Google Pub/Sub is a supported horizontal adapter, but durable feature coordination still needs the
+documented shared cache and stores. Choose it when managed GCP fanout fits the latency and request
+pattern; do not assume it replaces every Redis responsibility.
+
+### GKE node system configuration
+
+GKE Standard supports a node system configuration file for kubelet and a defined set of Linux
+sysctls. Google warns that changing it recreates nodes and recommends testing with a PodDisruption
+Budget. See [Customizing node system configuration](https://cloud.google.com/kubernetes-engine/docs/how-to/node-system-config).
+
+```yaml
+kubeletConfig:
+  allowedUnsafeSysctls:
+    - "net.core.somaxconn"
+
+linuxConfig:
+  sysctl:
+    net.core.somaxconn: "65535"
+    net.core.netdev_max_backlog: "16384"
+```
+
+Create a dedicated node pool with the file:
+
+```bash
+gcloud container node-pools create sockudo \
+  --cluster="$GKE_CLUSTER" \
+  --location="$GKE_LOCATION" \
+  --system-config-from-file=gke-sockudo-system.yaml
+```
+
+GKE accepts only its documented sysctl set and ranges. Check the current provider table before
+adding a value. Use an exact unsafe allowlist rather than `net.*`, then set the matching pod sysctl
+only when the node baseline is insufficient.
+
+### Cloud Run
+
+Cloud Run supports WebSockets, but treats them as long-running HTTP requests. Google currently
+documents a request timeout of up to 60 minutes, best-effort session affinity, and up to 1000
+concurrent connections per container. See
+[Using WebSockets on Cloud Run](https://cloud.google.com/run/docs/triggering/websockets).
+
+For Sockudo that means:
+
+- configure the maximum request timeout and expect forced reconnects
+- use a horizontal adapter and shared stores because a reconnect may reach another instance
+- enable and test Protocol V2 recovery when continuity matters
+- set minimum instances for latency and capacity rather than relying on a cold scale-out
+- set maximum concurrency only after measuring memory per socket and burst CPU
+- do not enable end-to-end HTTP/2 for the WebSocket service
+- account for active WebSocket instances in the billing model
+
+Cloud Run is useful when those constraints are acceptable. GKE Standard or Compute Engine is a
+better fit when connections should remain open indefinitely or node-level tuning is required.
+
+### Google Cloud service choices
+
+- Memorystore for Redis can provide shared Redis state close to GKE or Compute Engine
+- Cloud SQL or AlloyDB can provide supported relational app and durable stores
+- workload identity avoids shipping service-account JSON in images
+- place Sockudo, Redis, and database services in compatible regions and private networks
+- report load-balancer and Cloud NAT limits separately from pod or VM limits
+
+## Azure
+
+### Recommended shapes
+
+| Shape | Use when | Notes |
+| --- | --- | --- |
+| Virtual Machine Scale Sets | Full host control and dense, stable sockets. | Configure load balancing, health probes, and rolling upgrades explicitly. |
+| AKS | Kubernetes rollout, node pools, identities, and managed control plane. | Use a dedicated Linux node pool for custom OS or kubelet settings. |
+| Azure Container Apps | Managed container ingress for moderate workloads. | WebSocket ingress is supported; validate request/idle timeout and scaling behavior. |
+
+Azure Application Gateway and Azure Load Balancer have different layers, health semantics, and
+timeout controls. Document the selected path and test a quiet WebSocket through the public endpoint,
+not only a busy local client.
+
+### AKS custom node configuration
+
+AKS accepts separate kubelet and Linux OS configuration files when creating a cluster or node pool.
+Microsoft documents the supported ranges and notes that unsafe sysctls can affect node security and
+stability in [Customize AKS node configuration](https://learn.microsoft.com/azure/aks/custom-node-configuration).
+
+`aks-kubelet.json`:
+
+```json
+{
+  "allowedUnsafeSysctls": [
+    "net.core.somaxconn"
+  ]
+}
+```
+
+`aks-linux-os.json`:
+
+```json
+{
+  "sysctls": {
+    "netCoreSomaxconn": 65535,
+    "netCoreNetdevMaxBacklog": 16384,
+    "netIpv4TcpMaxSynBacklog": 65535,
+    "netIpv4TcpKeepaliveTime": 600,
+    "netIpv4TcpKeepaliveIntvl": 60,
+    "netIpv4TcpKeepaliveProbes": 5
+  }
+}
+```
+
+Create a dedicated pool:
+
+```bash
+az aks nodepool add \
+  --resource-group "$AKS_RESOURCE_GROUP" \
+  --cluster-name "$AKS_CLUSTER" \
+  --name sockudo \
+  --kubelet-config ./aks-kubelet.json \
+  --linux-os-config ./aks-linux-os.json
+```
+
+AKS uses camelCase names in the JSON API even though the documentation tables show kernel names.
+Provider defaults can already be high; for example, system-wide file handle ceilings on current
+AKS Linux images may not be the limiting `nofile`. Always inspect the process limit inside the pod.
+
+### Azure Container Apps
+
+Azure Container Apps ingress supports WebSockets. Environment ingress settings can include an idle
+request timeout, and the platform owns the underlying nodes. See
+[Container Apps ingress](https://learn.microsoft.com/azure/container-apps/ingress-overview) and
+[environment ingress configuration](https://learn.microsoft.com/azure/container-apps/ingress-environment-configuration).
+
+Use the same managed-container precautions as Cloud Run:
+
+- shared fanout and coordination from the first multi-replica deployment
+- minimum replicas sized for quiet socket capacity
+- tested reconnect and recovery behavior
+- no dependency on host sysctl or custom container-runtime limits
+- explicit ingress idle-timeout validation in the selected environment tier
+
+Use AKS or Virtual Machine Scale Sets when connection density requires host control.
+
+### Azure service choices
+
+- use a managed Redis-compatible service for the common shared adapter/cache path
+- Azure Database for PostgreSQL or MySQL can provide supported relational storage
+- use managed identities and Key Vault-backed secret delivery instead of static cloud credentials
+- use private endpoints or VNet integration for Redis and databases
+- watch SNAT/connection tracking for outbound dependencies and load generators
+
+## Other providers
+
+The same decision tree works on DigitalOcean, Hetzner, Oracle Cloud, Fly.io, Render, Railway, or an
+on-premises Kubernetes platform:
+
+1. Confirm native WebSocket support and the maximum idle or request duration.
+2. Confirm per-instance concurrent connection, file descriptor, bandwidth, and packet limits.
+3. Confirm whether you control node sysctls and process `rlimit`.
+4. Confirm scale-down and connection-drain semantics.
+5. Use a shared adapter before adding a second instance.
+6. Keep stateful dependencies close enough for the measured latency budget.
+7. Run a quiet-socket soak and reconnect storm, not only a short message-throughput test.
+
+If the provider does not publish a socket or timeout limit, treat it as an unknown to test and
+monitor, not as unlimited.

--- a/docs/content/docs/deployment/docker.mdx
+++ b/docs/content/docs/deployment/docker.mdx
@@ -1,0 +1,170 @@
+---
+title: Docker and Compose
+description: Run Sockudo in containers with mounted configuration, correct limits, health checks, and shared backends.
+icon: Container
+---
+
+The published Sockudo image runs as a non-root user and starts the binary with
+`--config /app/config/config.json`. For production, pin a release tag, mount or generate the exact
+configuration, inject secrets separately, and set limits on the container itself.
+
+## Production-like docker run
+
+```bash
+docker run -d \
+  --name sockudo \
+  --restart unless-stopped \
+  --init \
+  --stop-timeout 45 \
+  --ulimit nofile=262144:262144 \
+  --read-only \
+  --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+  --mount type=bind,src="$PWD/config.toml",dst=/app/config/production.toml,readonly \
+  --env-file "$PWD/sockudo.env" \
+  -p 6001:6001 \
+  -p 127.0.0.1:9601:9601 \
+  ghcr.io/sockudo/sockudo:4.7.0 \
+  sockudo --config /app/config/production.toml
+```
+
+The arguments after the image replace its default command, so include both `sockudo` and
+`--config`. Mount metrics only on a private or loopback interface unless the network policy already
+restricts it.
+
+The `CONFIG_FILE` environment value embedded in the image is descriptive; the server selects a
+non-default file through `--config`.
+
+## Compose profile
+
+This example keeps the Sockudo process immutable and connects it to an external or separately
+managed Redis:
+
+```yaml
+name: sockudo
+
+services:
+  sockudo:
+    image: ghcr.io/sockudo/sockudo:4.7.0
+    command: ["sockudo", "--config", "/app/config/production.toml"]
+    restart: unless-stopped
+    init: true
+    stop_grace_period: 45s
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    ports:
+      - "6001:6001"
+      - "127.0.0.1:9601:9601"
+    volumes:
+      - ./config/production.toml:/app/config/production.toml:ro
+    env_file:
+      - ./secrets/sockudo.env
+    environment:
+      HOST: "0.0.0.0"
+      PORT: "6001"
+      METRICS_HOST: "0.0.0.0"
+      METRICS_PORT: "9601"
+      INSTANCE_PROCESS_ID: "compose-1"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:6001/up/production"]
+      interval: 10s
+      timeout: 3s
+      start_period: 20s
+      retries: 3
+    logging:
+      driver: local
+      options:
+        max-size: "20m"
+        max-file: "5"
+```
+
+For local development, adding Redis to the same Compose project is convenient. In production, a
+single-host Redis container has the same host failure domain as Sockudo. Use a managed or
+independently operated Redis topology when the shared adapter, cache, queue, or rate limiter must
+survive that host.
+
+## Configuration and secrets
+
+Prefer this separation:
+
+- mount the complete non-secret TOML or JSON read-only
+- supply secret-backed environment variables through the orchestrator
+- mount TLS keys, provider credentials, and service-account JSON as read-only secret files
+- reference secret file paths from Sockudo configuration or environment
+
+An `env_file` is still a plaintext secret file on the Docker host. Limit its owner and mode, keep it
+out of image build context and source control, and rotate it through the host's secret-management
+workflow.
+
+Do not use Docker build arguments for credentials. Build arguments and layers can remain visible in
+image metadata or caches.
+
+## Limits: host versus container
+
+Three different layers can cap a container:
+
+| Layer | Check | Configure |
+| --- | --- | --- |
+| Sockudo admission | `SOCKUDO_MAX_CONNECTIONS` | Static config or environment |
+| Process `nofile` | `docker exec sockudo sh -c 'ulimit -n'` | `--ulimit` or Compose `ulimits` |
+| Host kernel and service manager | `sysctl`, Docker daemon unit limits | Host image, sysctl, and daemon configuration |
+
+Changing `/etc/security/limits.d` inside the image does not raise the running container's file
+limit. Set it through the runtime and verify from inside the container.
+
+Host-level connection queues and NIC settings remain host concerns. Namespaced sysctls may be set
+per container, but only after confirming the runtime supports them and the value is safe for other
+workloads.
+
+## CPU and memory
+
+Start with a memory limit that leaves room for peak sockets, payload buffers, adapter queues, and
+allocator fragmentation. An out-of-memory kill disconnects every client on that container at once.
+
+CPU quotas can create latency cliffs during reconnect or fanout bursts. Set CPU reservations, watch
+throttling metrics, and add a hard CPU limit only when multi-tenant isolation requires one and the
+load test includes the same quota.
+
+Measure:
+
+```bash
+docker stats sockudo
+docker inspect sockudo --format '{{json .HostConfig.Ulimits}}'
+docker exec sockudo sh -c 'ulimit -n; cat /proc/1/limits'
+docker exec sockudo sh -c 'curl -fsS http://127.0.0.1:6001/live'
+```
+
+## Health and startup ordering
+
+Use `/live` when the runtime needs to decide whether the process is alive. Use `/up` or
+`/up/<app-id>` when the load balancer needs dependency-aware readiness.
+
+Compose `depends_on` can order startup, but it does not make a dependency permanently available.
+Sockudo must still expose failed readiness and operators must alert on adapter, cache, queue, and
+app-manager failures.
+
+Do not restart a healthy process merely because Redis or a database is briefly slow. Repeated
+container restarts amplify reconnect load.
+
+## Multi-host containers
+
+Moving Compose services onto two VMs does not create Sockudo clustering automatically. Every
+Sockudo replica must have:
+
+- the same app identity and policy, or access to one shared app manager
+- a unique `INSTANCE_PROCESS_ID`
+- a shared horizontal adapter
+- a shared cache for cross-node coordination and distributed limits
+- durable queue and state backends where the enabled features require them
+- a WebSocket-aware load balancer with readiness and connection drain
+
+Do not place a local memory adapter behind a multi-host load balancer. Clients connected to
+different hosts would occupy isolated realtime islands.
+
+For larger container deployments, use the [Kubernetes and Helm](/docs/deployment/kubernetes)
+guide. For one dedicated container host, also apply the measured host guidance from
+[Linux VM and bare metal](/docs/deployment/linux).

--- a/docs/content/docs/deployment/index.mdx
+++ b/docs/content/docs/deployment/index.mdx
@@ -1,0 +1,110 @@
+---
+title: Deployment guide
+description: Choose a Sockudo production topology, configuration strategy, and rollout path.
+icon: Cloud
+---
+
+A good Sockudo deployment starts with the failure model, not the platform logo. Decide whether one
+process is sufficient, which state must survive a restart, and whether a client may reconnect to a
+different node. Those decisions determine the adapter, cache, queue, app manager, and history
+backends.
+
+<Cards>
+  <Card title="Static configuration" href="/docs/deployment/static-configuration" description="Use TOML or JSON for structure, environment variables for overrides, and secret stores for credentials." />
+  <Card title="Linux host" href="/docs/deployment/linux" description="Run a binary under systemd, raise file limits correctly, tune the node, and configure a reverse proxy." />
+  <Card title="Docker and Compose" href="/docs/deployment/docker" description="Mount configuration, set container limits, handle secrets, and move from one host to several." />
+  <Card title="Kubernetes and Helm" href="/docs/deployment/kubernetes" description="Configure probes, disruption budgets, resources, ingress, autoscaling, and pod or node sysctls." />
+  <Card title="Cloud platforms" href="/docs/deployment/cloud-platforms" description="Apply the same architecture on AWS, Google Cloud, and Azure, including managed-node tuning examples." />
+  <Card title="Capacity planning" href="/docs/deployment/capacity-planning" description="Budget connections, find the real bottleneck, and run geographically honest benchmarks." />
+</Cards>
+
+## Choose a topology
+
+| Deployment | Good fit | Runtime backends | Main limitation |
+| --- | --- | --- | --- |
+| One process, memory only | Local development, demos, CI | Local adapter, memory cache, queue, app manager, history | Restart loses process-local state; no failover. |
+| One production VM | Small stable workload with a simple operational model | Local adapter; static apps or a durable app manager; optional durable history | The host is one failure domain. |
+| Multiple nodes with Redis | Most regional production workloads | Redis adapter, cache, queue, and rate limiter; shared app manager when apps change dynamically | Redis availability and capacity become part of the realtime path. |
+| Multiple nodes with NATS | High fanout or high subscription churn | NATS adapter, Redis cache, durable queue and app manager | NATS carries fanout, but coordination and durable features still need shared stores. |
+| Durable Protocol V2 cluster | Recovery, history, mutable messages, annotations, AI Transport | Shared adapter and cache plus durable history and version stores | More write amplification and more dependencies to operate. |
+| Managed/serverless container platform | Moderate socket counts with platform-managed rollout and scaling | Shared adapter and stores from the first replica | Platform connection duration, concurrency, and node-tuning limits apply. |
+
+Memory drivers are not shared simply because several processes use identical configuration. Every
+multi-node deployment needs a horizontal adapter. Any feature whose correctness crosses nodes also
+needs its documented shared authority.
+
+## Recommended production baseline
+
+A conventional regional cluster has:
+
+- at least two Sockudo instances spread across failure domains
+- a load balancer that supports WebSocket upgrades and has a deliberate idle timeout
+- Redis or another supported horizontal adapter
+- a shared Redis or Redis Cluster cache for coordination, idempotency, and distributed rate limits
+- durable app storage if app records change at runtime
+- a durable queue when webhook or push work must survive a node failure
+- durable history and version storage when Protocol V2 recovery or mutable state must cross nodes
+- metrics, structured logs, readiness checks, and a tested drain path
+
+Start with [Scaling](/docs/server/scaling) for cross-node semantics and
+[Security](/docs/server/security) for network and secret boundaries.
+
+## Configuration strategy
+
+Use three layers with distinct responsibilities:
+
+1. Put stable structure in a version-controlled TOML or JSON file: enabled features, driver choices,
+   limits, queue reliability, history retention, and per-app policy.
+2. Put environment-specific addresses and non-secret switches in deployment variables or a
+   generated config file.
+3. Inject app secrets, database passwords, broker credentials, and provider keys from the
+   platform's secret store.
+
+Sockudo does not treat environment variables as a complete alternative syntax for every nested
+configuration field. Complex policy and multi-app definitions belong in a file or persistent app
+manager. See [Static configuration](/docs/deployment/static-configuration) for exact precedence and
+equivalent TOML and JSON examples.
+
+## Workload questions to answer first
+
+Document these inputs before choosing instance sizes:
+
+| Input | Why it matters |
+| --- | --- |
+| Peak concurrent sockets and reconnect surge | Sets file descriptor, memory, load-balancer, and admission budgets. |
+| Messages per second and average payload | Sets CPU, network, adapter, and serialization load. |
+| Subscribers per publish | Distinguishes ingest throughput from fanout throughput. |
+| Public, private, and presence mix | Adds authentication, membership, and transition work. |
+| Subscription churn | Can dominate otherwise quiet chat or room workloads. |
+| Protocol V1 or V2 features | Recovery, deltas, filtering, history, and mutations change state and compute costs. |
+| Retention and recovery objectives | Selects memory buffers versus durable stores. |
+| Client geography | Changes handshake time, RTT, reconnect behavior, and apparent benchmark throughput. |
+
+## Rollout sequence
+
+1. Build or pin one exact Sockudo image or binary version and required Cargo features.
+2. Validate the resolved config in staging, including startup logs and `/up/<app-id>`.
+3. Load test from realistic client regions and confirm the generators are not saturated.
+4. Set a per-node `SOCKUDO_MAX_CONNECTIONS` below the measured safe ceiling.
+5. Deploy at minimum capacity before enabling autoscaling.
+6. Remove a node while traffic is active and verify reconnect and recovery behavior.
+7. Fail or pause each shared dependency and verify readiness, alerts, and backpressure.
+8. Roll in small batches while watching connection churn, adapter errors, and recovery failures.
+
+## Production gate
+
+Do not call a deployment ready until all of these are true:
+
+- `/live` is used for liveness and startup checks
+- `/up` or `/up/<app-id>` is used for readiness
+- the load balancer idle timeout and Sockudo heartbeat behavior have been tested together
+- file descriptor limits have been checked in the actual process or container
+- credentials are absent from images, ConfigMaps, command lines, and logs
+- every replica has a stable, unique `INSTANCE_PROCESS_ID`
+- multi-node drivers and feature flags pass Sockudo startup validation
+- termination grace exceeds Sockudo's shutdown grace period
+- load testing includes connect, steady-state, fanout, churn, and reconnect phases
+- dashboards distinguish a Sockudo bottleneck from the load generator, load balancer, NAT, or broker
+
+Continue with [Static configuration](/docs/deployment/static-configuration), then select the
+platform-specific guide.

--- a/docs/content/docs/deployment/kubernetes.mdx
+++ b/docs/content/docs/deployment/kubernetes.mdx
@@ -1,0 +1,333 @@
+---
+title: Kubernetes and Helm
+description: Deploy Sockudo with production Helm values, safe probes, disruption controls, ingress, and node tuning.
+icon: Boxes
+---
+
+Kubernetes is a good Sockudo platform when you need repeatable rollouts, failure-domain placement,
+secret injection, metrics discovery, and several replicas. It does not remove the state model:
+pods still need shared adapters and stores, and scale-down still disconnects their clients.
+
+## Install the chart
+
+```bash
+helm upgrade --install sockudo ./charts/sockudo \
+  --namespace sockudo \
+  --create-namespace \
+  --values values-production.yaml
+```
+
+Pin the chart and image version in GitOps or release automation. Do not deploy `latest`.
+
+## Production values example
+
+The following is a regional three-pod baseline with one immutable app sourced from a Kubernetes
+Secret and Redis used for fanout, cache, queue, and rate limits:
+
+```yaml
+replicaCount: 3
+
+image:
+  repository: ghcr.io/sockudo/sockudo
+  tag: "4.7.0"
+  pullPolicy: IfNotPresent
+
+config:
+  mode: production
+  debug: false
+  logOutputFormat: json
+  rustLog: "info,sockudo=info"
+  shutdownGracePeriod: 30
+  adapterDriver: redis
+  appManagerDriver: memory
+  cacheDriver: redis
+  queueDriver: redis
+  rateLimiterDriver: redis
+  rateLimiter:
+    enabled: true
+    apiMaxRequests: 1000
+    apiWindowSeconds: 60
+    apiTrustHops: 1
+    wsMaxRequests: 100
+    wsWindowSeconds: 60
+    wsTrustHops: 1
+  metrics:
+    enabled: true
+
+defaultApp:
+  enabled: true
+  existingSecret: sockudo-app
+  maxConnections: 50000
+  enableClientMessages: false
+  enableUserAuthentication: true
+
+redis:
+  host: redis.internal
+  port: 6379
+  existingSecret: sockudo-redis
+
+extraEnv:
+  - name: SOCKUDO_MAX_CONNECTIONS
+    value: "50000"
+  - name: ADAPTER_FALLBACK_TO_LOCAL
+    value: "false"
+  - name: SOCKUDO_DEFAULT_APP_ALLOWED_ORIGINS
+    value: "https://app.example.com"
+
+resources:
+  requests:
+    cpu: "1"
+    memory: 1Gi
+  limits:
+    memory: 2Gi
+
+readinessProbe:
+  httpGet:
+    path: /up/production
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+livenessProbe:
+  httpGet:
+    path: /live
+    port: http
+  periodSeconds: 20
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+startupProbe:
+  httpGet:
+    path: /live
+    port: http
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 30
+
+terminationGracePeriodSeconds: 45
+
+pdb:
+  enabled: true
+  minAvailable: 2
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: sockudo
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "180"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "180"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+  hosts:
+    - host: ws.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: sockudo-tls
+      hosts:
+        - ws.example.com
+```
+
+Adapt the topology label selector when the release name or chart labels differ. If application
+records must change dynamically, select a durable app manager instead of `memory` and configure its
+database credentials from a Secret.
+
+Create the one-app Secret without placing values in the shell history or a checked-in manifest.
+The required keys are:
+
+```text
+default-app-id
+default-app-key
+default-app-secret
+```
+
+For advanced nested configuration, use the chart's `configJson` value or mount your own static
+file. Keep secret values out of `configJson`; combine it with `extraEnvFrom` or file-backed Secrets.
+
+## Probes
+
+Use different endpoints for different decisions:
+
+| Probe | Endpoint | Meaning |
+| --- | --- | --- |
+| Startup | `/live` | The process has started. |
+| Liveness | `/live` | The process runtime is alive. |
+| Readiness | `/up` or `/up/<app-id>` | Required apps and shared dependencies are available. |
+
+Do not use dependency-aware `/up` as liveness. Restarting every pod because Redis is slow creates a
+reconnect storm and does not repair Redis.
+
+Set probe timeout below its period and above normal dependency-check latency. Sockudo's
+`health_check_timeout_ms` bounds each dependency check separately.
+
+## Resources and connection admission
+
+Persistent connections do not map cleanly onto CPU-only autoscaling:
+
+- memory rises with sockets, subscriptions, pending writes, and per-connection feature state
+- CPU rises with handshake, auth, messages, fanout, compression, filtering, and reconnect bursts
+- a pod can have low CPU while holding too many quiet sockets to remove safely
+
+Set `SOCKUDO_MAX_CONNECTIONS` on every pod so a single replica cannot absorb more connections than
+its measured memory and file-descriptor budget. Keep minimum replicas high enough for the peak
+quiet-socket count even when CPU is low.
+
+CPU limits can throttle a pod during the exact reconnect or fanout burst it needs to process.
+Requests plus a memory limit are a reasonable starting point on a dedicated node pool. Add a CPU
+limit only when isolation requires it and benchmark with the same quota.
+
+## Autoscaling
+
+The chart can configure an HPA:
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 12
+  targetCPUUtilizationPercentage: 65
+  targetMemoryUtilizationPercentage: 75
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 30
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+```
+
+CPU and memory are fallback signals, not a complete realtime scaling policy. A stronger setup also
+uses active connections per pod, connection admission rejections, event-loop or fanout latency,
+adapter backlog, and reconnect rate through an external/custom metrics adapter.
+
+Scale up early. Scale down slowly and one pod at a time. Every removed pod makes its clients
+reconnect, so an aggressive HPA can oscillate and manufacture load.
+
+## Rollouts and disruptions
+
+Set:
+
+- a PodDisruptionBudget that leaves enough connection capacity online
+- zone or host topology spread
+- a termination grace period longer than `SHUTDOWN_GRACE_PERIOD`
+- a rollout `maxUnavailable` compatible with the PDB and remaining socket capacity
+- load-balancer deregistration or endpoint propagation time inside the drain budget
+
+During a rollout, watch connection count by pod. Kubernetes considers replica count, not how many
+sockets each replica owns. One terminating pod may hold a disproportionate share after a long
+uptime.
+
+If strict connection drain is required, remove readiness first, wait for endpoint and load-balancer
+propagation, then terminate. Test this behavior with the actual ingress controller; it is not
+identical across controllers.
+
+## Ingress and load balancers
+
+Confirm all layers:
+
+- accept HTTP/1.1 WebSocket upgrades
+- preserve `Upgrade` and `Connection` semantics
+- have idle timeouts above the heartbeat interval with margin
+- do not buffer WebSocket traffic
+- expose a dependency-aware readiness path
+- drain targets during pod termination
+
+The ingress annotation example above is specific to ingress-nginx. Use the equivalent settings for
+AWS Load Balancer Controller, Google Cloud Load Balancing, Azure Application Gateway, Traefik,
+Envoy, HAProxy, or a service mesh.
+
+Sticky sessions are not required for basic pub/sub with a shared adapter. They can reduce
+reconnect-to-new-node churn, but must not substitute for shared state.
+
+When preserving client IPs with `externalTrafficPolicy: Local` or proxy-protocol features, retest
+load distribution and health checks. Source-IP preservation can reduce the set of eligible nodes.
+
+## Pod and node sysctls
+
+First deploy with provider defaults and inspect counters. Managed Kubernetes node images already
+ship with non-trivial tuning, and an unnecessary override can reduce stability.
+
+Kubernetes classifies sysctls as safe or unsafe. Safe, namespaced values can be applied in the pod
+security context when the cluster version and admission policy allow them:
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  sysctls:
+    - name: net.ipv4.tcp_keepalive_time
+      value: "600"
+    - name: net.ipv4.tcp_keepalive_intvl
+      value: "60"
+    - name: net.ipv4.tcp_keepalive_probes
+      value: "5"
+```
+
+`net.core.somaxconn` is commonly treated as unsafe. A pod-level value requires both:
+
+1. an exact kubelet `allowedUnsafeSysctls` entry on every eligible node
+2. the matching `podSecurityContext.sysctls` value and an admission policy that permits it
+
+See Kubernetes' [sysctl documentation](https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/)
+and the provider-specific node-pool guide before enabling it. Do not grant a privileged container
+or broad `net.*` permission just to set one value.
+
+Node-level sysctl configuration and pod network namespaces are distinct. Verify the effective value
+inside the scheduled pod:
+
+```bash
+kubectl exec -n sockudo deploy/sockudo -- cat /proc/sys/net/core/somaxconn
+kubectl exec -n sockudo deploy/sockudo -- sh -c 'ulimit -n; cat /proc/1/limits'
+```
+
+Kubernetes has no portable pod field for POSIX `rlimit` values. The effective `nofile` comes from
+the container runtime and node image. If it is too low, change the runtime/node configuration or
+use a provider-supported node image customization, then verify again inside the pod.
+
+Provider examples are in [Cloud platforms](/docs/deployment/cloud-platforms).
+
+## Network capacity
+
+High socket counts can hit infrastructure before the pod:
+
+- load-balancer connection and target limits
+- node vNIC packets-per-second or bandwidth limits
+- CNI IP allocation and conntrack tables
+- NAT gateway state for outbound dependencies or load generators
+- cross-zone traffic and broker latency
+
+Inbound WebSockets do not consume a Sockudo pod's local ephemeral port range. Avoid “fixing”
+`ip_local_port_range` unless evidence points to an outbound connection or NAT bottleneck.
+
+## Verify the deployed state
+
+```bash
+helm get values sockudo -n sockudo
+kubectl get pods -n sockudo -o wide
+kubectl get pdb -n sockudo
+kubectl exec -n sockudo deploy/sockudo -- sh -c 'ulimit -n'
+kubectl port-forward -n sockudo svc/sockudo 6001:6001
+curl -fsS http://127.0.0.1:6001/live
+curl -fsS http://127.0.0.1:6001/up/production
+```
+
+Then run a node drain and a rolling restart under load. A manifest that renders successfully is not
+yet a tested realtime deployment.

--- a/docs/content/docs/deployment/linux.mdx
+++ b/docs/content/docs/deployment/linux.mdx
@@ -1,0 +1,253 @@
+---
+title: Linux VM and bare metal
+description: Run Sockudo under systemd with correct file limits, measured kernel tuning, and a WebSocket-aware proxy.
+icon: Server
+---
+
+A Linux VM is often the simplest production deployment for a known, stable workload. It gives you
+direct control over file limits, kernel settings, CPU scheduling, network queues, and the process
+lifecycle. Start with one host only if a host restart is an acceptable outage; use at least two
+hosts and a shared adapter for availability.
+
+## Host layout
+
+Use separate paths for the binary, configuration, secrets, and service account:
+
+```text
+/usr/local/bin/sockudo
+/etc/sockudo/config.toml
+/etc/sockudo/sockudo.env
+/etc/systemd/system/sockudo.service
+```
+
+The service account needs read access to its configuration and secret-backed files. Sockudo does
+not need root privileges when it binds to ports `6001` and `9601`.
+
+```bash
+sudo useradd --system --home /var/lib/sockudo --create-home --shell /usr/sbin/nologin sockudo
+sudo install -o root -g root -m 0755 target/release/sockudo /usr/local/bin/sockudo
+sudo install -d -o root -g sockudo -m 0750 /etc/sockudo
+sudo install -o root -g sockudo -m 0640 config/production.toml /etc/sockudo/config.toml
+```
+
+Keep `/etc/sockudo/sockudo.env` at mode `0640` or stricter. Do not put secrets directly in the
+systemd unit because unit contents are commonly collected in diagnostics and configuration
+management.
+
+## systemd unit
+
+```ini
+[Unit]
+Description=Sockudo realtime server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=sockudo
+Group=sockudo
+WorkingDirectory=/var/lib/sockudo
+EnvironmentFile=-/etc/sockudo/sockudo.env
+ExecStart=/usr/local/bin/sockudo --config /etc/sockudo/config.toml
+Restart=on-failure
+RestartSec=2s
+LimitNOFILE=1048576
+TimeoutStopSec=45s
+KillSignal=SIGTERM
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Set `TimeoutStopSec` longer than `shutdown_grace_period`. Add `ReadWritePaths=` only when a selected
+feature genuinely writes to local disk. A stricter security directive may need adjustment for a
+provider SDK or a TLS key path; keep any exception narrow.
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now sockudo
+sudo systemctl status sockudo
+```
+
+## File descriptor limits
+
+Every accepted socket consumes a file descriptor, as do logs, shared-backend connections, metrics,
+and internal listeners. Budget:
+
+```text
+required nofile >= planned sockets + backend connections + listeners + operational reserve
+```
+
+Use at least 10–20% reserve and never set `SOCKUDO_MAX_CONNECTIONS` equal to the hard `nofile`
+limit.
+
+`/etc/security/limits.d/*.conf` applies to PAM login sessions. It does not reliably change a
+systemd service. `LimitNOFILE=` in the unit is the relevant setting.
+
+Verify the running process rather than the shell:
+
+```bash
+systemctl show sockudo -p LimitNOFILE
+cat /proc/"$(pidof sockudo)"/limits | grep -i 'open files'
+ls /proc/"$(pidof sockudo)"/fd | wc -l
+```
+
+Also check system-wide pressure:
+
+```bash
+sysctl fs.file-max fs.nr_open
+cat /proc/sys/fs/file-nr
+```
+
+## Baseline kernel profile
+
+Treat this as a starting profile for a dedicated Sockudo node, not a universal requirement:
+
+```ini
+# /etc/sysctl.d/99-sockudo.conf
+
+# Listen and SYN queues for connection bursts.
+net.core.somaxconn = 65535
+net.ipv4.tcp_max_syn_backlog = 65535
+
+# Input backlog; raise only when packet drops show the default is too small.
+net.core.netdev_max_backlog = 16384
+
+# Detect dead peers eventually at the TCP layer. Sockudo protocol heartbeats
+# remain the primary application-level liveness mechanism.
+net.ipv4.tcp_keepalive_time = 600
+net.ipv4.tcp_keepalive_intvl = 60
+net.ipv4.tcp_keepalive_probes = 5
+
+# Avoid restarting congestion control from the initial window after idle.
+net.ipv4.tcp_slow_start_after_idle = 0
+```
+
+Apply and verify:
+
+```bash
+sudo sysctl --system
+sysctl net.core.somaxconn net.ipv4.tcp_max_syn_backlog
+sysctl net.core.netdev_max_backlog
+sysctl net.ipv4.tcp_keepalive_time net.ipv4.tcp_keepalive_intvl net.ipv4.tcp_keepalive_probes
+```
+
+Why these are not all “set once and forget” values:
+
+- a larger `somaxconn` helps only if the application's listen backlog and accept loop can use it
+- a larger SYN queue helps connection bursts, not steady-state message fanout
+- a larger `netdev_max_backlog` can trade drops for latency and memory when CPU is already saturated
+- TCP keepalive does not replace Sockudo's protocol ping/pong and should not fire more aggressively
+  than necessary
+- modern Linux already autotunes TCP buffers; raising `rmem_max` and `wmem_max` without high
+  bandwidth-delay-product evidence can increase per-socket memory risk
+
+Optional settings such as `tcp_fin_timeout`, socket buffer ceilings, IRQ affinity, CPU isolation,
+busy polling, and NIC ring sizes should follow a measured bottleneck. Record the before/after
+kernel counters and repeat the same workload.
+
+Do not widen `ip_local_port_range` to increase inbound WebSocket capacity. Inbound sockets use the
+server's listening port. The ephemeral range matters for high-volume outbound connections from
+Sockudo, a NAT gateway, or the load generator.
+
+## Inspect the network path
+
+Useful counters during a connect or reconnect surge:
+
+```bash
+ss -s
+ss -lnt
+nstat -az | grep -E 'ListenOverflows|ListenDrops|TCPBacklogDrop|TCPSynRetrans'
+ip -s link
+ethtool -S eth0
+```
+
+Interpret them together:
+
+- `ListenOverflows` or `ListenDrops` suggests the accept/listen path cannot keep up
+- interface drops suggest host networking, vNIC, or CPU pressure
+- SYN retransmits can be the client network, load balancer, firewall, or server
+- no server-side drops with low achieved load usually points upstream or at the generator
+
+## Reverse proxy example
+
+Terminate TLS at a load balancer or a carefully configured reverse proxy. NGINX needs HTTP/1.1
+upgrade forwarding and long enough timeouts:
+
+```nginx
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+upstream sockudo {
+    least_conn;
+    server 10.0.1.10:6001 max_fails=3 fail_timeout=10s;
+    server 10.0.2.10:6001 max_fails=3 fail_timeout=10s;
+}
+
+server {
+    listen 443 ssl;
+    server_name ws.example.com;
+
+    location / {
+        proxy_pass http://sockudo;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 180s;
+        proxy_send_timeout 180s;
+        proxy_buffering off;
+    }
+}
+```
+
+The default Sockudo `activity_timeout` is 120 seconds. Set every proxy or load-balancer idle timeout
+above the longest expected interval between application or heartbeat traffic, with margin. A
+180-second starting value works with the default, but validate it with the actual client SDKs and
+network path.
+
+If the proxy adds entries to `X-Forwarded-For`, configure `RATE_LIMITER_API_TRUST_HOPS` and
+`RATE_LIMITER_WS_TRUST_HOPS` to the exact trusted proxy count. Never trust a client-supplied chain
+from the public internet.
+
+## One host versus several
+
+| Concern | One host | Two or more hosts |
+| --- | --- | --- |
+| Adapter | `local` is valid | Use Redis, NATS, or another horizontal adapter |
+| App definitions | Static memory app can work | All nodes need identical static apps, or use a shared app manager |
+| Rate limits | Memory is per host | Use Redis or Redis Cluster for cluster-wide limits |
+| Queue | Memory work is lost with the host | Use a durable shared queue for webhooks and push |
+| History and mutations | Memory can be acceptable for tests | Use a supported durable backend |
+| Load balancer | Optional reverse proxy | Required, with health checks and drain |
+
+For multiple nodes, set `fallback_to_local = false`. A production cluster should fail readiness or
+startup when its horizontal adapter is unavailable instead of silently splitting into isolated
+local islands.
+
+## Drain and upgrade
+
+1. Remove the host from load-balancer readiness.
+2. Wait for the balancer's deregistration delay or connection drain policy.
+3. Stop Sockudo with `systemctl stop sockudo`.
+4. Allow `TimeoutStopSec` to cover Sockudo's configured shutdown grace.
+5. Replace the binary and configuration atomically.
+6. Start the service, wait for `/up/<app-id>`, then restore load-balancer membership.
+
+Watch reconnect attempts, recovery success, adapter errors, and connection distribution throughout
+the rollout. Continue with [Capacity planning](/docs/deployment/capacity-planning) before setting a
+production connection limit.

--- a/docs/content/docs/deployment/meta.json
+++ b/docs/content/docs/deployment/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "Deployment",
+  "icon": "Cloud",
+  "pages": [
+    "index",
+    "static-configuration",
+    "linux",
+    "docker",
+    "kubernetes",
+    "cloud-platforms",
+    "capacity-planning"
+  ]
+}

--- a/docs/content/docs/deployment/static-configuration.mdx
+++ b/docs/content/docs/deployment/static-configuration.mdx
@@ -1,0 +1,310 @@
+---
+title: Static configuration
+description: Configure Sockudo with TOML or JSON, understand environment precedence, and keep secrets out of static files.
+icon: FileCog
+---
+
+Sockudo supports a static TOML file, a legacy-compatible JSON file, and runtime environment
+overrides. Use a file for the complete deployment shape. Use environment variables for the subset
+of settings that vary per environment and for secret references supplied by the platform.
+
+## Loading order
+
+Configuration is resolved in this order; each later source wins:
+
+1. compiled defaults
+2. `config/config.toml` from the process working directory, when it exists and parses
+3. otherwise `config/config.json` from the process working directory
+4. the file passed with `--config`, when it loads successfully
+5. supported environment-variable overrides
+6. final configuration validation
+
+An explicit `.toml` path is parsed as TOML. Other filename extensions are parsed as JSON. Prefer a
+`.toml` or `.json` suffix so the format is obvious.
+
+```bash
+sockudo --config /etc/sockudo/config.toml
+sockudo --config /etc/sockudo/config.json
+```
+
+Use `--config` to select a non-default path. The `CONFIG_FILE` environment variable present in some
+container environments does not select the file by itself; the published image's default command
+passes it an explicit path.
+
+The current server logs an explicit file read or parse failure and retains the configuration
+resolved before that file. In production, alert on `explicit configuration load failed` and require
+the `explicit configuration applied` log before sending traffic. Validate the file in CI rather
+than relying only on process startup.
+
+Configuration is read at startup. Change it through a rollout or service restart; there is no
+general-purpose hot reload.
+
+## TOML or JSON?
+
+| Format | Prefer it when | Notes |
+| --- | --- | --- |
+| TOML | Humans maintain the file and comments are valuable. | Preferred for bare-metal, VM, and source deployments. |
+| JSON | A chart, control plane, or program generates the file. | Useful for Helm `configJson` and legacy installations; comments are not allowed. |
+| Environment only | A small, single-app deployment uses only supported overrides. | Not every nested policy has an environment equivalent. |
+
+TOML and JSON deserialize into the same `ServerOptions` structure. Missing fields receive code
+defaults; a static file is not merged field-by-field with the auto-discovered file. The selected
+file becomes the complete file-based configuration, then environment overrides are applied.
+
+## Equivalent single-node files
+
+This TOML profile keeps all state in one process and is suitable for a first production-like test,
+not for failover:
+
+```toml
+mode = "production"
+host = "0.0.0.0"
+port = 6001
+debug = false
+max_connections = 20000
+activity_timeout = 120
+shutdown_grace_period = 30
+
+[adapter]
+driver = "local"
+
+[cache]
+driver = "memory"
+
+[queue]
+driver = "memory"
+
+[rate_limiter]
+enabled = true
+driver = "memory"
+
+[metrics]
+enabled = true
+driver = "prometheus"
+host = "0.0.0.0"
+port = 9601
+
+[app_manager]
+driver = "memory"
+
+[app_manager.array]
+[[app_manager.array.apps]]
+id = "example"
+key = "replace-me"
+secret = "replace-me"
+enabled = true
+
+[app_manager.array.apps.policy.limits]
+max_connections = 20000
+max_client_events_per_second = 100
+
+[app_manager.array.apps.policy.features]
+enable_client_messages = false
+enable_user_authentication = true
+
+[app_manager.array.apps.policy.channels]
+allowed_origins = ["https://app.example.com"]
+```
+
+The equivalent JSON is:
+
+```json
+{
+  "mode": "production",
+  "host": "0.0.0.0",
+  "port": 6001,
+  "debug": false,
+  "max_connections": 20000,
+  "activity_timeout": 120,
+  "shutdown_grace_period": 30,
+  "adapter": {
+    "driver": "local"
+  },
+  "cache": {
+    "driver": "memory"
+  },
+  "queue": {
+    "driver": "memory"
+  },
+  "rate_limiter": {
+    "enabled": true,
+    "driver": "memory"
+  },
+  "metrics": {
+    "enabled": true,
+    "driver": "prometheus",
+    "host": "0.0.0.0",
+    "port": 9601
+  },
+  "app_manager": {
+    "driver": "memory",
+    "array": {
+      "apps": [
+        {
+          "id": "example",
+          "key": "replace-me",
+          "secret": "replace-me",
+          "enabled": true,
+          "policy": {
+            "limits": {
+              "max_connections": 20000,
+              "max_client_events_per_second": 100
+            },
+            "features": {
+              "enable_client_messages": false,
+              "enable_user_authentication": true
+            },
+            "channels": {
+              "allowed_origins": ["https://app.example.com"]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Replace the example credentials before use. For a committed production file, remove the entire
+inline app definition and bootstrap the app from a secret-backed environment, or use a persistent
+app manager.
+
+## Clustered Redis profile
+
+The stable structure can remain in TOML:
+
+```toml
+mode = "production"
+host = "0.0.0.0"
+port = 6001
+max_connections = 50000
+shutdown_grace_period = 30
+
+[adapter]
+driver = "redis"
+fallback_to_local = false
+
+[cache]
+driver = "redis"
+
+[queue]
+driver = "redis"
+
+[rate_limiter]
+enabled = true
+driver = "redis"
+
+[app_manager]
+driver = "memory"
+
+[metrics]
+enabled = true
+host = "0.0.0.0"
+port = 9601
+```
+
+Inject the shared address, node identity, and one immutable app at runtime:
+
+```bash
+REDIS_URL=rediss://sockudo@redis.internal:6379/0
+INSTANCE_PROCESS_ID=sockudo-a-01
+SOCKUDO_DEFAULT_APP_ENABLED=true
+SOCKUDO_DEFAULT_APP_ID=production
+SOCKUDO_DEFAULT_APP_KEY=secret-store-value
+SOCKUDO_DEFAULT_APP_SECRET=secret-store-value
+SOCKUDO_DEFAULT_APP_ALLOWED_ORIGINS=https://app.example.com
+```
+
+`REDIS_URL` updates the Redis adapter, cache, queue, and rate limiter connection. Driver selection
+still must be `redis`, either in the file or through `ADAPTER_DRIVER`, `CACHE_DRIVER`,
+`QUEUE_DRIVER`, and `RATE_LIMITER_DRIVER`.
+
+Use a persistent app manager instead of environment bootstrap when operators create, rotate, or
+disable multiple applications without rebuilding the deployment.
+
+## What belongs where
+
+| Setting | Static file | Environment | Secret store |
+| --- | --- | --- | --- |
+| Driver selection and feature gates | Yes | Optional rollout override | No |
+| Nested app/channel policy | Yes, or persistent app manager | Only the documented subset | Credentials only |
+| Retention, buffer, and queue reliability | Yes | Use supported overrides sparingly | No |
+| Per-environment hostnames and ports | Template or generated file | Yes | Only if address contains credentials |
+| App keys and secrets | Avoid in committed files | Inject from secret reference | Yes |
+| Redis, SQL, broker passwords | Avoid | Inject from secret reference | Yes |
+| TLS private keys and push provider keys | File path or credential reference | Path/reference only | Yes |
+
+Do not place secrets in image layers, Helm values committed to Git, Kubernetes ConfigMaps, process
+arguments, or Terraform plan output.
+
+## Environment override behavior
+
+Environment variables are explicit mappings in the Sockudo configuration loader, not a generic
+`SECTION_FIELD=value` translation. The [environment variable reference](/docs/reference/environment-variables)
+is the authoritative list.
+
+Several app-bootstrap variables have deliberate replacement behavior:
+
+- a complete `SOCKUDO_DEFAULT_APP_ID`, `SOCKUDO_DEFAULT_APP_KEY`, and
+  `SOCKUDO_DEFAULT_APP_SECRET` set registers the environment-backed default app
+- `SOCKUDO_DEFAULT_APP_ENABLED=false` disables that registration
+- `SOCKUDO_SKIP_INLINE_APPS=true` skips apps declared inside the file
+- `APP_MANAGER_REGISTER_INLINE_APPS=false` also prevents inline registration
+
+Avoid mixing an inline app and environment bootstrap accidentally. Choose one source for each app
+and confirm the startup messages.
+
+## Container and Kubernetes mounts
+
+Mount a read-only file into the published container and replace the default command:
+
+```bash
+docker run --rm \
+  --mount type=bind,src="$PWD/config.toml",dst=/app/config/production.toml,readonly \
+  ghcr.io/sockudo/sockudo:4.7.0 \
+  sockudo --config /app/config/production.toml
+```
+
+In Kubernetes, mount non-secret structure from a ConfigMap and inject secrets separately:
+
+```yaml
+containers:
+  - name: sockudo
+    args: ["--config", "/etc/sockudo/config.toml"]
+    envFrom:
+      - secretRef:
+          name: sockudo-runtime
+    volumeMounts:
+      - name: config
+        mountPath: /etc/sockudo
+        readOnly: true
+volumes:
+  - name: config
+    configMap:
+      name: sockudo-config
+```
+
+The Helm chart also accepts `configJson` for advanced generated configuration and
+`extraEnvFrom` for Secret or ConfigMap references.
+
+## Validate before rollout
+
+At minimum:
+
+```bash
+taplo check config.toml
+jq empty config.json
+sockudo --config /etc/sockudo/config.toml
+```
+
+For the startup check, use the same binary, features, environment, working directory, and mounted
+secrets as production. Confirm:
+
+- `explicit configuration applied`
+- `Applied environment variable overrides`
+- no `configuration validation failed`
+- `/live` returns success
+- `/up/<app-id>` returns success after shared dependencies are available
+
+Then continue with the [Linux](/docs/deployment/linux),
+[Docker](/docs/deployment/docker), or [Kubernetes](/docs/deployment/kubernetes) guide.

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -177,9 +177,16 @@ id = "app-id"
 key = "app-key"
 secret = "app-secret"
 enabled = true
+
+[app_manager.array.apps.policy.limits]
 max_connections = 10000
+
+[app_manager.array.apps.policy.features]
 enable_client_messages = false
 ```
+
+For exact loading precedence, equivalent JSON, secret injection, and clustered examples, see
+[Static configuration](/docs/deployment/static-configuration).
 
 ## Kubernetes with Helm
 
@@ -193,7 +200,8 @@ helm install sockudo ./charts/sockudo \
   --set serviceMonitor.enabled=true
 ```
 
-Use Kubernetes when you need autoscaling, service monitors, disruption budgets, secret-backed app credentials, and cluster-level rollout controls.
+Use Kubernetes when you need autoscaling, service monitors, disruption budgets, secret-backed app credentials, and cluster-level rollout controls. Continue with the production
+[Kubernetes and Helm guide](/docs/deployment/kubernetes).
 
 ## Verify
 
@@ -202,4 +210,5 @@ curl -f http://127.0.0.1:6001/up
 curl -f http://127.0.0.1:9601/metrics | head
 ```
 
-When health is green, continue with [First connection](/docs/getting-started/first-connection).
+When health is green, continue with [First connection](/docs/getting-started/first-connection). Before
+shipping, follow the [Deployment guide](/docs/deployment).

--- a/docs/content/docs/getting-started/overview.mdx
+++ b/docs/content/docs/getting-started/overview.mdx
@@ -14,7 +14,7 @@ Sockudo has four major surfaces:
 | --- | --- | --- |
 | WebSocket server | Accepts client connections, subscriptions, auth results, presence transitions, and realtime events. | [First connection](/docs/getting-started/first-connection) |
 | HTTP API | Lets trusted backends publish events, inspect channels, read history, mutate messages, and manage push. | [HTTP API](/docs/server/http-api) |
-| Client SDKs | Browser, mobile, desktop, and .NET realtime clients that subscribe and react to events. | [Realtime Clients](/docs/clients) |
+| Client SDKs | Browser, mobile, desktop, .NET, and Python realtime clients that subscribe and react to events. | [Realtime Clients](/docs/clients) |
 | Server SDKs | Backend libraries that sign auth responses, publish events, validate webhooks, and call REST endpoints. | [Server SDKs](/docs/server-sdks) |
 
 ## Pick your path

--- a/docs/content/docs/getting-started/overview.mdx
+++ b/docs/content/docs/getting-started/overview.mdx
@@ -23,7 +23,7 @@ Sockudo has four major surfaces:
 | --- | --- | --- |
 | A Pusher replacement | [Migration](/docs/getting-started/migration) and [Protocol reference](/docs/reference/protocol) | Existing clients connecting through Protocol V1 with unchanged auth and publish semantics. |
 | A new realtime product | [First connection](/docs/getting-started/first-connection) and [Authentication](/docs/getting-started/authentication) | Public, private, and presence channels wired through client and server SDKs. |
-| A clustered production deployment | [Scaling](/docs/server/scaling), [Security](/docs/server/security), and [Observability](/docs/server/observability) | Load-balanced nodes, shared adapter, health probes, metrics, and dependency-specific alerts. |
+| A clustered production deployment | [Deployment](/docs/deployment), [Scaling](/docs/server/scaling), and [Observability](/docs/server/observability) | Load-balanced nodes, shared adapter, health probes, metrics, and dependency-specific alerts. |
 | A durable collaboration or AI workflow | [Protocol V2](/docs/clients/protocol-v2), [History and recovery](/docs/server/history-recovery), and [Mutable messages](/docs/server/mutable-messages) | Serial continuity, message IDs, rewind, annotations, and safe retry behavior. |
 
 ## Protocol modes
@@ -83,4 +83,5 @@ A production deployment usually has:
   <Card title="Connect a client" href="/docs/getting-started/first-connection" description="Subscribe to a channel and publish from a backend." />
   <Card title="Add authentication" href="/docs/getting-started/authentication" description="Private, presence, encrypted, and user authentication." />
   <Card title="Migrate from Pusher" href="/docs/getting-started/migration" description="Compatibility notes and cutover strategy." />
+  <Card title="Deploy to production" href="/docs/deployment" description="Static configuration, Linux, Docker, Kubernetes, cloud platforms, and capacity planning." />
 </Cards>

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -50,7 +50,7 @@ Sockudo is a self-hosted realtime platform for teams that want Pusher-compatible
   <Card title="Connect the first loop" href="/docs/getting-started/first-connection" description="Subscribe from a client, publish from a trusted backend, add idempotency, and confirm metrics move." />
   <Card title="Migrate from Pusher" href="/docs/getting-started/migration" description="Map pusher-js, Laravel Echo, Channels auth, event names, and publish calls onto Sockudo." />
   <Card title="Design Protocol V2 streams" href="/docs/clients/protocol-v2" description="Use message IDs, serial continuity, rewind, deltas, tag filters, annotations, and recovery." />
-  <Card title="Operate a cluster" href="/docs/server/scaling" description="Pick adapters, load balancing strategy, fanout semantics, probes, metrics, and rollout checks." />
+  <Card title="Deploy to production" href="/docs/deployment" description="Choose a topology, configure files and secrets, tune hosts, and deploy on VMs, containers, Kubernetes, or cloud platforms." />
   <Card title="Reference the API" href="/docs/reference/http-endpoints" description="Find every server endpoint for publishing, channel state, history, mutations, annotations, push, and operations." />
 </Cards>
 
@@ -82,7 +82,7 @@ Sockudo sits between realtime clients and trusted backends. Clients hold WebSock
 3. Add private and presence channel auth from [Authentication](/docs/getting-started/authentication).
 4. Choose Protocol V1 or V2 from [Compatibility](/docs/reference/compatibility).
 5. Wire your client from [Realtime Clients](/docs/clients) and your backend from [Server SDKs](/docs/server-sdks).
-6. Harden the deployment with [Scaling](/docs/server/scaling), [Security](/docs/server/security), and [Observability](/docs/server/observability).
+6. Follow the [Deployment guide](/docs/deployment), then harden the runtime with [Scaling](/docs/server/scaling), [Security](/docs/server/security), and [Observability](/docs/server/observability).
 
 ## Developer quick loops
 

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -6,6 +6,7 @@
     "---Start---",
     "getting-started",
     "---Operate---",
+    "deployment",
     "server",
     "---Build---",
     "clients",

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -6,7 +6,10 @@ icon: Settings2
 
 Sockudo's TOML configuration is organized by runtime responsibility.
 
-For deployment overrides and secrets, use the complete [environment variable reference](/docs/reference/environment-variables). It lists every runtime variable parsed by the server and push subsystem.
+For configuration loading order, JSON equivalence, and guidance on what belongs in files,
+environment overrides, or secret stores, see [Static configuration](/docs/deployment/static-configuration).
+The complete [environment variable reference](/docs/reference/environment-variables) lists every
+runtime variable parsed by the server and push subsystem.
 
 ## Top-level
 

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -4,7 +4,15 @@ description: Complete Sockudo runtime environment variable reference.
 icon: Settings2
 ---
 
-Sockudo loads configuration from files first, then applies environment variable overrides. Values are parsed as strings unless the target option is numeric or boolean. Boolean values follow the server parser and accept common true/false forms.
+Sockudo loads configuration from files first, then applies supported environment variable
+overrides. Environment variables are explicit mappings, not a generic alternative syntax for every
+nested TOML or JSON field. Use them for deployment-specific values and secret injection; keep
+complex app policy, retention, queue reliability, and feature structure in a static file or
+persistent manager. See [Static configuration](/docs/deployment/static-configuration) for the full
+precedence and equivalent file examples.
+
+Values are parsed as strings unless the target option is numeric or boolean. Boolean values follow
+the server parser and accept common true/false forms.
 
 This page lists every runtime environment variable referenced by the server, core configuration loader, push subsystem, app managers, adapters, queues, and provider workers.
 

--- a/docs/content/docs/server-sdks/dotnet.mdx
+++ b/docs/content/docs/server-sdks/dotnet.mdx
@@ -33,6 +33,11 @@ var options = new SockudoOptions
 var sockudo = new Sockudo(APP_ID, APP_KEY, APP_SECRET, options);
 ```
 
+Register one `Sockudo` instance as a singleton and reuse it. `Host` overrides
+`Cluster`; `Encrypted` selects HTTPS; `RestClientTimeout` bounds requests; and
+`BatchEventDataSizeLimit` can reject oversized event data before sending it.
+Use HTTPS when the API crosses an untrusted network.
+
 ## Publish
 
 ```csharp
@@ -46,6 +51,36 @@ ITriggerResult result = await sockudo.TriggerAsync(
     }
 ).ConfigureAwait(false);
 ```
+
+Publish to several channels or send a batch:
+
+```csharp
+await sockudo.TriggerAsync(
+    new[] { "tenant-42:orders", "user-7:orders" },
+    "order.updated",
+    new { id = "ord_123", status = "paid" }
+).ConfigureAwait(false);
+
+await sockudo.TriggerAsync(new[]
+{
+    new Event
+    {
+        Channel = "orders",
+        EventName = "order.created",
+        Data = new { id = "ord_124" },
+    },
+    new Event
+    {
+        Channel = "orders",
+        EventName = "order.paid",
+        Data = new { id = "ord_124" },
+    },
+}).ConfigureAwait(false);
+```
+
+Set `TriggerOptions.SocketId` to exclude a sender that already applied the
+change. Use a stable `IdempotencyKey` for every publish that may be retried.
+Set `BatchEventDataSizeLimit` to the server's event-size limit to fail early.
 
 ## Auth
 
@@ -61,6 +96,15 @@ var channelData = new PresenceChannelData
 var presenceAuth = sockudo.Authenticate("presence-lobby", socketId, channelData).ToJson();
 ```
 
+Authentication methods sign a response; your endpoint must first authenticate
+the application session, authorize the exact channel, and derive presence
+identity from trusted state.
+
+For `private-encrypted-*`, set a 32-byte `EncryptionMasterKey` in
+`SockudoOptions`. The SDK encrypts published payloads and derives the channel
+shared secret used during auth. Keep the master key in a secret manager and
+continue to use TLS.
+
 ## State
 
 ```csharp
@@ -70,6 +114,59 @@ var channel = await sockudo.FetchStateForChannelAsync<object>("orders")
 var users = await sockudo.FetchUsersFromPresenceChannelAsync<object>("presence-lobby")
     .ConfigureAwait(false);
 ```
+
+Read bounded history and forward opaque cursors unchanged:
+
+```csharp
+var page = await sockudo.FetchHistoryForChannelAsync<object>(
+    "orders",
+    new { limit = 50, direction = "newest_first" }
+).ConfigureAwait(false);
+
+var presencePage = await sockudo.FetchPresenceHistoryForChannelAsync<object>(
+    "presence-lobby",
+    new { limit = 50, direction = "newest_first" }
+).ConfigureAwait(false);
+
+var snapshot = await sockudo.FetchPresenceSnapshotForChannelAsync<object>(
+    "presence-lobby",
+    new { at_serial = 4 }
+).ConfigureAwait(false);
+```
+
+Application state is an operational snapshot and should not be used as an
+authorization database.
+
+## Webhooks
+
+Preserve the original body and validate before deserializing business data:
+
+```csharp
+var webhook = sockudo.ProcessWebHook(receivedSignature, rawBody);
+if (!webhook.IsValid)
+{
+    return Results.Unauthorized();
+}
+
+await queue.EnqueueAsync(webhook.Events, cancellationToken);
+return Results.Accepted();
+```
+
+Do not normalize or log the raw body or signature. Make downstream processing
+idempotent.
+
+## User connection management
+
+```csharp
+await sockudo.TerminateUserConnectionsAsync("user-42")
+    .ConfigureAwait(false);
+
+await sockudo.ForceReconnectUserAsync("user-42")
+    .ConfigureAwait(false);
+```
+
+Terminate for immediate revocation; force reconnect when clients should obtain
+new auth or routing state.
 
 ## Signed push request
 
@@ -101,3 +198,19 @@ request.Headers.Add("X-Sockudo-Push-Capability", "push-admin");
 ```
 
 Prefer a first-class push helper when available in your SDK version; the signed request shape is the same.
+
+## Errors, retries, and application lifetime
+
+Inspect `ITriggerResult` and `IGetResult<T>` before using response data.
+Validation failures such as `EventDataSizeExceededException` should not be
+retried unchanged. Retry only transient HTTP failures, `429`, and suitable
+server errors with bounded backoff and the original idempotency key.
+
+- Register the SDK client as a singleton and reuse its HTTP resources.
+- Set `RestClientTimeout` below the ASP.NET request or worker deadline.
+- Pass cancellation through surrounding application operations where the SDK
+  overload supports it.
+- Keep credentials, event bodies, signed requests, webhooks, and provider
+  tokens out of logs.
+- Test payload limits, duplicate attempts, webhook retries, credential
+  rotation, and graceful host shutdown.

--- a/docs/content/docs/server-sdks/go.mdx
+++ b/docs/content/docs/server-sdks/go.mdx
@@ -29,13 +29,31 @@ var client = sockudo.Client{
 }
 ```
 
+Reuse the client for the lifetime of the process. Configure a custom
+`http.Client` to set the overall deadline and preserve connection pooling:
+
+```go
+client.HTTPClient = &http.Client{
+    Timeout: 5 * time.Second,
+    Transport: &http.Transport{
+        MaxIdleConns:        100,
+        MaxIdleConnsPerHost: 20,
+        IdleConnTimeout:     90 * time.Second,
+    },
+}
+```
+
+The default client timeout is five seconds. Set `Secure: true` for HTTPS in
+production. `ClientFromURL` and `ClientFromEnv("SOCKUDO_URL")` are convenient,
+but connection URLs contain credentials and must not be logged.
+
 ## Publish
 
 ```go
 data := map[string]string{"id": "ord_123"}
 key := "order-created-ord_123"
 
-err := client.TriggerWithParams(
+_, err := client.TriggerWithParams(
     "orders",
     "order.created",
     data,
@@ -46,11 +64,40 @@ if err != nil {
 }
 ```
 
+Publish the same event to multiple channels with `TriggerMulti`, batch
+independent events with `TriggerBatch`, and exclude an originating socket with
+`TriggerParams.SocketID`:
+
+```go
+socketID := "123.456"
+key := "order-paid:ord_123:v3"
+
+_, err := client.TriggerWithParams(
+    "orders",
+    "order.updated",
+    map[string]string{"id": "ord_123", "status": "paid"},
+    sockudo.TriggerParams{
+        SocketID:       &socketID,
+        IdempotencyKey: &key,
+    },
+)
+if err != nil {
+    return err
+}
+```
+
+Use a stable idempotency key for any publish a worker or HTTP handler may retry.
+Do not generate a new key for each attempt.
+
 ## Auth endpoint
 
 ```go
 func sockudoAuth(res http.ResponseWriter, req *http.Request) {
     params, _ := io.ReadAll(req.Body)
+    if !currentUserCanAccess(req.Context(), requestedChannel(params)) {
+        http.Error(res, "forbidden", http.StatusForbidden)
+        return
+    }
     response, err := client.AuthorizePrivateChannel(params)
     if err != nil {
         http.Error(res, "unauthorized", http.StatusUnauthorized)
@@ -72,6 +119,67 @@ member := sockudo.MemberData{
 
 response, err := client.AuthorizePresenceChannel(params, member)
 ```
+
+The SDK signs the form body; your handler still owns session authentication and
+channel authorization. Populate `MemberData` from trusted application state.
+Use `AuthenticateUser` for user-targeted events, then
+`TerminateUserConnections` or `ForceReconnectUser` when access changes.
+
+## State and history
+
+```go
+prefix := "presence-"
+info := "user_count"
+channels, err := client.Channels(sockudo.ChannelsParams{
+    FilterByPrefix: &prefix,
+    Info:           &info,
+})
+if err != nil {
+    return err
+}
+
+users, err := client.GetChannelUsers("presence-lobby")
+
+limit := 50
+direction := "newest_first"
+page, err := client.ChannelHistory("orders", sockudo.HistoryParams{
+    Limit:     &limit,
+    Direction: &direction,
+})
+```
+
+State is an operational snapshot, not an authorization source. History cursors
+are opaque and must be passed to the next call unchanged.
+
+## Webhooks
+
+Read and preserve the exact body bytes for signature validation:
+
+```go
+body, err := io.ReadAll(req.Body)
+if err != nil {
+    http.Error(res, "invalid body", http.StatusBadRequest)
+    return
+}
+
+webhook, err := client.Webhook(req.Header, body)
+if err != nil {
+    http.Error(res, "invalid signature", http.StatusUnauthorized)
+    return
+}
+
+enqueueWebhookEvents(webhook.Events)
+res.WriteHeader(http.StatusAccepted)
+```
+
+Do not decode the JSON first or log the raw body and signature.
+
+## End-to-end encrypted channels
+
+Set `EncryptionMasterKeyBase64` to a base64-encoded 32-byte key and publish only
+to `private-encrypted-*` names. The server SDK encrypts payloads and produces
+the shared secret during channel auth. Keep the master key in a secret manager
+and do not mix encrypted and unencrypted channels in one logical publish.
 
 ## Push notifications
 
@@ -104,3 +212,19 @@ _ = accepted
 ```
 
 The Go push helpers sign `/push/*` requests and force async publish behavior.
+
+## Errors and production guidance
+
+Every network operation returns an `error`; check it before using the response.
+Retry only transient network errors, `429`, and suitable server failures with
+bounded exponential backoff. Because an HTTP error can be ambiguous after the
+server accepted a request, every retried publish needs an idempotency key.
+
+- Reuse one `Client` and one tuned `http.Client`.
+- Set a timeout below the enclosing request or job deadline.
+- Pass request-scoped cancellation through your own surrounding workflow.
+- Keep credentials, signed URLs, provider tokens, and raw webhook content out
+  of logs.
+- Bound channel-history page sizes and validate all auth endpoint input.
+- Test duplicate attempts, key rotation, network interruption, and graceful
+  worker shutdown.

--- a/docs/content/docs/server-sdks/index.mdx
+++ b/docs/content/docs/server-sdks/index.mdx
@@ -23,6 +23,28 @@ archived/legacy mirrors.
 | .NET | `SockudoServer` | [.NET](/docs/server-sdks/dotnet) |
 | Swift | `Sockudo` via SwiftPM | [Swift](/docs/server-sdks/swift) |
 
+These packages share the Sockudo/Pusher HTTP signing protocol but differ in
+their typed helpers. When a new Sockudo endpoint is not yet wrapped by a
+language SDK, use its generic signed-request helper or generated signed URI
+rather than implementing HMAC signing independently.
+
+## Realtime client or server SDK?
+
+Use a server SDK in a trusted web application, API, worker, or job process. It
+does not maintain a WebSocket subscription. Use a
+[realtime client](/docs/clients) in browsers, mobile apps, desktop apps, or
+backend consumers that need to receive events continuously.
+
+| Task | Realtime client | Server SDK |
+| --- | --- | --- |
+| Subscribe and receive events | Yes | No |
+| Publish application events | Client events only where allowed | Yes |
+| Hold app secret | Never | Yes |
+| Authorize private/presence channels | Calls your backend | Signs the response |
+| Validate webhooks | No | Yes |
+| Query history and application state | Through a trusted proxy | Directly |
+| Manage push credentials and delivery | Through a trusted proxy | Directly |
+
 ## What belongs on the server
 
 - event publishing and batch publishing
@@ -31,6 +53,95 @@ archived/legacy mirrors.
 - webhook signature validation
 - history, versioned messages, annotations, and presence history reads
 - push device registration, channel push subscriptions, provider credentials, publish, scheduling, status, and delivery callbacks
+
+## Configure one reusable client
+
+Every SDK needs the app ID, public key, secret, HTTP host, port, and TLS mode.
+Load credentials from a secret manager or environment at process startup,
+validate them once, and reuse the configured client. Reuse preserves HTTP
+keep-alive pools and avoids per-request setup overhead.
+
+For a typical deployment:
+
+| Setting | Local development | Production |
+| --- | --- | --- |
+| Host | `127.0.0.1` | Internal service DNS or HTTPS API hostname |
+| Port | `6001` | Service port or `443` |
+| TLS | Optional | Required across untrusted networks |
+| Timeout | Short, explicit | Explicit and below the caller's deadline |
+| Credentials | Local test app | Secret manager, scoped per environment |
+
+Do not log connection URLs containing credentials, signed query strings,
+authorization responses, provider tokens, raw webhooks, or encryption keys.
+
+## Publishing model
+
+Use a single publish for one logical event, a multi-channel publish when the
+same event must reach several channels, and a batch when several independent
+events can share one HTTP request. Respect the per-SDK and server limits shown
+in each language guide.
+
+Exclude the originating `socket_id` when the sender has already applied its own
+change optimistically. Attach a stable idempotency key derived from the
+business operation whenever a request may be retried:
+
+```text
+order.created:tenant-42:order-123:version-1
+```
+
+An idempotency key identifies a logical operation, not an HTTP attempt. Reusing
+one key for different payloads can hide a real update.
+
+## Authorization endpoints
+
+A correct private or presence authorization handler performs this sequence:
+
+1. Authenticate the application's user session.
+2. Validate the `socket_id` and requested `channel_name`.
+3. Check tenant and resource access for that exact channel.
+4. Derive presence `user_id` and `user_info` from trusted application data.
+5. Ask the server SDK to sign the response.
+6. Return only the signed response to the client.
+
+Signing is not authorization by itself. Never implement an endpoint that signs
+every requested channel, and never accept presence identity directly from the
+untrusted client.
+
+For `private-encrypted-*`, configure the SDK's encryption master key and return
+the derived channel shared secret. Store and rotate the master key like any
+other high-value application secret.
+
+## Webhook handling
+
+Validate the signature against the exact raw request bytes before JSON
+decoding. Body parsing, whitespace normalization, or character re-encoding can
+change the signed bytes. Return a non-success response for an invalid signature
+and avoid logging the raw body.
+
+After validation, enqueue business processing and acknowledge quickly.
+Webhook handlers should be idempotent because delivery may be retried.
+
+## Errors, timeouts, and retries
+
+Retry only transient transport failures, `429`, and appropriate `5xx`
+responses. Do not retry validation, authentication, or authorization failures
+without changing the request. Use exponential backoff with jitter and a bounded
+attempt count.
+
+Publish retries require an idempotency key. Keep the SDK timeout shorter than
+the enclosing HTTP request or job deadline so the caller has time to handle the
+result. Record status code, operation, latency, and retry count without logging
+credentials or message content.
+
+## State, history, and pagination
+
+Application-state endpoints are operational snapshots, not a transactional
+database. Use them for occupied-channel and presence diagnostics rather than
+authorization decisions.
+
+History and presence history use bounded pages and opaque cursors. Pass cursors
+back unchanged; do not parse or construct them. A client performing a gap-free
+late join should subscribe first and request history through its attach serial.
 
 ## Push as a backend concern
 
@@ -55,3 +166,7 @@ await sockudo.publishPush({
 4. Validate private and presence channel access before signing.
 5. Validate webhook signatures before parsing business logic.
 6. Treat push publish responses as admission records and inspect status asynchronously.
+7. Set explicit connect/request timeouts and bounded retries.
+8. Monitor request latency, response status, rate limits, and webhook failures.
+9. Test credential rotation, duplicate delivery, Sockudo restarts, and network
+   interruption before production rollout.

--- a/docs/content/docs/server-sdks/java.mdx
+++ b/docs/content/docs/server-sdks/java.mdx
@@ -29,16 +29,65 @@ sockudo.setPort(6001);
 sockudo.setEncrypted(false);
 ```
 
+Create one instance and reuse it; the client is thread-safe and keeps a pooled
+HTTP connection manager. You can also configure it from
+`http://key:secret@host:port/apps/app-id`, but that URL contains credentials
+and must not be logged.
+
+Use `setEncrypted(true)` for HTTPS in production. Configure the synchronous or
+asynchronous HTTP client when you need an outbound proxy, connection pool
+limits, or request timeouts.
+
 ## Publish
 
 ```java
 Map<String, Object> data = new HashMap<>();
 data.put("id", "ord_123");
 
-TriggerOptions options = new TriggerOptions();
-options.setIdempotencyKey("order-created-ord_123");
+Result result = sockudo.trigger(
+    "orders",
+    "order.created",
+    data,
+    null,
+    "order-created-ord_123"
+);
+```
 
-sockudo.trigger("orders", "order.created", data, options);
+The SDK also supports multi-channel and batch publishing:
+
+```java
+sockudo.trigger(
+    List.of("tenant-42:orders", "user-7:orders"),
+    "order.updated",
+    Map.of("id", "ord_123", "status", "paid")
+);
+
+List<Event> batch = List.of(
+    new Event("orders", "order.created", Map.of("id", "ord_124")),
+    new Event("orders", "order.paid", Map.of("id", "ord_124"))
+);
+sockudo.trigger(batch);
+```
+
+Use the overload accepting a socket ID to exclude the originating connection.
+The five-argument overload accepts both `socketId` and `idempotencyKey`; each
+batch `Event` can also carry those values. Attach a stable key to any request
+that a job or HTTP handler may retry.
+
+All requests return `Result`. Inspect `getStatus()` and `getMessage()` rather
+than assuming a completed call succeeded:
+
+```java
+Result result = sockudo.trigger(
+    "orders",
+    "order.created",
+    data,
+    null,
+    "order-created-ord_123"
+);
+if (result.getStatus() != Status.SUCCESS) {
+    throw new IllegalStateException("Sockudo publish failed: " + result.getStatus());
+}
 ```
 
 ## Auth
@@ -56,6 +105,11 @@ String presenceAuth = sockudo.authenticate(
 );
 ```
 
+Authenticate the application session and authorize the exact channel before
+signing. Build `PresenceUser` from trusted server-side identity. Use
+`authenticateUser` for user-targeted events, then
+`terminateUserConnections` or `forceReconnectUser` when permissions change.
+
 ## Async
 
 ```java
@@ -66,6 +120,78 @@ async.setPort(6001);
 CompletableFuture<Result> result =
     async.trigger("orders", "order.created", Collections.singletonMap("id", "ord_123"));
 ```
+
+Compose the returned future and handle errors explicitly:
+
+```java
+async.trigger(
+        "orders",
+        "order.created",
+        data,
+        null,
+        "order-created-ord_123"
+    )
+    .thenAccept(response -> recordStatus(response.getStatus()))
+    .exceptionally(error -> {
+        scheduleRetry(operationId, error);
+        return null;
+    });
+```
+
+Tune the async client rather than blocking on every future. Async execution is
+not a durable queue; persist work separately when it must survive process
+failure.
+
+## State and history
+
+```java
+Result channels = sockudo.get(
+    "/channels",
+    Map.of("filter_by_prefix", "presence-", "info", "user_count")
+);
+Result users = sockudo.get("/channels/presence-lobby/users");
+
+Result page = sockudo.getChannelHistory(
+    "orders",
+    Map.of("limit", "50", "direction", "newest_first")
+);
+Result next = sockudo.getChannelHistory(
+    "orders",
+    Map.of("cursor", opaqueCursor)
+);
+```
+
+Presence history and snapshots have corresponding helpers. State is an
+operational snapshot; keep pages bounded and forward cursors unchanged.
+
+## Webhooks
+
+Validate the signature against the exact raw body before parsing:
+
+```java
+Validity validity = sockudo.validateWebhookSignature(
+    xPusherKey,
+    xPusherSignature,
+    rawBody
+);
+if (validity != Validity.VALID) {
+    throw new SecurityException("invalid Sockudo webhook");
+}
+
+Webhook webhook = sockudo.parseWebhook(rawBody);
+enqueueWebhookEvents(webhook.getEvents());
+```
+
+The parser preserves unknown event names and fields for forward compatibility.
+Do not log the raw body or signature.
+
+## End-to-end encrypted channels
+
+Pass a base64-encoded 32-byte encryption master key to the SDK constructor and
+publish only to `private-encrypted-*` names. The SDK encrypts the payload and
+derives the shared secret returned during auth. Do not mix encrypted and
+unencrypted channels in one publish, and keep the master key in a secret
+manager.
 
 ## Push notifications
 
@@ -96,3 +222,22 @@ sockudo.publishPush(request);
 ```
 
 Push helpers set `sync` to `false` and include the required Sockudo push capability header.
+
+## Concurrency, errors, and production guidance
+
+The synchronous client is thread-safe. Its default connection pool is small;
+increase `PoolingHttpClientConnectionManager.setDefaultMaxPerRoute` for
+high-concurrency services and set explicit timeouts.
+
+Retry only transient network errors, `429`, and suitable server failures with
+bounded exponential backoff. A retried publish must retain its original
+idempotency key. Authentication and validation errors require a request or
+configuration change.
+
+- Reuse the sync or async client.
+- Keep the SDK deadline shorter than the caller's deadline.
+- Validate and rate-limit auth/history endpoints.
+- Keep credentials, signed URIs, raw webhooks, payloads, and provider tokens
+  out of logs.
+- Test connection-pool saturation, duplicate attempts, credential rotation,
+  and graceful application shutdown.

--- a/docs/content/docs/server-sdks/node.mdx
+++ b/docs/content/docs/server-sdks/node.mdx
@@ -30,6 +30,27 @@ const sockudo = new Sockudo({
 });
 ```
 
+The package supports Node.js 16+ and ships TypeScript declarations. Create one
+instance at application startup and reuse it so HTTP connections can be pooled.
+
+| Option | Meaning | Typical production value |
+| --- | --- | --- |
+| `host` | HTTP API host without a scheme | Internal service DNS or API hostname |
+| `port` | HTTP API port | Service port or `443` |
+| `useTLS` | Use HTTPS | `true` outside a trusted local network |
+| `timeout` | Request timeout in milliseconds | Lower than the route or job deadline |
+| `agent` | Custom Node HTTP(S) agent | Keep-alive, proxy, and pool settings |
+
+You can also parse a connection URL:
+
+```ts
+const sockudo = Sockudo.forURL(
+  "https://app-key:app-secret@realtime-api.example.com/apps/app-id",
+);
+```
+
+Keep that URL in a secret manager and never write it to logs.
+
 ## Publish
 
 ```ts
@@ -42,6 +63,27 @@ await sockudo.triggerBatch([
   { channel: "orders", name: "order.paid", data: { id: "ord_124" } },
 ]);
 ```
+
+Publish the same event to several channels with an array, and exclude an
+originating socket when the sender already updated optimistically:
+
+```ts
+await sockudo.trigger(
+  ["tenant-42:orders", "user-7:orders"],
+  "order.updated",
+  { id: "ord_124", status: "paid" },
+  {
+    socket_id: "123.456",
+    idempotency_key: "order-paid:ord_124:v3",
+  },
+);
+```
+
+A multi-channel publish supports up to 100 channels; a batch supports up to 10
+events. Use a stable idempotency key for every publish that a queue worker or
+HTTP handler may retry. Passing `idempotency_key: true` asks the SDK to generate
+a UUID, but a business-derived key is better when separate attempts may run in
+different processes.
 
 ## Auth
 
@@ -61,6 +103,54 @@ app.post("/sockudo/auth", express.urlencoded({ extended: false }), (req, res) =>
 });
 ```
 
+Call application authorization before `authorizeChannel`; signing alone grants
+access. For user-targeted events, expose a separate authenticated endpoint:
+
+```ts
+app.post("/sockudo/user-auth", express.urlencoded({ extended: false }), (req, res) => {
+  const user = requireUser(req);
+  res.json(sockudo.authenticateUser(req.body.socket_id, {
+    id: user.id,
+    user_info: { name: user.name },
+  }));
+});
+```
+
+Disconnect or force reconnect all sockets for a compromised or changed user:
+
+```ts
+await sockudo.terminateUserConnections("user-42");
+await sockudo.forceReconnectUser("user-42");
+```
+
+## Webhooks
+
+Signature verification requires the exact raw body. In Express, install a raw
+parser on the webhook route before a global JSON parser consumes it:
+
+```ts
+app.post(
+  "/sockudo/webhook",
+  express.raw({ type: "application/json" }),
+  (req, res) => {
+    const webhook = sockudo.webhook({
+      rawBody: req.body.toString(),
+      headers: req.headers,
+    });
+
+    if (!webhook.isValid()) {
+      return res.status(401).send("invalid signature");
+    }
+
+    enqueueWebhookEvents(webhook.getEvents());
+    return res.sendStatus(202);
+  },
+);
+```
+
+During credential rotation, `isValid()` can accept additional old key/secret
+pairs for a bounded overlap window. Do not log the raw webhook or signature.
+
 ## State and history
 
 ```ts
@@ -71,6 +161,10 @@ const history = await sockudo.channelHistory("orders", {
   direction: "newest_first",
 });
 ```
+
+State queries describe current occupancy and should not be used as an
+authorization database. History cursors are opaque: pass `next_cursor` back to
+the next call unchanged and bound each page.
 
 ## Push notifications
 
@@ -102,3 +196,29 @@ const status = await sockudo.getPublishStatus(accepted.publish_id);
 ```
 
 Push helpers force async delivery with `sync: false` for production-safe fanout.
+
+## Errors, retries, and shutdown
+
+HTTP failures reject with `RequestError`, which exposes a status code for
+classification. Retry transient network errors, `429`, and suitable `5xx`
+responses with bounded backoff; do not retry `401`, `403`, or invalid payloads
+unchanged.
+
+```ts
+try {
+  await sockudo.trigger("orders", "order.created", payload, {
+    idempotency_key: operationId,
+  });
+} catch (error) {
+  if (error instanceof Sockudo.RequestError && error.statusCode === 429) {
+    await retryLater(operationId);
+  } else {
+    throw error;
+  }
+}
+```
+
+Reuse the client instead of constructing it per request, set a timeout below
+the caller's deadline, and drain application jobs during graceful shutdown.
+Never log `error.url` or `error.body` without redaction because they can contain
+signed parameters or application data.

--- a/docs/content/docs/server-sdks/php.mdx
+++ b/docs/content/docs/server-sdks/php.mdx
@@ -25,6 +25,29 @@ $sockudo = new Sockudo([
 ]);
 ```
 
+Create the client once in your framework service container and reuse it. The
+important options are:
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `host` | `127.0.0.1` | Sockudo HTTP API host |
+| `port` | `6001` | HTTP API port |
+| `useTLS` / `scheme` | `false` / `http` | Select HTTPS in production |
+| `timeout` | `30` seconds | Bound each request |
+| `path` | none | Optional reverse-proxy path prefix |
+
+Inject a configured Guzzle client when you need keep-alive, proxy, middleware,
+or retry policy:
+
+```php
+$http = new GuzzleHttp\Client([
+    'timeout' => 5.0,
+    'connect_timeout' => 2.0,
+]);
+
+$sockudo = new Sockudo($config, $http);
+```
+
 ## Publish
 
 ```php
@@ -38,6 +61,26 @@ $sockudo->triggerBatch([
 ]);
 ```
 
+Publish the same event to multiple channels with an array, and exclude the
+originating connection when it already applied the change:
+
+```php
+$sockudo->trigger(
+    ['tenant-42:orders', 'user-7:orders'],
+    'order.updated',
+    ['id' => 'ord_123', 'status' => 'paid'],
+    [
+        'socket_id' => '123.456',
+        'idempotency_key' => 'order-paid:ord_123:v3',
+    ],
+);
+```
+
+A batch accepts up to 10 events. Use `triggerAsync` or `triggerBatchAsync` when
+the surrounding runtime can compose Guzzle promises; calling `wait()` makes the
+operation synchronous again. Every retryable publish needs a stable,
+business-derived idempotency key.
+
 ## Auth
 
 ```php
@@ -50,6 +93,49 @@ $presence = $sockudo->authorizePresenceChannel(
     ['name' => 'Ada']
 );
 ```
+
+These methods sign a response; they do not decide whether a user may access a
+channel. Authenticate the session, validate the exact channel, and derive
+presence identity before calling them. Use `authenticateUser` for
+user-targeted events and `forceReconnectUser` when a user's permissions change.
+
+## Webhooks
+
+Pass the exact request headers and raw body to the SDK before JSON decoding:
+
+```php
+try {
+    $webhook = $sockudo->webhook($requestHeaders, $rawBody);
+    foreach ($webhook->get_events() as $event) {
+        enqueueWebhookEvent($event);
+    }
+} catch (\Sockudo\SockudoException $error) {
+    return response('invalid signature', 401);
+}
+```
+
+Signature failure throws. Do not normalize or log the body before validation.
+
+## State and history
+
+```php
+$channels = $sockudo->getChannels([
+    'filter_by_prefix' => 'presence-',
+    'info' => 'user_count',
+]);
+$users = $sockudo->getPresenceUsers('presence-lobby');
+
+$page = $sockudo->getChannelHistory('orders', [
+    'limit' => 50,
+    'direction' => 'newest_first',
+]);
+$next = $sockudo->getChannelHistory('orders', [
+    'cursor' => $page->next_cursor,
+]);
+```
+
+Treat application state as an operational snapshot. Keep history pages bounded
+and pass cursors back unchanged.
 
 ## Laravel broadcasting
 
@@ -67,6 +153,10 @@ $presence = $sockudo->authorizePresenceChannel(
     ],
 ],
 ```
+
+Store these values in Laravel's environment/secret configuration and enable
+TLS when the HTTP API crosses an untrusted network. Laravel broadcasting still
+uses your application authorization routes for private and presence channels.
 
 ## Push notifications
 
@@ -99,3 +189,21 @@ $status = $sockudo->getPublishStatus($accepted->publish_id);
 ```
 
 Push publishing is asynchronous by default. Use status APIs and provider callbacks for delivery diagnostics.
+
+## Logging, errors, and retries
+
+The client implements `Psr\Log\LoggerAwareInterface`, so attach the
+application's PSR-3 logger with `setLogger()`. Do not log request bodies,
+provider tokens, signed URLs, or credentials.
+
+Catch `ApiErrorException` for non-success API responses and
+`SockudoException` for SDK validation/configuration failures. Retry only
+transient network failures, `429`, and suitable `5xx` responses with bounded
+backoff. Retried publishes must retain their original idempotency key.
+
+- Reuse the SDK and Guzzle clients from the service container.
+- Keep the SDK timeout below the PHP request or queue-job timeout.
+- Move large batches and push fanout to queue workers.
+- Rate-limit and authorize auth/history endpoints.
+- Test duplicate attempts, queue retries, credential rotation, and worker
+  shutdown.

--- a/docs/content/docs/server-sdks/python.mdx
+++ b/docs/content/docs/server-sdks/python.mdx
@@ -4,6 +4,11 @@ description: Use the Python sync or async SDK for publishing, auth, history, ann
 icon: FileCode
 ---
 
+`sockudo-http-python` is the trusted HTTP SDK for APIs, workers, and web
+frameworks. It publishes and signs requests; it does not maintain a WebSocket
+subscription. Use [`sockudo-python`](/docs/clients/python) for an asyncio
+realtime consumer.
+
 ## Install
 
 ```bash
@@ -23,6 +28,21 @@ sockudo = Sockudo(
 )
 ```
 
+The package supports Python 3.9+. Create one client per process, reuse its
+HTTP pool, and close it during shutdown. Important options are:
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `timeout` | `4.0` seconds | Bound each HTTP operation |
+| `max_retries` | `3` | Retry eligible network/server failures |
+| `retry_base_delay` | `0.1` seconds | Base for retry backoff |
+| `auto_idempotency` | `False` | Generate keys when the caller omits one |
+| `http2` | `True` | Allow HTTP/2 where supported |
+| `verify_tls` | `True` | Verify the server certificate or use a CA bundle |
+
+Use `use_tls=True` in production. Do not disable certificate verification to
+work around a deployment problem.
+
 ## Publish
 
 ```python
@@ -35,6 +55,28 @@ sockudo.trigger(
     TriggerOptions(idempotency_key="order-created-ord_123"),
 )
 ```
+
+Inspect the returned `Result` rather than assuming a non-throwing call
+succeeded:
+
+```python
+result = sockudo.trigger(
+    ["tenant-42:orders", "user-7:orders"],
+    "order.updated",
+    {"id": "ord_123", "status": "paid"},
+    TriggerOptions(
+        socket_id="123.456",
+        idempotency_key="order-paid:ord_123:v3",
+    ),
+)
+
+if not result.ok:
+    raise RuntimeError(f"Sockudo publish failed: {result.status}")
+```
+
+Use batch publishing for independent events that can share one request. A
+business-derived idempotency key is preferable to auto-generation when
+separate workers may retry the same logical operation.
 
 ## Async
 
@@ -49,6 +91,11 @@ async with AsyncSockudo(
 ) as sockudo:
     await sockudo.trigger("orders", "order.created", {"id": "ord_123"})
 ```
+
+Use the synchronous client in traditional WSGI code and `AsyncSockudo` in
+ASGI/asyncio code. Do not call the synchronous client directly on an event
+loop. The context manager closes `httpx` resources; call `sockudo.close()` for a
+long-lived synchronous instance during process shutdown.
 
 ## Auth
 
@@ -65,6 +112,38 @@ presence_body = sockudo.authenticate(
 
 user_body = sockudo.authenticate_user("123.456", {"id": "user-42"})
 ```
+
+Authentication helpers only produce signatures. Your route must first
+authenticate the application session and authorize the exact channel. Derive
+presence and user identity from trusted server-side data.
+
+Configure `encryption_master_key_base64` to authorize and publish to
+`private-encrypted-*` channels. Keep that key in a secret manager and never
+return it to a client; the SDK returns only the derived shared secret.
+
+## State, user controls, and pagination
+
+```python
+from sockudo_http_python import ChannelsParams, PresenceHistoryParams
+
+channels = sockudo.list_channels(
+    ChannelsParams(
+        filter_by_prefix="presence-",
+        info=["subscription_count", "user_count"],
+    )
+)
+users = sockudo.get_channel_users("presence-lobby")
+presence_page = sockudo.get_channel_presence_history(
+    "presence-lobby",
+    PresenceHistoryParams(limit=50, direction="newest_first"),
+)
+
+sockudo.terminate_user_connections("user-42")
+sockudo.force_reconnect_user("user-42")
+```
+
+Treat state as an operational snapshot. Pass history cursors back unchanged and
+keep pages bounded.
 
 ## History and annotations
 
@@ -85,6 +164,37 @@ sockudo.publish_annotation(
     ),
 )
 ```
+
+Versioned update, append, and delete operations should use stable operation
+identities in the surrounding workflow. Preserve message and version serial
+order in downstream state. Annotation names and client IDs are application
+data; authorize them before publishing.
+
+## Webhooks
+
+Validate the signature against the exact raw request bytes before decoding
+JSON:
+
+```python
+validity = sockudo.validate_webhook_signature(
+    request.headers["X-Pusher-Key"],
+    request.headers["X-Pusher-Signature"],
+    raw_body,
+)
+
+if validity.value != "valid":
+    raise PermissionError("invalid Sockudo webhook")
+
+webhook = sockudo.parse_webhook(
+    request.headers["X-Pusher-Key"],
+    request.headers["X-Pusher-Signature"],
+    raw_body,
+)
+enqueue_events(webhook.events)
+```
+
+Configure your framework route so middleware does not replace or normalize the
+raw body before validation. Do not log the raw body or signature.
 
 ## Push notifications
 
@@ -118,3 +228,19 @@ sockudo.list_channel_push_subscriptions(PushSubscriptionParams(device_id="androi
 ```
 
 Push helper methods force `sync = False` and return the API result for status inspection.
+
+## Errors and production guidance
+
+Ordinary HTTP operations return `Result` with `Status.SUCCESS`,
+`CLIENT_ERROR`, `AUTHENTICATION_ERROR`, `SERVER_ERROR`, or `NETWORK_ERROR`.
+Only retry when `result.status.should_retry()` is true, or when your policy
+explicitly handles `429`. Retried publishes must carry an idempotency key.
+
+- Reuse the sync or async client and close it cleanly.
+- Keep the SDK timeout shorter than the request or job deadline.
+- Use a trusted CA bundle through `verify_tls` for private PKI.
+- Keep app secrets, signed URLs, webhook bodies, and provider tokens out of
+  logs.
+- Rate-limit auth and history proxy routes.
+- Test duplicate publish attempts, token/key rotation, network interruption,
+  and graceful worker shutdown.

--- a/docs/content/docs/server-sdks/ruby.mdx
+++ b/docs/content/docs/server-sdks/ruby.mdx
@@ -35,6 +35,14 @@ sockudo = Sockudo::Client.new(
 )
 ```
 
+Create one client in an initializer and reuse it. `use_tls` defaults to `true`;
+a custom `port` takes precedence. You can also load
+`SOCKUDO_URL=http://KEY:SECRET@HOST:PORT/apps/APP_ID` with
+`Sockudo::Client.from_env`, but treat the full URL as a secret and never log it.
+
+For applications behind an outbound proxy, configure `Sockudo.http_proxy`.
+Keep the SDK request timeout below the Rails request or job deadline.
+
 ## Publish
 
 ```ruby
@@ -51,6 +59,24 @@ sockudo.trigger_batch([
 ])
 ```
 
+Publish the same event to several channels with an array and exclude an
+originating connection when it already applied the update:
+
+```ruby
+sockudo.trigger(
+  ["tenant-42:orders", "user-7:orders"],
+  "order.updated",
+  { id: "ord_123", status: "paid" },
+  {
+    socket_id: "123.456",
+    idempotency_key: "order-paid:ord_123:v3"
+  }
+)
+```
+
+Multi-channel and batch calls accept up to 10 entries. Use a stable
+idempotency key for every publish that Active Job or another worker may retry.
+
 ## Auth
 
 ```ruby
@@ -64,6 +90,14 @@ presence_auth = sockudo.authenticate(
 )
 ```
 
+Signing is the last step of authorization. Authenticate the application
+session, validate the exact requested channel, and derive `user_id` from
+trusted server-side state before calling `authenticate`.
+
+Use `authenticate_user` for user-targeted events. When access changes,
+`terminate_user_connections` disconnects a user immediately and
+`force_reconnect_user` closes sockets with a reconnect instruction.
+
 ## Webhooks
 
 ```ruby
@@ -76,6 +110,58 @@ else
   head :unauthorized
 end
 ```
+
+Build the webhook from the original `Rack::Request` so validation sees the raw
+body and headers. Validate before processing, enqueue the events, and return
+quickly. Do not log the request body or signature.
+
+## State and history
+
+```ruby
+channels = sockudo.channels(filter_by_prefix: "presence-")
+info = sockudo.channel_info("presence-lobby", info: "user_count")
+users = sockudo.channel_users("presence-lobby")
+
+page = sockudo.channel_history(
+  "orders",
+  limit: 50,
+  direction: "newest_first"
+)
+next_page = sockudo.channel_history("orders", cursor: page[:next_cursor])
+
+presence_page = sockudo.channel_presence_history(
+  "presence-lobby",
+  limit: 50
+)
+snapshot = sockudo.channel_presence_snapshot(
+  "presence-lobby",
+  at_serial: 4
+)
+```
+
+State is an operational snapshot. Keep history pages bounded and pass opaque
+cursors back unchanged.
+
+## Async requests
+
+`trigger_async` and `get_async` use EventMachine when its reactor is active and
+otherwise return a threaded `HTTPClient::Connection` immediately:
+
+```ruby
+sockudo.trigger_async(
+  "orders",
+  "order.created",
+  { id: "ord_123" },
+  { idempotency_key: "order-created:ord_123" }
+).callback do
+  Rails.logger.info("sockudo publish accepted")
+end.errback do |error|
+  retry_publish_later(error)
+end
+```
+
+Use background jobs for work that must outlive a web request; an async method
+alone is not a durable queue.
 
 ## Push notifications
 
@@ -106,3 +192,36 @@ status = sockudo.get_publish_status(accepted[:publish_id])
 ```
 
 Use Rails jobs for push fanout workflows that also touch your product database.
+
+## Errors, logging, and retries
+
+All errors inherit from `Sockudo::Error`:
+
+```ruby
+begin
+  sockudo.trigger(
+    "orders",
+    "order.created",
+    payload,
+    idempotency_key: operation_id
+  )
+rescue Sockudo::AuthenticationError
+  # Fix credentials; do not retry unchanged.
+rescue Sockudo::HTTPError => error
+  retry_publish_later(error)
+rescue Sockudo::Error => error
+  report_sdk_error(error)
+end
+```
+
+Set `Sockudo.logger = Rails.logger` to use the application logger, but redact
+credentials, signed URLs, provider tokens, and event content. Retry only
+transient network failures, `429`, and suitable `5xx` responses with bounded
+backoff and the original idempotency key.
+
+- Reuse the client from a Rails initializer.
+- Keep request deadlines shorter than the web or job timeout.
+- Authorize and rate-limit auth/history endpoints.
+- Use jobs for fanout and push workflows.
+- Test duplicate delivery, credential rotation, webhook retries, and worker
+  shutdown.

--- a/docs/content/docs/server-sdks/rust.mdx
+++ b/docs/content/docs/server-sdks/rust.mdx
@@ -10,13 +10,13 @@ icon: FileCode
 [dependencies]
 sockudo-http = "2.1.0"
 tokio = { version = "1", features = ["full"] }
-serde_json = "1"
+sonic-rs = "0.5"
 ```
 
 ## Configure
 
 ```rust
-use sockudo_http::{Config, Pusher};
+use sockudo_http::{Config, Sockudo};
 
 let config = Config::builder()
     .app_id("app-id")
@@ -27,14 +27,22 @@ let config = Config::builder()
     .use_tls(false)
     .build()?;
 
-let sockudo = Pusher::new(config)?;
+let sockudo = Sockudo::new(config)?;
 ```
+
+The default TLS backend is rustls and encryption support is enabled by default.
+Create one `Sockudo` value at startup and share it with application state; its
+HTTP client is designed for reuse.
+
+Important builder options include `timeout`, `pool_max_idle_per_host`,
+`enable_retry`, and `max_retries`. Use TLS outside local development and set
+the SDK timeout below the surrounding request or job deadline.
 
 ## Publish
 
 ```rust
 use sockudo_http::{events::TriggerParams, Channel};
-use serde_json::json;
+use sonic_rs::json;
 
 let channels = vec![Channel::from_string("orders")?];
 let params = TriggerParams::builder()
@@ -46,10 +54,33 @@ sockudo
     .await?;
 ```
 
+Exclude an originating socket and attach a stable idempotency key with
+`TriggerParams`:
+
+```rust
+let params = TriggerParams::builder()
+    .socket_id("123.456")
+    .idempotency_key("order-paid:ord_123:v3")
+    .build();
+
+sockudo
+    .trigger(
+        &channels,
+        "order.updated",
+        json!({ "id": "ord_123", "status": "paid" }),
+        Some(params),
+    )
+    .await?;
+```
+
+Use a business-derived idempotency key for any operation that may be retried.
+Do not generate a new key on each attempt.
+
 ## Batch and tags
 
 ```rust
 use sockudo_http::events::BatchEvent;
+use sonic_rs::json;
 use std::collections::HashMap;
 
 let mut tags = HashMap::new();
@@ -61,10 +92,109 @@ let event = BatchEvent::new("order.created", "orders", json!({ "id": "ord_124" }
 sockudo.trigger_batch(vec![event]).await?;
 ```
 
+Tags are strings and require server-side tag filtering to be enabled. Avoid
+putting secrets or high-cardinality unbounded data in tags.
+
+## Channel and user authentication
+
+Perform application authorization before asking the SDK to sign:
+
+```rust
+use sockudo_http::{Channel, SockudoError};
+use sonic_rs::json;
+
+fn authorize_private(
+    sockudo: &Sockudo,
+    socket_id: &str,
+    channel_name: &str,
+) -> Result<sockudo_http::SocketAuth, SockudoError> {
+    let channel = Channel::from_string(channel_name)?;
+    sockudo.authorize_channel(socket_id, &channel, None)
+}
+
+let presence = Channel::from_string("presence-lobby")?;
+let member = json!({
+    "user_id": "user-42",
+    "user_info": { "name": "Ada" }
+});
+let auth = sockudo.authorize_channel("123.456", &presence, Some(&member))?;
+```
+
+The HTTP handler must derive channel access and presence identity from its
+authenticated session. For user-targeted events, use `authenticate_user` and
+`send_to_user`; use `terminate_user_connections` or `force_reconnect_user`
+when access changes.
+
+## History and pagination
+
+```rust
+use sockudo_http::HistoryParams;
+
+let page = sockudo
+    .channel_history_with_name(
+        "orders",
+        Some(&HistoryParams {
+            limit: Some(50),
+            direction: Some("newest_first".to_owned()),
+            ..Default::default()
+        }),
+    )
+    .await?;
+
+if let Some(cursor) = page.next_cursor {
+    let next_page = sockudo
+        .channel_history_with_name(
+            "orders",
+            Some(&HistoryParams {
+                cursor: Some(cursor),
+                ..Default::default()
+            }),
+        )
+        .await?;
+    process_history(next_page)?;
+}
+```
+
+Keep pages bounded and treat the cursor as opaque. Presence history and
+snapshots use the corresponding typed parameter structs.
+
+## Webhooks
+
+Validate the signature against the unchanged request body before processing
+events:
+
+```rust
+use std::collections::BTreeMap;
+
+fn verified_events(
+    sockudo: &Sockudo,
+    headers: &BTreeMap<String, String>,
+    raw_body: &str,
+) -> Result<Vec<sockudo_http::WebhookEvent>, SockudoError> {
+    let webhook = sockudo.webhook(headers, raw_body);
+    if !webhook.is_valid(None) {
+        return Err(SockudoError::Validation {
+            message: "invalid webhook signature".to_owned(),
+        });
+    }
+    Ok(webhook.get_events()?)
+}
+```
+
+Do not deserialize, normalize, or log the body before verification. Enqueue
+validated events and acknowledge quickly.
+
+## End-to-end encrypted channels
+
+Set `encryption_master_key_base64` on the config builder and publish to a
+`private-encrypted-*` channel. The SDK encrypts the event and returns a derived
+shared secret during channel auth. Keep the 32-byte master key in a secret
+manager and continue to use TLS.
+
 ## Push notifications
 
 ```rust
-use serde_json::json;
+use sonic_rs::json;
 
 sockudo.activate_device(&json!({
     "deviceId": "ios-device-1",
@@ -90,3 +220,28 @@ let response = sockudo.publish_push(&json!({
 ```
 
 Use Rust SDK push helpers for backend services that already own transactional state and need typed error handling around notification fanout.
+
+## Errors, retries, and graceful shutdown
+
+All fallible methods return `Result<T, SockudoError>`. Match the error category
+when policy differs:
+
+```rust
+match sockudo
+    .trigger(&channels, "order.created", payload, Some(params))
+    .await
+{
+    Ok(response) => record_status(response.status()),
+    Err(SockudoError::Request(error)) => schedule_retry(error)?,
+    Err(SockudoError::Validation { message }) => {
+        tracing::warn!(error = %message, "sockudo publish rejected");
+    }
+    Err(error) => return Err(error),
+}
+```
+
+Retries must be bounded and use an idempotency key. Share the SDK client rather
+than constructing it per request, do not hold application locks across
+`.await`, and use your service's cancellation mechanism to stop accepting new
+jobs before shutdown. Never log signed URLs, app secrets, event payloads, or
+raw webhook content.

--- a/docs/content/docs/server-sdks/swift.mdx
+++ b/docs/content/docs/server-sdks/swift.mdx
@@ -17,6 +17,10 @@ the `v2.1.0` Git tag and the mirror repository's root `Package.swift` manifest:
 .product(name: "Sockudo", package: "sockudo-http-swift")
 ```
 
+The package manifest supports Swift 5.3+, iOS 13+, macOS 10.15+, tvOS 13+, and watchOS
+6+. It also exports a `Pusher` compatibility product for existing integrations;
+new code should use `Sockudo`.
+
 ## Configure
 
 ```swift
@@ -27,9 +31,15 @@ let sockudo = Sockudo(options: try SockudoClientOptions(
     key: "app-key",
     secret: "app-secret",
     host: "127.0.0.1",
-    port: 6001
+    port: 6001,
+    useTLS: false
 ))
 ```
+
+`useTLS` defaults to `true`. Keep it enabled in production and use an HTTPS API
+hostname. Construct the client once in service/application state and reuse it.
+Initializers validate options and throw; propagate or handle those errors
+instead of using `try!`.
 
 ## Publish
 
@@ -51,6 +61,42 @@ sockudo.trigger(event: event) { result in
 }
 ```
 
+Publish to multiple channels or batch independent events:
+
+```swift
+let multi = try Event(
+    name: "order.updated",
+    data: ["id": "ord_123", "status": "paid"],
+    channels: [
+        Channel(name: "tenant-42:orders", type: .public),
+        Channel(name: "user-7:orders", type: .public),
+    ],
+    idempotencyKey: "order-paid:ord_123:v3"
+)
+
+let created = try Event(
+    name: "order.created",
+    data: ["id": "ord_124"],
+    channel: Channel(name: "orders", type: .public)
+)
+let paid = try Event(
+    name: "order.paid",
+    data: ["id": "ord_124"],
+    channel: Channel(name: "orders", type: .public)
+)
+
+sockudo.trigger(event: multi) { result in
+    handlePublishResult(result)
+}
+sockudo.trigger(events: [created, paid]) { result in
+    handlePublishResult(result)
+}
+```
+
+Use an event's `socketId` to exclude the originating connection. Batches accept
+up to 10 events. Any publish that may be retried needs a stable
+business-derived idempotency key.
+
 ## Auth
 
 ```swift
@@ -67,6 +113,81 @@ sockudo.authenticate(channel: presenceChannel, socketId: "123.456", userData: us
     print(result)
 }
 ```
+
+The SDK signs after your handler authenticates the session and authorizes the
+exact channel. Derive presence identity from trusted application state. Use
+`authenticateUser` for user-targeted events.
+
+## Webhooks
+
+Pass the original request to `verifyWebhook` before processing its body:
+
+```swift
+sockudo.verifyWebhook(request: receivedRequest) { result in
+    switch result {
+    case .success(let webhook):
+        enqueue(events: webhook.events)
+    case .failure:
+        rejectWebhook()
+    }
+}
+```
+
+Do not deserialize, normalize, or log the raw body before signature
+verification. Make downstream processing idempotent.
+
+## State and history
+
+```swift
+sockudo.channels(
+    withFilter: .presence,
+    attributeOptions: .userCount
+) { result in
+    handleChannels(result)
+}
+
+let orders = Channel(name: "orders", type: .public)
+sockudo.history(
+    for: orders,
+    options: .init(limit: 50, direction: "newest_first")
+) { result in
+    handleHistory(result)
+}
+
+let presence = Channel(name: "lobby", type: .presence)
+sockudo.presenceSnapshot(
+    for: presence,
+    options: .init(atSerial: 4)
+) { result in
+    handleSnapshot(result)
+}
+```
+
+Current state is an operational snapshot. Bound history pages and pass opaque
+cursors back unchanged.
+
+## End-to-end encrypted channels
+
+Pass a base64-encoded 32-byte `encryptionMasterKey` in
+`SockudoClientOptions`, then use a channel with type `.encrypted`. The SDK
+encrypts payloads and derives the auth shared secret. A single event cannot mix
+encrypted and unencrypted channels. Keep the master key in a secret manager
+and continue to use TLS.
+
+## User connection management
+
+```swift
+sockudo.terminateUserConnections(userId: "user-42") { result in
+    handleUserControl(result)
+}
+
+sockudo.forceReconnectUser(userId: "user-42") { result in
+    handleUserControl(result)
+}
+```
+
+Terminate for immediate revocation; force reconnect when the user should
+obtain refreshed auth or routing state.
 
 ## Push notifications
 
@@ -101,3 +222,19 @@ sockudo.publishPush(request: [
 ```
 
 Use Swift server SDKs in trusted services, not inside untrusted client apps with app secrets.
+
+## Errors, concurrency, and production guidance
+
+Every asynchronous operation completes with `Result`. Handle both cases and
+avoid force-unwrapping or `try!` in production. Retry only transient transport
+errors, `429`, and suitable server responses with bounded backoff. Retried
+publishes must retain their original idempotency key.
+
+- Reuse the configured client and its URL session.
+- Keep the SDK operation deadline below the enclosing request or job deadline.
+- Dispatch completion work to the appropriate actor or queue for your
+  application.
+- Keep credentials, signed URLs, raw webhooks, event data, and provider tokens
+  out of logs.
+- Test duplicate attempts, key rotation, webhook retries, and graceful service
+  shutdown.

--- a/docs/content/docs/server/configuration.mdx
+++ b/docs/content/docs/server/configuration.mdx
@@ -5,6 +5,8 @@ icon: SlidersHorizontal
 ---
 
 Sockudo configuration should describe the runtime shape explicitly: app storage, fanout adapter, cache, queue, protocol features, security controls, metrics, webhooks, and push notification providers.
+For TOML versus JSON, file discovery, `--config`, environment precedence, and secret placement, start
+with [Static configuration](/docs/deployment/static-configuration).
 
 ## Minimal local config
 
@@ -22,8 +24,12 @@ id = "app-id"
 key = "app-key"
 secret = "app-secret"
 enabled = true
-enable_client_messages = false
+
+[app_manager.array.apps.policy.limits]
 max_connections = 1000
+
+[app_manager.array.apps.policy.features]
+enable_client_messages = false
 ```
 
 ## Production shape

--- a/docs/content/docs/server/scaling.mdx
+++ b/docs/content/docs/server/scaling.mdx
@@ -164,7 +164,8 @@ Operational recommendations:
 
 ## Capacity checklist
 
-Before increasing traffic, run a scenario that covers:
+Before increasing traffic, follow [Capacity planning and benchmarks](/docs/deployment/capacity-planning)
+and run a scenario that covers:
 
 - peak connected clients
 - high-frequency channel fanout

--- a/docs/content/docs/server/security.mdx
+++ b/docs/content/docs/server/security.mdx
@@ -31,6 +31,8 @@ Configure allowed origins for browser clients. Do not use wildcard origins for a
 id = "app-id"
 key = "app-key"
 secret = "app-secret"
+
+[app_manager.array.apps.policy.channels]
 allowed_origins = [
   "https://app.example.com",
   "https://admin.example.com"
@@ -42,6 +44,7 @@ allowed_origins = [
 Client events allow subscribed clients to publish events to private or presence channels. Disable them unless the product explicitly needs peer-to-peer client events.
 
 ```toml
+[app_manager.array.apps.policy.features]
 enable_client_messages = false
 ```
 


### PR DESCRIPTION
## Summary

### Production deployment

- add a new top-level Deployment section covering topology selection, rollout gates, and production readiness
- document static TOML and JSON configuration, loading precedence, environment overrides, secret placement, and equivalent examples
- add practical Linux/systemd and Docker/Compose guides with file-descriptor and kernel-tuning guidance
- add a Kubernetes/Helm baseline covering probes, resource sizing, disruption budgets, autoscaling, ingress, sysctls, and connection draining
- add AWS, Google Cloud, and Azure patterns, including EKS AL2023 multipart user data and GKE/AKS node-pool examples
- add capacity-planning and benchmark guidance that separates Sockudo limits from load-generator, network, NAT, load-balancer, and shared-backend bottlenecks
- fix syntax-highlighted code blocks so formulas and examples render with a single container border and correctly aligned copy controls

### Realtime client SDKs

- add a comprehensive Python asyncio realtime-client guide for `sockudo-python`
- expand JavaScript, Swift, Kotlin, Flutter, and .NET guides with runtime requirements, connection lifecycle, cleanup, auth boundaries, presence, recovery, rewind, filters, deltas, encrypted channels, history proxies, mutable messages, and production checklists
- add client/server package-selection guidance so application secrets stay in trusted HTTP SDKs
- correct examples against package source, including Protocol V2 defaults and `sockudo:` event prefixes

### HTTP/server SDKs

- expand Node.js, Python, Go, Rust, PHP, Ruby, Java, .NET, and Swift guides
- document reusable client configuration, timeouts, batching, socket exclusion, stable idempotency keys, protected-channel authorization, raw-body webhook validation, state/history pagination, errors, retries, encryption, user controls, push, and graceful shutdown
- correct stale examples to match current public APIs, including the Rust `Sockudo`/`sonic-rs` surface, Go return values, and Java publish overloads

## Why

Deployment advice was fragmented across installation, scaling, configuration, and environment-variable pages. SDK documentation also stopped at basic install and publish/subscribe examples, leaving lifecycle, trust boundaries, failure handling, feature selection, and production operation unexplained. The Python realtime client existed in the monorepo but was absent from the documentation site.

This change gives operators and SDK users an end-to-end path while preserving existing runtime behavior and compatibility contracts. It changes documentation only.

## User impact

- operators can choose a topology, configure nodes, tune hosts safely, deploy across major cloud platforms, and benchmark without confusing generator limits with server capacity
- realtime developers can choose the correct package, connect and clean up safely, authorize protected features through a backend, and handle recovery failures explicitly
- backend developers get language-specific examples for safe retries, idempotency, webhook verification, pagination, encrypted channels, and secret handling

## Validation

- `cd docs && npm run types:check`
- `cd docs && npm run lint`
- `cd docs && npm run build`
- visually verified capacity-planning code blocks in the local rendered docs and checked computed wrapper/pre styles
- parsed changed TOML and JSON fenced examples
- verified internal `/docs/...` links across the documentation tree
- audited SDK examples against package manifests, READMEs, tests, and public source APIs
- `git diff --check`
