### PR TITLE
dashboard: complete app management, metrics, and push controls

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,6 +1,6 @@
 # Sockudo Operator Dashboard
 
-Separate admin UI for managing Sockudo apps and webhooks. Dashboard **users** are stored
+Separate admin UI for managing Sockudo apps, policy, observability, webhooks, and push. Dashboard **users** are stored
 in the dashboard database (migrations), not in environment variables.
 
 ## Structure
@@ -19,9 +19,13 @@ Bun + Hono service on port **3460** (`/api/v1/*`):
 
 - **Auth** — email/password login, JWT session cookies, logout, `/auth/me`
 - **Users** — DB-backed operators with `admin` and `operator` roles; create, update, delete, change password
-- **Apps** — list, create, update, delete Sockudo applications; rotate app secrets
+- **Apps** — list, create, update, delete Sockudo applications; rotate app secrets; manage the
+  complete app policy (limits, features, channels, namespaces, history, recovery, and idempotency)
 - **Webhooks** — per-app webhook CRUD against the Sockudo app store
-- **Ops** — proxy to Sockudo `/stats`, `/usage`, `/metrics`, and health endpoints
+- **Ops** — proxy to Sockudo `/stats`, `/usage`, `/metrics`, and health endpoints; the Prometheus
+  parser preserves HELP/TYPE metadata, labels, timestamps, and histogram families
+- **Push** — allowlisted, signed proxy for provider credentials, devices, subscriptions, publish
+  status, and dead letters; reads require a dashboard session and mutations require an admin
 - **Bootstrap** — automatic migrations and optional first-admin seed on startup
 
 Supports `mysql`, `pgsql`, and `dynamodb` app managers (not `memory`).
@@ -32,8 +36,11 @@ Vue 3 + Vite operator UI on port **5174**:
 
 - **Login** — session-based sign-in against the dashboard API
 - **Apps** — browse and manage applications
-- **App detail** — edit limits, credentials, and webhooks per app
-- **Metrics** — Sockudo stats and Prometheus summary views
+- **App detail** — structured General, Limits, Channels, Reliability, and Webhooks editors
+- **Metrics** — configurable Prometheus workbench with metric discovery, value/rate/average panels,
+  per-app filtering, SVG time-series, scrape intervals, and bounded browser-local history
+- **Push manager** — upload APNs, FCM, Web Push, HMS, or WNS credentials; inspect devices and
+  subscriptions; publish notifications; inspect status and replay dead letters
 - **Users** — admin-only user management
 
 Docker services: `dashboard-api`, `dashboard-web` (see [Docker](#docker) below).
@@ -52,6 +59,10 @@ Docker services: `dashboard-api`, `dashboard-web` (see [Docker](#docker) below).
    HTTP_API_USAGE_ENABLED=true
    METRICS_ENABLED=true
    ```
+
+3. For push management, build Sockudo with the `push` feature and configure durable push storage.
+   Credential upload also requires `PUSH_CREDENTIAL_ENCRYPTION_KEY`. Provider delivery features
+   and credentials are loaded by Sockudo itself; the dashboard does not run delivery workers.
 
 ## Quick start
 
@@ -238,7 +249,28 @@ Roles: `admin` (full access including user management), `operator` (apps/webhook
 ## Cache note
 
 Sockudo caches apps in memory. After dashboard app/webhook changes, nodes may take up to
-`CACHE_TTL_SECONDS` to pick up updates.
+the app-manager database cache TTL (300 seconds by default) to pick up updates. Secret rotations,
+disables, and deletes have the same propagation window on already-running nodes.
+
+## Metrics model
+
+The dashboard API scrapes the single endpoint configured by `SOCKUDO_METRICS_URL`. Panels and a
+bounded six-hour/180-point history are stored in the operator's browser, not in the dashboard
+database. This makes the built-in workbench useful without another dependency, but it is not a
+cluster-wide time-series database. Use Prometheus plus Grafana for durable retention, alerting,
+multi-node aggregation, and long-range queries.
+
+## Push credential model
+
+- Provider material travels from an admin browser through the authenticated dashboard API to
+  Sockudo and is not stored by the dashboard.
+- Sockudo encrypts credential material and list responses expose only provider, credential ID, and
+  version. The UI therefore reports a credential as **stored**, never as active or healthy.
+- FCM and APNs credential selection is currently boot-time and app-specific; a worker restart may
+  be required after rotation.
+- Stored Web Push, HMS, and WNS credentials are not yet consumed by all monolith worker paths;
+  consult the server push configuration for the provider-specific runtime requirements.
+- The native API currently has no credential delete or provider-readiness endpoint.
 
 ## Security
 
@@ -248,3 +280,6 @@ Sockudo caches apps in memory. After dashboard app/webhook changes, nodes may ta
 - Existing sessions are rejected immediately when their user is deleted or disabled, and password changes invalidate previously issued sessions. Current database roles are applied on every protected request, so demotions take effect immediately.
 - Deploying this hardening change invalidates older dashboard cookies that lack the credential-version, issuer, and audience claims; operators must sign in again once.
 - Put the dashboard behind TLS and restrict network access.
+- Push credential uploads and notification publishing are admin-only. Signed upstream URLs,
+  app secrets, provider private keys, service-account JSON, and credential bodies are never logged
+  or returned by the dashboard proxy.

--- a/dashboard/api/src/db/dynamodb.ts
+++ b/dashboard/api/src/db/dynamodb.ts
@@ -14,7 +14,7 @@ import {
   type AppRecord,
   type AppUpdateInput,
 } from "../types/app.ts";
-import { type AppsRepository } from "./types.ts";
+import { type AppsRepository, rowToApp } from "./types.ts";
 
 export class DynamodbAppsRepository implements AppsRepository {
   private client: DynamoDBClient;
@@ -89,14 +89,9 @@ export class DynamodbAppsRepository implements AppsRepository {
       key: input.key ?? existing.key,
       secret: input.secret ?? existing.secret,
       enabled: input.enabled ?? existing.enabled,
-      policy: mergePolicy({
-        ...existing.policy,
-        ...input.policy,
-        limits: { ...existing.policy.limits, ...input.policy?.limits },
-        features: { ...existing.policy.features, ...input.policy?.features },
-        channels: { ...existing.policy.channels, ...input.policy?.channels },
-        webhooks: input.policy?.webhooks ?? existing.policy.webhooks,
-      }),
+      policy: input.replace_policy
+        ? mergePolicy(input.policy)
+        : mergePolicy(input.policy, existing.policy),
     };
 
     await this.client.send(
@@ -135,21 +130,91 @@ export class DynamodbAppsRepository implements AppsRepository {
 
   private itemToApp(item: Record<string, unknown>): AppRecord {
     const policyRaw = item.policy;
-    let policy: AppPolicy;
     if (typeof policyRaw === "string") {
-      policy = JSON.parse(policyRaw) as AppPolicy;
-    } else if (policyRaw && typeof policyRaw === "object") {
-      policy = policyRaw as AppPolicy;
-    } else {
-      throw new Error(`Invalid policy for app ${item.id}`);
+      return {
+        id: String(item.id),
+        key: String(item.key),
+        secret: String(item.secret),
+        enabled: item.enabled !== false,
+        policy: JSON.parse(policyRaw) as AppPolicy,
+      };
+    }
+    if (policyRaw && typeof policyRaw === "object") {
+      return {
+        id: String(item.id),
+        key: String(item.key),
+        secret: String(item.secret),
+        enabled: item.enabled !== false,
+        policy: policyRaw as AppPolicy,
+      };
     }
 
-    return {
+    const optionalNumber = (key: string): number | null => {
+      const value = item[key];
+      return value == null || !Number.isFinite(Number(value))
+        ? null
+        : Number(value);
+    };
+    const optionalBoolean = (key: string): boolean | null => {
+      const value = item[key];
+      return typeof value === "boolean" ? value : null;
+    };
+    const optionalJson = <T>(key: string): T | null => {
+      const value = item[key];
+      if (value == null) return null;
+      if (typeof value === "object") return value as T;
+      if (typeof value !== "string") return null;
+      try {
+        return JSON.parse(value) as T;
+      } catch {
+        return null;
+      }
+    };
+
+    return rowToApp({
       id: String(item.id),
       key: String(item.key),
       secret: String(item.secret),
       enabled: item.enabled !== false,
-      policy,
-    };
+      policy: null,
+      webhooks: optionalJson<AppPolicy["webhooks"]>("webhooks"),
+      allowed_origins: Array.isArray(item.allowed_origins)
+        ? item.allowed_origins.map(String)
+        : optionalJson<string[]>("allowed_origins"),
+      max_connections: optionalNumber("max_connections") ?? 10_000,
+      enable_client_messages: item.enable_client_messages === true,
+      max_backend_events_per_second: optionalNumber(
+        "max_backend_events_per_second",
+      ),
+      max_client_events_per_second:
+        optionalNumber("max_client_events_per_second") ?? 1_000,
+      max_read_requests_per_second: optionalNumber(
+        "max_read_requests_per_second",
+      ),
+      max_presence_members_per_channel: optionalNumber(
+        "max_presence_members_per_channel",
+      ),
+      max_presence_member_size_in_kb: optionalNumber(
+        "max_presence_member_size_in_kb",
+      ),
+      max_channel_name_length: optionalNumber("max_channel_name_length"),
+      max_event_channels_at_once: optionalNumber(
+        "max_event_channels_at_once",
+      ),
+      max_event_name_length: optionalNumber("max_event_name_length"),
+      max_event_payload_in_kb: optionalNumber("max_event_payload_in_kb"),
+      max_event_batch_size: optionalNumber("max_event_batch_size"),
+      enable_user_authentication: optionalBoolean(
+        "enable_user_authentication",
+      ),
+      enable_watchlist_events: optionalBoolean("enable_watchlist_events"),
+      channel_delta_compression: optionalJson<
+        AppPolicy["channels"]["channel_delta_compression"]
+      >("channel_delta_compression"),
+      idempotency: optionalJson<AppPolicy["idempotency"]>("idempotency"),
+      connection_recovery: optionalJson<AppPolicy["connection_recovery"]>(
+        "connection_recovery",
+      ),
+    });
   }
 }

--- a/dashboard/api/src/db/mysql.ts
+++ b/dashboard/api/src/db/mysql.ts
@@ -40,8 +40,12 @@ export class MysqlAppsRepository implements AppsRepository {
       SELECT id, \`key\`, secret, enabled, policy, webhooks, allowed_origins,
              max_connections, enable_client_messages,
              max_backend_events_per_second, max_client_events_per_second,
-             max_read_requests_per_second, enable_user_authentication,
-             enable_watchlist_events
+             max_read_requests_per_second, max_presence_members_per_channel,
+             max_presence_member_size_in_kb, max_channel_name_length,
+             max_event_channels_at_once, max_event_name_length,
+             max_event_payload_in_kb, max_event_batch_size,
+             enable_user_authentication, enable_watchlist_events,
+             channel_delta_compression, idempotency, connection_recovery
       FROM \`${this.table}\`
       ORDER BY id ASC
     `);
@@ -54,8 +58,12 @@ export class MysqlAppsRepository implements AppsRepository {
       SELECT id, \`key\`, secret, enabled, policy, webhooks, allowed_origins,
              max_connections, enable_client_messages,
              max_backend_events_per_second, max_client_events_per_second,
-             max_read_requests_per_second, enable_user_authentication,
-             enable_watchlist_events
+             max_read_requests_per_second, max_presence_members_per_channel,
+             max_presence_member_size_in_kb, max_channel_name_length,
+             max_event_channels_at_once, max_event_name_length,
+             max_event_payload_in_kb, max_event_batch_size,
+             enable_user_authentication, enable_watchlist_events,
+             channel_delta_compression, idempotency, connection_recovery
       FROM \`${this.table}\`
       WHERE id = ?
     `,
@@ -80,8 +88,9 @@ export class MysqlAppsRepository implements AppsRepository {
         max_event_channels_at_once, max_event_name_length,
         max_event_payload_in_kb, max_event_batch_size,
         enable_user_authentication, enable_watchlist_events,
-        policy, webhooks, allowed_origins
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        policy, webhooks, allowed_origins, channel_delta_compression,
+        idempotency, connection_recovery
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         input.id,
@@ -105,6 +114,9 @@ export class MysqlAppsRepository implements AppsRepository {
         JSON.stringify(policy),
         JSON.stringify(policy.webhooks ?? []),
         JSON.stringify(policy.channels.allowed_origins ?? ["*"]),
+        JSON.stringify(policy.channels.channel_delta_compression ?? null),
+        JSON.stringify(policy.idempotency ?? null),
+        JSON.stringify(policy.connection_recovery ?? null),
       ],
     );
 
@@ -117,14 +129,9 @@ export class MysqlAppsRepository implements AppsRepository {
     const existing = await this.findById(id);
     if (!existing) throw new Error("App not found");
 
-    const policy = mergePolicy({
-      ...existing.policy,
-      ...input.policy,
-      limits: { ...existing.policy.limits, ...input.policy?.limits },
-      features: { ...existing.policy.features, ...input.policy?.features },
-      channels: { ...existing.policy.channels, ...input.policy?.channels },
-      webhooks: input.policy?.webhooks ?? existing.policy.webhooks,
-    });
+    const policy = input.replace_policy
+      ? mergePolicy(input.policy)
+      : mergePolicy(input.policy, existing.policy);
     const flat = policyToFlat(policy);
     const key = input.key ?? existing.key;
     const secret = input.secret ?? existing.secret;
@@ -141,7 +148,8 @@ export class MysqlAppsRepository implements AppsRepository {
         max_event_name_length = ?, max_event_payload_in_kb = ?,
         max_event_batch_size = ?, enable_user_authentication = ?,
         enable_watchlist_events = ?, policy = ?, webhooks = ?,
-        allowed_origins = ?
+        allowed_origins = ?, channel_delta_compression = ?,
+        idempotency = ?, connection_recovery = ?
       WHERE id = ?
     `,
       [
@@ -165,6 +173,9 @@ export class MysqlAppsRepository implements AppsRepository {
         JSON.stringify(policy),
         JSON.stringify(policy.webhooks ?? []),
         JSON.stringify(policy.channels.allowed_origins ?? ["*"]),
+        JSON.stringify(policy.channels.channel_delta_compression ?? null),
+        JSON.stringify(policy.idempotency ?? null),
+        JSON.stringify(policy.connection_recovery ?? null),
         id,
       ],
     );
@@ -216,6 +227,34 @@ export class MysqlAppsRepository implements AppsRepository {
         row.max_read_requests_per_second != null
           ? Number(row.max_read_requests_per_second)
           : null,
+      max_presence_members_per_channel:
+        row.max_presence_members_per_channel != null
+          ? Number(row.max_presence_members_per_channel)
+          : null,
+      max_presence_member_size_in_kb:
+        row.max_presence_member_size_in_kb != null
+          ? Number(row.max_presence_member_size_in_kb)
+          : null,
+      max_channel_name_length:
+        row.max_channel_name_length != null
+          ? Number(row.max_channel_name_length)
+          : null,
+      max_event_channels_at_once:
+        row.max_event_channels_at_once != null
+          ? Number(row.max_event_channels_at_once)
+          : null,
+      max_event_name_length:
+        row.max_event_name_length != null
+          ? Number(row.max_event_name_length)
+          : null,
+      max_event_payload_in_kb:
+        row.max_event_payload_in_kb != null
+          ? Number(row.max_event_payload_in_kb)
+          : null,
+      max_event_batch_size:
+        row.max_event_batch_size != null
+          ? Number(row.max_event_batch_size)
+          : null,
       enable_user_authentication:
         row.enable_user_authentication != null
           ? Boolean(row.enable_user_authentication)
@@ -224,6 +263,13 @@ export class MysqlAppsRepository implements AppsRepository {
         row.enable_watchlist_events != null
           ? Boolean(row.enable_watchlist_events)
           : null,
+      channel_delta_compression: parseJson<
+        AppPolicy["channels"]["channel_delta_compression"]
+      >(row.channel_delta_compression),
+      idempotency: parseJson<AppPolicy["idempotency"]>(row.idempotency),
+      connection_recovery: parseJson<AppPolicy["connection_recovery"]>(
+        row.connection_recovery,
+      ),
     });
   }
 }

--- a/dashboard/api/src/db/postgres.ts
+++ b/dashboard/api/src/db/postgres.ts
@@ -53,8 +53,12 @@ export class PostgresAppsRepository implements AppsRepository {
       SELECT id, key, secret, enabled, policy, webhooks, allowed_origins,
              max_connections, enable_client_messages,
              max_backend_events_per_second, max_client_events_per_second,
-             max_read_requests_per_second, enable_user_authentication,
-             enable_watchlist_events
+             max_read_requests_per_second, max_presence_members_per_channel,
+             max_presence_member_size_in_kb, max_channel_name_length,
+             max_event_channels_at_once, max_event_name_length,
+             max_event_payload_in_kb, max_event_batch_size,
+             enable_user_authentication, enable_watchlist_events,
+             channel_delta_compression, idempotency, connection_recovery
       FROM ${this.table}
       ORDER BY id ASC
     `);
@@ -74,9 +78,29 @@ export class PostgresAppsRepository implements AppsRepository {
           row.max_backend_events_per_second as number | null,
         max_read_requests_per_second:
           row.max_read_requests_per_second as number | null,
+        max_presence_members_per_channel:
+          row.max_presence_members_per_channel as number | null,
+        max_presence_member_size_in_kb:
+          row.max_presence_member_size_in_kb as number | null,
+        max_channel_name_length: row.max_channel_name_length as number | null,
+        max_event_channels_at_once:
+          row.max_event_channels_at_once as number | null,
+        max_event_name_length: row.max_event_name_length as number | null,
+        max_event_payload_in_kb:
+          row.max_event_payload_in_kb as number | null,
+        max_event_batch_size: row.max_event_batch_size as number | null,
         enable_user_authentication:
           row.enable_user_authentication as boolean | null,
         enable_watchlist_events: row.enable_watchlist_events as boolean | null,
+        channel_delta_compression: parseJsonbValue<
+          AppPolicy["channels"]["channel_delta_compression"]
+        >(row.channel_delta_compression),
+        idempotency: parseJsonbValue<AppPolicy["idempotency"]>(
+          row.idempotency,
+        ),
+        connection_recovery: parseJsonbValue<
+          AppPolicy["connection_recovery"]
+        >(row.connection_recovery),
       }),
     );
   }
@@ -87,8 +111,12 @@ export class PostgresAppsRepository implements AppsRepository {
       SELECT id, key, secret, enabled, policy, webhooks, allowed_origins,
              max_connections, enable_client_messages,
              max_backend_events_per_second, max_client_events_per_second,
-             max_read_requests_per_second, enable_user_authentication,
-             enable_watchlist_events
+             max_read_requests_per_second, max_presence_members_per_channel,
+             max_presence_member_size_in_kb, max_channel_name_length,
+             max_event_channels_at_once, max_event_name_length,
+             max_event_payload_in_kb, max_event_batch_size,
+             enable_user_authentication, enable_watchlist_events,
+             channel_delta_compression, idempotency, connection_recovery
       FROM ${this.table}
       WHERE id = $1
     `,
@@ -111,9 +139,26 @@ export class PostgresAppsRepository implements AppsRepository {
         row.max_backend_events_per_second as number | null,
       max_read_requests_per_second:
         row.max_read_requests_per_second as number | null,
+      max_presence_members_per_channel:
+        row.max_presence_members_per_channel as number | null,
+      max_presence_member_size_in_kb:
+        row.max_presence_member_size_in_kb as number | null,
+      max_channel_name_length: row.max_channel_name_length as number | null,
+      max_event_channels_at_once:
+        row.max_event_channels_at_once as number | null,
+      max_event_name_length: row.max_event_name_length as number | null,
+      max_event_payload_in_kb: row.max_event_payload_in_kb as number | null,
+      max_event_batch_size: row.max_event_batch_size as number | null,
       enable_user_authentication:
         row.enable_user_authentication as boolean | null,
       enable_watchlist_events: row.enable_watchlist_events as boolean | null,
+      channel_delta_compression: parseJsonbValue<
+        AppPolicy["channels"]["channel_delta_compression"]
+      >(row.channel_delta_compression),
+      idempotency: parseJsonbValue<AppPolicy["idempotency"]>(row.idempotency),
+      connection_recovery: parseJsonbValue<
+        AppPolicy["connection_recovery"]
+      >(row.connection_recovery),
     });
   }
 
@@ -132,10 +177,12 @@ export class PostgresAppsRepository implements AppsRepository {
         max_event_channels_at_once, max_event_name_length,
         max_event_payload_in_kb, max_event_batch_size,
         enable_user_authentication, enable_watchlist_events,
-        policy, webhooks, allowed_origins
+        policy, webhooks, allowed_origins, channel_delta_compression,
+        idempotency, connection_recovery
       ) VALUES (
         $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16,
-        $17, $18, $19::text::jsonb, $20::text::jsonb, $21::text::jsonb
+        $17, $18, $19::text::jsonb, $20::text::jsonb, $21::text::jsonb,
+        $22::text::jsonb, $23::text::jsonb, $24::text::jsonb
       )
     `,
       [
@@ -160,6 +207,9 @@ export class PostgresAppsRepository implements AppsRepository {
         JSON.stringify(policy),
         JSON.stringify(policy.webhooks ?? []),
         JSON.stringify(policy.channels.allowed_origins ?? ["*"]),
+        JSON.stringify(policy.channels.channel_delta_compression ?? null),
+        JSON.stringify(policy.idempotency ?? null),
+        JSON.stringify(policy.connection_recovery ?? null),
       ],
     );
 
@@ -172,14 +222,9 @@ export class PostgresAppsRepository implements AppsRepository {
     const existing = await this.findById(id);
     if (!existing) throw new Error("App not found");
 
-    const policy = mergePolicy({
-      ...existing.policy,
-      ...input.policy,
-      limits: { ...existing.policy.limits, ...input.policy?.limits },
-      features: { ...existing.policy.features, ...input.policy?.features },
-      channels: { ...existing.policy.channels, ...input.policy?.channels },
-      webhooks: input.policy?.webhooks ?? existing.policy.webhooks,
-    });
+    const policy = input.replace_policy
+      ? mergePolicy(input.policy)
+      : mergePolicy(input.policy, existing.policy);
     const flat = policyToFlat(policy);
     const key = input.key ?? existing.key;
     const secret = input.secret ?? existing.secret;
@@ -197,8 +242,11 @@ export class PostgresAppsRepository implements AppsRepository {
         max_event_batch_size = $15, enable_user_authentication = $16,
         enable_watchlist_events = $17, policy = $18::text::jsonb,
         webhooks = $19::text::jsonb, allowed_origins = $20::text::jsonb,
+        channel_delta_compression = $21::text::jsonb,
+        idempotency = $22::text::jsonb,
+        connection_recovery = $23::text::jsonb,
         updated_at = CURRENT_TIMESTAMP
-      WHERE id = $21
+      WHERE id = $24
     `,
       [
         key,
@@ -221,6 +269,9 @@ export class PostgresAppsRepository implements AppsRepository {
         JSON.stringify(policy),
         JSON.stringify(policy.webhooks ?? []),
         JSON.stringify(policy.channels.allowed_origins ?? ["*"]),
+        JSON.stringify(policy.channels.channel_delta_compression ?? null),
+        JSON.stringify(policy.idempotency ?? null),
+        JSON.stringify(policy.connection_recovery ?? null),
         id,
       ],
     );

--- a/dashboard/api/src/db/types.ts
+++ b/dashboard/api/src/db/types.ts
@@ -69,8 +69,20 @@ export function rowToApp(row: {
   max_client_events_per_second?: number;
   max_backend_events_per_second?: number | null;
   max_read_requests_per_second?: number | null;
+  max_presence_members_per_channel?: number | null;
+  max_presence_member_size_in_kb?: number | null;
+  max_channel_name_length?: number | null;
+  max_event_channels_at_once?: number | null;
+  max_event_name_length?: number | null;
+  max_event_payload_in_kb?: number | null;
+  max_event_batch_size?: number | null;
   enable_user_authentication?: boolean | null;
   enable_watchlist_events?: boolean | null;
+  channel_delta_compression?:
+    | AppPolicy["channels"]["channel_delta_compression"]
+    | null;
+  idempotency?: AppPolicy["idempotency"] | null;
+  connection_recovery?: AppPolicy["connection_recovery"] | null;
 }): AppRecord {
   if (row.policy) {
     return {
@@ -95,6 +107,16 @@ export function rowToApp(row: {
           row.max_backend_events_per_second ?? undefined,
         max_read_requests_per_second:
           row.max_read_requests_per_second ?? undefined,
+        max_presence_members_per_channel:
+          row.max_presence_members_per_channel ?? undefined,
+        max_presence_member_size_in_kb:
+          row.max_presence_member_size_in_kb ?? undefined,
+        max_channel_name_length: row.max_channel_name_length ?? undefined,
+        max_event_channels_at_once:
+          row.max_event_channels_at_once ?? undefined,
+        max_event_name_length: row.max_event_name_length ?? undefined,
+        max_event_payload_in_kb: row.max_event_payload_in_kb ?? undefined,
+        max_event_batch_size: row.max_event_batch_size ?? undefined,
       },
       features: {
         enable_client_messages: row.enable_client_messages ?? false,
@@ -103,8 +125,12 @@ export function rowToApp(row: {
       },
       channels: {
         allowed_origins: row.allowed_origins ?? ["*"],
+        channel_delta_compression:
+          row.channel_delta_compression ?? undefined,
       },
       webhooks: row.webhooks ?? [],
+      idempotency: row.idempotency ?? undefined,
+      connection_recovery: row.connection_recovery ?? undefined,
     },
   };
 }

--- a/dashboard/api/src/index.ts
+++ b/dashboard/api/src/index.ts
@@ -8,6 +8,7 @@ import { createAppsRoutes } from "./routes/apps.ts";
 import { createWebhooksRoutes } from "./routes/webhooks.ts";
 import { createUsersRoutes } from "./routes/users.ts";
 import { createOpsRoutes } from "./routes/ops.ts";
+import { createPushRoutes } from "./routes/push.ts";
 
 const appsRepo = createAppsRepository();
 const dashboard = await bootstrapDashboard();
@@ -36,6 +37,7 @@ app.route("/api/v1/auth", createAuthRoutes(dashboard.users));
 app.route("/api/v1/users", createUsersRoutes(dashboard.users));
 app.route("/api/v1/apps", createAppsRoutes(appsRepo, dashboard.users));
 app.route("/api/v1/apps", createWebhooksRoutes(appsRepo, dashboard.users));
+app.route("/api/v1/apps", createPushRoutes(appsRepo, dashboard.users));
 app.route("/api/v1/ops", createOpsRoutes(dashboard.users));
 
 const server = Bun.serve({
@@ -65,4 +67,4 @@ process.on("SIGINT", async () => {
   process.exit(0);
 });
 
-export default app;
+export { app };

--- a/dashboard/api/src/routes/ops.ts
+++ b/dashboard/api/src/routes/ops.ts
@@ -8,6 +8,7 @@ import {
   fetchSockudoHealth,
   fetchSockudoStats,
   fetchSockudoUsage,
+  parsePrometheusMetrics,
   parsePrometheusText,
   summarizeMetrics,
 } from "../services/sockudo.ts";
@@ -52,7 +53,7 @@ export function createOpsRoutes(usersRepo: UsersRepository) {
       if (c.req.query("format") === "text") {
         return c.text(text);
       }
-      return c.json({ samples: parsePrometheusText(text) });
+      return c.json(parsePrometheusMetrics(text));
     } catch (err) {
       const message = err instanceof Error ? err.message : "Metrics unavailable";
       return c.json({ error: message }, 502);

--- a/dashboard/api/src/routes/push.test.ts
+++ b/dashboard/api/src/routes/push.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { createSession, sessionCookie } from "../auth/session.ts";
+import type { UsersRepository } from "../db/users-repository.ts";
+import type { AppsRepository } from "../db/types.ts";
+import type {
+  SockudoPushRequestOptions,
+  SockudoPushRequester,
+} from "../services/sockudo-push.ts";
+import type { AppRecord } from "../types/app.ts";
+import type { DashboardUser, UserRole } from "../types/user.ts";
+import { createPushRoutes } from "./push.ts";
+
+const managedApp: AppRecord = {
+  id: "app-1",
+  key: "public-key",
+  secret: "never-return-this-app-secret",
+  enabled: true,
+  policy: {
+    limits: {
+      max_connections: 100,
+      max_client_events_per_second: 10,
+    },
+    features: { enable_client_messages: false },
+    channels: {},
+  },
+};
+
+function dashboardUser(role: UserRole): DashboardUser {
+  return {
+    id: `${role}-1`,
+    email: `${role}@example.com`,
+    password_hash: `$argon2id$${role}-password-hash`,
+    name: role,
+    role,
+    active: true,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function usersRepository(user: DashboardUser): UsersRepository {
+  return {
+    findById: async (id: string) => (id === user.id ? user : null),
+  } as unknown as UsersRepository;
+}
+
+function appsRepository(app: AppRecord | null = managedApp): AppsRepository {
+  return {
+    findById: async (id: string) => (app?.id === id ? app : null),
+  } as unknown as AppsRepository;
+}
+
+async function cookieFor(user: DashboardUser): Promise<string> {
+  const token = await createSession({
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    role: user.role,
+    passwordHash: user.password_hash,
+  });
+  return sessionCookie(token).split(";")[0]!;
+}
+
+interface CapturedCall {
+  app: AppRecord;
+  options: SockudoPushRequestOptions;
+}
+
+function requesterReturning(
+  calls: CapturedCall[],
+  body: unknown = { ok: true },
+  status = 200,
+): SockudoPushRequester {
+  return async <T>(app: AppRecord, options: SockudoPushRequestOptions) => {
+    calls.push({ app, options });
+    return { status, body: body as T };
+  };
+}
+
+function testApp(
+  role: UserRole,
+  requester: SockudoPushRequester,
+  repo: AppsRepository = appsRepository(),
+) {
+  const user = dashboardUser(role);
+  const api = new Hono();
+  api.route(
+    "/api/v1/apps",
+    createPushRoutes(repo, usersRepository(user), requester),
+  );
+  return { api, user };
+}
+
+describe("dashboard push routes", () => {
+  test("requires a current dashboard session for reads", async () => {
+    const calls: CapturedCall[] = [];
+    const { api } = testApp("operator", requesterReturning(calls));
+
+    const response = await api.request(
+      "/api/v1/apps/app-1/push/credentials",
+    );
+
+    expect(response.status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("allows operators to read and only forwards allowlisted query keys", async () => {
+    const calls: CapturedCall[] = [];
+    const responseBody = {
+      items: [],
+      next_cursor: null,
+      has_more: false,
+    };
+    const { api, user } = testApp(
+      "operator",
+      requesterReturning(calls, responseBody),
+    );
+    const cookie = await cookieFor(user);
+
+    const response = await api.request(
+      "/api/v1/apps/app-1/push/credentials?limit=25&cursor=opaque&auth_signature=attacker",
+      { headers: { cookie } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(responseBody);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.app.secret).toBe(managedApp.secret);
+    expect(calls[0]!.options).toEqual({
+      method: "GET",
+      path: "/apps/app-1/push/credentials",
+      query: { limit: "25", cursor: "opaque" },
+    });
+    expect(JSON.stringify(await responseBody)).not.toContain(managedApp.secret);
+  });
+
+  test("prevents operators from publishing or uploading credentials", async () => {
+    const calls: CapturedCall[] = [];
+    const { api, user } = testApp("operator", requesterReturning(calls));
+    const cookie = await cookieFor(user);
+
+    const publish = await api.request("/api/v1/apps/app-1/push/publish", {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json" },
+      body: JSON.stringify({
+        recipients: [{ type: "channel", channel: "news" }],
+        payload: { title: "hello" },
+      }),
+    });
+    const upload = await api.request(
+      "/api/v1/apps/app-1/push/credentials/fcm",
+      {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json" },
+        body: JSON.stringify({ serviceAccountJson: { project_id: "project" } }),
+      },
+    );
+
+    expect(publish.status).toBe(403);
+    expect(upload.status).toBe(403);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("maps the admin management routes to fixed native push paths", async () => {
+    const calls: CapturedCall[] = [];
+    const { api, user } = testApp("admin", requesterReturning(calls));
+    const cookie = await cookieFor(user);
+    const headers = { cookie, "content-type": "application/json" };
+
+    expect(
+      (
+        await api.request("/api/v1/apps/app-1/push/credentials/apns", {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            credentialId: "primary",
+            teamId: "team",
+            keyId: "key",
+            privateKey: "private",
+          }),
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await api.request("/api/v1/apps/app-1/push/devices/device%2Fone", {
+          method: "DELETE",
+          headers: { cookie },
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await api.request("/api/v1/apps/app-1/push/publish", {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            recipients: [{ type: "channel", channel: "news" }],
+            payload: { title: "Hello" },
+          }),
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await api.request(
+          "/api/v1/apps/app-1/push/dead-letters/dead%2Fone/replay",
+          {
+            method: "POST",
+            headers,
+          },
+        )
+      ).status,
+    ).toBe(200);
+
+    expect(
+      calls.map(({ options }) => ({
+        method: options.method,
+        path: options.path,
+      })),
+    ).toEqual([
+      {
+        method: "POST",
+        path: "/apps/app-1/push/credentials/apns",
+      },
+      {
+        method: "DELETE",
+        path: "/apps/app-1/push/deviceRegistrations/device%2Fone",
+      },
+      {
+        method: "POST",
+        path: "/apps/app-1/push/publish",
+      },
+      {
+        method: "POST",
+        path: "/apps/app-1/push/deadLetters/dead%2Fone/replay",
+      },
+    ]);
+    expect(calls[3]!.options.body).toEqual({});
+  });
+
+  test("maps subscription, status, and dead-letter reads", async () => {
+    const calls: CapturedCall[] = [];
+    const { api, user } = testApp("operator", requesterReturning(calls));
+    const cookie = await cookieFor(user);
+
+    await api.request(
+      "/api/v1/apps/app-1/push/subscriptions?channel=private-news&deviceId=device-1&limit=10&ignored=true",
+      { headers: { cookie } },
+    );
+    await api.request(
+      "/api/v1/apps/app-1/push/publish/publish%2Fone/status",
+      { headers: { cookie } },
+    );
+    await api.request(
+      "/api/v1/apps/app-1/push/dead-letters?provider=apns&sinceMs=100&untilMs=200&limit=5",
+      { headers: { cookie } },
+    );
+
+    expect(calls.map(({ options }) => options)).toEqual([
+      {
+        method: "GET",
+        path: "/apps/app-1/push/channelSubscriptions",
+        query: {
+          channel: "private-news",
+          deviceId: "device-1",
+          limit: "10",
+        },
+      },
+      {
+        method: "GET",
+        path: "/apps/app-1/push/publish/publish%2Fone/status",
+      },
+      {
+        method: "GET",
+        path: "/apps/app-1/push/deadLetters",
+        query: {
+          provider: "apns",
+          sinceMs: "100",
+          untilMs: "200",
+          limit: "5",
+        },
+      },
+    ]);
+  });
+
+  test("returns safe local errors without exposing app or signed secrets", async () => {
+    const requester: SockudoPushRequester = async () => {
+      throw new Error(
+        `failed URL ?auth_signature=signed with ${managedApp.secret}`,
+      );
+    };
+    const { api, user } = testApp("operator", requester);
+    const cookie = await cookieFor(user);
+
+    const response = await api.request(
+      "/api/v1/apps/app-1/push/credentials",
+      { headers: { cookie } },
+    );
+    const text = await response.text();
+
+    expect(response.status).toBe(502);
+    expect(text).toContain("Sockudo push request failed");
+    expect(text).not.toContain("auth_signature");
+    expect(text).not.toContain(managedApp.secret);
+  });
+
+  test("rejects unsupported providers and missing apps before proxying", async () => {
+    const calls: CapturedCall[] = [];
+    const requester = requesterReturning(calls);
+    const { api, user } = testApp("admin", requester);
+    const cookie = await cookieFor(user);
+
+    const provider = await api.request(
+      "/api/v1/apps/app-1/push/credentials/unknown",
+      {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json" },
+        body: "{}",
+      },
+    );
+
+    const missingApi = testApp(
+      "admin",
+      requester,
+      appsRepository(null),
+    ).api;
+    const missing = await missingApi.request(
+      "/api/v1/apps/app-1/push/devices",
+      { headers: { cookie } },
+    );
+
+    expect(provider.status).toBe(400);
+    expect(missing.status).toBe(404);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/dashboard/api/src/routes/push.ts
+++ b/dashboard/api/src/routes/push.ts
@@ -1,0 +1,375 @@
+import { Hono } from "hono";
+import {
+  createRequireAdmin,
+  createRequireAuth,
+} from "../auth/middleware.ts";
+import type { UsersRepository } from "../db/users-repository.ts";
+import type { AppsRepository } from "../db/types.ts";
+import {
+  requestSockudoPush,
+  SockudoPushTransportError,
+  type SockudoPushQuery,
+  type SockudoPushRequester,
+  type SockudoPushResponse,
+} from "../services/sockudo-push.ts";
+import type { AppRecord } from "../types/app.ts";
+import type { AppVariables } from "../types/hono.ts";
+import type {
+  PushCredentialRouteProvider,
+  PushPublishInput,
+} from "../types/push.ts";
+
+const MAX_JSON_BODY_BYTES = 1_048_576;
+const CREDENTIAL_PROVIDERS = new Set<PushCredentialRouteProvider>([
+  "fcm",
+  "apns",
+  "webpush",
+  "hms",
+  "wns",
+]);
+
+interface JsonObjectResult {
+  value?: Record<string, unknown>;
+  error?: string;
+  status?: 400 | 413;
+}
+
+async function readJsonObject(request: Request): Promise<JsonObjectResult> {
+  const declaredLength = Number(request.headers.get("content-length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > MAX_JSON_BODY_BYTES
+  ) {
+    return { error: "Request body is too large", status: 413 };
+  }
+
+  const text = await request.text();
+  if (new TextEncoder().encode(text).byteLength > MAX_JSON_BODY_BYTES) {
+    return { error: "Request body is too large", status: 413 };
+  }
+  if (!text) return { error: "JSON object body is required", status: 400 };
+
+  try {
+    const value: unknown = JSON.parse(text);
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return { error: "JSON object body is required", status: 400 };
+    }
+    return { value: value as Record<string, unknown> };
+  } catch {
+    return { error: "Request body must be valid JSON", status: 400 };
+  }
+}
+
+function hasNonEmptyString(
+  value: Record<string, unknown>,
+  key: string,
+): boolean {
+  return typeof value[key] === "string" && value[key].trim().length > 0;
+}
+
+function credentialValidationError(
+  provider: PushCredentialRouteProvider,
+  value: Record<string, unknown>,
+): string | null {
+  if (
+    value.credentialId !== undefined &&
+    !hasNonEmptyString(value, "credentialId")
+  ) {
+    return "credentialId must be a non-empty string";
+  }
+  if (
+    value.version !== undefined &&
+    (!Number.isSafeInteger(value.version) || Number(value.version) < 1)
+  ) {
+    return "version must be a positive integer";
+  }
+
+  switch (provider) {
+    case "fcm":
+      return value.serviceAccountJson &&
+        typeof value.serviceAccountJson === "object" &&
+        !Array.isArray(value.serviceAccountJson)
+        ? null
+        : "serviceAccountJson must be an object";
+    case "apns": {
+      const hasCertificate =
+        hasNonEmptyString(value, "p12") || hasNonEmptyString(value, "pem");
+      const hasToken =
+        hasNonEmptyString(value, "teamId") &&
+        hasNonEmptyString(value, "keyId") &&
+        hasNonEmptyString(value, "privateKey");
+      return hasCertificate || hasToken
+        ? null
+        : "Provide p12, pem, or teamId/keyId/privateKey APNs credentials";
+    }
+    case "webpush":
+      return hasNonEmptyString(value, "publicKey") &&
+        hasNonEmptyString(value, "privateKey")
+        ? null
+        : "publicKey and privateKey are required";
+    case "hms":
+      return hasNonEmptyString(value, "hmsAppId") &&
+        hasNonEmptyString(value, "clientSecret")
+        ? null
+        : "hmsAppId and clientSecret are required";
+    case "wns":
+      return hasNonEmptyString(value, "packageSid") &&
+        hasNonEmptyString(value, "clientSecret")
+        ? null
+        : "packageSid and clientSecret are required";
+  }
+}
+
+function queryFrom(
+  request: { query(name: string): string | undefined },
+  keys: readonly string[],
+): SockudoPushQuery {
+  const query: SockudoPushQuery = {};
+  for (const key of keys) {
+    const value = request.query(key);
+    if (value !== undefined) query[key] = value;
+  }
+  return query;
+}
+
+function nativePath(app: AppRecord, suffix: string): string {
+  return `/apps/${app.id}/push/${suffix}`;
+}
+
+function proxyResponse(result: SockudoPushResponse): Response {
+  const headers = new Headers({ "cache-control": "no-store" });
+  if (result.body !== null) {
+    headers.set("content-type", "application/json; charset=UTF-8");
+  }
+  if (result.retryAfter) headers.set("retry-after", result.retryAfter);
+  if (result.forcedAsync) {
+    headers.set("x-sockudo-push-forced-async", result.forcedAsync);
+  }
+  return new Response(
+    result.body === null ? null : JSON.stringify(result.body),
+    { status: result.status, headers },
+  );
+}
+
+async function withApp(
+  repo: AppsRepository,
+  appId: string,
+  run: (app: AppRecord) => Promise<Response>,
+): Promise<Response> {
+  const app = await repo.findById(appId);
+  if (!app) {
+    return Response.json({ error: "App not found" }, { status: 404 });
+  }
+  if (!/^[A-Za-z0-9_-]{1,128}$/.test(app.id)) {
+    return Response.json(
+      { error: "App id is not valid for the Sockudo push API" },
+      { status: 400 },
+    );
+  }
+  try {
+    return await run(app);
+  } catch (error) {
+    if (
+      error instanceof SockudoPushTransportError ||
+      error instanceof TypeError
+    ) {
+      return Response.json(
+        { error: "Sockudo push API is unavailable" },
+        { status: 502 },
+      );
+    }
+    return Response.json(
+      { error: "Sockudo push request failed" },
+      { status: 502 },
+    );
+  }
+}
+
+export function createPushRoutes(
+  repo: AppsRepository,
+  usersRepo: UsersRepository,
+  requester: SockudoPushRequester = requestSockudoPush,
+) {
+  const push = new Hono<{ Variables: AppVariables }>();
+  const requireAuth = createRequireAuth(usersRepo);
+  const requireAdmin = createRequireAdmin(usersRepo);
+
+  push.use("*", requireAuth);
+
+  push.get("/:appId/push/credentials", async (c) =>
+    withApp(repo, c.req.param("appId"), async (app) =>
+      proxyResponse(
+        await requester(app, {
+          method: "GET",
+          path: nativePath(app, "credentials"),
+          query: queryFrom(c.req, ["limit", "cursor"]),
+        }),
+      ),
+    ),
+  );
+
+  push.post(
+    "/:appId/push/credentials/:provider",
+    requireAdmin,
+    async (c) => {
+      const provider = c.req.param("provider");
+      if (!CREDENTIAL_PROVIDERS.has(provider as PushCredentialRouteProvider)) {
+        return c.json({ error: "Unsupported push credential provider" }, 400);
+      }
+      const parsed = await readJsonObject(c.req.raw);
+      if (!parsed.value) {
+        return c.json(
+          { error: parsed.error ?? "Invalid request body" },
+          parsed.status ?? 400,
+        );
+      }
+      const validationError = credentialValidationError(
+        provider as PushCredentialRouteProvider,
+        parsed.value,
+      );
+      if (validationError) return c.json({ error: validationError }, 400);
+
+      return withApp(repo, c.req.param("appId"), async (app) =>
+        proxyResponse(
+          await requester(app, {
+            method: "POST",
+            path: nativePath(app, `credentials/${provider}`),
+            body: parsed.value,
+          }),
+        ),
+      );
+    },
+  );
+
+  push.get("/:appId/push/devices", async (c) =>
+    withApp(repo, c.req.param("appId"), async (app) =>
+      proxyResponse(
+        await requester(app, {
+          method: "GET",
+          path: nativePath(app, "deviceRegistrations"),
+          query: queryFrom(c.req, ["limit", "cursor"]),
+        }),
+      ),
+    ),
+  );
+
+  push.delete(
+    "/:appId/push/devices/:deviceId",
+    requireAdmin,
+    async (c) =>
+      withApp(repo, c.req.param("appId"), async (app) =>
+        proxyResponse(
+          await requester(app, {
+            method: "DELETE",
+            path: nativePath(
+              app,
+              `deviceRegistrations/${encodeURIComponent(c.req.param("deviceId"))}`,
+            ),
+          }),
+        ),
+      ),
+  );
+
+  push.get("/:appId/push/subscriptions", async (c) =>
+    withApp(repo, c.req.param("appId"), async (app) =>
+      proxyResponse(
+        await requester(app, {
+          method: "GET",
+          path: nativePath(app, "channelSubscriptions"),
+          query: queryFrom(c.req, [
+            "channel",
+            "deviceId",
+            "limit",
+            "cursor",
+          ]),
+        }),
+      ),
+    ),
+  );
+
+  push.post("/:appId/push/publish", requireAdmin, async (c) => {
+    const parsed = await readJsonObject(c.req.raw);
+    if (!parsed.value) {
+      return c.json(
+        { error: parsed.error ?? "Invalid request body" },
+        parsed.status ?? 400,
+      );
+    }
+    if (
+      !Array.isArray(parsed.value.recipients) ||
+      parsed.value.recipients.length === 0 ||
+      !parsed.value.payload ||
+      typeof parsed.value.payload !== "object" ||
+      Array.isArray(parsed.value.payload)
+    ) {
+      return c.json(
+        { error: "recipients and a payload object are required" },
+        400,
+      );
+    }
+
+    return withApp(repo, c.req.param("appId"), async (app) =>
+      proxyResponse(
+        await requester(app, {
+          method: "POST",
+          path: nativePath(app, "publish"),
+          body: parsed.value as unknown as PushPublishInput,
+        }),
+      ),
+    );
+  });
+
+  push.get("/:appId/push/publish/:publishId/status", async (c) =>
+    withApp(repo, c.req.param("appId"), async (app) =>
+      proxyResponse(
+        await requester(app, {
+          method: "GET",
+          path: nativePath(
+            app,
+            `publish/${encodeURIComponent(c.req.param("publishId"))}/status`,
+          ),
+        }),
+      ),
+    ),
+  );
+
+  push.get("/:appId/push/dead-letters", async (c) =>
+    withApp(repo, c.req.param("appId"), async (app) =>
+      proxyResponse(
+        await requester(app, {
+          method: "GET",
+          path: nativePath(app, "deadLetters"),
+          query: queryFrom(c.req, [
+            "limit",
+            "cursor",
+            "provider",
+            "sinceMs",
+            "untilMs",
+          ]),
+        }),
+      ),
+    ),
+  );
+
+  push.post(
+    "/:appId/push/dead-letters/:deadLetterId/replay",
+    requireAdmin,
+    async (c) =>
+      withApp(repo, c.req.param("appId"), async (app) =>
+        proxyResponse(
+          await requester(app, {
+            method: "POST",
+            path: nativePath(
+              app,
+              `deadLetters/${encodeURIComponent(
+                c.req.param("deadLetterId"),
+              )}/replay`,
+            ),
+            body: {},
+          }),
+        ),
+      ),
+  );
+
+  return push;
+}

--- a/dashboard/api/src/services/sockudo-push.test.ts
+++ b/dashboard/api/src/services/sockudo-push.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { AppRecord } from "../types/app.ts";
+import {
+  createSignedSockudoPushRequest,
+  requestSockudoPush,
+} from "./sockudo-push.ts";
+
+const originalFetch = globalThis.fetch;
+
+const app: AppRecord = {
+  id: "app-1",
+  key: "public-key",
+  secret: "top-secret",
+  enabled: true,
+  policy: {
+    limits: {
+      max_connections: 100,
+      max_client_events_per_second: 10,
+    },
+    features: { enable_client_messages: false },
+    channels: {},
+  },
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("Sockudo push request signing", () => {
+  test("signs GET query parameters using the Pusher canonical form", () => {
+    const signed = createSignedSockudoPushRequest(
+      app,
+      {
+        method: "GET",
+        path: "/apps/app-1/push/deviceRegistrations",
+        query: { cursor: "next page", limit: 50 },
+      },
+      1_785_312_000,
+      "http://sockudo.internal:6001",
+    );
+
+    const url = new URL(signed.url);
+    expect(url.pathname).toBe("/apps/app-1/push/deviceRegistrations");
+    expect(url.searchParams.get("cursor")).toBe("next page");
+    expect(url.searchParams.get("limit")).toBe("50");
+    expect(url.searchParams.get("auth_key")).toBe("public-key");
+    expect(url.searchParams.get("auth_timestamp")).toBe("1785312000");
+    expect(url.searchParams.get("auth_version")).toBe("1.0");
+    expect(url.searchParams.get("body_md5")).toBeNull();
+    expect(url.searchParams.get("auth_signature")).toBe(
+      "fef85f045e082ed950e634bcab8da70f19fe7aba2342bd48c3c0d99f32e11f03",
+    );
+    expect(signed.url).not.toContain(app.secret);
+    expect(signed.body).toBeUndefined();
+  });
+
+  test("hashes the exact POST JSON body before signing", () => {
+    const body = {
+      recipients: [{ type: "channel", channel: "news" }],
+      payload: { title: "Hello", body: "World" },
+    };
+    const signed = createSignedSockudoPushRequest(
+      app,
+      {
+        method: "POST",
+        path: "/apps/app-1/push/publish",
+        body,
+      },
+      1_785_312_000,
+      "http://sockudo.internal:6001",
+    );
+
+    const url = new URL(signed.url);
+    expect(signed.body).toBe(JSON.stringify(body));
+    expect(url.searchParams.get("body_md5")).toBe(
+      "7ecae25d7d55afefdc5253911cb128f3",
+    );
+    expect(url.searchParams.get("auth_signature")).toBe(
+      "0445b34247211230d30e92e0b4a8dec976d079a367308702d76b413ad3a21cec",
+    );
+    expect(signed.headers.get("content-type")).toBe("application/json");
+    expect(signed.headers.get("x-sockudo-push-capability")).toBe(
+      "push-admin",
+    );
+  });
+
+  test("rejects caller-supplied authentication parameters", () => {
+    expect(() =>
+      createSignedSockudoPushRequest(
+        app,
+        {
+          method: "GET",
+          path: "/apps/app-1/push/credentials",
+          query: { auth_signature: "attacker-controlled" },
+        },
+        1_785_312_000,
+      ),
+    ).toThrow("Reserved Sockudo authentication query key");
+  });
+
+  test("preserves camelCase query keys while signing their lowercase form", () => {
+    const signed = createSignedSockudoPushRequest(
+      app,
+      {
+        method: "GET",
+        path: "/apps/app-1/push/deadLetters",
+        query: { deviceId: "device-1", sinceMs: 100 },
+      },
+      1_785_312_000,
+      "http://sockudo.internal:6001",
+    );
+    const url = new URL(signed.url);
+
+    expect(url.searchParams.get("deviceId")).toBe("device-1");
+    expect(url.searchParams.get("sinceMs")).toBe("100");
+    expect(url.searchParams.has("deviceid")).toBe(false);
+    expect(url.searchParams.has("sincems")).toBe(false);
+  });
+
+  test("redacts credential and signing material from upstream JSON", async () => {
+    globalThis.fetch = (async () =>
+      Response.json({
+        credential_id: "fcm",
+        secret: app.secret,
+        nested: {
+          privateKey: "private-material",
+          error: `failed at ?auth_signature=signed&body_md5=digest`,
+        },
+      })) as unknown as typeof fetch;
+
+    const result = await requestSockudoPush(app, {
+      method: "GET",
+      path: "/apps/app-1/push/credentials",
+    });
+
+    expect(result.body).toEqual({
+      credential_id: "fcm",
+      secret: "[REDACTED]",
+      nested: {
+        privateKey: "[REDACTED]",
+        error: "[REDACTED]",
+      },
+    });
+    expect(JSON.stringify(result.body)).not.toContain(app.secret);
+    expect(JSON.stringify(result.body)).not.toContain("private-material");
+    expect(JSON.stringify(result.body)).not.toContain("auth_signature");
+  });
+
+  test("does not expose a signed URL when the upstream request fails", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      throw new Error(`network failure for ${String(input)}`);
+    }) as unknown as typeof fetch;
+
+    await expect(
+      requestSockudoPush(app, {
+        method: "GET",
+        path: "/apps/app-1/push/credentials",
+      }),
+    ).rejects.toThrow("Sockudo push API is unavailable");
+  });
+});

--- a/dashboard/api/src/services/sockudo-push.ts
+++ b/dashboard/api/src/services/sockudo-push.ts
@@ -1,0 +1,228 @@
+import { createHash, createHmac } from "node:crypto";
+import { config } from "../config.ts";
+import type { AppRecord } from "../types/app.ts";
+
+const RESERVED_QUERY_KEYS = new Set([
+  "auth_key",
+  "auth_signature",
+  "auth_timestamp",
+  "auth_version",
+  "body_md5",
+]);
+
+const APP_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+export type SockudoPushMethod = "GET" | "POST" | "DELETE";
+export type SockudoPushQuery = Record<
+  string,
+  string | number | boolean | undefined
+>;
+
+export interface SockudoPushRequestOptions {
+  method: SockudoPushMethod;
+  path: string;
+  query?: SockudoPushQuery;
+  body?: unknown;
+}
+
+export interface SignedSockudoPushRequest {
+  url: string;
+  headers: Headers;
+  body?: string;
+}
+
+export interface SockudoPushResponse<T = unknown> {
+  status: number;
+  body: T | null;
+  retryAfter?: string;
+  forcedAsync?: string;
+}
+
+export type SockudoPushRequester = <T = unknown>(
+  app: AppRecord,
+  options: SockudoPushRequestOptions,
+) => Promise<SockudoPushResponse<T>>;
+
+export class SockudoPushTransportError extends Error {
+  constructor() {
+    super("Sockudo push API is unavailable");
+    this.name = "SockudoPushTransportError";
+  }
+}
+
+function normalizeQuery(
+  query: SockudoPushQuery | undefined,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [rawKey, rawValue] of Object.entries(query ?? {})) {
+    const lowercaseKey = rawKey.toLowerCase();
+    if (RESERVED_QUERY_KEYS.has(lowercaseKey)) {
+      throw new Error(
+        `Reserved Sockudo authentication query key: ${lowercaseKey}`,
+      );
+    }
+    if (
+      Object.keys(normalized).some(
+        (existing) => existing.toLowerCase() === lowercaseKey,
+      )
+    ) {
+      throw new Error(`Duplicate Sockudo query key: ${lowercaseKey}`);
+    }
+    if (rawValue !== undefined) normalized[rawKey] = String(rawValue);
+  }
+  return normalized;
+}
+
+function canonicalQuery(params: Record<string, string>): string {
+  return Object.entries(params)
+    .map(([key, value]) => [key.toLowerCase(), value] as const)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+}
+
+function validatePushPath(app: AppRecord, path: string): void {
+  if (!APP_ID_PATTERN.test(app.id)) {
+    throw new Error("App id is not valid for the Sockudo push API");
+  }
+  const prefix = `/apps/${app.id}/push/`;
+  if (!path.startsWith(prefix) || path.includes("?") || path.includes("#")) {
+    throw new Error("Sockudo push request path is outside the allowed app scope");
+  }
+}
+
+export function createSignedSockudoPushRequest(
+  app: AppRecord,
+  options: SockudoPushRequestOptions,
+  nowSeconds = Math.floor(Date.now() / 1_000),
+  baseUrl = config.sockudoHttpUrl,
+): SignedSockudoPushRequest {
+  validatePushPath(app, options.path);
+
+  const body =
+    options.body === undefined ? undefined : JSON.stringify(options.body);
+  const params = normalizeQuery(options.query);
+  params.auth_key = app.key;
+  params.auth_timestamp = String(nowSeconds);
+  params.auth_version = "1.0";
+  if (options.method === "POST") {
+    params.body_md5 = createHash("md5")
+      .update(body ?? "", "utf8")
+      .digest("hex");
+  } else if (body !== undefined) {
+    throw new Error(`${options.method} push requests cannot include a body`);
+  }
+
+  const stringToSign = [
+    options.method,
+    options.path,
+    canonicalQuery(params),
+  ].join("\n");
+  const signature = createHmac("sha256", app.secret)
+    .update(stringToSign, "utf8")
+    .digest("hex");
+
+  const url = new URL(options.path, baseUrl);
+  for (const key of Object.keys(params).sort()) {
+    url.searchParams.append(key, params[key]!);
+  }
+  url.searchParams.append("auth_signature", signature);
+
+  const headers = new Headers({
+    "x-sockudo-push-capability": "push-admin",
+  });
+  if (body !== undefined) {
+    headers.set("content-type", "application/json");
+  }
+
+  return { url: url.toString(), headers, body };
+}
+
+function sanitizeResponseValue(value: unknown, appSecret: string): unknown {
+  if (typeof value === "string") {
+    if (
+      value.includes("auth_signature=") ||
+      value.includes("body_md5=") ||
+      value.includes(appSecret)
+    ) {
+      return "[REDACTED]";
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeResponseValue(item, appSecret));
+  }
+  if (!value || typeof value !== "object") return value;
+
+  const redactedKeys = new Set([
+    "secret",
+    "privatekey",
+    "private_key",
+    "clientsecret",
+    "client_secret",
+    "serviceaccountjson",
+    "service_account_json",
+    "p12",
+    "p12password",
+    "p12_password",
+    "pem",
+    "auth_signature",
+    "body_md5",
+  ]);
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    result[key] = redactedKeys.has(key.toLowerCase())
+      ? "[REDACTED]"
+      : sanitizeResponseValue(item, appSecret);
+  }
+  return result;
+}
+
+async function parseResponseBody(
+  response: Response,
+  appSecret: string,
+): Promise<unknown | null> {
+  if (response.status === 204) return null;
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return sanitizeResponseValue(JSON.parse(text), appSecret);
+  } catch {
+    return response.ok
+      ? { error: "Sockudo push API returned an unexpected response" }
+      : { error: "Sockudo push API rejected the request" };
+  }
+}
+
+export const requestSockudoPush: SockudoPushRequester = async <T>(
+  app: AppRecord,
+  options: SockudoPushRequestOptions,
+): Promise<SockudoPushResponse<T>> => {
+  let signed: SignedSockudoPushRequest;
+  try {
+    signed = createSignedSockudoPushRequest(app, options);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("App id")) {
+      throw error;
+    }
+    throw new SockudoPushTransportError();
+  }
+
+  try {
+    const response = await fetch(signed.url, {
+      method: options.method,
+      headers: signed.headers,
+      body: signed.body,
+      signal: AbortSignal.timeout(10_000),
+    });
+    return {
+      status: response.status,
+      body: (await parseResponseBody(response, app.secret)) as T | null,
+      retryAfter: response.headers.get("retry-after") ?? undefined,
+      forcedAsync:
+        response.headers.get("x-sockudo-push-forced-async") ?? undefined,
+    };
+  } catch {
+    throw new SockudoPushTransportError();
+  }
+};

--- a/dashboard/api/src/services/sockudo.test.ts
+++ b/dashboard/api/src/services/sockudo.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import {
+  discoverPrometheusPrefix,
+  parsePrometheusMetrics,
+  parsePrometheusText,
+  summarizeMetrics,
+} from "./sockudo.ts";
+
+describe("Prometheus text parsing", () => {
+  test("parses metadata, standard labels, escapes, and optional timestamps", () => {
+    const text = String.raw`
+# HELP custom_connected Active\nconnections
+# TYPE custom_connected gauge
+custom_connected{app_id="app-a",port="6001",detail="west, \"primary\" \\ route\nnext"} 3 1710000000000
+# TYPE custom_requests_total counter
+custom_requests_total{app_id="app-a"} 1.25e+03
+`;
+
+    const parsed = parsePrometheusMetrics(text);
+
+    expect(parsed.samples).toEqual([
+      {
+        name: "custom_connected",
+        labels: {
+          app_id: "app-a",
+          port: "6001",
+          detail: 'west, "primary" \\ route\nnext',
+        },
+        value: 3,
+        timestamp: 1_710_000_000_000,
+      },
+      {
+        name: "custom_requests_total",
+        labels: { app_id: "app-a" },
+        value: 1_250,
+      },
+    ]);
+    expect(parsed.families).toEqual([
+      {
+        name: "custom_connected",
+        type: "gauge",
+        help: "Active\nconnections",
+        samples: [parsed.samples[0]],
+      },
+      {
+        name: "custom_requests_total",
+        type: "counter",
+        samples: [parsed.samples[1]],
+      },
+    ]);
+    expect(Number.isNaN(Date.parse(parsed.scraped_at))).toBeFalse();
+  });
+
+  test("groups histogram exposition samples into one metric family", () => {
+    const text = `
+# HELP request_latency_seconds Request latency.
+# TYPE request_latency_seconds histogram
+request_latency_seconds_bucket{le="0.5"} 2
+request_latency_seconds_bucket{le="+Inf"} 3
+request_latency_seconds_sum 1.25
+request_latency_seconds_count 3
+`;
+
+    const parsed = parsePrometheusMetrics(text);
+
+    expect(parsed.families).toHaveLength(1);
+    expect(parsed.families[0].name).toBe("request_latency_seconds");
+    expect(parsed.families[0].type).toBe("histogram");
+    expect(parsed.families[0].help).toBe("Request latency.");
+    expect(parsed.families[0].samples).toHaveLength(4);
+    expect(parsed.families[0].samples[1].labels.le).toBe("+Inf");
+  });
+
+  test("skips malformed or non-finite samples without losing valid samples", () => {
+    const text = String.raw`
+valid_metric{label="ok"} 4
+broken_label{label="unterminated} 1
+broken_escape{label="\t"} 2
+broken_timestamp 3 1.5
+not_finite NaN
+too_many_fields 4 1710000000000 extra
+`;
+
+    expect(parsePrometheusText(text)).toEqual([
+      { name: "valid_metric", labels: { label: "ok" }, value: 4 },
+    ]);
+  });
+
+  test("keeps the legacy flat sample parser contract", () => {
+    const samples = parsePrometheusText(
+      'sockudo_connected{app_id="app-a",port="6001"} 2\n',
+    );
+
+    expect(Array.isArray(samples)).toBeTrue();
+    expect(samples).toEqual([
+      {
+        name: "sockudo_connected",
+        labels: { app_id: "app-a", port: "6001" },
+        value: 2,
+      },
+    ]);
+  });
+});
+
+describe("Prometheus summaries", () => {
+  test("uses the actual connected metric and aggregates ports by app", () => {
+    const samples = parsePrometheusText(`
+sockudo_connected{app_id="app-b",port="6001"} 2
+sockudo_connected{app_id="app-a",port="6001"} 3
+sockudo_connected{app_id="app-a",port="6002"} 1
+sockudo_new_connections_total{app_id="app-a",port="6001"} 8
+`);
+
+    const summary = summarizeMetrics(samples);
+
+    expect(summary.metrics_prefix).toBe("sockudo_");
+    expect(summary.connected_sockets).toBe(6);
+    expect(summary.new_connections_total).toBe(8);
+    expect(summary.by_app).toEqual([
+      { app_id: "app-a", connected_sockets: 4 },
+      { app_id: "app-b", connected_sockets: 2 },
+    ]);
+  });
+
+  test("discovers a custom prefix and applies it to all summary metrics", () => {
+    const samples = parsePrometheusText(`
+tenant_tokio_workers_count 4
+tenant_connected{app_id="app-a",port="6001"} 5
+tenant_ws_messages_received_total{app_id="app-a",port="6001"} 12
+sockudo_push_ws_messages_received_total{app="other"} 99
+tenant_history_write_failures_total{app_id="app-a",port="6001"} 2
+`);
+
+    expect(discoverPrometheusPrefix(samples)).toBe("tenant_");
+    expect(summarizeMetrics(samples)).toMatchObject({
+      metrics_prefix: "tenant_",
+      connected_sockets: 5,
+      ws_messages_received_total: 12,
+      history_write_failures_total: 2,
+    });
+  });
+});

--- a/dashboard/api/src/services/sockudo.ts
+++ b/dashboard/api/src/services/sockudo.ts
@@ -46,72 +46,380 @@ export interface MetricSample {
   name: string;
   labels: Record<string, string>;
   value: number;
+  timestamp?: number;
 }
 
-export function parsePrometheusText(text: string): MetricSample[] {
-  const samples: MetricSample[] = [];
-  for (const line of text.split("\n")) {
-    if (!line || line.startsWith("#")) continue;
-    const space = line.lastIndexOf(" ");
-    if (space <= 0) continue;
-    const value = Number(line.slice(space + 1));
-    if (!Number.isFinite(value)) continue;
-    const metricPart = line.slice(0, space);
-    const braceStart = metricPart.indexOf("{");
-    if (braceStart === -1) {
-      samples.push({ name: metricPart, labels: {}, value });
+export type PrometheusMetricType =
+  | "counter"
+  | "gauge"
+  | "histogram"
+  | "summary"
+  | "untyped";
+
+export interface MetricFamily {
+  name: string;
+  type: PrometheusMetricType;
+  help?: string;
+  samples: MetricSample[];
+}
+
+export interface ParsedPrometheusMetrics {
+  samples: MetricSample[];
+  families: MetricFamily[];
+  scraped_at: string;
+}
+
+interface MetricMetadata {
+  name: string;
+  type?: PrometheusMetricType;
+  help?: string;
+}
+
+const PROMETHEUS_TYPES = new Set<PrometheusMetricType>([
+  "counter",
+  "gauge",
+  "histogram",
+  "summary",
+  "untyped",
+]);
+
+const PREFIX_DISCOVERY_SUFFIXES = [
+  "tokio_workers_count",
+  "tokio_active_tasks",
+  "connected",
+  "new_connections_total",
+  "new_disconnections_total",
+  "ws_messages_received_total",
+  "ws_messages_sent_total",
+  "http_calls_received_total",
+] as const;
+
+function unescapePrometheusText(value: string): string | null {
+  let result = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char !== "\\") {
+      result += char;
       continue;
     }
-    const name = metricPart.slice(0, braceStart);
-    const labelsRaw = metricPart.slice(braceStart + 1, -1);
-    const labels: Record<string, string> = {};
-    for (const pair of labelsRaw.match(/(?:[^,"\\]|\\.)+/g) ?? []) {
-      const eq = pair.indexOf("=");
-      if (eq === -1) continue;
-      const key = pair.slice(0, eq).trim();
-      const raw = pair.slice(eq + 1).trim();
-      labels[key] = raw.replace(/^"|"$/g, "").replace(/\\"/g, '"');
-    }
-    samples.push({ name, labels, value });
+
+    const escaped = value[index + 1];
+    if (escaped === undefined) return null;
+    if (escaped === "n") result += "\n";
+    else if (escaped === "\\" || escaped === '"') result += escaped;
+    else return null;
+    index += 1;
   }
-  return samples;
+  return result;
+}
+
+function parsePrometheusLabels(raw: string): Record<string, string> | null {
+  const labels: Record<string, string> = {};
+  let index = 0;
+
+  const skipWhitespace = () => {
+    while (index < raw.length && /\s/.test(raw[index])) index += 1;
+  };
+
+  while (index < raw.length) {
+    skipWhitespace();
+    if (index >= raw.length) break;
+
+    const nameStart = index;
+    if (!/[a-zA-Z_]/.test(raw[index])) return null;
+    index += 1;
+    while (index < raw.length && /[a-zA-Z0-9_]/.test(raw[index])) {
+      index += 1;
+    }
+    const name = raw.slice(nameStart, index);
+
+    skipWhitespace();
+    if (raw[index] !== "=") return null;
+    index += 1;
+    skipWhitespace();
+    if (raw[index] !== '"') return null;
+    index += 1;
+
+    let encodedValue = "";
+    let closed = false;
+    while (index < raw.length) {
+      const char = raw[index];
+      if (char === '"') {
+        closed = true;
+        index += 1;
+        break;
+      }
+      if (char === "\\") {
+        const escaped = raw[index + 1];
+        if (escaped === undefined) return null;
+        encodedValue += `\\${escaped}`;
+        index += 2;
+        continue;
+      }
+      encodedValue += char;
+      index += 1;
+    }
+    if (!closed || Object.hasOwn(labels, name)) return null;
+
+    const value = unescapePrometheusText(encodedValue);
+    if (value === null) return null;
+    labels[name] = value;
+
+    skipWhitespace();
+    if (index >= raw.length) break;
+    if (raw[index] !== ",") return null;
+    index += 1;
+    skipWhitespace();
+    if (index >= raw.length) return null;
+  }
+
+  return labels;
+}
+
+function splitPrometheusSampleLine(
+  line: string,
+): { metric: string; value: string; timestamp?: string } | null {
+  let inQuotes = false;
+  let escaped = false;
+  let separator = -1;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (inQuotes) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inQuotes = false;
+      continue;
+    }
+    if (char === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      separator = index;
+      break;
+    }
+  }
+
+  if (separator <= 0 || inQuotes || escaped) return null;
+  const metric = line.slice(0, separator);
+  const fields = line.slice(separator).trim().split(/\s+/);
+  if (fields.length < 1 || fields.length > 2) return null;
+  return {
+    metric,
+    value: fields[0],
+    ...(fields[1] === undefined ? {} : { timestamp: fields[1] }),
+  };
+}
+
+function parsePrometheusSample(line: string): MetricSample | null {
+  const split = splitPrometheusSampleLine(line);
+  if (!split) return null;
+
+  const value = Number(split.value);
+  if (!Number.isFinite(value)) return null;
+
+  let timestamp: number | undefined;
+  if (split.timestamp !== undefined) {
+    if (!/^-?\d+$/.test(split.timestamp)) return null;
+    timestamp = Number(split.timestamp);
+    if (!Number.isFinite(timestamp)) return null;
+  }
+
+  const braceStart = split.metric.indexOf("{");
+  let name = split.metric;
+  let labels: Record<string, string> = {};
+  if (braceStart !== -1) {
+    if (!split.metric.endsWith("}")) return null;
+    name = split.metric.slice(0, braceStart);
+    const parsedLabels = parsePrometheusLabels(
+      split.metric.slice(braceStart + 1, -1),
+    );
+    if (!parsedLabels) return null;
+    labels = parsedLabels;
+  }
+
+  if (!/^[a-zA-Z_:][a-zA-Z0-9_:]*$/.test(name)) return null;
+  return {
+    name,
+    labels,
+    value,
+    ...(timestamp === undefined ? {} : { timestamp }),
+  };
+}
+
+function metricFamilyName(
+  sampleName: string,
+  metadata: Map<string, MetricMetadata>,
+): string {
+  if (metadata.has(sampleName)) return sampleName;
+
+  for (const entry of metadata.values()) {
+    if (
+      (entry.type === "histogram" || entry.type === "summary") &&
+      (sampleName === `${entry.name}_sum` ||
+        sampleName === `${entry.name}_count` ||
+        (entry.type === "histogram" &&
+          sampleName === `${entry.name}_bucket`))
+    ) {
+      return entry.name;
+    }
+    if (
+      entry.type === "counter" &&
+      !entry.name.endsWith("_total") &&
+      sampleName === `${entry.name}_total`
+    ) {
+      return entry.name;
+    }
+  }
+
+  return sampleName;
+}
+
+export function parsePrometheusMetrics(text: string): ParsedPrometheusMetrics {
+  const samples: MetricSample[] = [];
+  const metadata = new Map<string, MetricMetadata>();
+
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const helpMatch = line.match(/^#\s+HELP\s+(\S+)\s+(.*)$/);
+    if (helpMatch) {
+      const help = unescapePrometheusText(helpMatch[2]);
+      if (help !== null) {
+        const current = metadata.get(helpMatch[1]);
+        metadata.set(helpMatch[1], {
+          name: helpMatch[1],
+          ...current,
+          help,
+        });
+      }
+      continue;
+    }
+
+    const typeMatch = line.match(/^#\s+TYPE\s+(\S+)\s+(\S+)\s*$/);
+    if (typeMatch && PROMETHEUS_TYPES.has(typeMatch[2] as PrometheusMetricType)) {
+      const current = metadata.get(typeMatch[1]);
+      metadata.set(typeMatch[1], {
+        name: typeMatch[1],
+        ...current,
+        type: typeMatch[2] as PrometheusMetricType,
+      });
+      continue;
+    }
+
+    if (line.startsWith("#")) continue;
+    const sample = parsePrometheusSample(line);
+    if (sample) samples.push(sample);
+  }
+
+  const families = new Map<string, MetricFamily>();
+  for (const entry of metadata.values()) {
+    families.set(entry.name, {
+      name: entry.name,
+      type: entry.type ?? "untyped",
+      ...(entry.help === undefined ? {} : { help: entry.help }),
+      samples: [],
+    });
+  }
+  for (const sample of samples) {
+    const familyName = metricFamilyName(sample.name, metadata);
+    const entry = metadata.get(familyName);
+    let family = families.get(familyName);
+    if (!family) {
+      family = {
+        name: familyName,
+        type: entry?.type ?? "untyped",
+        ...(entry?.help === undefined ? {} : { help: entry.help }),
+        samples: [],
+      };
+      families.set(familyName, family);
+    }
+    family.samples.push(sample);
+  }
+
+  return {
+    samples,
+    families: [...families.values()],
+    scraped_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * Parses Prometheus text into the legacy flat sample array.
+ *
+ * Keep this wrapper for the existing `/metrics` response shape. New callers
+ * that need HELP/TYPE metadata should use `parsePrometheusMetrics`.
+ */
+export function parsePrometheusText(text: string): MetricSample[] {
+  return parsePrometheusMetrics(text).samples;
+}
+
+export function discoverPrometheusPrefix(
+  samples: MetricSample[],
+): string | null {
+  for (const suffix of PREFIX_DISCOVERY_SUFFIXES) {
+    const sample = samples.find(
+      (candidate) => candidate.name.endsWith(suffix),
+    );
+    if (sample) return sample.name.slice(0, -suffix.length);
+  }
+  return null;
 }
 
 export function summarizeMetrics(samples: MetricSample[]) {
-  const sumByName = (name: string) =>
-    samples
-      .filter((s) => s.name === name)
-      .reduce((acc, s) => acc + s.value, 0);
-
-  const gaugeByName = (name: string) => {
-    const matches = samples.filter((s) => s.name === name);
-    return matches.reduce((acc, s) => acc + s.value, 0);
+  const metricsPrefix = discoverPrometheusPrefix(samples);
+  const samplesBySuffix = (suffix: string) => {
+    if (metricsPrefix !== null) {
+      const exact = samples.filter(
+        (sample) => sample.name === `${metricsPrefix}${suffix}`,
+      );
+      if (exact.length > 0) return exact;
+    }
+    return samples.filter((sample) => sample.name.endsWith(suffix));
   };
+  const sumBySuffix = (suffix: string) =>
+    samplesBySuffix(suffix)
+      .reduce((acc, sample) => acc + sample.value, 0);
+
+  const connectedSamples = samplesBySuffix("connected");
+  const connectedByApp = new Map<string, number>();
+  for (const sample of connectedSamples) {
+    const appId = sample.labels.app_id;
+    if (!appId) continue;
+    connectedByApp.set(
+      appId,
+      (connectedByApp.get(appId) ?? 0) + sample.value,
+    );
+  }
 
   return {
-    connected_sockets: gaugeByName("sockudo_connected_sockets"),
-    new_connections_total: sumByName("sockudo_new_connections_total"),
-    new_disconnections_total: sumByName("sockudo_new_disconnections_total"),
-    ws_messages_received_total: sumByName("sockudo_ws_messages_received_total"),
-    ws_messages_sent_total: sumByName("sockudo_ws_messages_sent_total"),
-    http_calls_received_total: sumByName("sockudo_http_calls_received_total"),
-    channel_subscriptions_total: sumByName(
-      "sockudo_channel_subscriptions_total",
+    metrics_prefix: metricsPrefix,
+    connected_sockets: connectedSamples.reduce(
+      (acc, sample) => acc + sample.value,
+      0,
     ),
-    channel_unsubscriptions_total: sumByName(
-      "sockudo_channel_unsubscriptions_total",
+    new_connections_total: sumBySuffix("new_connections_total"),
+    new_disconnections_total: sumBySuffix("new_disconnections_total"),
+    ws_messages_received_total: sumBySuffix("ws_messages_received_total"),
+    ws_messages_sent_total: sumBySuffix("ws_messages_sent_total"),
+    http_calls_received_total: sumBySuffix("http_calls_received_total"),
+    channel_subscriptions_total: sumBySuffix("channel_subscriptions_total"),
+    channel_unsubscriptions_total: sumBySuffix(
+      "channel_unsubscriptions_total",
     ),
-    rate_limit_triggered_total: sumByName("sockudo_rate_limit_triggered_total"),
-    connection_errors_total: sumByName("sockudo_connection_errors_total"),
-    history_writes_total: sumByName("sockudo_history_writes_total"),
-    history_write_failures_total: sumByName(
-      "sockudo_history_write_failures_total",
+    rate_limit_triggered_total: sumBySuffix("rate_limit_triggered_total"),
+    connection_errors_total: sumBySuffix("connection_errors_total"),
+    history_writes_total: sumBySuffix("history_writes_total"),
+    history_write_failures_total: sumBySuffix(
+      "history_write_failures_total",
     ),
-    by_app: samples
-      .filter((s) => s.name === "sockudo_connected_sockets" && s.labels.app_id)
-      .map((s) => ({
-        app_id: s.labels.app_id,
-        connected_sockets: s.value,
-      })),
+    by_app: [...connectedByApp.entries()]
+      .map(([app_id, connected_sockets]) => ({
+        app_id,
+        connected_sockets,
+      }))
+      .sort((left, right) => left.app_id.localeCompare(right.app_id)),
   };
 }

--- a/dashboard/api/src/types/app.test.ts
+++ b/dashboard/api/src/types/app.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { rowToApp } from "../db/types.ts";
+import { mergePolicy, type AppPolicy } from "./app.ts";
+
+function exhaustivePolicy(): AppPolicy {
+  return {
+    limits: {
+      max_connections: 250,
+      max_backend_events_per_second: 80,
+      max_client_events_per_second: 40,
+      max_read_requests_per_second: 20,
+      max_presence_members_per_channel: 200,
+      max_presence_member_size_in_kb: 4,
+      max_channel_name_length: 180,
+      max_event_channels_at_once: 12,
+      max_event_name_length: 96,
+      max_event_payload_in_kb: 64,
+      max_event_batch_size: 15,
+      decay_seconds: 3,
+      terminate_on_limit: true,
+      message_rate_limit: {
+        enabled: true,
+        max_attempts: 90,
+        decay_seconds: 30,
+        terminate_on_limit: false,
+      },
+    },
+    features: {
+      enable_client_messages: true,
+      enable_user_authentication: true,
+      enable_watchlist_events: true,
+    },
+    channels: {
+      allowed_origins: ["https://app.example.com"],
+      annotations_enabled: true,
+      channel_delta_compression: {
+        "prices-*": {
+          enabled: true,
+          algorithm: "Fossil",
+          conflation_key: "data.symbol",
+          max_messages_per_key: 8,
+          max_conflation_keys: 100,
+          enable_tags: true,
+        },
+      },
+      channel_namespaces: [
+        {
+          name: "trading",
+          channel_name_pattern: "^trading:",
+          max_channel_name_length: 120,
+          annotations_enabled: true,
+          allow_user_limited_channels: true,
+          allow_subscribe_for_client: true,
+          allow_publish_for_client: false,
+          allow_presence_for_client: true,
+          history: {
+            rewind_enabled: true,
+            retention_window_seconds: 3_600,
+            max_messages_per_channel: 5_000,
+            max_bytes_per_channel: 10_000_000,
+          },
+          presence_history: {
+            enabled: true,
+            retention_window_seconds: 600,
+            max_events_per_channel: 1_000,
+            max_bytes_per_channel: 2_000_000,
+          },
+        },
+      ],
+    },
+    webhooks: [
+      {
+        url: "https://hooks.example.com/sockudo",
+        event_types: ["message_version_created"],
+        filter: { channel_namespace: "trading" },
+        retry: { enabled: true, max_attempts: 5 },
+      },
+    ],
+    idempotency: { enabled: true, ttl_seconds: 600 },
+    connection_recovery: {
+      enabled: true,
+      buffer_ttl_seconds: 120,
+      max_buffer_size: 2_000,
+    },
+    history: {
+      enabled: true,
+      rewind_enabled: true,
+      retention_window_seconds: 86_400,
+      max_messages_per_channel: 50_000,
+      max_bytes_per_channel: 100_000_000,
+    },
+    presence_history: {
+      enabled: true,
+      retention_window_seconds: 3_600,
+      max_events_per_channel: 20_000,
+      max_bytes_per_channel: 50_000_000,
+    },
+  };
+}
+
+describe("app policy merging", () => {
+  test("preserves every untouched advanced field during a narrow update", () => {
+    const base = exhaustivePolicy();
+    const merged = mergePolicy(
+      {
+        limits: { max_connections: 500 },
+        history: { enabled: false },
+      },
+      base,
+    );
+
+    expect(merged.limits.max_connections).toBe(500);
+    expect(merged.history).toEqual({
+      ...base.history,
+      enabled: false,
+    });
+    expect(merged.limits.message_rate_limit).toEqual(
+      base.limits.message_rate_limit,
+    );
+    expect(merged.channels).toEqual(base.channels);
+    expect(merged.connection_recovery).toEqual(base.connection_recovery);
+    expect(merged.presence_history).toEqual(base.presence_history);
+    expect(merged.webhooks).toEqual(base.webhooks);
+  });
+
+  test("deep-merges a partial all-message rate-limit update", () => {
+    const base = exhaustivePolicy();
+    const merged = mergePolicy(
+      {
+        limits: {
+          message_rate_limit: {
+            ...base.limits.message_rate_limit!,
+            max_attempts: 120,
+          },
+        },
+      },
+      base,
+    );
+
+    expect(merged.limits.message_rate_limit).toEqual({
+      enabled: true,
+      max_attempts: 120,
+      decay_seconds: 30,
+      terminate_on_limit: false,
+    });
+  });
+
+  test("returns a clone when no update is supplied", () => {
+    const base = exhaustivePolicy();
+    const merged = mergePolicy(undefined, base);
+    merged.channels.allowed_origins?.push("https://other.example.com");
+
+    expect(merged).not.toBe(base);
+    expect(base.channels.allowed_origins).toEqual([
+      "https://app.example.com",
+    ]);
+  });
+});
+
+describe("legacy app rows", () => {
+  test("reconstructs advanced flat and JSON policy fields without data loss", () => {
+    const app = rowToApp({
+      id: "legacy-app",
+      key: "legacy-key",
+      secret: "legacy-secret",
+      enabled: true,
+      policy: null,
+      max_connections: 400,
+      max_client_events_per_second: 50,
+      max_presence_members_per_channel: 120,
+      max_presence_member_size_in_kb: 8,
+      max_channel_name_length: 140,
+      max_event_channels_at_once: 16,
+      max_event_name_length: 80,
+      max_event_payload_in_kb: 96,
+      max_event_batch_size: 20,
+      channel_delta_compression: { "prices-*": "fossil" },
+      idempotency: { enabled: true, ttl_seconds: 300 },
+      connection_recovery: {
+        enabled: true,
+        buffer_ttl_seconds: 90,
+        max_buffer_size: 500,
+      },
+    });
+
+    expect(app.policy.limits).toMatchObject({
+      max_connections: 400,
+      max_client_events_per_second: 50,
+      max_presence_members_per_channel: 120,
+      max_presence_member_size_in_kb: 8,
+      max_channel_name_length: 140,
+      max_event_channels_at_once: 16,
+      max_event_name_length: 80,
+      max_event_payload_in_kb: 96,
+      max_event_batch_size: 20,
+    });
+    expect(app.policy.channels.channel_delta_compression).toEqual({
+      "prices-*": "fossil",
+    });
+    expect(app.policy.idempotency).toEqual({
+      enabled: true,
+      ttl_seconds: 300,
+    });
+    expect(app.policy.connection_recovery).toEqual({
+      enabled: true,
+      buffer_ttl_seconds: 90,
+      max_buffer_size: 500,
+    });
+  });
+});

--- a/dashboard/api/src/types/app.ts
+++ b/dashboard/api/src/types/app.ts
@@ -39,6 +39,12 @@ export interface AppLimitsPolicy {
   max_event_batch_size?: number;
   decay_seconds?: number;
   terminate_on_limit?: boolean;
+  message_rate_limit?: {
+    enabled: boolean;
+    max_attempts: number;
+    decay_seconds: number;
+    terminate_on_limit: boolean;
+  };
 }
 
 export interface AppFeaturesPolicy {
@@ -50,13 +56,49 @@ export interface AppFeaturesPolicy {
 export interface AppChannelsPolicy {
   allowed_origins?: string[];
   annotations_enabled?: boolean;
-  channel_namespaces?: Array<{
-    name: string;
-    channel_name_pattern: string;
-    max_channel_name_length?: number;
-    allow_user_limited_channels?: boolean;
-    annotations_enabled?: boolean;
-  }>;
+  channel_delta_compression?: Record<
+    string,
+    | "inherit"
+    | "disabled"
+    | "fossil"
+    | "xdelta3"
+    | {
+        enabled?: boolean;
+        algorithm?: "Fossil" | "Xdelta3";
+        conflation_key?: string;
+        max_messages_per_key?: number;
+        max_conflation_keys?: number;
+        enable_tags?: boolean;
+      }
+  >;
+  channel_namespaces?: ChannelNamespace[];
+}
+
+export interface NamespaceHistoryConfig {
+  rewind_enabled?: boolean;
+  retention_window_seconds?: number;
+  max_messages_per_channel?: number;
+  max_bytes_per_channel?: number;
+}
+
+export interface NamespacePresenceHistoryConfig {
+  enabled?: boolean;
+  retention_window_seconds?: number;
+  max_events_per_channel?: number;
+  max_bytes_per_channel?: number;
+}
+
+export interface ChannelNamespace {
+  name: string;
+  channel_name_pattern?: string;
+  max_channel_name_length?: number;
+  annotations_enabled?: boolean;
+  allow_user_limited_channels?: boolean;
+  allow_subscribe_for_client?: boolean;
+  allow_publish_for_client?: boolean;
+  allow_presence_for_client?: boolean;
+  history?: NamespaceHistoryConfig;
+  presence_history?: NamespacePresenceHistoryConfig;
 }
 
 export interface AppPolicy {
@@ -98,14 +140,34 @@ export interface AppCreateInput {
   key: string;
   secret: string;
   enabled?: boolean;
-  policy?: Partial<AppPolicy>;
+  policy?: AppPolicyInput;
 }
 
 export interface AppUpdateInput {
   key?: string;
   secret?: string;
   enabled?: boolean;
-  policy?: Partial<AppPolicy>;
+  policy?: AppPolicyInput;
+  /**
+   * Treat `policy` as the complete desired app policy.
+   *
+   * Dashboard section editors submit this so removing an optional override is
+   * intentional. API clients that omit it retain deep partial-merge behavior.
+   */
+  replace_policy?: boolean;
+}
+
+export interface AppPolicyInput {
+  limits?: Partial<AppLimitsPolicy>;
+  features?: Partial<AppFeaturesPolicy>;
+  channels?: Partial<AppChannelsPolicy>;
+  webhooks?: Webhook[];
+  idempotency?: Partial<NonNullable<AppPolicy["idempotency"]>>;
+  connection_recovery?: Partial<
+    NonNullable<AppPolicy["connection_recovery"]>
+  >;
+  history?: Partial<NonNullable<AppPolicy["history"]>>;
+  presence_history?: Partial<NonNullable<AppPolicy["presence_history"]>>;
 }
 
 export const DEFAULT_POLICY: AppPolicy = {
@@ -144,17 +206,42 @@ export const WEBHOOK_EVENT_TYPES = [
   "annotation_deleted",
 ] as const;
 
-export function mergePolicy(partial?: Partial<AppPolicy>): AppPolicy {
-  if (!partial) return structuredClone(DEFAULT_POLICY);
+export function mergePolicy(
+  partial?: AppPolicyInput,
+  base: AppPolicy = DEFAULT_POLICY,
+): AppPolicy {
+  if (!partial) return structuredClone(base);
+
+  const mergeOptional = <T extends object>(
+    previous: T | undefined,
+    next: Partial<T> | undefined,
+  ): T | undefined => {
+    if (next === undefined) return previous ? { ...previous } : undefined;
+    return { ...(previous ?? ({} as T)), ...next };
+  };
+
   return {
-    limits: { ...DEFAULT_POLICY.limits, ...partial.limits },
-    features: { ...DEFAULT_POLICY.features, ...partial.features },
-    channels: { ...DEFAULT_POLICY.channels, ...partial.channels },
-    webhooks: partial.webhooks ?? DEFAULT_POLICY.webhooks,
-    idempotency: partial.idempotency,
-    connection_recovery: partial.connection_recovery,
-    history: partial.history,
-    presence_history: partial.presence_history,
+    limits: {
+      ...base.limits,
+      ...partial.limits,
+      message_rate_limit: mergeOptional(
+        base.limits.message_rate_limit,
+        partial.limits?.message_rate_limit,
+      ),
+    },
+    features: { ...base.features, ...partial.features },
+    channels: { ...base.channels, ...partial.channels },
+    webhooks: partial.webhooks ?? base.webhooks,
+    idempotency: mergeOptional(base.idempotency, partial.idempotency),
+    connection_recovery: mergeOptional(
+      base.connection_recovery,
+      partial.connection_recovery,
+    ),
+    history: mergeOptional(base.history, partial.history),
+    presence_history: mergeOptional(
+      base.presence_history,
+      partial.presence_history,
+    ),
   };
 }
 

--- a/dashboard/api/src/types/push.ts
+++ b/dashboard/api/src/types/push.ts
@@ -1,0 +1,180 @@
+export type PushProvider =
+  | "fcm"
+  | "apns"
+  | "webPush"
+  | "hms"
+  | "wns"
+  | "realtime";
+
+export type PushCredentialProvider = Exclude<PushProvider, "realtime">;
+export type PushCredentialRouteProvider =
+  | "fcm"
+  | "apns"
+  | "webpush"
+  | "hms"
+  | "wns";
+
+export interface PushListResponse<T> {
+  items: T[];
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+export interface PushCredential {
+  app_id: string;
+  credential_id: string;
+  provider: PushCredentialProvider;
+  version: number;
+}
+
+interface VersionedCredentialInput {
+  credentialId?: string;
+  version?: number;
+}
+
+export interface FcmCredentialInput extends VersionedCredentialInput {
+  serviceAccountJson: Record<string, unknown>;
+}
+
+export interface ApnsCredentialInput extends VersionedCredentialInput {
+  p12?: string;
+  p12Password?: string;
+  pem?: string;
+  teamId?: string;
+  keyId?: string;
+  privateKey?: string;
+}
+
+export interface WebPushCredentialInput extends VersionedCredentialInput {
+  publicKey: string;
+  privateKey: string;
+}
+
+export interface HmsCredentialInput extends VersionedCredentialInput {
+  hmsAppId: string;
+  clientSecret: string;
+}
+
+export interface WnsCredentialInput extends VersionedCredentialInput {
+  packageSid: string;
+  clientSecret: string;
+}
+
+export interface PushCredentialInputByProvider {
+  fcm: FcmCredentialInput;
+  apns: ApnsCredentialInput;
+  webpush: WebPushCredentialInput;
+  hms: HmsCredentialInput;
+  wns: WnsCredentialInput;
+}
+
+export interface PushDeviceRecipient {
+  transportType: "gcm" | "apns" | "web" | "hms" | "wns" | "realtime";
+  provider: PushProvider;
+  tokenHash: string;
+}
+
+export interface PushDevice {
+  appId: string;
+  id: string;
+  clientId?: string;
+  formFactor: string;
+  platform: string;
+  timezone: string;
+  locale: string;
+  lastActiveAtMs: number;
+  pushState: "ACTIVE" | "FAILING" | "FAILED";
+  pushFailureCount: number;
+  recipient: PushDeviceRecipient;
+}
+
+export interface PushChannelSubscription {
+  appId: string;
+  channel: string;
+  deviceId: string;
+  clientId?: string;
+  provider: PushProvider;
+  tokenHash: string;
+  credentialVersion?: number;
+}
+
+export type PushTarget =
+  | { type: "device"; device_id?: string; deviceId?: string }
+  | { type: "client"; client_id?: string; clientId?: string }
+  | { type: "channel"; channel: string }
+  | { type: "registeredTopic"; topic: string }
+  | { type: "userTopic"; topic: string }
+  | {
+      type: "providerTopic";
+      provider: PushProvider;
+      topic: string;
+    }
+  | {
+      type: "providerCondition";
+      provider: PushProvider;
+      condition: string;
+    }
+  | { type: "indexedFilter"; filter: Record<string, unknown> }
+  | {
+      type: "recipient";
+      recipient: Record<string, unknown>;
+    };
+
+export interface PushPayload {
+  templateId?: string;
+  templateData?: unknown;
+  title?: string;
+  body?: string;
+  icon?: string;
+  sound?: string;
+  collapseKey?: string;
+}
+
+export interface PushProviderOverride {
+  provider: PushProvider;
+  payload: unknown;
+}
+
+export interface PushPublishInput {
+  publishId?: string;
+  recipients: PushTarget[];
+  payload: PushPayload;
+  providerOverrides?: PushProviderOverride[];
+  sync?: boolean;
+  notBeforeMs?: number;
+  expiresAtMs?: number;
+}
+
+export interface PushPublishAccepted {
+  publishId: string;
+  status: string;
+  expectedRecipients: number;
+  fanoutRegime: string;
+  renderedPayloads: Array<{
+    provider: PushProvider;
+    payload: unknown;
+    usedOverride: boolean;
+  }>;
+}
+
+export interface PushPublishStatus {
+  appId: string;
+  publishId: string;
+  state: string;
+  counters: Record<string, number>;
+  fanoutRegime?: string;
+  retryAfterMs?: number;
+  errorReason?: string;
+}
+
+export interface PushDeadLetter {
+  deadLetterId: string;
+  appId: string;
+  publishId: string;
+  provider?: PushProvider;
+  stage: string;
+  key: string;
+  reason: string;
+  occurredAtMs: number;
+  replayable: boolean;
+}

--- a/dashboard/web/src/api/client.ts
+++ b/dashboard/web/src/api/client.ts
@@ -1,9 +1,77 @@
+export interface Webhook {
+  url?: string;
+  lambda_function?: string;
+  lambda?: { function_name: string; region: string };
+  event_types: string[];
+  filter?: {
+    channel_prefix?: string;
+    channel_suffix?: string;
+    channel_pattern?: string;
+    channel_namespace?: string;
+    channel_namespaces?: string[];
+  };
+  headers?: Record<string, string>;
+  retry?: {
+    enabled?: boolean;
+    max_attempts?: number;
+    max_elapsed_time_ms?: number;
+    initial_backoff_ms?: number;
+    max_backoff_ms?: number;
+  };
+  request_timeout_ms?: number;
+}
+
+export interface MessageRateLimit {
+  enabled: boolean;
+  max_attempts: number;
+  decay_seconds: number;
+  terminate_on_limit: boolean;
+}
+
+export interface HistoryPolicy {
+  enabled?: boolean;
+  rewind_enabled?: boolean;
+  retention_window_seconds?: number;
+  max_messages_per_channel?: number;
+  max_bytes_per_channel?: number;
+}
+
+export interface PresenceHistoryPolicy {
+  enabled?: boolean;
+  retention_window_seconds?: number;
+  max_events_per_channel?: number;
+  max_bytes_per_channel?: number;
+}
+
+export interface ChannelNamespace {
+  name: string;
+  channel_name_pattern?: string;
+  max_channel_name_length?: number;
+  annotations_enabled?: boolean;
+  allow_user_limited_channels?: boolean;
+  allow_subscribe_for_client?: boolean;
+  allow_publish_for_client?: boolean;
+  allow_presence_for_client?: boolean;
+  history?: Omit<HistoryPolicy, "enabled">;
+  presence_history?: PresenceHistoryPolicy;
+}
+
 export interface AppPolicy {
   limits: {
     max_connections: number;
     max_client_events_per_second: number;
     max_backend_events_per_second?: number;
     max_read_requests_per_second?: number;
+    max_presence_members_per_channel?: number;
+    max_presence_member_size_in_kb?: number;
+    max_channel_name_length?: number;
+    max_event_channels_at_once?: number;
+    max_event_name_length?: number;
+    max_event_payload_in_kb?: number;
+    max_event_batch_size?: number;
+    decay_seconds?: number;
+    terminate_on_limit?: boolean;
+    message_rate_limit?: MessageRateLimit;
   };
   features: {
     enable_client_messages: boolean;
@@ -12,15 +80,33 @@ export interface AppPolicy {
   };
   channels: {
     allowed_origins?: string[];
+    annotations_enabled?: boolean;
+    channel_delta_compression?: Record<
+      string,
+      | "inherit"
+      | "disabled"
+      | "fossil"
+      | "xdelta3"
+      | {
+          enabled?: boolean;
+          algorithm?: "Fossil" | "Xdelta3";
+          conflation_key?: string;
+          max_messages_per_key?: number;
+          max_conflation_keys?: number;
+          enable_tags?: boolean;
+        }
+    >;
+    channel_namespaces?: ChannelNamespace[];
   };
   webhooks?: Webhook[];
-}
-
-export interface Webhook {
-  url?: string;
-  event_types: string[];
-  filter?: { channel_prefix?: string; channel_pattern?: string };
-  headers?: Record<string, string>;
+  idempotency?: { enabled?: boolean; ttl_seconds?: number };
+  connection_recovery?: {
+    enabled?: boolean;
+    buffer_ttl_seconds?: number;
+    max_buffer_size?: number;
+  };
+  history?: HistoryPolicy;
+  presence_history?: PresenceHistoryPolicy;
 }
 
 export interface App {
@@ -45,6 +131,26 @@ export interface MetricsSummary {
   by_app: Array<{ app_id: string; connected_sockets: number }>;
 }
 
+export interface MetricSample {
+  name: string;
+  labels: Record<string, string>;
+  value: number;
+  timestamp?: number;
+}
+
+export interface MetricFamily {
+  name: string;
+  help?: string;
+  type?: "counter" | "gauge" | "histogram" | "summary" | "untyped";
+  samples: MetricSample[];
+}
+
+export interface MetricsResponse {
+  samples: MetricSample[];
+  families?: MetricFamily[];
+  scraped_at?: string;
+}
+
 export interface StatsResponse {
   totals: {
     apps: number;
@@ -61,6 +167,201 @@ export interface StatsResponse {
     };
   }>;
   memory: { used: number; total: number; percent: number };
+}
+
+export type PushProvider =
+  | "fcm"
+  | "apns"
+  | "webPush"
+  | "hms"
+  | "wns"
+  | "realtime";
+
+export type PushCredentialProvider = Exclude<PushProvider, "realtime">;
+export type PushCredentialRouteProvider =
+  | "fcm"
+  | "apns"
+  | "webpush"
+  | "hms"
+  | "wns";
+
+export interface PushListResponse<T> {
+  items: T[];
+  next_cursor: string | null;
+  has_more: boolean;
+}
+
+export interface PushCredential {
+  app_id: string;
+  credential_id: string;
+  provider: PushCredentialProvider;
+  version: number;
+}
+
+interface VersionedPushCredentialInput {
+  credentialId?: string;
+  version?: number;
+}
+
+export interface FcmPushCredentialInput
+  extends VersionedPushCredentialInput {
+  serviceAccountJson: Record<string, unknown>;
+}
+
+export interface ApnsPushCredentialInput
+  extends VersionedPushCredentialInput {
+  p12?: string;
+  p12Password?: string;
+  pem?: string;
+  teamId?: string;
+  keyId?: string;
+  privateKey?: string;
+}
+
+export interface WebPushCredentialInput
+  extends VersionedPushCredentialInput {
+  publicKey: string;
+  privateKey: string;
+}
+
+export interface HmsPushCredentialInput
+  extends VersionedPushCredentialInput {
+  hmsAppId: string;
+  clientSecret: string;
+}
+
+export interface WnsPushCredentialInput
+  extends VersionedPushCredentialInput {
+  packageSid: string;
+  clientSecret: string;
+}
+
+export interface PushCredentialInputByProvider {
+  fcm: FcmPushCredentialInput;
+  apns: ApnsPushCredentialInput;
+  webpush: WebPushCredentialInput;
+  hms: HmsPushCredentialInput;
+  wns: WnsPushCredentialInput;
+}
+
+export interface PushDeviceRecipient {
+  transportType: "gcm" | "apns" | "web" | "hms" | "wns" | "realtime";
+  provider: PushProvider;
+  tokenHash: string;
+}
+
+export interface PushDevice {
+  appId: string;
+  id: string;
+  clientId?: string;
+  formFactor: string;
+  platform: string;
+  timezone: string;
+  locale: string;
+  lastActiveAtMs: number;
+  pushState: "ACTIVE" | "FAILING" | "FAILED";
+  pushFailureCount: number;
+  recipient: PushDeviceRecipient;
+}
+
+export interface PushChannelSubscription {
+  appId: string;
+  channel: string;
+  deviceId: string;
+  clientId?: string;
+  provider: PushProvider;
+  tokenHash: string;
+  credentialVersion?: number;
+}
+
+export type PushTarget =
+  | { type: "device"; device_id: string }
+  | { type: "client"; client_id: string }
+  | { type: "channel"; channel: string }
+  | { type: "registeredTopic"; topic: string }
+  | { type: "userTopic"; topic: string }
+  | { type: "providerTopic"; provider: PushProvider; topic: string }
+  | {
+      type: "providerCondition";
+      provider: PushProvider;
+      condition: string;
+    }
+  | { type: "indexedFilter"; filter: Record<string, unknown> }
+  | { type: "recipient"; recipient: Record<string, unknown> };
+
+export interface PushPayload {
+  templateId?: string;
+  templateData?: unknown;
+  title?: string;
+  body?: string;
+  icon?: string;
+  sound?: string;
+  collapseKey?: string;
+}
+
+export interface PushProviderOverride {
+  provider: PushProvider;
+  payload: unknown;
+}
+
+export interface PushPublishInput {
+  publishId?: string;
+  recipients: PushTarget[];
+  payload: PushPayload;
+  providerOverrides?: PushProviderOverride[];
+  sync?: boolean;
+  notBeforeMs?: number;
+  expiresAtMs?: number;
+}
+
+export interface PushPublishAccepted {
+  publishId: string;
+  status: string;
+  expectedRecipients: number;
+  fanoutRegime: string;
+  renderedPayloads: Array<{
+    provider: PushProvider;
+    payload: unknown;
+    usedOverride: boolean;
+  }>;
+}
+
+export interface PushPublishStatus {
+  appId: string;
+  publishId: string;
+  state: string;
+  counters: Record<string, number>;
+  fanoutRegime?: string;
+  retryAfterMs?: number;
+  errorReason?: string;
+}
+
+export interface PushDeadLetter {
+  deadLetterId: string;
+  appId: string;
+  publishId: string;
+  provider?: PushProvider;
+  stage: string;
+  key: string;
+  reason: string;
+  occurredAtMs: number;
+  replayable: boolean;
+}
+
+export interface PushPageQuery {
+  limit?: number;
+  cursor?: string;
+}
+
+export interface PushSubscriptionQuery extends PushPageQuery {
+  channel?: string;
+  deviceId?: string;
+}
+
+export interface PushDeadLetterQuery extends PushPageQuery {
+  provider?: PushCredentialRouteProvider;
+  sinceMs?: number;
+  untilMs?: number;
 }
 
 import type { DashboardUser, UserRole } from "@/types/user";
@@ -85,6 +386,20 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     throw new ApiError(data.error ?? res.statusText, res.status);
   }
   return data as T;
+}
+
+function withQuery(
+  path: string,
+  query?: object,
+): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (value !== undefined && value !== "") {
+      search.set(key, String(value));
+    }
+  }
+  const encoded = search.toString();
+  return encoded ? `${path}?${encoded}` : path;
 }
 
 export const api = {
@@ -148,7 +463,10 @@ export const api = {
       method: "POST",
       body: JSON.stringify(body),
     }),
-  updateApp: (id: string, body: Partial<App>) =>
+  updateApp: (
+    id: string,
+    body: Partial<App> & { replace_policy?: boolean },
+  ) =>
     request<App>(`/api/v1/apps/${id}`, {
       method: "PUT",
       body: JSON.stringify(body),
@@ -173,8 +491,59 @@ export const api = {
     request<App>(`/api/v1/apps/${appId}/webhooks/${index}`, {
       method: "DELETE",
     }),
+  listPushCredentials: (appId: string, query?: PushPageQuery) =>
+    request<PushListResponse<PushCredential>>(
+      withQuery(`/api/v1/apps/${appId}/push/credentials`, query),
+    ),
+  storePushCredential: <P extends PushCredentialRouteProvider>(
+    appId: string,
+    provider: P,
+    body: PushCredentialInputByProvider[P],
+  ) =>
+    request<PushCredential>(
+      `/api/v1/apps/${appId}/push/credentials/${provider}`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      },
+    ),
+  listPushDevices: (appId: string, query?: PushPageQuery) =>
+    request<PushListResponse<PushDevice>>(
+      withQuery(`/api/v1/apps/${appId}/push/devices`, query),
+    ),
+  deletePushDevice: (appId: string, deviceId: string) =>
+    request<unknown>(
+      `/api/v1/apps/${appId}/push/devices/${encodeURIComponent(deviceId)}`,
+      { method: "DELETE" },
+    ),
+  listPushSubscriptions: (
+    appId: string,
+    query?: PushSubscriptionQuery,
+  ) =>
+    request<PushListResponse<PushChannelSubscription>>(
+      withQuery(`/api/v1/apps/${appId}/push/subscriptions`, query),
+    ),
+  publishPush: (appId: string, body: PushPublishInput) =>
+    request<PushPublishAccepted>(`/api/v1/apps/${appId}/push/publish`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  getPushPublishStatus: (appId: string, publishId: string) =>
+    request<PushPublishStatus>(
+      `/api/v1/apps/${appId}/push/publish/${encodeURIComponent(publishId)}/status`,
+    ),
+  listPushDeadLetters: (appId: string, query?: PushDeadLetterQuery) =>
+    request<PushListResponse<PushDeadLetter>>(
+      withQuery(`/api/v1/apps/${appId}/push/dead-letters`, query),
+    ),
+  replayPushDeadLetter: (appId: string, deadLetterId: string) =>
+    request<unknown>(
+      `/api/v1/apps/${appId}/push/dead-letters/${encodeURIComponent(deadLetterId)}/replay`,
+      { method: "POST", body: JSON.stringify({}) },
+    ),
   metricsSummary: () =>
     request<MetricsSummary>("/api/v1/ops/metrics/summary"),
+  metrics: () => request<MetricsResponse>("/api/v1/ops/metrics"),
   stats: () => request<StatsResponse>("/api/v1/ops/stats"),
   opsConfig: () =>
     request<{

--- a/dashboard/web/src/components/Layout.vue
+++ b/dashboard/web/src/components/Layout.vue
@@ -1,13 +1,30 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRouter, RouterLink, RouterView } from "vue-router";
-import { Activity, LayoutGrid, LogOut, Radio, Users } from "lucide-vue-next";
+import {
+  Activity,
+  Database,
+  LayoutGrid,
+  LogOut,
+  Radio,
+  ShieldCheck,
+  Users,
+} from "lucide-vue-next";
 import { useAuthStore } from "@/stores/auth";
 import { api } from "@/api/client";
 
 const auth = useAuthStore();
 const router = useRouter();
 const driver = ref("");
+const initials = computed(() => {
+  const identity = auth.user?.name || auth.email || "Operator";
+  return identity
+    .split(/\s+|@/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+});
 
 onMounted(async () => {
   try {
@@ -25,61 +42,193 @@ async function logout() {
 </script>
 
 <template>
-  <div class="flex h-screen overflow-hidden">
-    <aside class="w-64 shrink-0 border-r border-surface-800 bg-surface-900/50 p-4 flex flex-col">
-      <div class="mb-8 px-2">
-        <div class="flex items-center gap-2 text-brand-400">
-          <Radio class="w-5 h-5" />
-          <span class="font-semibold text-surface-100">Sockudo</span>
+  <div class="flex min-h-screen lg:h-screen lg:overflow-hidden">
+    <aside
+      class="relative hidden w-72 shrink-0 flex-col overflow-hidden border-r border-surface-800/80 bg-surface-950/75 px-4 py-5 backdrop-blur-2xl lg:flex"
+    >
+      <div
+        class="pointer-events-none absolute -left-24 -top-24 h-56 w-56 rounded-full bg-brand-600/15 blur-3xl"
+      />
+
+      <div class="relative mb-8 flex items-center gap-3 px-2">
+        <div
+          class="flex h-10 w-10 items-center justify-center rounded-xl border border-brand-400/25 bg-brand-500/15 text-brand-300 shadow-lg shadow-brand-950/30"
+        >
+          <Radio class="h-5 w-5" />
         </div>
-        <p class="text-xs text-surface-500 mt-1 px-0.5">Operator Dashboard</p>
-        <p v-if="driver" class="text-[10px] text-surface-600 mt-2 font-mono">
-          driver: {{ driver }}
-        </p>
+        <div class="min-w-0">
+          <div class="flex items-center gap-2">
+            <span class="font-semibold tracking-tight text-surface-50">Sockudo</span>
+            <span
+              class="rounded-full border border-surface-700/70 bg-surface-800/60 px-1.5 py-0.5 text-[0.55rem] font-semibold uppercase tracking-wider text-surface-500"
+            >
+              Ops
+            </span>
+          </div>
+          <p class="mt-0.5 text-xs text-surface-500">Realtime control plane</p>
+        </div>
       </div>
 
-      <nav class="space-y-1 flex-1">
+      <p class="mb-2 px-3 text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-surface-600">
+        Workspace
+      </p>
+      <nav class="relative flex-1 space-y-1">
         <RouterLink
           to="/"
-          class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-surface-300 hover:bg-surface-800"
-          active-class="!bg-brand-600/15 !text-brand-300"
+          class="group flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-surface-400 transition hover:bg-surface-800/60 hover:text-surface-100"
+          active-class="!bg-brand-500/12 !text-brand-200 ring-1 ring-inset ring-brand-400/15"
         >
-          <LayoutGrid class="w-4 h-4" />
-          Apps
+          <LayoutGrid class="h-4 w-4 text-surface-500 group-hover:text-surface-300" />
+          <span class="font-medium">Applications</span>
         </RouterLink>
         <RouterLink
           to="/metrics"
-          class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-surface-300 hover:bg-surface-800"
-          active-class="!bg-brand-600/15 !text-brand-300"
+          class="group flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-surface-400 transition hover:bg-surface-800/60 hover:text-surface-100"
+          active-class="!bg-brand-500/12 !text-brand-200 ring-1 ring-inset ring-brand-400/15"
         >
-          <Activity class="w-4 h-4" />
-          Metrics
+          <Activity class="h-4 w-4 text-surface-500 group-hover:text-surface-300" />
+          <span class="font-medium">Observability</span>
         </RouterLink>
         <RouterLink
           v-if="auth.isAdmin"
           to="/users"
-          class="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-surface-300 hover:bg-surface-800"
-          active-class="!bg-brand-600/15 !text-brand-300"
+          class="group flex items-center gap-3 rounded-xl px-3 py-3 text-sm text-surface-400 transition hover:bg-surface-800/60 hover:text-surface-100"
+          active-class="!bg-brand-500/12 !text-brand-200 ring-1 ring-inset ring-brand-400/15"
         >
-          <Users class="w-4 h-4" />
-          Users
+          <Users class="h-4 w-4 text-surface-500 group-hover:text-surface-300" />
+          <span class="font-medium">Team access</span>
         </RouterLink>
       </nav>
 
-      <div class="border-t border-surface-800 pt-4 mt-4">
-        <p class="text-xs text-surface-500 px-2 mb-2 truncate">
-          {{ auth.user?.name || auth.email }}
-          <span v-if="auth.isAdmin" class="text-brand-400">(admin)</span>
-        </p>
-        <button class="btn-secondary w-full flex items-center justify-center gap-2" @click="logout">
-          <LogOut class="w-4 h-4" />
-          Sign out
+      <div
+        v-if="driver"
+        class="relative mb-3 flex items-center gap-3 rounded-xl border border-surface-800 bg-surface-900/55 px-3 py-3"
+      >
+        <div
+          class="flex h-8 w-8 items-center justify-center rounded-lg"
+          :class="
+            driver === 'unknown'
+              ? 'bg-amber-500/10 text-amber-300'
+              : 'bg-emerald-500/10 text-emerald-300'
+          "
+        >
+          <Database class="h-4 w-4" />
+        </div>
+        <div class="min-w-0">
+          <p class="text-[0.62rem] font-semibold uppercase tracking-wider text-surface-600">
+            App manager
+          </p>
+          <p class="truncate font-mono text-xs text-surface-300">{{ driver }}</p>
+        </div>
+        <span
+          class="ml-auto h-2 w-2 rounded-full"
+          :class="
+            driver === 'unknown'
+              ? 'bg-amber-400'
+              : 'bg-emerald-400 shadow-[0_0_10px_rgba(52,211,153,0.6)]'
+          "
+        />
+      </div>
+
+      <div
+        class="relative flex items-center gap-3 rounded-xl border border-surface-800/80 bg-surface-900/45 p-2"
+      >
+        <div
+          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-surface-800 text-xs font-semibold text-brand-200"
+        >
+          {{ initials }}
+        </div>
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-xs font-medium text-surface-200">
+            {{ auth.user?.name || auth.email }}
+          </p>
+          <p class="mt-0.5 flex items-center gap-1 text-[0.62rem] text-surface-600">
+            <ShieldCheck v-if="auth.isAdmin" class="h-3 w-3 text-brand-400" />
+            {{ auth.isAdmin ? "Administrator" : "Operator" }}
+          </p>
+        </div>
+        <button
+          class="icon-button"
+          title="Sign out"
+          aria-label="Sign out"
+          @click="logout"
+        >
+          <LogOut class="h-3.5 w-3.5" />
         </button>
       </div>
     </aside>
 
-    <main class="flex-1 overflow-y-auto p-6 lg:p-8">
-      <div class="max-w-6xl mx-auto">
+    <main class="min-w-0 flex-1 overflow-y-auto">
+      <header
+        class="sticky top-0 z-30 border-b border-surface-800/80 bg-surface-950/85 px-4 py-3 backdrop-blur-xl lg:hidden"
+      >
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2.5">
+            <div
+              class="flex h-8 w-8 items-center justify-center rounded-lg bg-brand-500/15 text-brand-300"
+            >
+              <Radio class="h-4 w-4" />
+            </div>
+            <div>
+              <p class="text-sm font-semibold text-surface-100">Sockudo</p>
+              <p class="text-[0.6rem] uppercase tracking-widest text-surface-600">Control plane</p>
+            </div>
+          </div>
+          <div class="flex items-center gap-2">
+            <span
+              v-if="driver"
+              class="hidden items-center gap-1.5 rounded-full border border-surface-800 bg-surface-900 px-2.5 py-1 font-mono text-[0.62rem] text-surface-500 sm:flex"
+            >
+              <span
+                class="h-1.5 w-1.5 rounded-full"
+                :class="driver === 'unknown' ? 'bg-amber-400' : 'bg-emerald-400'"
+              />
+              {{ driver }}
+            </span>
+            <button
+              class="icon-button"
+              title="Sign out"
+              aria-label="Sign out"
+              @click="logout"
+            >
+              <LogOut class="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+
+        <nav
+          class="-mb-3 mt-3 grid gap-1 pb-2"
+          :class="auth.isAdmin ? 'grid-cols-3' : 'grid-cols-2'"
+        >
+          <RouterLink
+            to="/"
+            class="flex min-w-0 items-center justify-center gap-1.5 rounded-lg px-2 py-2 text-[0.68rem] font-medium text-surface-500 sm:text-xs"
+            active-class="!bg-brand-500/12 !text-brand-200"
+          >
+            <LayoutGrid class="h-3.5 w-3.5" />
+            Applications
+          </RouterLink>
+          <RouterLink
+            to="/metrics"
+            class="flex min-w-0 items-center justify-center gap-1.5 rounded-lg px-2 py-2 text-[0.68rem] font-medium text-surface-500 sm:text-xs"
+            active-class="!bg-brand-500/12 !text-brand-200"
+          >
+            <Activity class="h-3.5 w-3.5" />
+            Observability
+          </RouterLink>
+          <RouterLink
+            v-if="auth.isAdmin"
+            to="/users"
+            class="flex min-w-0 items-center justify-center gap-1.5 rounded-lg px-2 py-2 text-[0.68rem] font-medium text-surface-500 sm:text-xs"
+            active-class="!bg-brand-500/12 !text-brand-200"
+          >
+            <Users class="h-3.5 w-3.5" />
+            Team access
+          </RouterLink>
+        </nav>
+      </header>
+
+      <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
         <RouterView />
       </div>
     </main>

--- a/dashboard/web/src/components/MetricChart.vue
+++ b/dashboard/web/src/components/MetricChart.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+  id: string;
+  points: Array<{ at: number; value: number }>;
+  color?: string;
+}>();
+
+const width = 420;
+const height = 118;
+const padding = 7;
+
+const domain = computed(() => {
+  if (!props.points.length) return { min: 0, max: 1 };
+  const values = props.points.map((point) => point.value);
+  let min = Math.min(...values);
+  let max = Math.max(...values);
+  if (min === max) {
+    const offset = Math.max(Math.abs(min) * 0.1, 1);
+    min -= offset;
+    max += offset;
+  }
+  return { min, max };
+});
+
+const coordinates = computed(() =>
+  props.points.map((point, index) => {
+    const x =
+      props.points.length <= 1
+        ? width / 2
+        : padding + (index / (props.points.length - 1)) * (width - padding * 2);
+    const y =
+      height -
+      padding -
+      ((point.value - domain.value.min) / (domain.value.max - domain.value.min)) *
+        (height - padding * 2);
+    return { ...point, x, y };
+  }),
+);
+
+const linePath = computed(() =>
+  coordinates.value
+    .map((point, index) => `${index === 0 ? "M" : "L"}${point.x},${point.y}`)
+    .join(" "),
+);
+
+const areaPath = computed(() => {
+  if (!coordinates.value.length) return "";
+  const first = coordinates.value[0];
+  const last = coordinates.value.at(-1)!;
+  return `${linePath.value} L${last.x},${height} L${first.x},${height} Z`;
+});
+</script>
+
+<template>
+  <div class="metric-chart">
+    <svg
+      v-if="points.length"
+      :viewBox="`0 0 ${width} ${height}`"
+      preserveAspectRatio="none"
+      role="img"
+      aria-label="Metric history"
+    >
+      <defs>
+        <linearGradient :id="`fill-${id}`" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" :stop-color="color ?? '#748ffc'" stop-opacity="0.28" />
+          <stop offset="100%" :stop-color="color ?? '#748ffc'" stop-opacity="0" />
+        </linearGradient>
+      </defs>
+      <line v-for="line in [0.25, 0.5, 0.75]" :key="line" x1="0" :y1="height * line" :x2="width" :y2="height * line" />
+      <path :d="areaPath" :fill="`url(#fill-${id})`" />
+      <path :d="linePath" fill="none" :stroke="color ?? '#748ffc'" />
+      <circle
+        v-if="coordinates.length"
+        :cx="coordinates.at(-1)!.x"
+        :cy="coordinates.at(-1)!.y"
+        r="3"
+        :fill="color ?? '#748ffc'"
+      />
+    </svg>
+    <div v-else class="flex h-full items-center justify-center text-xs text-surface-600">
+      Waiting for samples
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.metric-chart {
+  height: 7.4rem;
+  width: 100%;
+}
+
+svg {
+  display: block;
+  height: 100%;
+  width: 100%;
+  overflow: visible;
+}
+
+line {
+  stroke: rgb(51 65 85 / 0.45);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+path {
+  stroke-width: 1.8;
+  vector-effect: non-scaling-stroke;
+}
+
+path[fill] {
+  stroke: none;
+}
+
+circle {
+  vector-effect: non-scaling-stroke;
+}
+</style>

--- a/dashboard/web/src/components/NumberField.vue
+++ b/dashboard/web/src/components/NumberField.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+defineProps<{
+  modelValue?: number;
+  label: string;
+  hint?: string;
+  min?: number;
+  step?: number;
+  placeholder?: string;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: number | undefined];
+}>();
+
+function update(event: Event) {
+  const raw = (event.target as HTMLInputElement).value.trim();
+  emit("update:modelValue", raw === "" ? undefined : Number(raw));
+}
+</script>
+
+<template>
+  <label class="block">
+    <span class="field-label">{{ label }}</span>
+    <input
+      :value="modelValue ?? ''"
+      type="number"
+      class="input-field"
+      :min="min ?? 0"
+      :step="step ?? 1"
+      :placeholder="placeholder"
+      @input="update"
+    />
+    <span v-if="hint" class="field-hint">{{ hint }}</span>
+  </label>
+</template>

--- a/dashboard/web/src/components/TriStateControl.vue
+++ b/dashboard/web/src/components/TriStateControl.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+defineProps<{
+  modelValue?: boolean;
+  label: string;
+  hint?: string;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: boolean | undefined];
+}>();
+</script>
+
+<template>
+  <div class="setting-row">
+    <div class="min-w-0">
+      <p class="text-sm font-medium text-surface-200">{{ label }}</p>
+      <p v-if="hint" class="text-xs leading-5 text-surface-500 mt-0.5">{{ hint }}</p>
+    </div>
+    <div class="segmented shrink-0" role="group" :aria-label="label">
+      <button
+        type="button"
+        :class="{ active: modelValue === undefined }"
+        @click="emit('update:modelValue', undefined)"
+      >
+        Inherit
+      </button>
+      <button
+        type="button"
+        :class="{ active: modelValue === true }"
+        @click="emit('update:modelValue', true)"
+      >
+        On
+      </button>
+      <button
+        type="button"
+        :class="{ active: modelValue === false }"
+        @click="emit('update:modelValue', false)"
+      >
+        Off
+      </button>
+    </div>
+  </div>
+</template>

--- a/dashboard/web/src/pages/AppDetailPage.vue
+++ b/dashboard/web/src/pages/AppDetailPage.vue
@@ -1,26 +1,70 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, toRaw, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { ArrowLeft, Plus, RefreshCw, Trash2 } from "lucide-vue-next";
-import { api, type App, type Webhook } from "@/api/client";
+import {
+  ArrowLeft,
+  BellRing,
+  Check,
+  ChevronRight,
+  KeyRound,
+  Plus,
+  RefreshCw,
+  Save,
+  Trash2,
+} from "lucide-vue-next";
+import NumberField from "@/components/NumberField.vue";
+import TriStateControl from "@/components/TriStateControl.vue";
+import {
+  api,
+  type App,
+  type ChannelNamespace,
+  type Webhook,
+} from "@/api/client";
+
+type Section = "general" | "limits" | "channels" | "reliability" | "webhooks";
+type OptionalPolicy = "idempotency" | "connection_recovery" | "history" | "presence_history";
 
 const route = useRoute();
 const router = useRouter();
 const appId = computed(() => route.params.id as string);
-
+const activeSection = ref<Section>("general");
 const app = ref<App | null>(null);
-const webhooks = ref<Webhook[]>([]);
 const loading = ref(true);
 const saving = ref(false);
+const saved = ref(false);
 const error = ref<string | null>(null);
 const revealSecret = ref(false);
+
+const sections: Array<{ id: Section; label: string; description: string }> = [
+  { id: "general", label: "General", description: "Credentials and app capabilities" },
+  { id: "limits", label: "Limits", description: "Traffic, payload, and presence guardrails" },
+  { id: "channels", label: "Channels", description: "Origins, namespaces, and delta rules" },
+  { id: "reliability", label: "Reliability", description: "Recovery, history, and idempotency" },
+  { id: "webhooks", label: "Webhooks", description: "Event delivery and retry policies" },
+];
+
+const origins = computed({
+  get: () => app.value?.policy.channels.allowed_origins?.join(", ") ?? "",
+  set: (value: string) => {
+    if (!app.value) return;
+    app.value.policy.channels.allowed_origins = value
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean);
+  },
+});
+
+const deltaRules = computed(() =>
+  Object.entries(app.value?.policy.channels.channel_delta_compression ?? {}),
+);
+const newDeltaPattern = ref("");
+const newDeltaMode = ref<"inherit" | "disabled" | "fossil" | "xdelta3">("fossil");
+
 const showWebhookForm = ref(false);
 const editingWebhookIndex = ref<number | null>(null);
-
-const webhookForm = ref<Webhook>({
-  url: "",
-  event_types: ["channel_occupied"],
-});
+const webhookTarget = ref<"url" | "lambda">("url");
+const webhookHeaders = ref("{}");
+const webhookForm = ref<Webhook>(newWebhook());
 
 const eventTypeOptions = [
   "channel_occupied",
@@ -30,8 +74,11 @@ const eventTypeOptions = [
   "member_removed",
   "member_updated",
   "client_event",
+  "cache_miss",
   "ai_turn_started",
   "ai_turn_ended",
+  "ai_cancel_requested",
+  "ai_stream_orphaned",
   "message_version_created",
   "annotation_created",
   "annotation_deleted",
@@ -40,16 +87,19 @@ const eventTypeOptions = [
 onMounted(load);
 watch(appId, load);
 
+function newWebhook(): Webhook {
+  return {
+    url: "",
+    event_types: ["channel_occupied"],
+    retry: { enabled: true, max_attempts: 3 },
+  };
+}
+
 async function load() {
   loading.value = true;
   error.value = null;
   try {
-    const [appData, hooks] = await Promise.all([
-      api.getApp(appId.value, revealSecret.value),
-      api.listWebhooks(appId.value),
-    ]);
-    app.value = appData;
-    webhooks.value = hooks;
+    app.value = await api.getApp(appId.value);
   } catch (err) {
     error.value = err instanceof Error ? err.message : "Failed to load app";
   } finally {
@@ -60,13 +110,18 @@ async function load() {
 async function saveApp() {
   if (!app.value) return;
   saving.value = true;
+  saved.value = false;
+  error.value = null;
   try {
     app.value = await api.updateApp(appId.value, {
       key: app.value.key,
       enabled: app.value.enabled,
       policy: app.value.policy,
+      replace_policy: true,
     });
-    error.value = null;
+    revealSecret.value = false;
+    saved.value = true;
+    window.setTimeout(() => (saved.value = false), 2_000);
   } catch (err) {
     error.value = err instanceof Error ? err.message : "Save failed";
   } finally {
@@ -74,36 +129,130 @@ async function saveApp() {
   }
 }
 
-async function rotateSecret() {
-  if (!confirm("Rotate app secret? Existing signed API calls will fail until updated.")) return;
+async function toggleSecret() {
+  if (!app.value) return;
   try {
-    revealSecret.value = true;
+    revealSecret.value = !revealSecret.value;
+    const fresh = await api.getApp(appId.value, revealSecret.value);
+    app.value.secret = fresh.secret;
+  } catch (err) {
+    revealSecret.value = false;
+    error.value = err instanceof Error ? err.message : "Secret lookup failed";
+  }
+}
+
+async function rotateSecret() {
+  if (!confirm("Rotate this app secret? Existing signed API calls will stop working.")) return;
+  try {
     app.value = await api.rotateSecret(appId.value);
+    revealSecret.value = true;
   } catch (err) {
     error.value = err instanceof Error ? err.message : "Rotate failed";
   }
 }
 
+function enableMessageRateLimit() {
+  if (!app.value) return;
+  app.value.policy.limits.message_rate_limit = {
+    enabled: false,
+    max_attempts: 60,
+    decay_seconds: 60,
+    terminate_on_limit: false,
+  };
+}
+
+function addNamespace() {
+  if (!app.value) return;
+  const namespaces = (app.value.policy.channels.channel_namespaces ??= []);
+  namespaces.push({ name: `namespace-${namespaces.length + 1}` });
+}
+
+function removeNamespace(index: number) {
+  app.value?.policy.channels.channel_namespaces?.splice(index, 1);
+}
+
+function addDeltaRule() {
+  if (!app.value || !newDeltaPattern.value.trim()) return;
+  const rules = (app.value.policy.channels.channel_delta_compression ??= {});
+  rules[newDeltaPattern.value.trim()] = newDeltaMode.value;
+  newDeltaPattern.value = "";
+}
+
+function updateDeltaRule(pattern: string, mode: string) {
+  if (!app.value || mode === "advanced") return;
+  const rules = (app.value.policy.channels.channel_delta_compression ??= {});
+  rules[pattern] = mode as "inherit" | "disabled" | "fossil" | "xdelta3";
+}
+
+function removeDeltaRule(pattern: string) {
+  if (!app.value?.policy.channels.channel_delta_compression) return;
+  delete app.value.policy.channels.channel_delta_compression[pattern];
+}
+
+function addPolicyOverride(section: OptionalPolicy) {
+  if (!app.value) return;
+  if (section === "idempotency") app.value.policy.idempotency = {};
+  if (section === "connection_recovery") app.value.policy.connection_recovery = {};
+  if (section === "history") app.value.policy.history = {};
+  if (section === "presence_history") app.value.policy.presence_history = {};
+}
+
+function removePolicyOverride(section: OptionalPolicy) {
+  if (!app.value) return;
+  delete app.value.policy[section];
+}
+
 function resetWebhookForm() {
-  webhookForm.value = { url: "", event_types: ["channel_occupied"] };
+  webhookForm.value = newWebhook();
+  webhookTarget.value = "url";
+  webhookHeaders.value = "{}";
   editingWebhookIndex.value = null;
   showWebhookForm.value = false;
 }
 
+function openNewWebhook() {
+  resetWebhookForm();
+  showWebhookForm.value = true;
+}
+
 function editWebhook(index: number) {
+  const hook = app.value?.policy.webhooks?.[index];
+  if (!hook) return;
   editingWebhookIndex.value = index;
-  webhookForm.value = structuredClone(webhooks.value[index]);
+  webhookForm.value = structuredClone(toRaw(hook));
+  webhookForm.value.retry ??= { enabled: true, max_attempts: 3 };
+  webhookTarget.value = hook.lambda || hook.lambda_function ? "lambda" : "url";
+  webhookHeaders.value = JSON.stringify(hook.headers ?? {}, null, 2);
   showWebhookForm.value = true;
 }
 
 async function saveWebhook() {
+  error.value = null;
   try {
-    if (editingWebhookIndex.value !== null) {
-      await api.updateWebhook(appId.value, editingWebhookIndex.value, webhookForm.value);
-    } else {
-      await api.createWebhook(appId.value, webhookForm.value);
+    const parsedHeaders = JSON.parse(webhookHeaders.value || "{}");
+    if (!parsedHeaders || Array.isArray(parsedHeaders) || typeof parsedHeaders !== "object") {
+      throw new Error("Webhook headers must be a JSON object");
     }
-    webhooks.value = await api.listWebhooks(appId.value);
+    webhookForm.value.headers =
+      Object.keys(parsedHeaders).length > 0 ? parsedHeaders : undefined;
+
+    if (webhookTarget.value === "url") {
+      delete webhookForm.value.lambda;
+      delete webhookForm.value.lambda_function;
+    } else {
+      delete webhookForm.value.url;
+    }
+
+    const updated =
+      editingWebhookIndex.value === null
+        ? await api.createWebhook(appId.value, webhookForm.value)
+        : await api.updateWebhook(
+            appId.value,
+            editingWebhookIndex.value,
+            webhookForm.value,
+          );
+    app.value = updated;
+    revealSecret.value = false;
     resetWebhookForm();
   } catch (err) {
     error.value = err instanceof Error ? err.message : "Webhook save failed";
@@ -113,217 +262,967 @@ async function saveWebhook() {
 async function deleteWebhook(index: number) {
   if (!confirm("Delete this webhook?")) return;
   try {
-    await api.deleteWebhook(appId.value, index);
-    webhooks.value = await api.listWebhooks(appId.value);
+    app.value = await api.deleteWebhook(appId.value, index);
+    revealSecret.value = false;
   } catch (err) {
     error.value = err instanceof Error ? err.message : "Delete failed";
   }
 }
 
 function toggleEventType(type: string) {
-  const set = new Set(webhookForm.value.event_types);
-  if (set.has(type)) set.delete(type);
-  else set.add(type);
-  webhookForm.value.event_types = [...set];
+  const selected = new Set(webhookForm.value.event_types);
+  if (selected.has(type)) selected.delete(type);
+  else selected.add(type);
+  webhookForm.value.event_types = [...selected];
+}
+
+function webhookDestination(hook: Webhook) {
+  if (hook.url) return hook.url;
+  if (hook.lambda) return `${hook.lambda.function_name} · ${hook.lambda.region}`;
+  return hook.lambda_function ?? "Lambda target";
 }
 </script>
 
 <template>
   <div>
-    <button
-      class="btn-secondary btn-sm flex items-center gap-1 mb-4"
-      @click="router.push({ name: 'apps' })"
-    >
-      <ArrowLeft class="w-3 h-3" />
-      Back to apps
+    <button class="back-link" @click="router.push({ name: 'apps' })">
+      <ArrowLeft class="w-4 h-4" />
+      Applications
     </button>
 
-    <div v-if="loading" class="text-surface-400">Loading...</div>
+    <div v-if="loading" class="empty-state">Loading application configuration…</div>
 
     <template v-else-if="app">
-      <div class="flex items-start justify-between mb-6">
-        <div>
-          <h1 class="text-2xl font-semibold font-mono text-brand-300">{{ app.id }}</h1>
-          <p class="text-sm text-surface-400 mt-1">Edit app configuration and webhooks</p>
-        </div>
-        <button class="btn-primary" :disabled="saving" @click="saveApp">
-          {{ saving ? "Saving..." : "Save changes" }}
-        </button>
-      </div>
-
-      <p v-if="error" class="text-red-400 text-sm mb-4">{{ error }}</p>
-
-      <div class="grid lg:grid-cols-2 gap-6 mb-8">
-        <div class="panel p-6 space-y-4">
-          <h2 class="font-medium text-surface-200">Credentials</h2>
-          <div>
-            <label class="section-title">App Key</label>
-            <input v-model="app.key" class="input-field font-mono" />
-          </div>
-          <div>
-            <label class="section-title">Secret</label>
-            <div class="flex gap-2">
-              <input :value="app.secret" class="input-field font-mono flex-1" readonly />
-              <button class="btn-secondary btn-sm" @click="revealSecret = !revealSecret; load()">
-                {{ revealSecret ? "Hide" : "Reveal" }}
-              </button>
-              <button class="btn-secondary btn-sm flex items-center gap-1" @click="rotateSecret">
-                <RefreshCw class="w-3 h-3" />
-                Rotate
-              </button>
+      <header class="page-header">
+        <div class="min-w-0">
+          <div class="flex items-center gap-3">
+            <div class="app-avatar">{{ app.id.slice(0, 2).toUpperCase() }}</div>
+            <div class="min-w-0">
+              <div class="flex items-center gap-2">
+                <h1 class="page-title font-mono truncate">{{ app.id }}</h1>
+                <span :class="app.enabled ? 'status-positive' : 'status-negative'" class="status-pill">
+                  {{ app.enabled ? "Enabled" : "Disabled" }}
+                </span>
+              </div>
+              <p class="page-subtitle">Application policy and delivery configuration</p>
             </div>
-          </div>
-          <label class="flex items-center gap-2 text-sm text-surface-300">
-            <input v-model="app.enabled" type="checkbox" class="rounded" />
-            Enabled
-          </label>
-        </div>
-
-        <div class="panel p-6 space-y-4">
-          <h2 class="font-medium text-surface-200">Limits</h2>
-          <div class="grid grid-cols-2 gap-4">
-            <div>
-              <label class="section-title">Max connections</label>
-              <input
-                v-model.number="app.policy.limits.max_connections"
-                type="number"
-                class="input-field"
-              />
-            </div>
-            <div>
-              <label class="section-title">Client events / sec</label>
-              <input
-                v-model.number="app.policy.limits.max_client_events_per_second"
-                type="number"
-                class="input-field"
-              />
-            </div>
-            <div>
-              <label class="section-title">Backend events / sec</label>
-              <input
-                v-model.number="app.policy.limits.max_backend_events_per_second"
-                type="number"
-                class="input-field"
-              />
-            </div>
-            <div>
-              <label class="section-title">Read requests / sec</label>
-              <input
-                v-model.number="app.policy.limits.max_read_requests_per_second"
-                type="number"
-                class="input-field"
-              />
-            </div>
-          </div>
-          <label class="flex items-center gap-2 text-sm text-surface-300">
-            <input
-              v-model="app.policy.features.enable_client_messages"
-              type="checkbox"
-              class="rounded"
-            />
-            Enable client messages
-          </label>
-          <label class="flex items-center gap-2 text-sm text-surface-300">
-            <input
-              v-model="app.policy.features.enable_user_authentication"
-              type="checkbox"
-              class="rounded"
-            />
-            Enable user authentication
-          </label>
-          <div>
-            <label class="section-title">Allowed origins (comma-separated)</label>
-            <input
-              :value="(app.policy.channels.allowed_origins ?? []).join(', ')"
-              class="input-field"
-              @input="
-                app.policy.channels.allowed_origins = ($event.target as HTMLInputElement).value
-                  .split(',')
-                  .map((s) => s.trim())
-                  .filter(Boolean)
-              "
-            />
           </div>
         </div>
-      </div>
-
-      <div class="panel p-6">
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="font-medium text-surface-200">Webhooks</h2>
+        <div class="flex flex-wrap items-center gap-2">
           <button
-            class="btn-primary btn-sm flex items-center gap-1"
-            @click="resetWebhookForm(); showWebhookForm = true"
+            class="btn-secondary flex items-center gap-2"
+            @click="router.push({ name: 'app-push', params: { id: app.id } })"
           >
-            <Plus class="w-3 h-3" />
-            Add webhook
+            <BellRing class="w-4 h-4" />
+            Push manager
+          </button>
+          <button class="btn-primary flex items-center gap-2" :disabled="saving" @click="saveApp">
+            <Check v-if="saved" class="w-4 h-4" />
+            <Save v-else class="w-4 h-4" />
+            {{ saved ? "Saved" : saving ? "Saving…" : "Save changes" }}
           </button>
         </div>
+      </header>
 
-        <div v-if="showWebhookForm" class="border border-surface-700 rounded-lg p-4 mb-4 space-y-4">
-          <div>
-            <label class="section-title">URL</label>
-            <input v-model="webhookForm.url" class="input-field" placeholder="https://..." />
-          </div>
-          <div>
-            <label class="section-title">Event types</label>
-            <div class="flex flex-wrap gap-2">
-              <button
-                v-for="type in eventTypeOptions"
-                :key="type"
-                type="button"
-                class="text-xs px-2 py-1 rounded border"
-                :class="
-                  webhookForm.event_types.includes(type)
-                    ? 'border-brand-500 bg-brand-500/15 text-brand-300'
-                    : 'border-surface-600 text-surface-400'
-                "
-                @click="toggleEventType(type)"
-              >
-                {{ type }}
-              </button>
-            </div>
-          </div>
-          <div>
-            <label class="section-title">Channel prefix filter (optional)</label>
-            <input
-              :value="webhookForm.filter?.channel_prefix ?? ''"
-              class="input-field"
-              @input="
-                webhookForm.filter = {
-                  ...webhookForm.filter,
-                  channel_prefix: ($event.target as HTMLInputElement).value || undefined,
-                }
-              "
-            />
-          </div>
-          <div class="flex gap-2">
-            <button class="btn-primary btn-sm" @click="saveWebhook">Save webhook</button>
-            <button class="btn-secondary btn-sm" @click="resetWebhookForm">Cancel</button>
-          </div>
-        </div>
+      <div v-if="error" class="alert alert-error mb-5">{{ error }}</div>
 
-        <div v-if="webhooks.length === 0" class="text-surface-500 text-sm">
-          No webhooks configured.
-        </div>
-        <div v-else class="space-y-3">
-          <div
-            v-for="(hook, index) in webhooks"
-            :key="index"
-            class="border border-surface-700 rounded-lg p-4 flex justify-between gap-4"
+      <div class="app-settings-layout">
+        <nav class="settings-nav panel">
+          <button
+            v-for="section in sections"
+            :key="section.id"
+            type="button"
+            :class="{ active: activeSection === section.id }"
+            @click="activeSection = section.id"
           >
-            <div class="min-w-0">
-              <p class="font-mono text-sm text-brand-300 truncate">{{ hook.url }}</p>
-              <p class="text-xs text-surface-500 mt-1">
-                {{ hook.event_types.join(", ") }}
-              </p>
-            </div>
-            <div class="flex gap-2 shrink-0">
-              <button class="btn-secondary btn-sm" @click="editWebhook(index)">Edit</button>
-              <button class="btn-danger btn-sm" @click="deleteWebhook(index)">
-                <Trash2 class="w-3 h-3" />
-              </button>
-            </div>
-          </div>
+            <span>
+              <strong>{{ section.label }}</strong>
+              <small>{{ section.description }}</small>
+            </span>
+            <ChevronRight class="w-4 h-4" />
+          </button>
+        </nav>
+
+        <div class="min-w-0 space-y-5">
+          <template v-if="activeSection === 'general'">
+            <section class="settings-card">
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Identity</p>
+                  <h2>API credentials</h2>
+                  <p>Use these values for realtime clients and signed server requests.</p>
+                </div>
+                <KeyRound class="w-5 h-5 text-brand-300" />
+              </div>
+              <div class="grid md:grid-cols-2 gap-4">
+                <label>
+                  <span class="field-label">App ID</span>
+                  <input :value="app.id" class="input-field font-mono" disabled />
+                </label>
+                <label>
+                  <span class="field-label">App key</span>
+                  <input v-model.trim="app.key" class="input-field font-mono" />
+                </label>
+                <label class="md:col-span-2">
+                  <span class="field-label">App secret</span>
+                  <div class="flex flex-col sm:flex-row gap-2">
+                    <input
+                      :value="app.secret"
+                      class="input-field font-mono flex-1"
+                      readonly
+                      autocomplete="off"
+                    />
+                    <button class="btn-secondary" type="button" @click="toggleSecret">
+                      {{ revealSecret ? "Hide" : "Reveal" }}
+                    </button>
+                    <button
+                      class="btn-secondary flex items-center justify-center gap-2"
+                      type="button"
+                      @click="rotateSecret"
+                    >
+                      <RefreshCw class="w-4 h-4" />
+                      Rotate
+                    </button>
+                  </div>
+                </label>
+              </div>
+              <div class="alert alert-warning mt-5">
+                App changes are read from the configured app-manager database. Running Sockudo
+                nodes may retain cached policy until their database cache TTL expires.
+              </div>
+            </section>
+
+            <section class="settings-card">
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Capabilities</p>
+                  <h2>Application features</h2>
+                  <p>Choose which client-originated protocol features this app can use.</p>
+                </div>
+              </div>
+              <label class="setting-row">
+                <span>
+                  <span class="block text-sm font-medium text-surface-200">Application enabled</span>
+                  <span class="block text-xs text-surface-500 mt-1">
+                    Disabled apps reject new authenticated connections and API calls.
+                  </span>
+                </span>
+                <input v-model="app.enabled" type="checkbox" class="toggle-input" />
+              </label>
+              <label class="setting-row">
+                <span>
+                  <span class="block text-sm font-medium text-surface-200">Client messages</span>
+                  <span class="block text-xs text-surface-500 mt-1">
+                    Allow clients to publish client-prefixed events.
+                  </span>
+                </span>
+                <input
+                  v-model="app.policy.features.enable_client_messages"
+                  type="checkbox"
+                  class="toggle-input"
+                />
+              </label>
+              <TriStateControl
+                v-model="app.policy.features.enable_user_authentication"
+                label="User authentication"
+                hint="Enable authenticated user sign-in and user-scoped features."
+              />
+              <TriStateControl
+                v-model="app.policy.features.enable_watchlist_events"
+                label="Watchlist events"
+                hint="Emit user watchlist state changes to compatible clients."
+              />
+            </section>
+          </template>
+
+          <template v-else-if="activeSection === 'limits'">
+            <section class="settings-card">
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Capacity</p>
+                  <h2>Connection and request limits</h2>
+                  <p>Blank optional values inherit the server-wide configuration.</p>
+                </div>
+              </div>
+              <div class="grid md:grid-cols-2 gap-4">
+                <label>
+                  <span class="field-label">Max connections</span>
+                  <input
+                    v-model.number="app.policy.limits.max_connections"
+                    type="number"
+                    min="0"
+                    class="input-field"
+                  />
+                </label>
+                <NumberField
+                  v-model="app.policy.limits.max_backend_events_per_second"
+                  label="Backend events / second"
+                  hint="Signed HTTP API publishes."
+                />
+                <label>
+                  <span class="field-label">Client events / second</span>
+                  <input
+                    v-model.number="app.policy.limits.max_client_events_per_second"
+                    type="number"
+                    min="0"
+                    class="input-field"
+                  />
+                </label>
+                <NumberField
+                  v-model="app.policy.limits.max_read_requests_per_second"
+                  label="Read requests / second"
+                />
+                <NumberField
+                  v-model="app.policy.limits.decay_seconds"
+                  label="Client-event window (seconds)"
+                  hint="Sliding window used by the client-event limiter."
+                />
+              </div>
+              <label class="setting-row mt-4">
+                <span>
+                  <span class="block text-sm font-medium text-surface-200">
+                    Terminate when client-event limit is exceeded
+                  </span>
+                  <span class="block text-xs text-surface-500 mt-1">
+                    Otherwise only the over-limit event is rejected.
+                  </span>
+                </span>
+                <input
+                  v-model="app.policy.limits.terminate_on_limit"
+                  type="checkbox"
+                  class="toggle-input"
+                />
+              </label>
+            </section>
+
+            <section class="settings-card">
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Protocol guardrails</p>
+                  <h2>Channels and event payloads</h2>
+                </div>
+              </div>
+              <div class="grid md:grid-cols-2 gap-4">
+                <NumberField
+                  v-model="app.policy.limits.max_channel_name_length"
+                  label="Channel name length"
+                />
+                <NumberField
+                  v-model="app.policy.limits.max_event_name_length"
+                  label="Event name length"
+                />
+                <NumberField
+                  v-model="app.policy.limits.max_event_channels_at_once"
+                  label="Channels per event"
+                />
+                <NumberField
+                  v-model="app.policy.limits.max_event_payload_in_kb"
+                  label="Event payload (KiB)"
+                />
+                <NumberField
+                  v-model="app.policy.limits.max_event_batch_size"
+                  label="Events per batch"
+                />
+              </div>
+            </section>
+
+            <section class="settings-card">
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Presence</p>
+                  <h2>Presence limits</h2>
+                </div>
+              </div>
+              <div class="grid md:grid-cols-2 gap-4">
+                <NumberField
+                  v-model="app.policy.limits.max_presence_members_per_channel"
+                  label="Members per channel"
+                />
+                <NumberField
+                  v-model="app.policy.limits.max_presence_member_size_in_kb"
+                  label="Member data (KiB)"
+                />
+              </div>
+            </section>
+
+            <section class="settings-card">
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Abuse protection</p>
+                  <h2>All-message rate limiter</h2>
+                  <p>Applies to every inbound WebSocket message, not just client events.</p>
+                </div>
+                <button
+                  v-if="!app.policy.limits.message_rate_limit"
+                  class="btn-secondary btn-sm"
+                  @click="enableMessageRateLimit"
+                >
+                  Add override
+                </button>
+                <button
+                  v-else
+                  class="btn-secondary btn-sm"
+                  @click="delete app.policy.limits.message_rate_limit"
+                >
+                  Use server defaults
+                </button>
+              </div>
+              <div v-if="app.policy.limits.message_rate_limit" class="space-y-4">
+                <label class="setting-row">
+                  <span class="text-sm font-medium text-surface-200">Enabled</span>
+                  <input
+                    v-model="app.policy.limits.message_rate_limit.enabled"
+                    type="checkbox"
+                    class="toggle-input"
+                  />
+                </label>
+                <div class="grid md:grid-cols-2 gap-4">
+                  <NumberField
+                    v-model="app.policy.limits.message_rate_limit.max_attempts"
+                    label="Maximum messages"
+                  />
+                  <NumberField
+                    v-model="app.policy.limits.message_rate_limit.decay_seconds"
+                    label="Window (seconds)"
+                  />
+                </div>
+                <label class="setting-row">
+                  <span class="text-sm font-medium text-surface-200">Terminate connection</span>
+                  <input
+                    v-model="app.policy.limits.message_rate_limit.terminate_on_limit"
+                    type="checkbox"
+                    class="toggle-input"
+                  />
+                </label>
+              </div>
+              <div v-else class="inherit-state">Using the server-wide message limiter.</div>
+            </section>
+          </template>
+
+          <template v-else-if="activeSection === 'channels'">
+            <section class="settings-card">
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Access</p>
+                  <h2>Origins and annotations</h2>
+                </div>
+              </div>
+              <label>
+                <span class="field-label">Allowed origins</span>
+                <input
+                  v-model="origins"
+                  class="input-field font-mono"
+                  placeholder="https://app.example.com, https://*.example.com"
+                />
+                <span class="field-hint">Comma-separated patterns. Use * only for trusted development.</span>
+              </label>
+              <div class="mt-4">
+                <TriStateControl
+                  v-model="app.policy.channels.annotations_enabled"
+                  label="Message annotations"
+                  hint="Allow reactions and other annotation records on compatible channels."
+                />
+              </div>
+            </section>
+
+            <section class="settings-card">
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Namespaces</p>
+                  <h2>Channel policy overrides</h2>
+                  <p>Match names like namespace:room and override permissions or retention.</p>
+                </div>
+                <button class="btn-secondary btn-sm flex items-center gap-1" @click="addNamespace">
+                  <Plus class="w-3.5 h-3.5" />
+                  Add namespace
+                </button>
+              </div>
+
+              <div
+                v-if="!app.policy.channels.channel_namespaces?.length"
+                class="inherit-state"
+              >
+                No namespace-specific policy. All channels inherit the app settings.
+              </div>
+              <div v-else class="space-y-4">
+                <div
+                  v-for="(namespace, index) in app.policy.channels.channel_namespaces"
+                  :key="index"
+                  class="subcard"
+                >
+                  <div class="flex items-center justify-between gap-3 mb-4">
+                    <p class="font-mono text-sm text-brand-300">
+                      {{ namespace.name || `namespace-${index + 1}` }}
+                    </p>
+                    <button
+                      class="icon-button danger"
+                      :aria-label="`Remove namespace ${namespace.name || index + 1}`"
+                      @click="removeNamespace(index)"
+                    >
+                      <Trash2 class="w-4 h-4" />
+                    </button>
+                  </div>
+                  <div class="grid md:grid-cols-2 gap-4">
+                    <label>
+                      <span class="field-label">Namespace</span>
+                      <input v-model.trim="namespace.name" class="input-field font-mono" />
+                    </label>
+                    <label>
+                      <span class="field-label">Channel regex</span>
+                      <input
+                        v-model.trim="namespace.channel_name_pattern"
+                        class="input-field font-mono"
+                        placeholder="Optional"
+                      />
+                    </label>
+                    <NumberField
+                      v-model="namespace.max_channel_name_length"
+                      label="Maximum channel length"
+                    />
+                  </div>
+                  <div class="grid lg:grid-cols-2 gap-x-5 mt-4">
+                    <TriStateControl
+                      v-model="namespace.allow_subscribe_for_client"
+                      label="Client subscribe"
+                    />
+                    <TriStateControl
+                      v-model="namespace.allow_publish_for_client"
+                      label="Client publish"
+                    />
+                    <TriStateControl
+                      v-model="namespace.allow_presence_for_client"
+                      label="Client presence"
+                    />
+                    <TriStateControl
+                      v-model="namespace.allow_user_limited_channels"
+                      label="User-limited channels"
+                    />
+                    <TriStateControl
+                      v-model="namespace.annotations_enabled"
+                      label="Annotations"
+                    />
+                  </div>
+                  <div class="grid lg:grid-cols-2 gap-4 mt-4">
+                    <div class="nested-policy">
+                      <div class="flex justify-between gap-2 mb-3">
+                        <p class="text-sm font-medium">History override</p>
+                        <button
+                          v-if="!namespace.history"
+                          class="text-button"
+                          :aria-label="`Add history override for ${namespace.name || `namespace ${index + 1}`}`"
+                          @click="namespace.history = {}"
+                        >
+                          Add
+                        </button>
+                        <button
+                          v-else
+                          class="text-button"
+                          :aria-label="`Remove history override for ${namespace.name || `namespace ${index + 1}`}`"
+                          @click="delete namespace.history"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                      <template v-if="namespace.history">
+                        <TriStateControl
+                          v-model="namespace.history.rewind_enabled"
+                          label="Rewind"
+                        />
+                        <NumberField
+                          v-model="namespace.history.retention_window_seconds"
+                          label="Retention (seconds)"
+                        />
+                        <NumberField
+                          v-model="namespace.history.max_messages_per_channel"
+                          label="Messages per channel"
+                        />
+                        <NumberField
+                          v-model="namespace.history.max_bytes_per_channel"
+                          label="Bytes per channel"
+                        />
+                      </template>
+                      <p v-else class="text-xs text-surface-500">Inherits app history.</p>
+                    </div>
+                    <div class="nested-policy">
+                      <div class="flex justify-between gap-2 mb-3">
+                        <p class="text-sm font-medium">Presence history override</p>
+                        <button
+                          v-if="!namespace.presence_history"
+                          class="text-button"
+                          :aria-label="`Add presence history override for ${namespace.name || `namespace ${index + 1}`}`"
+                          @click="namespace.presence_history = {}"
+                        >
+                          Add
+                        </button>
+                        <button
+                          v-else
+                          class="text-button"
+                          :aria-label="`Remove presence history override for ${namespace.name || `namespace ${index + 1}`}`"
+                          @click="delete namespace.presence_history"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                      <template v-if="namespace.presence_history">
+                        <TriStateControl
+                          v-model="namespace.presence_history.enabled"
+                          label="Enabled"
+                        />
+                        <NumberField
+                          v-model="namespace.presence_history.retention_window_seconds"
+                          label="Retention (seconds)"
+                        />
+                        <NumberField
+                          v-model="namespace.presence_history.max_events_per_channel"
+                          label="Events per channel"
+                        />
+                        <NumberField
+                          v-model="namespace.presence_history.max_bytes_per_channel"
+                          label="Bytes per channel"
+                        />
+                      </template>
+                      <p v-else class="text-xs text-surface-500">Inherits app presence history.</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section class="settings-card">
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Protocol V2</p>
+                  <h2>Delta compression rules</h2>
+                  <p>Set the delivery algorithm by exact channel or channel pattern.</p>
+                </div>
+              </div>
+              <div v-if="deltaRules.length" class="space-y-2 mb-4">
+                <div v-for="[pattern, config] in deltaRules" :key="pattern" class="rule-row">
+                  <code>{{ pattern }}</code>
+                  <select
+                    class="input-field !w-auto"
+                    :aria-label="`Compression mode for ${pattern}`"
+                    :value="typeof config === 'string' ? config : 'advanced'"
+                    @change="updateDeltaRule(pattern, ($event.target as HTMLSelectElement).value)"
+                  >
+                    <option value="inherit">Inherit</option>
+                    <option value="disabled">Disabled</option>
+                    <option value="fossil">Fossil</option>
+                    <option value="xdelta3">Xdelta3</option>
+                    <option v-if="typeof config === 'object'" value="advanced">
+                      Advanced conflation
+                    </option>
+                  </select>
+                  <button
+                    class="icon-button danger"
+                    :aria-label="`Remove delta rule ${pattern}`"
+                    @click="removeDeltaRule(pattern)"
+                  >
+                    <Trash2 class="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+              <div class="grid sm:grid-cols-[1fr_150px_auto] gap-2">
+                <input
+                  v-model.trim="newDeltaPattern"
+                  class="input-field font-mono"
+                  placeholder="channel or pattern"
+                />
+                <select
+                  v-model="newDeltaMode"
+                  class="input-field"
+                  aria-label="New delta compression mode"
+                >
+                  <option value="inherit">Inherit</option>
+                  <option value="disabled">Disabled</option>
+                  <option value="fossil">Fossil</option>
+                  <option value="xdelta3">Xdelta3</option>
+                </select>
+                <button class="btn-secondary" @click="addDeltaRule">Add rule</button>
+              </div>
+            </section>
+          </template>
+
+          <template v-else-if="activeSection === 'reliability'">
+            <section
+              v-for="section in ([
+                ['idempotency', 'Idempotency', 'Suppress duplicate signed publishes.'],
+                ['connection_recovery', 'Connection recovery', 'Keep a bounded hot replay buffer.'],
+                ['history', 'Durable history', 'Persist messages for history and rewind.'],
+                ['presence_history', 'Presence history', 'Persist member transition records.'],
+              ] as const)"
+              :key="section[0]"
+              class="settings-card"
+            >
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Reliability policy</p>
+                  <h2>{{ section[1] }}</h2>
+                  <p>{{ section[2] }}</p>
+                </div>
+                <button
+                  v-if="!app.policy[section[0]]"
+                  class="btn-secondary btn-sm"
+                  :aria-label="`Add ${section[1]} override`"
+                  @click="addPolicyOverride(section[0])"
+                >
+                  Add override
+                </button>
+                <button
+                  v-else
+                  class="btn-secondary btn-sm"
+                  :aria-label="`Use server defaults for ${section[1]}`"
+                  @click="removePolicyOverride(section[0])"
+                >
+                  Use server defaults
+                </button>
+              </div>
+
+              <div v-if="!app.policy[section[0]]" class="inherit-state">
+                This app inherits the server-wide {{ section[1].toLowerCase() }} configuration.
+              </div>
+
+              <template v-else-if="section[0] === 'idempotency' && app.policy.idempotency">
+                <TriStateControl v-model="app.policy.idempotency.enabled" label="Enabled" />
+                <NumberField
+                  v-model="app.policy.idempotency.ttl_seconds"
+                  label="Deduplication TTL (seconds)"
+                />
+              </template>
+
+              <template
+                v-else-if="
+                  section[0] === 'connection_recovery' && app.policy.connection_recovery
+                "
+              >
+                <TriStateControl v-model="app.policy.connection_recovery.enabled" label="Enabled" />
+                <div class="grid md:grid-cols-2 gap-4 mt-4">
+                  <NumberField
+                    v-model="app.policy.connection_recovery.buffer_ttl_seconds"
+                    label="Buffer TTL (seconds)"
+                  />
+                  <NumberField
+                    v-model="app.policy.connection_recovery.max_buffer_size"
+                    label="Maximum buffered messages"
+                  />
+                </div>
+              </template>
+
+              <template v-else-if="section[0] === 'history' && app.policy.history">
+                <TriStateControl v-model="app.policy.history.enabled" label="Enabled" />
+                <TriStateControl v-model="app.policy.history.rewind_enabled" label="Rewind" />
+                <div class="grid md:grid-cols-2 gap-4 mt-4">
+                  <NumberField
+                    v-model="app.policy.history.retention_window_seconds"
+                    label="Retention (seconds)"
+                  />
+                  <NumberField
+                    v-model="app.policy.history.max_messages_per_channel"
+                    label="Messages per channel"
+                  />
+                  <NumberField
+                    v-model="app.policy.history.max_bytes_per_channel"
+                    label="Bytes per channel"
+                  />
+                </div>
+              </template>
+
+              <template
+                v-else-if="section[0] === 'presence_history' && app.policy.presence_history"
+              >
+                <TriStateControl v-model="app.policy.presence_history.enabled" label="Enabled" />
+                <div class="grid md:grid-cols-2 gap-4 mt-4">
+                  <NumberField
+                    v-model="app.policy.presence_history.retention_window_seconds"
+                    label="Retention (seconds)"
+                  />
+                  <NumberField
+                    v-model="app.policy.presence_history.max_events_per_channel"
+                    label="Events per channel"
+                  />
+                  <NumberField
+                    v-model="app.policy.presence_history.max_bytes_per_channel"
+                    label="Bytes per channel"
+                  />
+                </div>
+              </template>
+            </section>
+          </template>
+
+          <template v-else>
+            <section class="settings-card">
+              <div class="card-heading">
+                <div>
+                  <p class="eyebrow">Delivery</p>
+                  <h2>Webhooks</h2>
+                  <p>Forward selected realtime events to HTTP or AWS Lambda targets.</p>
+                </div>
+                <button class="btn-primary btn-sm flex items-center gap-1" @click="openNewWebhook">
+                  <Plus class="w-3.5 h-3.5" />
+                  Add webhook
+                </button>
+              </div>
+
+              <div v-if="showWebhookForm" class="subcard mb-5 space-y-4">
+                <div>
+                  <span class="field-label">Destination</span>
+                  <div class="segmented w-fit">
+                    <button
+                      :class="{ active: webhookTarget === 'url' }"
+                      :aria-pressed="webhookTarget === 'url'"
+                      @click="webhookTarget = 'url'"
+                    >
+                      HTTP URL
+                    </button>
+                    <button
+                      :class="{ active: webhookTarget === 'lambda' }"
+                      :aria-pressed="webhookTarget === 'lambda'"
+                      @click="webhookTarget = 'lambda'"
+                    >
+                      AWS Lambda
+                    </button>
+                  </div>
+                </div>
+                <label v-if="webhookTarget === 'url'">
+                  <span class="field-label">URL</span>
+                  <input
+                    v-model.trim="webhookForm.url"
+                    class="input-field"
+                    placeholder="https://hooks.example.com/sockudo"
+                  />
+                </label>
+                <div v-else class="grid md:grid-cols-2 gap-4">
+                  <label>
+                    <span class="field-label">Function name</span>
+                    <input
+                      :value="webhookForm.lambda?.function_name ?? ''"
+                      class="input-field"
+                      @input="
+                        webhookForm.lambda = {
+                          function_name: ($event.target as HTMLInputElement).value,
+                          region: webhookForm.lambda?.region ?? '',
+                        }
+                      "
+                    />
+                  </label>
+                  <label>
+                    <span class="field-label">AWS region</span>
+                    <input
+                      :value="webhookForm.lambda?.region ?? ''"
+                      class="input-field"
+                      placeholder="eu-west-1"
+                      @input="
+                        webhookForm.lambda = {
+                          function_name: webhookForm.lambda?.function_name ?? '',
+                          region: ($event.target as HTMLInputElement).value,
+                        }
+                      "
+                    />
+                  </label>
+                </div>
+
+                <div>
+                  <span class="field-label">Event types</span>
+                  <div class="flex flex-wrap gap-2">
+                    <button
+                      v-for="type in eventTypeOptions"
+                      :key="type"
+                      type="button"
+                      class="event-chip"
+                      :class="{ active: webhookForm.event_types.includes(type) }"
+                      :aria-pressed="webhookForm.event_types.includes(type)"
+                      @click="toggleEventType(type)"
+                    >
+                      {{ type }}
+                    </button>
+                  </div>
+                </div>
+
+                <div class="grid md:grid-cols-2 gap-4">
+                  <label>
+                    <span class="field-label">Channel prefix</span>
+                    <input
+                      :value="webhookForm.filter?.channel_prefix ?? ''"
+                      class="input-field"
+                      @input="
+                        webhookForm.filter = {
+                          ...webhookForm.filter,
+                          channel_prefix: ($event.target as HTMLInputElement).value || undefined,
+                        }
+                      "
+                    />
+                  </label>
+                  <label>
+                    <span class="field-label">Channel suffix</span>
+                    <input
+                      :value="webhookForm.filter?.channel_suffix ?? ''"
+                      class="input-field"
+                      @input="
+                        webhookForm.filter = {
+                          ...webhookForm.filter,
+                          channel_suffix: ($event.target as HTMLInputElement).value || undefined,
+                        }
+                      "
+                    />
+                  </label>
+                  <label>
+                    <span class="field-label">Channel regex</span>
+                    <input
+                      :value="webhookForm.filter?.channel_pattern ?? ''"
+                      class="input-field font-mono"
+                      @input="
+                        webhookForm.filter = {
+                          ...webhookForm.filter,
+                          channel_pattern: ($event.target as HTMLInputElement).value || undefined,
+                        }
+                      "
+                    />
+                  </label>
+                  <label>
+                    <span class="field-label">Namespace</span>
+                    <input
+                      :value="webhookForm.filter?.channel_namespace ?? ''"
+                      class="input-field"
+                      @input="
+                        webhookForm.filter = {
+                          ...webhookForm.filter,
+                          channel_namespace:
+                            ($event.target as HTMLInputElement).value || undefined,
+                        }
+                      "
+                    />
+                  </label>
+                  <label>
+                    <span class="field-label">Namespaces (comma-separated)</span>
+                    <input
+                      :value="webhookForm.filter?.channel_namespaces?.join(', ') ?? ''"
+                      class="input-field"
+                      @input="
+                        webhookForm.filter = {
+                          ...webhookForm.filter,
+                          channel_namespaces: ($event.target as HTMLInputElement).value
+                            .split(',')
+                            .map((value) => value.trim())
+                            .filter(Boolean),
+                        }
+                      "
+                    />
+                  </label>
+                </div>
+
+                <div class="grid md:grid-cols-2 gap-4">
+                  <label class="setting-row md:col-span-2 !py-2">
+                    <span class="text-sm font-medium text-surface-200">Retry delivery</span>
+                    <input
+                      v-model="webhookForm.retry!.enabled"
+                      type="checkbox"
+                      class="toggle-input"
+                    />
+                  </label>
+                  <label>
+                    <span class="field-label">Request timeout (ms)</span>
+                    <input
+                      v-model.number="webhookForm.request_timeout_ms"
+                      type="number"
+                      min="0"
+                      class="input-field"
+                    />
+                  </label>
+                  <label>
+                    <span class="field-label">Retry attempts</span>
+                    <input
+                      v-model.number="webhookForm.retry!.max_attempts"
+                      type="number"
+                      min="0"
+                      class="input-field"
+                    />
+                  </label>
+                  <label>
+                    <span class="field-label">Initial backoff (ms)</span>
+                    <input
+                      v-model.number="webhookForm.retry!.initial_backoff_ms"
+                      type="number"
+                      min="0"
+                      class="input-field"
+                    />
+                  </label>
+                  <label>
+                    <span class="field-label">Maximum backoff (ms)</span>
+                    <input
+                      v-model.number="webhookForm.retry!.max_backoff_ms"
+                      type="number"
+                      min="0"
+                      class="input-field"
+                    />
+                  </label>
+                  <label>
+                    <span class="field-label">Maximum retry time (ms)</span>
+                    <input
+                      v-model.number="webhookForm.retry!.max_elapsed_time_ms"
+                      type="number"
+                      min="0"
+                      class="input-field"
+                    />
+                  </label>
+                </div>
+                <label>
+                  <span class="field-label">Headers (JSON)</span>
+                  <textarea
+                    v-model="webhookHeaders"
+                    rows="4"
+                    class="input-field font-mono resize-y"
+                    placeholder='{ "X-Service-Key": "..." }'
+                  />
+                  <span class="field-hint">
+                    Header values may contain credentials. They remain in the app policy database.
+                  </span>
+                </label>
+                <div class="flex gap-2">
+                  <button class="btn-primary btn-sm" @click="saveWebhook">Save webhook</button>
+                  <button class="btn-secondary btn-sm" @click="resetWebhookForm">Cancel</button>
+                </div>
+              </div>
+
+              <div v-if="!app.policy.webhooks?.length" class="inherit-state">
+                No webhooks configured.
+              </div>
+              <div v-else class="space-y-3">
+                <div
+                  v-for="(hook, index) in app.policy.webhooks"
+                  :key="index"
+                  class="webhook-row"
+                >
+                  <div class="min-w-0">
+                    <p class="font-mono text-sm text-brand-300 truncate">
+                      {{ webhookDestination(hook) }}
+                    </p>
+                    <p class="text-xs text-surface-500 mt-1">
+                      {{ hook.event_types.length }} event types
+                      <span v-if="hook.retry?.enabled !== false">
+                        · retries {{ hook.retry?.max_attempts ?? "default" }}
+                      </span>
+                    </p>
+                  </div>
+                  <div class="flex gap-2 shrink-0">
+                    <button
+                      class="btn-secondary btn-sm"
+                      :aria-label="`Edit webhook ${webhookDestination(hook)}`"
+                      @click="editWebhook(index)"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      class="icon-button danger"
+                      :aria-label="`Delete webhook ${webhookDestination(hook)}`"
+                      @click="deleteWebhook(index)"
+                    >
+                      <Trash2 class="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </template>
         </div>
       </div>
     </template>

--- a/dashboard/web/src/pages/AppPushPage.vue
+++ b/dashboard/web/src/pages/AppPushPage.vue
@@ -1,0 +1,1628 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Bell,
+  ChevronRight,
+  Database,
+  KeyRound,
+  RefreshCw,
+  RotateCcw,
+  Search,
+  Send,
+  ShieldCheck,
+  Smartphone,
+  Trash2,
+  Users,
+} from "lucide-vue-next";
+import {
+  api,
+  type PushChannelSubscription,
+  type PushCredential,
+  type PushCredentialRouteProvider,
+  type PushDeadLetter,
+  type PushDevice,
+  type PushProvider,
+  type PushPublishAccepted,
+  type PushPublishStatus,
+  type PushTarget,
+} from "@/api/client";
+import { useAuthStore } from "@/stores/auth";
+
+type PushSection = "credentials" | "devices" | "delivery" | "dead-letters";
+type ApnsMode = "token" | "p12" | "pem";
+type BasicTargetType = "channel" | "device" | "client";
+
+const route = useRoute();
+const router = useRouter();
+const auth = useAuthStore();
+const appId = computed(() => route.params.id as string);
+
+const sections: Array<{
+  id: PushSection;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "credentials",
+    label: "Credentials",
+    description: "Provider keys",
+  },
+  {
+    id: "devices",
+    label: "Devices",
+    description: "Registrations",
+  },
+  {
+    id: "delivery",
+    label: "Delivery",
+    description: "Compose & inspect",
+  },
+  {
+    id: "dead-letters",
+    label: "Dead letters",
+    description: "Failures & replay",
+  },
+];
+
+const providers: Array<{
+  id: PushCredentialRouteProvider;
+  responseId: Exclude<PushProvider, "realtime">;
+  short: string;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "fcm",
+    responseId: "fcm",
+    short: "FCM",
+    label: "Firebase Cloud Messaging",
+    description: "Android and Firebase-backed apps",
+  },
+  {
+    id: "apns",
+    responseId: "apns",
+    short: "APNs",
+    label: "Apple Push Notification service",
+    description: "iPhone, iPad, macOS, and Apple platforms",
+  },
+  {
+    id: "webpush",
+    responseId: "webPush",
+    short: "Web",
+    label: "Web Push",
+    description: "Browser push with VAPID keys",
+  },
+  {
+    id: "hms",
+    responseId: "hms",
+    short: "HMS",
+    label: "Huawei Mobile Services",
+    description: "Huawei devices and AppGallery apps",
+  },
+  {
+    id: "wns",
+    responseId: "wns",
+    short: "WNS",
+    label: "Windows Notification Service",
+    description: "Windows and Microsoft Store apps",
+  },
+];
+
+const activeSection = ref<PushSection>("credentials");
+const refreshing = ref(false);
+const notice = ref<string | null>(null);
+
+const credentials = ref<PushCredential[]>([]);
+const credentialsCursor = ref<string | null>(null);
+const credentialsHasMore = ref(false);
+const credentialsLoading = ref(false);
+const credentialsError = ref<string | null>(null);
+
+const devices = ref<PushDevice[]>([]);
+const devicesCursor = ref<string | null>(null);
+const devicesHasMore = ref(false);
+const devicesLoading = ref(false);
+const devicesError = ref<string | null>(null);
+const deletingDeviceId = ref<string | null>(null);
+
+const subscriptions = ref<PushChannelSubscription[]>([]);
+const subscriptionsCursor = ref<string | null>(null);
+const subscriptionsHasMore = ref(false);
+const subscriptionsLoading = ref(false);
+const subscriptionsError = ref<string | null>(null);
+const subscriptionChannel = ref("");
+const subscriptionDeviceId = ref("");
+
+const deadLetters = ref<PushDeadLetter[]>([]);
+const deadLettersCursor = ref<string | null>(null);
+const deadLettersHasMore = ref(false);
+const deadLettersLoading = ref(false);
+const deadLettersError = ref<string | null>(null);
+const deadLetterProvider = ref<"" | PushCredentialRouteProvider>("");
+const replayingDeadLetterId = ref<string | null>(null);
+
+const selectedProvider = ref<PushCredentialRouteProvider | null>(null);
+const savingCredential = ref(false);
+const credentialError = ref<string | null>(null);
+const credentialDraft = reactive({
+  credentialId: "",
+  version: 1,
+  fcmJson: "",
+  apnsMode: "token" as ApnsMode,
+  apnsTeamId: "",
+  apnsKeyId: "",
+  apnsPrivateKey: "",
+  apnsP12: "",
+  apnsP12Password: "",
+  apnsPem: "",
+  webPushPublicKey: "",
+  webPushPrivateKey: "",
+  hmsAppId: "",
+  hmsClientSecret: "",
+  wnsPackageSid: "",
+  wnsClientSecret: "",
+});
+
+const composer = reactive({
+  targetType: "channel" as BasicTargetType,
+  targetValue: "",
+  title: "",
+  body: "",
+  icon: "",
+  sound: "",
+  collapseKey: "",
+  publishId: "",
+  sync: false,
+});
+const publishing = ref(false);
+const publishError = ref<string | null>(null);
+const acceptedPublish = ref<PushPublishAccepted | null>(null);
+
+const statusPublishId = ref("");
+const publishStatus = ref<PushPublishStatus | null>(null);
+const statusLoading = ref(false);
+const statusError = ref<string | null>(null);
+
+const selectedProviderDetails = computed(() =>
+  providers.find((provider) => provider.id === selectedProvider.value),
+);
+
+const statusCounters = computed(() =>
+  Object.entries(publishStatus.value?.counters ?? {}).sort(([left], [right]) =>
+    left.localeCompare(right),
+  ),
+);
+
+function messageFrom(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+function providerLabel(provider?: PushProvider): string {
+  if (!provider) return "Unassigned";
+  if (provider === "webPush") return "Web Push";
+  if (provider === "realtime") return "Realtime";
+  return provider.toUpperCase();
+}
+
+function credentialCount(
+  provider: (typeof providers)[number],
+): number {
+  return credentials.value.filter(
+    (credential) => credential.provider === provider.responseId,
+  ).length;
+}
+
+function formatDate(timestampMs: number): string {
+  if (!timestampMs) return "—";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestampMs));
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat().format(value);
+}
+
+function setNotice(message: string): void {
+  notice.value = message;
+  window.setTimeout(() => {
+    if (notice.value === message) notice.value = null;
+  }, 6_000);
+}
+
+async function loadCredentials(reset = true): Promise<void> {
+  if (credentialsLoading.value) return;
+  credentialsLoading.value = true;
+  credentialsError.value = null;
+  try {
+    const page = await api.listPushCredentials(appId.value, {
+      limit: 50,
+      cursor: reset ? undefined : credentialsCursor.value ?? undefined,
+    });
+    credentials.value = reset
+      ? page.items
+      : [...credentials.value, ...page.items];
+    credentialsCursor.value = page.next_cursor;
+    credentialsHasMore.value = page.has_more;
+  } catch (error) {
+    credentialsError.value = messageFrom(
+      error,
+      "Failed to load stored credentials",
+    );
+  } finally {
+    credentialsLoading.value = false;
+  }
+}
+
+async function loadDevices(reset = true): Promise<void> {
+  if (devicesLoading.value) return;
+  devicesLoading.value = true;
+  devicesError.value = null;
+  try {
+    const page = await api.listPushDevices(appId.value, {
+      limit: 50,
+      cursor: reset ? undefined : devicesCursor.value ?? undefined,
+    });
+    devices.value = reset ? page.items : [...devices.value, ...page.items];
+    devicesCursor.value = page.next_cursor;
+    devicesHasMore.value = page.has_more;
+  } catch (error) {
+    devicesError.value = messageFrom(
+      error,
+      "Failed to load device registrations",
+    );
+  } finally {
+    devicesLoading.value = false;
+  }
+}
+
+async function loadSubscriptions(reset = true): Promise<void> {
+  if (subscriptionsLoading.value) return;
+  subscriptionsLoading.value = true;
+  subscriptionsError.value = null;
+  try {
+    const page = await api.listPushSubscriptions(appId.value, {
+      channel: subscriptionChannel.value.trim() || undefined,
+      deviceId: subscriptionDeviceId.value.trim() || undefined,
+      limit: 50,
+      cursor: reset ? undefined : subscriptionsCursor.value ?? undefined,
+    });
+    subscriptions.value = reset
+      ? page.items
+      : [...subscriptions.value, ...page.items];
+    subscriptionsCursor.value = page.next_cursor;
+    subscriptionsHasMore.value = page.has_more;
+  } catch (error) {
+    subscriptionsError.value = messageFrom(
+      error,
+      "Failed to load channel subscriptions",
+    );
+  } finally {
+    subscriptionsLoading.value = false;
+  }
+}
+
+async function loadDeadLetters(reset = true): Promise<void> {
+  if (deadLettersLoading.value) return;
+  deadLettersLoading.value = true;
+  deadLettersError.value = null;
+  try {
+    const page = await api.listPushDeadLetters(appId.value, {
+      provider: deadLetterProvider.value || undefined,
+      limit: 50,
+      cursor: reset ? undefined : deadLettersCursor.value ?? undefined,
+    });
+    deadLetters.value = reset
+      ? page.items
+      : [...deadLetters.value, ...page.items];
+    deadLettersCursor.value = page.next_cursor;
+    deadLettersHasMore.value = page.has_more;
+  } catch (error) {
+    deadLettersError.value = messageFrom(
+      error,
+      "Failed to load dead letters",
+    );
+  } finally {
+    deadLettersLoading.value = false;
+  }
+}
+
+async function refreshAll(): Promise<void> {
+  refreshing.value = true;
+  await Promise.all([
+    loadCredentials(true),
+    loadDevices(true),
+    loadSubscriptions(true),
+    loadDeadLetters(true),
+  ]);
+  refreshing.value = false;
+}
+
+function clearCredentialDraft(): void {
+  credentialDraft.credentialId = "";
+  credentialDraft.version = 1;
+  credentialDraft.fcmJson = "";
+  credentialDraft.apnsMode = "token";
+  credentialDraft.apnsTeamId = "";
+  credentialDraft.apnsKeyId = "";
+  credentialDraft.apnsPrivateKey = "";
+  credentialDraft.apnsP12 = "";
+  credentialDraft.apnsP12Password = "";
+  credentialDraft.apnsPem = "";
+  credentialDraft.webPushPublicKey = "";
+  credentialDraft.webPushPrivateKey = "";
+  credentialDraft.hmsAppId = "";
+  credentialDraft.hmsClientSecret = "";
+  credentialDraft.wnsPackageSid = "";
+  credentialDraft.wnsClientSecret = "";
+  credentialError.value = null;
+}
+
+function openCredentialForm(provider: PushCredentialRouteProvider): void {
+  clearCredentialDraft();
+  selectedProvider.value = provider;
+}
+
+function closeCredentialForm(): void {
+  clearCredentialDraft();
+  selectedProvider.value = null;
+}
+
+function credentialMetadata(): {
+  credentialId?: string;
+  version: number;
+} {
+  if (
+    !Number.isSafeInteger(credentialDraft.version) ||
+    credentialDraft.version < 1
+  ) {
+    throw new Error("Credential version must be a positive integer");
+  }
+  return {
+    credentialId: credentialDraft.credentialId.trim() || undefined,
+    version: credentialDraft.version,
+  };
+}
+
+async function submitCredential(): Promise<void> {
+  const provider = selectedProvider.value;
+  if (!provider || !auth.isAdmin) return;
+  savingCredential.value = true;
+  credentialError.value = null;
+  try {
+    const metadata = credentialMetadata();
+    let stored: PushCredential;
+
+    switch (provider) {
+      case "fcm": {
+        let serviceAccountJson: unknown;
+        try {
+          serviceAccountJson = JSON.parse(credentialDraft.fcmJson);
+        } catch {
+          throw new Error("Service account JSON is not valid JSON");
+        }
+        if (
+          !serviceAccountJson ||
+          typeof serviceAccountJson !== "object" ||
+          Array.isArray(serviceAccountJson)
+        ) {
+          throw new Error("Service account JSON must be an object");
+        }
+        stored = await api.storePushCredential(appId.value, "fcm", {
+          ...metadata,
+          serviceAccountJson: serviceAccountJson as Record<string, unknown>,
+        });
+        break;
+      }
+      case "apns": {
+        if (
+          credentialDraft.apnsMode === "token" &&
+          (!credentialDraft.apnsTeamId.trim() ||
+            !credentialDraft.apnsKeyId.trim() ||
+            !credentialDraft.apnsPrivateKey.trim())
+        ) {
+          throw new Error(
+            "Team ID, key ID, and private key are required for APNs token authentication",
+          );
+        }
+        if (
+          credentialDraft.apnsMode === "p12" &&
+          !credentialDraft.apnsP12.trim()
+        ) {
+          throw new Error("A PKCS#12 payload is required");
+        }
+        if (
+          credentialDraft.apnsMode === "pem" &&
+          !credentialDraft.apnsPem.trim()
+        ) {
+          throw new Error("A PEM certificate and key payload is required");
+        }
+        stored = await api.storePushCredential(appId.value, "apns", {
+          ...metadata,
+          ...(credentialDraft.apnsMode === "token"
+            ? {
+                teamId: credentialDraft.apnsTeamId.trim(),
+                keyId: credentialDraft.apnsKeyId.trim(),
+                privateKey: credentialDraft.apnsPrivateKey.trim(),
+              }
+            : {}),
+          ...(credentialDraft.apnsMode === "p12"
+            ? {
+                p12: credentialDraft.apnsP12.trim(),
+                p12Password:
+                  credentialDraft.apnsP12Password.trim() || undefined,
+              }
+            : {}),
+          ...(credentialDraft.apnsMode === "pem"
+            ? { pem: credentialDraft.apnsPem.trim() }
+            : {}),
+        });
+        break;
+      }
+      case "webpush":
+        if (
+          !credentialDraft.webPushPublicKey.trim() ||
+          !credentialDraft.webPushPrivateKey.trim()
+        ) {
+          throw new Error("Both VAPID public and private keys are required");
+        }
+        stored = await api.storePushCredential(appId.value, "webpush", {
+          ...metadata,
+          publicKey: credentialDraft.webPushPublicKey.trim(),
+          privateKey: credentialDraft.webPushPrivateKey.trim(),
+        });
+        break;
+      case "hms":
+        if (
+          !credentialDraft.hmsAppId.trim() ||
+          !credentialDraft.hmsClientSecret.trim()
+        ) {
+          throw new Error("HMS app ID and client secret are required");
+        }
+        stored = await api.storePushCredential(appId.value, "hms", {
+          ...metadata,
+          hmsAppId: credentialDraft.hmsAppId.trim(),
+          clientSecret: credentialDraft.hmsClientSecret.trim(),
+        });
+        break;
+      case "wns":
+        if (
+          !credentialDraft.wnsPackageSid.trim() ||
+          !credentialDraft.wnsClientSecret.trim()
+        ) {
+          throw new Error("Package SID and client secret are required");
+        }
+        stored = await api.storePushCredential(appId.value, "wns", {
+          ...metadata,
+          packageSid: credentialDraft.wnsPackageSid.trim(),
+          clientSecret: credentialDraft.wnsClientSecret.trim(),
+        });
+        break;
+    }
+
+    const label = providerLabel(stored.provider);
+    closeCredentialForm();
+    await loadCredentials(true);
+    setNotice(
+      `${label} credential “${stored.credential_id}” version ${stored.version} was stored. Restart the matching provider worker to load it.`,
+    );
+  } catch (error) {
+    credentialError.value = messageFrom(
+      error,
+      "Failed to store provider credential",
+    );
+  } finally {
+    savingCredential.value = false;
+  }
+}
+
+async function deleteDevice(device: PushDevice): Promise<void> {
+  if (!auth.isAdmin) return;
+  if (
+    !window.confirm(
+      `Delete device registration “${device.id}”? Its channel subscriptions will no longer deliver push notifications.`,
+    )
+  ) {
+    return;
+  }
+  deletingDeviceId.value = device.id;
+  devicesError.value = null;
+  try {
+    await api.deletePushDevice(appId.value, device.id);
+    await Promise.all([loadDevices(true), loadSubscriptions(true)]);
+    setNotice(`Device “${device.id}” was removed.`);
+  } catch (error) {
+    devicesError.value = messageFrom(
+      error,
+      "Failed to delete device registration",
+    );
+  } finally {
+    deletingDeviceId.value = null;
+  }
+}
+
+function composerTarget(): PushTarget {
+  const value = composer.targetValue.trim();
+  if (!value) throw new Error("A recipient value is required");
+  switch (composer.targetType) {
+    case "channel":
+      return { type: "channel", channel: value };
+    case "device":
+      return { type: "device", device_id: value };
+    case "client":
+      return { type: "client", client_id: value };
+  }
+}
+
+async function publishNotification(): Promise<void> {
+  if (!auth.isAdmin) return;
+  publishing.value = true;
+  publishError.value = null;
+  acceptedPublish.value = null;
+  try {
+    const target = composerTarget();
+    if (!composer.title.trim() && !composer.body.trim()) {
+      throw new Error("Add a notification title or body");
+    }
+    const accepted = await api.publishPush(appId.value, {
+      publishId: composer.publishId.trim() || undefined,
+      recipients: [target],
+      payload: {
+        title: composer.title.trim() || undefined,
+        body: composer.body.trim() || undefined,
+        icon: composer.icon.trim() || undefined,
+        sound: composer.sound.trim() || undefined,
+        collapseKey: composer.collapseKey.trim() || undefined,
+      },
+      sync: composer.sync,
+    });
+    acceptedPublish.value = accepted;
+    statusPublishId.value = accepted.publishId;
+    composer.publishId = "";
+    composer.title = "";
+    composer.body = "";
+    composer.icon = "";
+    composer.sound = "";
+    composer.collapseKey = "";
+    setNotice(`Push “${accepted.publishId}” was accepted for delivery.`);
+  } catch (error) {
+    publishError.value = messageFrom(
+      error,
+      "Failed to publish notification",
+    );
+  } finally {
+    publishing.value = false;
+  }
+}
+
+async function lookupPublishStatus(): Promise<void> {
+  const publishId = statusPublishId.value.trim();
+  if (!publishId) {
+    statusError.value = "Enter a publish ID";
+    return;
+  }
+  statusLoading.value = true;
+  statusError.value = null;
+  try {
+    publishStatus.value = await api.getPushPublishStatus(
+      appId.value,
+      publishId,
+    );
+  } catch (error) {
+    publishStatus.value = null;
+    statusError.value = messageFrom(error, "Failed to load publish status");
+  } finally {
+    statusLoading.value = false;
+  }
+}
+
+async function replayDeadLetter(deadLetter: PushDeadLetter): Promise<void> {
+  if (!auth.isAdmin || !deadLetter.replayable) return;
+  if (
+    !window.confirm(
+      `Replay dead letter “${deadLetter.deadLetterId}” for publish “${deadLetter.publishId}”?`,
+    )
+  ) {
+    return;
+  }
+  replayingDeadLetterId.value = deadLetter.deadLetterId;
+  deadLettersError.value = null;
+  try {
+    await api.replayPushDeadLetter(appId.value, deadLetter.deadLetterId);
+    statusPublishId.value = deadLetter.publishId;
+    await loadDeadLetters(true);
+    setNotice(
+      `Dead letter “${deadLetter.deadLetterId}” was submitted for replay.`,
+    );
+  } catch (error) {
+    deadLettersError.value = messageFrom(
+      error,
+      "Failed to replay dead letter",
+    );
+  } finally {
+    replayingDeadLetterId.value = null;
+  }
+}
+
+onMounted(refreshAll);
+watch(appId, refreshAll);
+</script>
+
+<template>
+  <div>
+    <button
+      class="back-link"
+      type="button"
+      @click="router.push({ name: 'app-detail', params: { id: appId } })"
+    >
+      <ArrowLeft class="w-4 h-4" />
+      Back to app settings
+    </button>
+
+    <header class="page-header">
+      <div class="flex items-start gap-4">
+        <div
+          class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-brand-400/20 bg-brand-500/12 text-brand-300"
+        >
+          <Bell class="w-6 h-6" />
+        </div>
+        <div>
+          <p class="eyebrow">Application · {{ appId }}</p>
+          <h1 class="page-title">Push Manager</h1>
+          <p class="page-subtitle">
+            Store provider credentials, inspect registered devices, and follow delivery outcomes.
+          </p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <span
+          class="status-pill"
+          :class="auth.isAdmin ? 'status-positive' : 'bg-surface-800 text-surface-400'"
+        >
+          {{ auth.isAdmin ? "Admin controls" : "Read only" }}
+        </span>
+        <button
+          class="btn-secondary flex items-center gap-2"
+          type="button"
+          :disabled="refreshing"
+          @click="refreshAll"
+        >
+          <RefreshCw class="w-4 h-4" :class="{ 'animate-spin': refreshing }" />
+          Refresh
+        </button>
+      </div>
+    </header>
+
+    <div v-if="notice" class="alert border-emerald-400/20 bg-emerald-500/10 text-emerald-200 mb-5">
+      {{ notice }}
+    </div>
+
+    <div v-if="!auth.isAdmin" class="alert alert-warning mb-5 flex items-start gap-3">
+      <ShieldCheck class="w-5 h-5 shrink-0 mt-0.5" />
+      <p>
+        Operators can inspect push state. Uploading credentials, publishing, deleting devices, and
+        replaying dead letters require an administrator.
+      </p>
+    </div>
+
+    <div class="alert alert-warning mb-6">
+      <div class="flex items-start gap-3">
+        <AlertTriangle class="w-5 h-5 shrink-0 mt-0.5" />
+        <div>
+          <p class="font-medium text-amber-100">Stored does not mean active</p>
+          <p class="mt-1 text-xs leading-5">
+            A stored credential only confirms that Sockudo accepted a durable credential record.
+            Delivery also requires the matching provider feature and runtime flag, a configured
+            credential-encryption key, and a running provider worker. Existing workers load changed
+            stored credentials after restart; an upload does not prove provider connectivity.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
+      <div class="panel p-4">
+        <div class="flex items-center justify-between">
+          <KeyRound class="w-4 h-4 text-brand-300" />
+          <span class="text-[0.65rem] uppercase tracking-wider text-surface-600">loaded</span>
+        </div>
+        <p class="mt-3 text-2xl font-semibold">{{ formatNumber(credentials.length) }}</p>
+        <p class="mt-1 text-xs text-surface-500">Stored credentials</p>
+      </div>
+      <div class="panel p-4">
+        <div class="flex items-center justify-between">
+          <Smartphone class="w-4 h-4 text-sky-300" />
+          <span class="text-[0.65rem] uppercase tracking-wider text-surface-600">loaded</span>
+        </div>
+        <p class="mt-3 text-2xl font-semibold">{{ formatNumber(devices.length) }}</p>
+        <p class="mt-1 text-xs text-surface-500">Device registrations</p>
+      </div>
+      <div class="panel p-4">
+        <div class="flex items-center justify-between">
+          <Users class="w-4 h-4 text-violet-300" />
+          <span class="text-[0.65rem] uppercase tracking-wider text-surface-600">loaded</span>
+        </div>
+        <p class="mt-3 text-2xl font-semibold">{{ formatNumber(subscriptions.length) }}</p>
+        <p class="mt-1 text-xs text-surface-500">Channel subscriptions</p>
+      </div>
+      <div class="panel p-4">
+        <div class="flex items-center justify-between">
+          <AlertTriangle class="w-4 h-4 text-amber-300" />
+          <span class="text-[0.65rem] uppercase tracking-wider text-surface-600">loaded</span>
+        </div>
+        <p class="mt-3 text-2xl font-semibold">{{ formatNumber(deadLetters.length) }}</p>
+        <p class="mt-1 text-xs text-surface-500">Dead letters</p>
+      </div>
+    </div>
+
+    <nav
+      class="panel mb-6 grid grid-cols-4 gap-1 overflow-hidden p-2 sm:flex sm:overflow-x-auto"
+      aria-label="Push manager sections"
+    >
+      <button
+        v-for="section in sections"
+        :key="section.id"
+        type="button"
+        :aria-pressed="activeSection === section.id"
+        class="min-w-0 flex-1 rounded-xl px-1.5 py-3 text-center transition-colors sm:min-w-max sm:px-4 sm:text-left"
+        :class="
+          activeSection === section.id
+            ? 'bg-brand-500/12 text-brand-200'
+            : 'text-surface-400 hover:bg-surface-800/60 hover:text-surface-200'
+        "
+        @click="activeSection = section.id"
+      >
+        <span class="block text-[0.68rem] font-medium sm:text-sm">{{ section.label }}</span>
+        <span class="mt-0.5 hidden text-[0.68rem] text-surface-600 sm:block">
+          {{ section.description }}
+        </span>
+      </button>
+    </nav>
+
+    <section v-if="activeSection === 'credentials'" class="space-y-5">
+      <div class="settings-card">
+        <div class="card-heading">
+          <div>
+            <p class="eyebrow">Provider access</p>
+            <h2>Stored credentials</h2>
+            <p>
+              Upload encrypted provider material. Sockudo never returns secret material after it is
+              stored.
+            </p>
+          </div>
+          <Database class="w-5 h-5 text-surface-500" />
+        </div>
+
+        <p v-if="credentialsError" class="alert alert-error mb-4">{{ credentialsError }}</p>
+
+        <div class="grid md:grid-cols-2 xl:grid-cols-3 gap-3">
+          <article
+            v-for="provider in providers"
+            :key="provider.id"
+            class="subcard flex min-h-44 flex-col"
+            :class="{ 'border-brand-400/35 bg-brand-500/5': selectedProvider === provider.id }"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div
+                class="flex h-10 w-10 items-center justify-center rounded-xl bg-surface-800 font-semibold text-brand-200"
+              >
+                {{ provider.short }}
+              </div>
+              <span
+                class="status-pill"
+                :class="credentialCount(provider) ? 'status-positive' : 'bg-surface-800 text-surface-500'"
+              >
+                {{ credentialCount(provider) }} stored
+              </span>
+            </div>
+            <h3 class="mt-4 text-sm font-semibold text-surface-100">{{ provider.label }}</h3>
+            <p class="mt-1 flex-1 text-xs leading-5 text-surface-500">
+              {{ provider.description }}
+            </p>
+            <button
+              v-if="auth.isAdmin"
+              class="mt-4 flex items-center justify-between text-left text-xs font-medium text-brand-300 hover:text-brand-200"
+              type="button"
+              :aria-label="`Store or rotate ${provider.label} credential`"
+              @click="openCredentialForm(provider.id)"
+            >
+              Store or rotate
+              <ChevronRight class="w-4 h-4" />
+            </button>
+          </article>
+        </div>
+      </div>
+
+      <form
+        v-if="selectedProvider && selectedProviderDetails && auth.isAdmin"
+        class="settings-card"
+        autocomplete="off"
+        @submit.prevent="submitCredential"
+      >
+        <div class="card-heading">
+          <div>
+            <p class="eyebrow">Memory-only form</p>
+            <h2>{{ selectedProviderDetails.label }}</h2>
+            <p>
+              Values stay only in this tab and are cleared after a successful upload or when you
+              close this form.
+            </p>
+          </div>
+          <button class="text-button" type="button" @click="closeCredentialForm">Close</button>
+        </div>
+
+        <p v-if="credentialError" class="alert alert-error mb-5">{{ credentialError }}</p>
+
+        <div class="grid md:grid-cols-2 gap-4 mb-5">
+          <label>
+            <span class="field-label">Credential ID</span>
+            <input
+              v-model.trim="credentialDraft.credentialId"
+              class="input-field font-mono"
+              autocomplete="off"
+              :placeholder="`${selectedProvider}-primary`"
+            />
+            <span class="field-hint">Leave blank to use Sockudo’s provider default ID.</span>
+          </label>
+          <label>
+            <span class="field-label">Version</span>
+            <input
+              v-model.number="credentialDraft.version"
+              class="input-field"
+              type="number"
+              min="1"
+              step="1"
+              autocomplete="off"
+            />
+            <span class="field-hint">Increment this when rotating existing material.</span>
+          </label>
+        </div>
+
+        <div v-if="selectedProvider === 'fcm'" class="space-y-4">
+          <label>
+            <span class="field-label">Service account JSON</span>
+            <textarea
+              v-model="credentialDraft.fcmJson"
+              class="input-field min-h-56 resize-y font-mono text-xs"
+              autocomplete="off"
+              spellcheck="false"
+              placeholder='{ "type": "service_account", "project_id": "..." }'
+            />
+            <span class="field-hint">
+              Paste the complete Google service-account object. It is encrypted before durable
+              storage.
+            </span>
+          </label>
+        </div>
+
+        <div v-else-if="selectedProvider === 'apns'" class="space-y-4">
+          <div>
+            <span class="field-label">Authentication material</span>
+            <div class="segmented">
+              <button
+                v-for="mode in (['token', 'p12', 'pem'] as ApnsMode[])"
+                :key="mode"
+                type="button"
+                :class="{ active: credentialDraft.apnsMode === mode }"
+                :aria-pressed="credentialDraft.apnsMode === mode"
+                @click="credentialDraft.apnsMode = mode"
+              >
+                {{ mode === "token" ? "Apple .p8 key" : mode.toUpperCase() }}
+              </button>
+            </div>
+          </div>
+
+          <div v-if="credentialDraft.apnsMode === 'token'" class="grid md:grid-cols-2 gap-4">
+            <label>
+              <span class="field-label">Apple Team ID</span>
+              <input
+                v-model.trim="credentialDraft.apnsTeamId"
+                class="input-field font-mono"
+                autocomplete="off"
+              />
+            </label>
+            <label>
+              <span class="field-label">Key ID</span>
+              <input
+                v-model.trim="credentialDraft.apnsKeyId"
+                class="input-field font-mono"
+                autocomplete="off"
+              />
+            </label>
+            <label class="md:col-span-2">
+              <span class="field-label">Private .p8 key</span>
+              <textarea
+                v-model="credentialDraft.apnsPrivateKey"
+                class="input-field min-h-44 resize-y font-mono text-xs"
+                autocomplete="off"
+                spellcheck="false"
+                placeholder="-----BEGIN PRIVATE KEY-----"
+              />
+            </label>
+          </div>
+
+          <div v-else-if="credentialDraft.apnsMode === 'p12'" class="grid md:grid-cols-2 gap-4">
+            <label class="md:col-span-2">
+              <span class="field-label">PKCS#12 payload</span>
+              <textarea
+                v-model="credentialDraft.apnsP12"
+                class="input-field min-h-36 resize-y font-mono text-xs"
+                autocomplete="off"
+                spellcheck="false"
+                placeholder="Base64-encoded .p12 content"
+              />
+            </label>
+            <label>
+              <span class="field-label">Certificate password</span>
+              <input
+                v-model="credentialDraft.apnsP12Password"
+                class="input-field"
+                type="password"
+                autocomplete="off"
+              />
+            </label>
+          </div>
+
+          <label v-else>
+            <span class="field-label">PEM certificate and private key</span>
+            <textarea
+              v-model="credentialDraft.apnsPem"
+              class="input-field min-h-52 resize-y font-mono text-xs"
+              autocomplete="off"
+              spellcheck="false"
+              placeholder="-----BEGIN CERTIFICATE-----"
+            />
+          </label>
+
+          <p class="alert border-sky-400/15 bg-sky-500/8 text-xs text-sky-200/80">
+            The APNs topic and production/sandbox endpoint remain provider-worker runtime settings;
+            they are not part of this stored credential record.
+          </p>
+        </div>
+
+        <div v-else-if="selectedProvider === 'webpush'" class="grid md:grid-cols-2 gap-4">
+          <label>
+            <span class="field-label">VAPID public key</span>
+            <textarea
+              v-model="credentialDraft.webPushPublicKey"
+              class="input-field min-h-32 resize-y font-mono text-xs"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </label>
+          <label>
+            <span class="field-label">VAPID private key</span>
+            <textarea
+              v-model="credentialDraft.webPushPrivateKey"
+              class="input-field min-h-32 resize-y font-mono text-xs"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </label>
+        </div>
+
+        <div v-else-if="selectedProvider === 'hms'" class="grid md:grid-cols-2 gap-4">
+          <label>
+            <span class="field-label">HMS App ID</span>
+            <input
+              v-model.trim="credentialDraft.hmsAppId"
+              class="input-field font-mono"
+              autocomplete="off"
+            />
+          </label>
+          <label>
+            <span class="field-label">Client secret</span>
+            <input
+              v-model="credentialDraft.hmsClientSecret"
+              class="input-field"
+              type="password"
+              autocomplete="off"
+            />
+          </label>
+        </div>
+
+        <div v-else-if="selectedProvider === 'wns'" class="grid md:grid-cols-2 gap-4">
+          <label>
+            <span class="field-label">Package SID</span>
+            <input
+              v-model.trim="credentialDraft.wnsPackageSid"
+              class="input-field font-mono"
+              autocomplete="off"
+            />
+          </label>
+          <label>
+            <span class="field-label">Client secret</span>
+            <input
+              v-model="credentialDraft.wnsClientSecret"
+              class="input-field"
+              type="password"
+              autocomplete="off"
+            />
+          </label>
+        </div>
+
+        <div class="mt-6 flex flex-wrap items-center gap-3 border-t border-surface-800 pt-5">
+          <button class="btn-primary flex items-center gap-2" type="submit" :disabled="savingCredential">
+            <KeyRound class="w-4 h-4" />
+            {{ savingCredential ? "Storing securely..." : "Store credential" }}
+          </button>
+          <button class="btn-secondary" type="button" @click="closeCredentialForm">Cancel</button>
+          <span class="text-xs text-surface-600">
+            Secret material cannot be retrieved after upload.
+          </span>
+        </div>
+      </form>
+
+      <div class="settings-card">
+        <div class="card-heading">
+          <div>
+            <h2>Credential inventory</h2>
+            <p>Metadata only. This list does not expose provider secret material or worker state.</p>
+          </div>
+        </div>
+
+        <div v-if="credentials.length" class="overflow-x-auto">
+          <table class="w-full min-w-160 text-sm">
+            <thead class="text-left text-xs uppercase tracking-wider text-surface-500">
+              <tr>
+                <th class="pb-3 font-medium">Provider</th>
+                <th class="pb-3 font-medium">Credential ID</th>
+                <th class="pb-3 font-medium">Version</th>
+                <th class="pb-3 text-right font-medium">Record state</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="credential in credentials"
+                :key="`${credential.provider}:${credential.credential_id}`"
+                class="border-t border-surface-800"
+              >
+                <td class="py-4 font-medium text-surface-200">
+                  {{ providerLabel(credential.provider) }}
+                </td>
+                <td class="py-4 font-mono text-xs text-brand-200">
+                  {{ credential.credential_id }}
+                </td>
+                <td class="py-4 text-surface-400">v{{ credential.version }}</td>
+                <td class="py-4 text-right">
+                  <span class="status-pill status-positive">Stored</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-else-if="!credentialsLoading" class="inherit-state">
+          No provider credentials are stored for this app.
+        </div>
+        <div v-else class="inherit-state">Loading stored credentials…</div>
+
+        <button
+          v-if="credentialsHasMore"
+          class="btn-secondary btn-sm mt-4"
+          type="button"
+          :disabled="credentialsLoading"
+          @click="loadCredentials(false)"
+        >
+          Load more credentials
+        </button>
+      </div>
+    </section>
+
+    <section v-else-if="activeSection === 'devices'" class="space-y-5">
+      <div class="settings-card">
+        <div class="card-heading">
+          <div>
+            <p class="eyebrow">Device inventory</p>
+            <h2>Registered devices</h2>
+            <p>Provider tokens stay redacted; hashes are shown for operational correlation.</p>
+          </div>
+          <Smartphone class="w-5 h-5 text-surface-500" />
+        </div>
+
+        <p v-if="devicesError" class="alert alert-error mb-4">{{ devicesError }}</p>
+
+        <div v-if="devices.length" class="overflow-x-auto">
+          <table class="w-full min-w-240 text-sm">
+            <thead class="text-left text-xs uppercase tracking-wider text-surface-500">
+              <tr>
+                <th class="pb-3 font-medium">Device</th>
+                <th class="pb-3 font-medium">Client</th>
+                <th class="pb-3 font-medium">Platform</th>
+                <th class="pb-3 font-medium">Provider</th>
+                <th class="pb-3 font-medium">State</th>
+                <th class="pb-3 font-medium">Last active</th>
+                <th class="pb-3 text-right font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="device in devices" :key="device.id" class="border-t border-surface-800">
+                <td class="py-4">
+                  <p class="font-mono text-xs text-brand-200">{{ device.id }}</p>
+                  <p class="mt-1 max-w-44 truncate font-mono text-[0.65rem] text-surface-600">
+                    {{ device.recipient.tokenHash }}
+                  </p>
+                </td>
+                <td class="py-4 text-surface-400">{{ device.clientId || "—" }}</td>
+                <td class="py-4">
+                  <p class="text-surface-300">{{ device.platform }}</p>
+                  <p class="text-xs text-surface-600">{{ device.formFactor }}</p>
+                </td>
+                <td class="py-4 text-surface-400">{{ providerLabel(device.recipient.provider) }}</td>
+                <td class="py-4">
+                  <span
+                    class="status-pill"
+                    :class="
+                      device.pushState === 'ACTIVE'
+                        ? 'status-positive'
+                        : device.pushState === 'FAILED'
+                          ? 'status-negative'
+                          : 'bg-amber-500/12 text-amber-300'
+                    "
+                  >
+                    {{ device.pushState }}
+                  </span>
+                  <p v-if="device.pushFailureCount" class="mt-1 text-[0.65rem] text-surface-600">
+                    {{ device.pushFailureCount }} failures
+                  </p>
+                </td>
+                <td class="py-4 text-xs text-surface-500">
+                  {{ formatDate(device.lastActiveAtMs) }}
+                </td>
+                <td class="py-4 text-right">
+                  <button
+                    v-if="auth.isAdmin"
+                    class="icon-button danger"
+                    type="button"
+                    :disabled="deletingDeviceId === device.id"
+                    title="Delete device registration"
+                    :aria-label="`Delete device registration ${device.id}`"
+                    @click="deleteDevice(device)"
+                  >
+                    <Trash2 class="w-4 h-4" />
+                  </button>
+                  <span v-else class="text-xs text-surface-600">Read only</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-else-if="!devicesLoading" class="inherit-state">
+          No devices are registered for this app.
+        </div>
+        <div v-else class="inherit-state">Loading device registrations…</div>
+
+        <button
+          v-if="devicesHasMore"
+          class="btn-secondary btn-sm mt-4"
+          type="button"
+          :disabled="devicesLoading"
+          @click="loadDevices(false)"
+        >
+          Load more devices
+        </button>
+      </div>
+
+      <div class="settings-card">
+        <div class="card-heading">
+          <div>
+            <p class="eyebrow">Audience routing</p>
+            <h2>Channel subscriptions</h2>
+            <p>See which registered devices receive channel-targeted notifications.</p>
+          </div>
+          <Users class="w-5 h-5 text-surface-500" />
+        </div>
+
+        <form class="grid gap-3 md:grid-cols-[1fr_1fr_auto] mb-5" @submit.prevent="loadSubscriptions(true)">
+          <label>
+            <span class="field-label">Channel</span>
+            <input
+              v-model="subscriptionChannel"
+              class="input-field font-mono"
+              placeholder="notifications:user-123"
+            />
+          </label>
+          <label>
+            <span class="field-label">Device ID</span>
+            <input
+              v-model="subscriptionDeviceId"
+              class="input-field font-mono"
+              placeholder="device-123"
+            />
+          </label>
+          <button
+            class="btn-secondary self-end flex items-center justify-center gap-2"
+            type="submit"
+            :disabled="subscriptionsLoading"
+          >
+            <Search class="w-4 h-4" />
+            Filter
+          </button>
+        </form>
+
+        <p v-if="subscriptionsError" class="alert alert-error mb-4">
+          {{ subscriptionsError }}
+        </p>
+
+        <div v-if="subscriptions.length" class="overflow-x-auto">
+          <table class="w-full min-w-200 text-sm">
+            <thead class="text-left text-xs uppercase tracking-wider text-surface-500">
+              <tr>
+                <th class="pb-3 font-medium">Channel</th>
+                <th class="pb-3 font-medium">Device</th>
+                <th class="pb-3 font-medium">Client</th>
+                <th class="pb-3 font-medium">Provider</th>
+                <th class="pb-3 text-right font-medium">Credential version</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="subscription in subscriptions"
+                :key="`${subscription.channel}:${subscription.deviceId}`"
+                class="border-t border-surface-800"
+              >
+                <td class="py-4 font-mono text-xs text-brand-200">
+                  {{ subscription.channel }}
+                </td>
+                <td class="py-4 font-mono text-xs text-surface-300">
+                  {{ subscription.deviceId }}
+                </td>
+                <td class="py-4 text-surface-400">{{ subscription.clientId || "—" }}</td>
+                <td class="py-4 text-surface-400">{{ providerLabel(subscription.provider) }}</td>
+                <td class="py-4 text-right text-surface-500">
+                  {{ subscription.credentialVersion ?? "default" }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div v-else-if="!subscriptionsLoading" class="inherit-state">
+          No matching channel subscriptions.
+        </div>
+        <div v-else class="inherit-state">Loading channel subscriptions…</div>
+
+        <button
+          v-if="subscriptionsHasMore"
+          class="btn-secondary btn-sm mt-4"
+          type="button"
+          :disabled="subscriptionsLoading"
+          @click="loadSubscriptions(false)"
+        >
+          Load more subscriptions
+        </button>
+      </div>
+    </section>
+
+    <section v-else-if="activeSection === 'delivery'" class="grid lg:grid-cols-2 gap-5 items-start">
+      <div class="settings-card">
+        <div class="card-heading">
+          <div>
+            <p class="eyebrow">Test delivery</p>
+            <h2>Compose notification</h2>
+            <p>Send one basic notification to a channel, device, or client target.</p>
+          </div>
+          <Send class="w-5 h-5 text-surface-500" />
+        </div>
+
+        <form v-if="auth.isAdmin" class="space-y-4" @submit.prevent="publishNotification">
+          <p v-if="publishError" class="alert alert-error">{{ publishError }}</p>
+
+          <div class="grid grid-cols-[9rem_minmax(0,1fr)] gap-3">
+            <label>
+              <span class="field-label">Target type</span>
+              <select v-model="composer.targetType" class="input-field">
+                <option value="channel">Channel</option>
+                <option value="device">Device</option>
+                <option value="client">Client</option>
+              </select>
+            </label>
+            <label>
+              <span class="field-label">
+                {{ composer.targetType === "channel" ? "Channel" : composer.targetType === "device" ? "Device ID" : "Client ID" }}
+              </span>
+              <input
+                v-model="composer.targetValue"
+                class="input-field font-mono"
+                :placeholder="
+                  composer.targetType === 'channel'
+                    ? 'notifications:user-123'
+                    : composer.targetType === 'device'
+                      ? 'device-123'
+                      : 'client-123'
+                "
+              />
+            </label>
+          </div>
+
+          <label>
+            <span class="field-label">Title</span>
+            <input v-model="composer.title" class="input-field" placeholder="Your order is ready" />
+          </label>
+          <label>
+            <span class="field-label">Body</span>
+            <textarea
+              v-model="composer.body"
+              class="input-field min-h-28 resize-y"
+              placeholder="Open the app to see the latest update."
+            />
+          </label>
+
+          <details class="subcard">
+            <summary class="cursor-pointer text-sm font-medium text-surface-300">
+              Optional delivery fields
+            </summary>
+            <div class="grid md:grid-cols-2 gap-4 mt-4">
+              <label>
+                <span class="field-label">Publish ID</span>
+                <input v-model="composer.publishId" class="input-field font-mono" />
+                <span class="field-hint">Reuse a stable ID for idempotent retries.</span>
+              </label>
+              <label>
+                <span class="field-label">Collapse key</span>
+                <input v-model="composer.collapseKey" class="input-field font-mono" />
+              </label>
+              <label>
+                <span class="field-label">Icon</span>
+                <input v-model="composer.icon" class="input-field" />
+              </label>
+              <label>
+                <span class="field-label">Sound</span>
+                <input v-model="composer.sound" class="input-field" />
+              </label>
+              <label class="md:col-span-2 flex items-start gap-3 rounded-lg bg-surface-950/30 p-3">
+                <input v-model="composer.sync" type="checkbox" class="toggle-input mt-0.5" />
+                <span>
+                  <span class="block text-sm text-surface-300">Request synchronous fanout</span>
+                  <span class="field-hint !mt-0">
+                    Sockudo may force large fanouts to remain asynchronous.
+                  </span>
+                </span>
+              </label>
+            </div>
+          </details>
+
+          <button class="btn-primary w-full flex items-center justify-center gap-2" type="submit" :disabled="publishing">
+            <Send class="w-4 h-4" />
+            {{ publishing ? "Submitting..." : "Publish notification" }}
+          </button>
+        </form>
+
+        <div v-else class="inherit-state">
+          Publishing is available to administrators. You can still inspect any publish by ID.
+        </div>
+
+        <div v-if="acceptedPublish" class="mt-5 rounded-xl border border-emerald-400/20 bg-emerald-500/8 p-4">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-sm font-medium text-emerald-200">Publish accepted</p>
+              <p class="mt-1 font-mono text-xs text-emerald-300/80">
+                {{ acceptedPublish.publishId }}
+              </p>
+            </div>
+            <span class="status-pill status-positive">{{ acceptedPublish.status }}</span>
+          </div>
+          <div class="mt-4 grid grid-cols-2 gap-3 text-xs">
+            <div class="rounded-lg bg-surface-950/30 p-3">
+              <span class="text-surface-600">Expected recipients</span>
+              <p class="mt-1 text-surface-200">{{ formatNumber(acceptedPublish.expectedRecipients) }}</p>
+            </div>
+            <div class="rounded-lg bg-surface-950/30 p-3">
+              <span class="text-surface-600">Fanout regime</span>
+              <p class="mt-1 text-surface-200">{{ acceptedPublish.fanoutRegime }}</p>
+            </div>
+          </div>
+          <p v-if="acceptedPublish.renderedPayloads.length" class="mt-3 text-xs text-surface-500">
+            Rendered for
+            {{
+              acceptedPublish.renderedPayloads
+                .map((rendered) => providerLabel(rendered.provider))
+                .join(", ")
+            }}.
+          </p>
+        </div>
+      </div>
+
+      <div class="settings-card lg:sticky lg:top-6">
+        <div class="card-heading">
+          <div>
+            <p class="eyebrow">Durable outcome</p>
+            <h2>Publish status</h2>
+            <p>Look up acceptance, dispatch, retry, and terminal delivery counters.</p>
+          </div>
+          <Search class="w-5 h-5 text-surface-500" />
+        </div>
+
+        <form class="flex gap-2" @submit.prevent="lookupPublishStatus">
+          <input
+            v-model="statusPublishId"
+            class="input-field min-w-0 font-mono"
+            placeholder="publish-id"
+          />
+          <button class="btn-secondary shrink-0" type="submit" :disabled="statusLoading">
+            {{ statusLoading ? "Loading..." : "Look up" }}
+          </button>
+        </form>
+
+        <p v-if="statusError" class="alert alert-error mt-4">{{ statusError }}</p>
+
+        <div v-if="publishStatus" class="mt-5 space-y-4">
+          <div class="subcard">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <p class="font-mono text-xs text-brand-200">{{ publishStatus.publishId }}</p>
+                <p v-if="publishStatus.fanoutRegime" class="mt-1 text-xs text-surface-600">
+                  {{ publishStatus.fanoutRegime }}
+                </p>
+              </div>
+              <span
+                class="status-pill"
+                :class="
+                  ['failed', 'rejected', 'expired'].includes(publishStatus.state.toLowerCase())
+                    ? 'status-negative'
+                    : ['delivered', 'complete', 'completed'].includes(
+                          publishStatus.state.toLowerCase(),
+                        )
+                      ? 'status-positive'
+                      : 'bg-brand-500/12 text-brand-200'
+                "
+              >
+                {{ publishStatus.state }}
+              </span>
+            </div>
+            <p v-if="publishStatus.errorReason" class="alert alert-error mt-4">
+              {{ publishStatus.errorReason }}
+            </p>
+            <p v-if="publishStatus.retryAfterMs" class="mt-3 text-xs text-amber-300">
+              Retry suggested after {{ formatNumber(publishStatus.retryAfterMs) }} ms.
+            </p>
+          </div>
+
+          <div v-if="statusCounters.length" class="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            <div
+              v-for="[counter, value] in statusCounters"
+              :key="counter"
+              class="rounded-lg border border-surface-800 bg-surface-950/30 p-3"
+            >
+              <p class="text-lg font-semibold text-surface-200">{{ formatNumber(value) }}</p>
+              <p class="mt-1 break-words text-[0.65rem] text-surface-600">{{ counter }}</p>
+            </div>
+          </div>
+
+          <button
+            class="btn-secondary btn-sm flex items-center gap-2"
+            type="button"
+            :disabled="statusLoading"
+            @click="lookupPublishStatus"
+          >
+            <RefreshCw class="w-3.5 h-3.5" />
+            Refresh status
+          </button>
+        </div>
+
+        <div v-else-if="!statusError" class="inherit-state mt-5">
+          Enter a publish ID to inspect its durable status.
+        </div>
+      </div>
+    </section>
+
+    <section v-else class="settings-card">
+      <div class="card-heading">
+        <div>
+          <p class="eyebrow">Failure recovery</p>
+          <h2>Dead letters</h2>
+          <p>Inspect failed push work and replay only entries Sockudo marks as replayable.</p>
+        </div>
+        <AlertTriangle class="w-5 h-5 text-surface-500" />
+      </div>
+
+      <div class="mb-5 flex flex-wrap items-end gap-3">
+        <label class="w-52">
+          <span class="field-label">Provider</span>
+          <select v-model="deadLetterProvider" class="input-field" @change="loadDeadLetters(true)">
+            <option value="">All providers</option>
+            <option v-for="provider in providers" :key="provider.id" :value="provider.id">
+              {{ provider.label }}
+            </option>
+          </select>
+        </label>
+        <button
+          class="btn-secondary flex items-center gap-2"
+          type="button"
+          :disabled="deadLettersLoading"
+          @click="loadDeadLetters(true)"
+        >
+          <RefreshCw class="w-4 h-4" />
+          Refresh failures
+        </button>
+      </div>
+
+      <p v-if="deadLettersError" class="alert alert-error mb-4">{{ deadLettersError }}</p>
+
+      <div v-if="deadLetters.length" class="space-y-3">
+        <article
+          v-for="deadLetter in deadLetters"
+          :key="deadLetter.deadLetterId"
+          class="subcard"
+        >
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div class="min-w-0">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="status-pill status-negative">{{ deadLetter.stage }}</span>
+                <span class="status-pill bg-surface-800 text-surface-400">
+                  {{ providerLabel(deadLetter.provider) }}
+                </span>
+                <span
+                  class="status-pill"
+                  :class="
+                    deadLetter.replayable
+                      ? 'bg-amber-500/12 text-amber-300'
+                      : 'bg-surface-800 text-surface-600'
+                  "
+                >
+                  {{ deadLetter.replayable ? "Replayable" : "Terminal" }}
+                </span>
+              </div>
+              <p class="mt-3 text-sm leading-6 text-surface-300">{{ deadLetter.reason }}</p>
+              <dl class="mt-4 grid gap-x-6 gap-y-2 text-xs sm:grid-cols-2">
+                <div>
+                  <dt class="text-surface-600">Publish</dt>
+                  <dd class="mt-0.5 break-all font-mono text-brand-200">
+                    {{ deadLetter.publishId }}
+                  </dd>
+                </div>
+                <div>
+                  <dt class="text-surface-600">Occurred</dt>
+                  <dd class="mt-0.5 text-surface-400">{{ formatDate(deadLetter.occurredAtMs) }}</dd>
+                </div>
+                <div>
+                  <dt class="text-surface-600">Dead-letter ID</dt>
+                  <dd class="mt-0.5 break-all font-mono text-surface-400">
+                    {{ deadLetter.deadLetterId }}
+                  </dd>
+                </div>
+                <div>
+                  <dt class="text-surface-600">Key</dt>
+                  <dd class="mt-0.5 break-all font-mono text-surface-400">
+                    {{ deadLetter.key }}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+            <button
+              v-if="auth.isAdmin && deadLetter.replayable"
+              class="btn-secondary btn-sm shrink-0 flex items-center gap-2"
+              type="button"
+              :disabled="replayingDeadLetterId === deadLetter.deadLetterId"
+              :aria-label="`Replay dead letter ${deadLetter.deadLetterId}`"
+              @click="replayDeadLetter(deadLetter)"
+            >
+              <RotateCcw class="w-4 h-4" />
+              {{
+                replayingDeadLetterId === deadLetter.deadLetterId
+                  ? "Replaying..."
+                  : "Replay"
+              }}
+            </button>
+          </div>
+        </article>
+      </div>
+      <div v-else-if="!deadLettersLoading" class="inherit-state">
+        No matching dead letters.
+      </div>
+      <div v-else class="inherit-state">Loading dead letters…</div>
+
+      <button
+        v-if="deadLettersHasMore"
+        class="btn-secondary btn-sm mt-4"
+        type="button"
+        :disabled="deadLettersLoading"
+        @click="loadDeadLetters(false)"
+      >
+        Load more dead letters
+      </button>
+    </section>
+  </div>
+</template>

--- a/dashboard/web/src/pages/AppsPage.vue
+++ b/dashboard/web/src/pages/AppsPage.vue
@@ -1,7 +1,19 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
-import { Plus, Trash2, Pencil } from "lucide-vue-next";
+import {
+  AppWindow,
+  ArrowRight,
+  Gauge,
+  KeyRound,
+  Plus,
+  RadioTower,
+  RefreshCw,
+  Trash2,
+  UsersRound,
+  Webhook,
+  X,
+} from "lucide-vue-next";
 import { api, type App, type StatsResponse } from "@/api/client";
 
 const router = useRouter();
@@ -10,6 +22,7 @@ const stats = ref<StatsResponse | null>(null);
 const loading = ref(true);
 const error = ref<string | null>(null);
 const showCreate = ref(false);
+const enabledApps = computed(() => apps.value.filter((app) => app.enabled).length);
 
 const form = ref({
   id: "",
@@ -41,6 +54,19 @@ function connectionsFor(appId: string) {
   return stats.value?.apps.find((a) => a.app_id === appId)?.connections ?? 0;
 }
 
+function appInitials(appId: string) {
+  return appId
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+}
+
+function webhookCount(app: App) {
+  return app.webhook_count ?? app.policy.webhooks?.length ?? 0;
+}
+
 async function createApp() {
   try {
     const created = await api.createApp({
@@ -70,119 +96,339 @@ async function removeApp(app: App) {
 
 <template>
   <div>
-    <div class="flex items-center justify-between mb-6">
+    <div class="page-header">
       <div>
-        <h1 class="text-2xl font-semibold text-surface-100">Applications</h1>
-        <p class="text-sm text-surface-400 mt-1">
-          Manage Sockudo apps stored in your configured app manager database.
+        <p class="eyebrow">Application manager</p>
+        <h1 class="page-title">Applications</h1>
+        <p class="page-subtitle">
+          Configure credentials, delivery policies, limits, and integrations for every realtime
+          app.
         </p>
       </div>
-      <button class="btn-primary flex items-center gap-2" @click="showCreate = !showCreate">
-        <Plus class="w-4 h-4" />
-        New app
+      <div class="flex items-center gap-2">
+        <button
+          class="btn-secondary flex items-center gap-2"
+          aria-label="Refresh applications"
+          :disabled="loading"
+          @click="load"
+        >
+          <RefreshCw class="h-4 w-4" :class="{ 'animate-spin': loading }" />
+          <span class="hidden sm:inline">Refresh</span>
+        </button>
+        <button class="btn-primary flex items-center gap-2" @click="showCreate = !showCreate">
+          <Plus class="h-4 w-4" />
+          New app
+        </button>
+      </div>
+    </div>
+
+    <div class="mb-6 grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
+      <div class="panel relative overflow-hidden p-4 sm:p-5">
+        <AppWindow class="absolute right-4 top-4 h-5 w-5 text-brand-400/50" />
+        <p class="text-xs font-medium text-surface-500">Registered apps</p>
+        <p class="mt-2 text-2xl font-semibold tracking-tight text-surface-50">{{ apps.length }}</p>
+        <p class="mt-1 text-[0.68rem] text-surface-600">{{ enabledApps }} currently enabled</p>
+      </div>
+      <div class="panel relative overflow-hidden p-4 sm:p-5">
+        <RadioTower class="absolute right-4 top-4 h-5 w-5 text-emerald-400/50" />
+        <p class="text-xs font-medium text-surface-500">Live connections</p>
+        <p class="mt-2 text-2xl font-semibold tracking-tight text-surface-50">
+          {{ stats?.totals.connections ?? "—" }}
+        </p>
+        <p class="mt-1 flex items-center gap-1.5 text-[0.68rem] text-surface-600">
+          <span
+            class="h-1.5 w-1.5 rounded-full"
+            :class="stats ? 'bg-emerald-400' : 'bg-surface-600'"
+          />
+          {{ stats ? "Runtime connected" : "Runtime unavailable" }}
+        </p>
+      </div>
+      <div class="panel relative overflow-hidden p-4 sm:p-5">
+        <UsersRound class="absolute right-4 top-4 h-5 w-5 text-sky-400/50" />
+        <p class="text-xs font-medium text-surface-500">Users online</p>
+        <p class="mt-2 text-2xl font-semibold tracking-tight text-surface-50">
+          {{ stats?.totals.users ?? "—" }}
+        </p>
+        <p class="mt-1 text-[0.68rem] text-surface-600">Across all applications</p>
+      </div>
+      <div class="panel relative overflow-hidden p-4 sm:p-5">
+        <Gauge class="absolute right-4 top-4 h-5 w-5 text-amber-400/50" />
+        <p class="text-xs font-medium text-surface-500">Memory used</p>
+        <p class="mt-2 text-2xl font-semibold tracking-tight text-surface-50">
+          {{ stats ? `${stats.memory.percent.toFixed(1)}%` : "—" }}
+        </p>
+        <div class="mt-2 h-1 overflow-hidden rounded-full bg-surface-800">
+          <div
+            class="h-full rounded-full bg-gradient-to-r from-brand-500 to-sky-400 transition-all"
+            :style="{ width: `${Math.min(stats?.memory.percent ?? 0, 100)}%` }"
+          />
+        </div>
+      </div>
+    </div>
+
+    <form v-if="showCreate" class="panel mb-6 overflow-hidden" @submit.prevent="createApp">
+      <div
+        class="flex items-start justify-between gap-4 border-b border-surface-800 bg-surface-900/40 px-5 py-4 sm:px-6"
+      >
+        <div>
+          <p class="text-sm font-semibold text-surface-100">Create application</p>
+          <p class="mt-1 text-xs text-surface-500">
+            Give the app a stable identifier and API key. Its secret can be generated for you.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="icon-button"
+          aria-label="Close create form"
+          @click="showCreate = false"
+        >
+          <X class="h-4 w-4" />
+        </button>
+      </div>
+      <div class="grid gap-5 px-5 py-5 sm:px-6 md:grid-cols-2">
+        <div>
+          <label for="new-app-id" class="field-label">App ID</label>
+          <input
+            id="new-app-id"
+            v-model="form.id"
+            class="input-field font-mono"
+            placeholder="customer-portal"
+            required
+          />
+          <span class="field-hint">Used in API routes and operational reporting.</span>
+        </div>
+        <div>
+          <label for="new-app-key" class="field-label">App key</label>
+          <input
+            id="new-app-key"
+            v-model="form.key"
+            class="input-field font-mono"
+            placeholder="customer-portal-key"
+            required
+          />
+          <span class="field-hint">Public identifier used by realtime clients.</span>
+        </div>
+        <div>
+          <label for="new-app-secret" class="field-label">Secret</label>
+          <div class="relative">
+            <KeyRound
+              class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-600"
+            />
+            <input
+              id="new-app-secret"
+              v-model="form.secret"
+              class="input-field pl-9 font-mono"
+              placeholder="Auto-generate a secure secret"
+            />
+          </div>
+          <span class="field-hint">Optional. Leave blank to generate one automatically.</span>
+        </div>
+        <label
+          class="flex cursor-pointer items-center justify-between gap-4 rounded-xl border border-surface-800 bg-surface-950/30 px-4 py-3"
+        >
+          <span>
+            <span class="block text-sm font-medium text-surface-200">Enable immediately</span>
+            <span class="mt-1 block text-xs text-surface-500">
+              Accept connections as soon as the app is created.
+            </span>
+          </span>
+          <input v-model="form.enabled" type="checkbox" class="toggle-input" />
+        </label>
+      </div>
+      <div
+        class="flex justify-end gap-2 border-t border-surface-800 bg-surface-950/25 px-5 py-4 sm:px-6"
+      >
+        <button type="button" class="btn-secondary" @click="showCreate = false">Cancel</button>
+        <button type="submit" class="btn-primary flex items-center gap-2">
+          <Plus class="h-4 w-4" />
+          Create application
+        </button>
+      </div>
+    </form>
+
+    <div v-if="error" class="alert alert-error mb-5 flex items-start justify-between gap-4">
+      <span>{{ error }}</span>
+      <button class="text-red-200/70 hover:text-red-100" aria-label="Dismiss error" @click="error = null">
+        <X class="h-4 w-4" />
       </button>
     </div>
 
-    <div v-if="stats" class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-      <div class="panel p-4">
-        <p class="text-xs text-surface-500">Registered apps</p>
-        <p class="text-2xl font-semibold mt-1">{{ stats.totals.apps }}</p>
+    <div v-if="loading" class="panel overflow-hidden">
+      <div class="border-b border-surface-800 px-5 py-4">
+        <div class="h-4 w-36 animate-pulse rounded bg-surface-800" />
       </div>
-      <div class="panel p-4">
-        <p class="text-xs text-surface-500">Live connections</p>
-        <p class="text-2xl font-semibold mt-1">{{ stats.totals.connections }}</p>
-      </div>
-      <div class="panel p-4">
-        <p class="text-xs text-surface-500">Users online</p>
-        <p class="text-2xl font-semibold mt-1">{{ stats.totals.users }}</p>
-      </div>
-      <div class="panel p-4">
-        <p class="text-xs text-surface-500">Memory used</p>
-        <p class="text-2xl font-semibold mt-1">{{ stats.memory.percent.toFixed(1) }}%</p>
+      <div v-for="index in 4" :key="index" class="flex items-center gap-4 border-b border-surface-800/70 px-5 py-4 last:border-0">
+        <div class="h-11 w-11 animate-pulse rounded-xl bg-surface-800" />
+        <div class="flex-1 space-y-2">
+          <div class="h-3 w-32 animate-pulse rounded bg-surface-800" />
+          <div class="h-2.5 w-48 animate-pulse rounded bg-surface-800/70" />
+        </div>
       </div>
     </div>
 
-    <div v-if="showCreate" class="panel p-6 mb-6 space-y-4">
-      <h2 class="font-medium text-surface-200">Create application</h2>
-      <div class="grid md:grid-cols-2 gap-4">
-        <div>
-          <label class="section-title">App ID</label>
-          <input v-model="form.id" class="input-field" placeholder="my-app" />
-        </div>
-        <div>
-          <label class="section-title">App Key</label>
-          <input v-model="form.key" class="input-field" placeholder="my-app-key" />
-        </div>
-        <div class="md:col-span-2">
-          <label class="section-title">Secret (optional — auto-generated)</label>
-          <input v-model="form.secret" class="input-field font-mono" />
-        </div>
+    <div v-else-if="apps.length === 0" class="empty-state">
+      <div
+        class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-500/10 text-brand-300"
+      >
+        <AppWindow class="h-5 w-5" />
       </div>
-      <div class="flex gap-2">
-        <button class="btn-primary" @click="createApp">Create</button>
-        <button class="btn-secondary" @click="showCreate = false">Cancel</button>
-      </div>
+      <p class="font-medium text-surface-200">No applications yet</p>
+      <p class="mx-auto mt-1 max-w-sm text-xs leading-5 text-surface-500">
+        Create your first app to issue credentials, accept realtime connections, and configure
+        delivery policies.
+      </p>
+      <button class="btn-primary mt-5 inline-flex items-center gap-2" @click="showCreate = true">
+        <Plus class="h-4 w-4" />
+        Create first app
+      </button>
     </div>
 
-    <p v-if="error" class="text-red-400 text-sm mb-4">{{ error }}</p>
-
-    <div v-if="loading" class="text-surface-400">Loading apps...</div>
-
-    <div v-else class="panel overflow-hidden">
-      <table class="w-full text-sm">
-        <thead class="bg-surface-800/50 text-surface-400 text-left">
+    <div v-else>
+      <div class="panel hidden overflow-hidden md:block">
+        <div class="flex items-center justify-between border-b border-surface-800 px-5 py-4">
+          <div>
+            <p class="text-sm font-semibold text-surface-200">Application registry</p>
+            <p class="mt-0.5 text-xs text-surface-600">
+              {{ apps.length }} {{ apps.length === 1 ? "application" : "applications" }} configured
+            </p>
+          </div>
+          <span class="status-pill status-positive">
+            {{ enabledApps }} active
+          </span>
+        </div>
+        <table class="w-full text-sm">
+          <thead class="bg-surface-950/25 text-left">
           <tr>
-            <th class="px-4 py-3 font-medium">ID</th>
-            <th class="px-4 py-3 font-medium">Key</th>
-            <th class="px-4 py-3 font-medium">Status</th>
-            <th class="px-4 py-3 font-medium">Connections</th>
-            <th class="px-4 py-3 font-medium">Webhooks</th>
-            <th class="px-4 py-3 font-medium text-right">Actions</th>
+              <th class="px-5 py-3 text-[0.68rem] font-semibold uppercase tracking-wider text-surface-600">
+                Application
+              </th>
+              <th class="px-4 py-3 text-[0.68rem] font-semibold uppercase tracking-wider text-surface-600">
+                Status
+              </th>
+              <th class="px-4 py-3 text-[0.68rem] font-semibold uppercase tracking-wider text-surface-600">
+                Connections
+              </th>
+              <th class="px-4 py-3 text-[0.68rem] font-semibold uppercase tracking-wider text-surface-600">
+                Webhooks
+              </th>
+              <th class="px-5 py-3 text-right text-[0.68rem] font-semibold uppercase tracking-wider text-surface-600">
+                Actions
+              </th>
           </tr>
         </thead>
         <tbody>
           <tr
             v-for="app in apps"
             :key="app.id"
-            class="border-t border-surface-800 hover:bg-surface-800/30"
+              class="border-t border-surface-800/80 transition-colors hover:bg-surface-800/25"
           >
-            <td class="px-4 py-3 font-mono text-brand-300">{{ app.id }}</td>
-            <td class="px-4 py-3 font-mono text-surface-300">{{ app.key }}</td>
-            <td class="px-4 py-3">
+              <td class="px-5 py-4">
+                <div class="flex min-w-0 items-center gap-3">
+                  <div class="app-avatar">{{ appInitials(app.id) }}</div>
+                  <div class="min-w-0">
+                    <p class="truncate font-medium text-surface-100">{{ app.id }}</p>
+                    <p class="mt-1 flex items-center gap-1.5 truncate font-mono text-[0.68rem] text-surface-600">
+                      <KeyRound class="h-3 w-3 shrink-0" />
+                      {{ app.key }}
+                    </p>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-4">
               <span
-                class="text-xs px-2 py-0.5 rounded-full"
-                :class="app.enabled ? 'bg-green-500/15 text-green-400' : 'bg-red-500/15 text-red-400'"
+                  class="status-pill"
+                  :class="app.enabled ? 'status-positive' : 'status-negative'"
               >
-                {{ app.enabled ? "enabled" : "disabled" }}
+                  {{ app.enabled ? "Enabled" : "Disabled" }}
               </span>
             </td>
-            <td class="px-4 py-3">{{ connectionsFor(app.id) }}</td>
-            <td class="px-4 py-3">{{ app.webhook_count ?? app.policy.webhooks?.length ?? 0 }}</td>
-            <td class="px-4 py-3">
-              <div class="flex justify-end gap-2">
+              <td class="px-4 py-4">
+                <span class="inline-flex items-center gap-2 text-surface-300">
+                  <span
+                    class="h-1.5 w-1.5 rounded-full"
+                    :class="connectionsFor(app.id) > 0 ? 'bg-emerald-400' : 'bg-surface-700'"
+                  />
+                  {{ connectionsFor(app.id) }}
+                </span>
+              </td>
+              <td class="px-4 py-4">
+                <span class="inline-flex items-center gap-2 text-surface-400">
+                  <Webhook class="h-3.5 w-3.5 text-surface-600" />
+                  {{ webhookCount(app) }}
+                </span>
+              </td>
+              <td class="px-5 py-4">
+                <div class="flex justify-end gap-2">
                 <button
-                  class="btn-secondary btn-sm flex items-center gap-1"
+                    class="btn-secondary btn-sm flex items-center gap-1.5"
                   @click="router.push({ name: 'app-detail', params: { id: app.id } })"
                 >
-                  <Pencil class="w-3 h-3" />
-                  Edit
+                    Configure
+                    <ArrowRight class="h-3 w-3" />
                 </button>
                 <button
-                  class="btn-danger btn-sm flex items-center gap-1"
+                    class="icon-button danger"
+                    :aria-label="`Delete ${app.id}`"
                   @click="removeApp(app)"
                 >
-                  <Trash2 class="w-3 h-3" />
+                    <Trash2 class="h-3.5 w-3.5" />
                 </button>
               </div>
             </td>
           </tr>
-          <tr v-if="apps.length === 0">
-            <td colspan="6" class="px-4 py-8 text-center text-surface-500">
-              No apps yet. Create one to get started.
-            </td>
-          </tr>
         </tbody>
       </table>
+      </div>
+
+      <div class="space-y-3 md:hidden">
+        <article v-for="app in apps" :key="app.id" class="panel p-4">
+          <div class="flex items-start gap-3">
+            <div class="app-avatar">{{ appInitials(app.id) }}</div>
+            <div class="min-w-0 flex-1">
+              <div class="flex items-start justify-between gap-2">
+                <div class="min-w-0">
+                  <h2 class="truncate text-sm font-semibold text-surface-100">{{ app.id }}</h2>
+                  <p class="mt-1 truncate font-mono text-[0.68rem] text-surface-600">{{ app.key }}</p>
+                </div>
+                <span
+                  class="status-pill"
+                  :class="app.enabled ? 'status-positive' : 'status-negative'"
+                >
+                  {{ app.enabled ? "Enabled" : "Disabled" }}
+                </span>
+              </div>
+              <div class="mt-4 grid grid-cols-2 gap-2">
+                <div class="rounded-lg bg-surface-950/40 px-3 py-2">
+                  <p class="text-[0.62rem] uppercase tracking-wide text-surface-600">Connections</p>
+                  <p class="mt-1 text-sm font-medium text-surface-300">
+                    {{ connectionsFor(app.id) }}
+                  </p>
+                </div>
+                <div class="rounded-lg bg-surface-950/40 px-3 py-2">
+                  <p class="text-[0.62rem] uppercase tracking-wide text-surface-600">Webhooks</p>
+                  <p class="mt-1 text-sm font-medium text-surface-300">{{ webhookCount(app) }}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mt-4 flex gap-2 border-t border-surface-800 pt-3">
+            <button
+              class="btn-secondary flex flex-1 items-center justify-center gap-2"
+              @click="router.push({ name: 'app-detail', params: { id: app.id } })"
+            >
+              Configure
+              <ArrowRight class="h-3.5 w-3.5" />
+            </button>
+            <button
+              class="icon-button danger h-auto w-10"
+              :aria-label="`Delete ${app.id}`"
+              @click="removeApp(app)"
+            >
+              <Trash2 class="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </article>
+      </div>
     </div>
   </div>
 </template>

--- a/dashboard/web/src/pages/LoginPage.vue
+++ b/dashboard/web/src/pages/LoginPage.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { Radio } from "lucide-vue-next";
+import {
+  Activity,
+  AppWindow,
+  Database,
+  LoaderCircle,
+  LockKeyhole,
+  Radio,
+  ShieldCheck,
+} from "lucide-vue-next";
 import { useAuthStore } from "@/stores/auth";
 
 const auth = useAuthStore();
@@ -23,30 +31,141 @@ async function submit() {
 </script>
 
 <template>
-  <div class="min-h-screen flex items-center justify-center p-4">
-    <div class="panel w-full max-w-md p-8">
-      <div class="flex items-center gap-2 text-brand-400 mb-2">
-        <Radio class="w-6 h-6" />
-        <h1 class="text-xl font-semibold text-surface-100">Sockudo Dashboard</h1>
-      </div>
-      <p class="text-sm text-surface-400 mb-8">
-        Sign in to manage apps, webhooks, and metrics.
-      </p>
+  <div class="relative min-h-screen overflow-hidden">
+    <div
+      class="pointer-events-none absolute -left-48 -top-48 h-[34rem] w-[34rem] rounded-full bg-brand-600/15 blur-3xl"
+    />
+    <div
+      class="pointer-events-none absolute -bottom-56 right-0 h-[36rem] w-[36rem] rounded-full bg-sky-500/8 blur-3xl"
+    />
 
-      <form class="space-y-4" @submit.prevent="submit">
-        <div>
-          <label class="section-title">Email</label>
-          <input v-model="email" type="email" class="input-field" required />
+    <div class="relative mx-auto grid min-h-screen max-w-7xl lg:grid-cols-[1.05fr_0.95fr]">
+      <section class="hidden flex-col justify-between px-10 py-10 lg:flex xl:px-16 xl:py-14">
+        <div class="flex items-center gap-3">
+          <div
+            class="flex h-11 w-11 items-center justify-center rounded-2xl border border-brand-400/25 bg-brand-500/15 text-brand-300 shadow-xl shadow-brand-950/30"
+          >
+            <Radio class="h-5 w-5" />
+          </div>
+          <div>
+            <p class="font-semibold tracking-tight text-surface-50">Sockudo</p>
+            <p class="text-xs text-surface-500">Realtime infrastructure</p>
+          </div>
         </div>
-        <div>
-          <label class="section-title">Password</label>
-          <input v-model="password" type="password" class="input-field" required />
+
+        <div class="max-w-xl py-14">
+          <p class="eyebrow">Operator control plane</p>
+          <h1 class="text-4xl font-semibold leading-tight tracking-tight text-surface-50 xl:text-5xl">
+            Run every realtime app from one focused workspace.
+          </h1>
+          <p class="mt-5 max-w-lg text-base leading-7 text-surface-400">
+            Configure application policy, inspect live traffic, and manage delivery infrastructure
+            without leaving the dashboard.
+          </p>
+
+          <div class="mt-10 grid max-w-lg gap-3 sm:grid-cols-3">
+            <div class="rounded-2xl border border-surface-800 bg-surface-900/45 p-4">
+              <AppWindow class="h-5 w-5 text-brand-300" />
+              <p class="mt-4 text-sm font-medium text-surface-200">App policy</p>
+              <p class="mt-1 text-xs leading-5 text-surface-600">Credentials, limits, and channels</p>
+            </div>
+            <div class="rounded-2xl border border-surface-800 bg-surface-900/45 p-4">
+              <Activity class="h-5 w-5 text-emerald-300" />
+              <p class="mt-4 text-sm font-medium text-surface-200">Live metrics</p>
+              <p class="mt-1 text-xs leading-5 text-surface-600">Operational signals at a glance</p>
+            </div>
+            <div class="rounded-2xl border border-surface-800 bg-surface-900/45 p-4">
+              <Database class="h-5 w-5 text-sky-300" />
+              <p class="mt-4 text-sm font-medium text-surface-200">Durable state</p>
+              <p class="mt-1 text-xs leading-5 text-surface-600">Database-backed configuration</p>
+            </div>
+          </div>
         </div>
-        <p v-if="auth.error" class="text-sm text-red-400">{{ auth.error }}</p>
-        <button type="submit" class="btn-primary w-full" :disabled="auth.loading">
-          {{ auth.loading ? "Signing in..." : "Sign in" }}
-        </button>
-      </form>
+
+        <p class="flex items-center gap-2 text-xs text-surface-600">
+          <ShieldCheck class="h-4 w-4 text-emerald-400/70" />
+          Authenticated operator access
+        </p>
+      </section>
+
+      <section class="flex min-h-screen items-center justify-center px-4 py-10 sm:px-8 lg:border-l lg:border-surface-800/70">
+        <div class="w-full max-w-md">
+          <div class="mb-8 flex items-center gap-3 lg:hidden">
+            <div
+              class="flex h-10 w-10 items-center justify-center rounded-xl bg-brand-500/15 text-brand-300"
+            >
+              <Radio class="h-5 w-5" />
+            </div>
+            <div>
+              <p class="font-semibold text-surface-100">Sockudo</p>
+              <p class="text-xs text-surface-600">Operator dashboard</p>
+            </div>
+          </div>
+
+          <div class="panel overflow-hidden">
+            <div class="border-b border-surface-800/80 px-6 py-6 sm:px-8 sm:py-7">
+              <div
+                class="mb-5 flex h-11 w-11 items-center justify-center rounded-xl bg-surface-800/80 text-brand-300 ring-1 ring-inset ring-surface-700/60"
+              >
+                <LockKeyhole class="h-5 w-5" />
+              </div>
+              <h2 class="text-xl font-semibold tracking-tight text-surface-50">Welcome back</h2>
+              <p class="mt-2 text-sm leading-6 text-surface-500">
+                Sign in with your operator account to continue.
+              </p>
+            </div>
+
+            <form class="space-y-5 px-6 py-6 sm:px-8 sm:py-7" @submit.prevent="submit">
+              <div>
+                <label for="login-email" class="field-label">Email address</label>
+                <input
+                  id="login-email"
+                  v-model="email"
+                  type="email"
+                  class="input-field"
+                  autocomplete="email"
+                  placeholder="you@example.com"
+                  required
+                />
+              </div>
+              <div>
+                <label for="login-password" class="field-label">Password</label>
+                <input
+                  id="login-password"
+                  v-model="password"
+                  type="password"
+                  class="input-field"
+                  autocomplete="current-password"
+                  placeholder="Enter your password"
+                  required
+                />
+              </div>
+
+              <p v-if="auth.error" class="alert alert-error" role="alert">{{ auth.error }}</p>
+
+              <button
+                type="submit"
+                class="btn-primary flex w-full items-center justify-center gap-2 py-2.5"
+                :disabled="auth.loading"
+              >
+                <LoaderCircle v-if="auth.loading" class="h-4 w-4 animate-spin" />
+                {{ auth.loading ? "Signing in..." : "Sign in to dashboard" }}
+              </button>
+            </form>
+
+            <div class="border-t border-surface-800/80 bg-surface-950/25 px-6 py-4 sm:px-8">
+              <p class="flex items-center justify-center gap-2 text-[0.68rem] text-surface-600">
+                <ShieldCheck class="h-3.5 w-3.5 text-emerald-400/70" />
+                Session protected with secure, HTTP-only authentication
+              </p>
+            </div>
+          </div>
+
+          <p class="mt-6 text-center text-xs text-surface-700">
+            Sockudo operator workspace
+          </p>
+        </div>
+      </section>
     </div>
   </div>
 </template>

--- a/dashboard/web/src/pages/MetricsPage.vue
+++ b/dashboard/web/src/pages/MetricsPage.vue
@@ -1,133 +1,686 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from "vue";
-import { RefreshCw } from "lucide-vue-next";
-import { api, type MetricsSummary } from "@/api/client";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import {
+  Activity,
+  Gauge,
+  Pause,
+  Plus,
+  RefreshCw,
+  Search,
+  Settings2,
+  Trash2,
+  X,
+} from "lucide-vue-next";
+import MetricChart from "@/components/MetricChart.vue";
+import {
+  api,
+  type MetricFamily,
+  type MetricSample,
+  type MetricsResponse,
+} from "@/api/client";
 
-const summary = ref<MetricsSummary | null>(null);
+type ViewMode = "value" | "rate" | "average";
+
+interface PanelConfig {
+  id: string;
+  metric: string;
+  title: string;
+  view: ViewMode;
+  color: string;
+}
+
+interface Point {
+  at: number;
+  value: number;
+}
+
+interface StoredMetricsState {
+  version: 1;
+  interval: number;
+  appFilter: string;
+  panels: PanelConfig[];
+  history: Record<string, Point[]>;
+}
+
+const STORAGE_KEY = "sockudo.metrics.workbench.v1";
+const MAX_POINTS = 180;
+const MAX_POINT_AGE_MS = 6 * 60 * 60 * 1_000;
+const COLORS = ["#748ffc", "#38bdf8", "#34d399", "#fbbf24", "#f472b6", "#a78bfa"];
+
+const families = ref<MetricFamily[]>([]);
+const panels = ref<PanelConfig[]>([]);
+const history = ref<Record<string, Point[]>>({});
+const currentValues = ref<Record<string, number | undefined>>({});
+const intervalSeconds = ref(15);
+const appFilter = ref("*");
 const loading = ref(true);
+const refreshing = ref(false);
 const error = ref<string | null>(null);
-let timer: ReturnType<typeof setInterval> | null = null;
+const lastScrape = ref<string | null>(null);
+const showPicker = ref(false);
+const pickerSearch = ref("");
+const seededDefaults = ref(false);
+const isHidden = ref(false);
+const previousCounters = new Map<string, { at: number; value: number }>();
+let timer: ReturnType<typeof setTimeout> | null = null;
+let inFlight = false;
+
+const availableApps = computed(() => {
+  const ids = new Set<string>();
+  for (const family of families.value) {
+    for (const sample of family.samples) {
+      const id = sample.labels.app_id ?? sample.labels.app;
+      if (id) ids.add(id);
+    }
+  }
+  return [...ids].sort();
+});
+
+const filteredFamilies = computed(() => {
+  const query = pickerSearch.value.trim().toLowerCase();
+  return families.value
+    .filter((family) => {
+      if (!query) return true;
+      return (
+        family.name.toLowerCase().includes(query) ||
+        family.help?.toLowerCase().includes(query) ||
+        categoryFor(family.name).toLowerCase().includes(query)
+      );
+    })
+    .sort((left, right) => {
+      const category = categoryFor(left.name).localeCompare(categoryFor(right.name));
+      return category || left.name.localeCompare(right.name);
+    });
+});
 
 onMounted(() => {
-  load();
-  timer = setInterval(load, 15_000);
+  restore();
+  isHidden.value = document.hidden;
+  document.addEventListener("visibilitychange", visibilityChanged);
+  void load();
 });
 
 onUnmounted(() => {
-  if (timer) clearInterval(timer);
+  if (timer) clearTimeout(timer);
+  document.removeEventListener("visibilitychange", visibilityChanged);
 });
 
-async function load() {
+watch(intervalSeconds, () => {
+  saveState();
+  schedule();
+});
+
+watch(appFilter, () => {
+  previousCounters.clear();
+  history.value = Object.fromEntries(panels.value.map((panel) => [panel.id, []]));
+  currentValues.value = {};
+  saveState();
+  void load();
+});
+
+function restore() {
   try {
-    summary.value = await api.metricsSummary();
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const stored = JSON.parse(raw) as StoredMetricsState;
+    if (stored.version !== 1 || !Array.isArray(stored.panels)) return;
+    const cutoff = Date.now() - MAX_POINT_AGE_MS;
+    panels.value = stored.panels;
+    intervalSeconds.value = [5, 15, 30, 60].includes(stored.interval)
+      ? stored.interval
+      : 15;
+    appFilter.value = stored.appFilter || "*";
+    history.value = Object.fromEntries(
+      Object.entries(stored.history ?? {}).map(([id, points]) => [
+        id,
+        points
+          .filter(
+            (point) =>
+              Number.isFinite(point.at) &&
+              Number.isFinite(point.value) &&
+              point.at >= cutoff,
+          )
+          .slice(-MAX_POINTS),
+      ]),
+    );
+    seededDefaults.value = true;
+  } catch {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+function saveState() {
+  const state: StoredMetricsState = {
+    version: 1,
+    interval: intervalSeconds.value,
+    appFilter: appFilter.value,
+    panels: panels.value,
+    history: history.value,
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function visibilityChanged() {
+  isHidden.value = document.hidden;
+  if (!document.hidden) void load();
+}
+
+function schedule() {
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(() => void load(), intervalSeconds.value * 1_000);
+}
+
+async function load() {
+  if (inFlight) return;
+  if (document.hidden) {
+    schedule();
+    return;
+  }
+  inFlight = true;
+  refreshing.value = true;
+  try {
+    const response = await api.metrics();
+    families.value = normalizeFamilies(response);
+    lastScrape.value = response.scraped_at ?? new Date().toISOString();
+    seedPanels();
+    samplePanels(Date.now());
     error.value = null;
   } catch (err) {
     error.value = err instanceof Error ? err.message : "Metrics unavailable";
   } finally {
+    inFlight = false;
     loading.value = false;
+    refreshing.value = false;
+    schedule();
   }
 }
 
-function formatNum(n: number) {
-  return new Intl.NumberFormat().format(Math.round(n));
+function normalizeFamilies(response: MetricsResponse): MetricFamily[] {
+  if (response.families?.length) return response.families;
+  const grouped = new Map<string, MetricSample[]>();
+  for (const sample of response.samples) {
+    const samples = grouped.get(sample.name) ?? [];
+    samples.push(sample);
+    grouped.set(sample.name, samples);
+  }
+  return [...grouped.entries()].map(([name, samples]) => ({
+    name,
+    type: name.endsWith("_total") ? "counter" : "untyped",
+    samples,
+  }));
+}
+
+function seedPanels() {
+  if (seededDefaults.value) return;
+  const defaults: Array<[string, string, ViewMode]> = [
+    ["connected", "Connected sockets", "value"],
+    ["ws_messages_received_total", "WebSocket messages in", "rate"],
+    ["ws_messages_sent_total", "WebSocket messages out", "rate"],
+    ["http_calls_received_total", "HTTP API calls", "rate"],
+    ["connection_errors_total", "Connection errors", "rate"],
+    ["process_resident_memory_bytes", "Resident memory", "value"],
+    ["tokio_active_tasks", "Tokio active tasks", "value"],
+    ["push_publish_accepted_total", "Push accepted", "rate"],
+  ];
+
+  const used = new Set<string>();
+  for (const [suffix, title, view] of defaults) {
+    const family = families.value
+      .filter((candidate) => candidate.name.endsWith(suffix))
+      .sort((left, right) => left.name.length - right.name.length)[0];
+    if (!family || used.has(family.name)) continue;
+    used.add(family.name);
+    panels.value.push({
+      id: crypto.randomUUID(),
+      metric: family.name,
+      title,
+      view,
+      color: COLORS[panels.value.length % COLORS.length],
+    });
+  }
+  if (panels.value.length === 0) {
+    for (const family of families.value.slice(0, 6)) addPanel(family, false);
+  }
+  seededDefaults.value = true;
+  saveState();
+}
+
+function samplesFor(family: MetricFamily): MetricSample[] {
+  if (appFilter.value === "*") return family.samples;
+  const isAppScoped = family.samples.some(
+    (sample) => sample.labels.app_id !== undefined || sample.labels.app !== undefined,
+  );
+  if (!isAppScoped) return family.samples;
+  return family.samples.filter(
+    (sample) =>
+      sample.labels.app_id === appFilter.value || sample.labels.app === appFilter.value,
+  );
+}
+
+function panelScopeLabel(panel: PanelConfig) {
+  if (appFilter.value === "*") return "All app label values";
+  const family = families.value.find((candidate) => candidate.name === panel.metric);
+  const isAppScoped = family?.samples.some(
+    (sample) => sample.labels.app_id !== undefined || sample.labels.app !== undefined,
+  );
+  return isAppScoped ? `app = ${appFilter.value}` : "Global metric (not app-labelled)";
+}
+
+function rawValue(family: MetricFamily, view: ViewMode): number | undefined {
+  const samples = samplesFor(family);
+  if (samples.length === 0) return 0;
+  if (view === "average" || family.type === "histogram" || family.type === "summary") {
+    const sum = samples
+      .filter((sample) => sample.name === `${family.name}_sum`)
+      .reduce((total, sample) => total + sample.value, 0);
+    const count = samples
+      .filter((sample) => sample.name === `${family.name}_count`)
+      .reduce((total, sample) => total + sample.value, 0);
+    return count > 0 ? sum / count : 0;
+  }
+  const primary = samples.filter(
+    (sample) =>
+      sample.name === family.name ||
+      sample.name === `${family.name}_total` ||
+      (!sample.name.endsWith("_bucket") &&
+        !sample.name.endsWith("_sum") &&
+        !sample.name.endsWith("_count")),
+  );
+  return primary.reduce((total, sample) => total + sample.value, 0);
+}
+
+function samplePanel(panel: PanelConfig, now: number) {
+  const family = families.value.find((candidate) => candidate.name === panel.metric);
+  if (!family) {
+    currentValues.value[panel.id] = undefined;
+    return;
+  }
+  const raw = rawValue(family, panel.view);
+  if (raw === undefined) return;
+
+  let value: number | undefined = raw;
+  if (panel.view === "rate") {
+    const previousKey = `${panel.id}:${appFilter.value}`;
+    const previous = previousCounters.get(previousKey);
+    previousCounters.set(previousKey, { at: now, value: raw });
+    if (!previous || now <= previous.at) value = undefined;
+    else {
+      const delta = raw >= previous.value ? raw - previous.value : raw;
+      value = delta / ((now - previous.at) / 1_000);
+    }
+  }
+  currentValues.value[panel.id] = value;
+  if (value === undefined || !Number.isFinite(value)) return;
+  const cutoff = now - MAX_POINT_AGE_MS;
+  const points = (history.value[panel.id] ?? [])
+    .filter((point) => point.at >= cutoff)
+    .concat({ at: now, value })
+    .slice(-MAX_POINTS);
+  history.value[panel.id] = points;
+}
+
+function samplePanels(now: number) {
+  for (const panel of panels.value) samplePanel(panel, now);
+  saveState();
+}
+
+function addPanel(family: MetricFamily, closePicker = true) {
+  const view: ViewMode =
+    family.type === "counter"
+      ? "rate"
+      : family.type === "histogram" || family.type === "summary"
+        ? "average"
+        : "value";
+  const panel: PanelConfig = {
+    id: crypto.randomUUID(),
+    metric: family.name,
+    title: prettyMetricName(family.name),
+    view,
+    color: COLORS[panels.value.length % COLORS.length],
+  };
+  panels.value.push(panel);
+  history.value[panel.id] = [];
+  if (closePicker) showPicker.value = false;
+  saveState();
+  samplePanel(panel, Date.now());
+}
+
+function removePanel(id: string) {
+  panels.value = panels.value.filter((panel) => panel.id !== id);
+  delete history.value[id];
+  delete currentValues.value[id];
+  previousCounters.delete(`${id}:${appFilter.value}`);
+  saveState();
+}
+
+function changeView(panel: PanelConfig) {
+  history.value[panel.id] = [];
+  delete currentValues.value[panel.id];
+  previousCounters.delete(`${panel.id}:${appFilter.value}`);
+  saveState();
+  samplePanel(panel, Date.now());
+}
+
+function resetDashboard() {
+  if (!confirm("Reset the metrics dashboard to its discovered defaults?")) return;
+  panels.value = [];
+  history.value = {};
+  currentValues.value = {};
+  previousCounters.clear();
+  seededDefaults.value = false;
+  localStorage.removeItem(STORAGE_KEY);
+  seedPanels();
+  samplePanels(Date.now());
+}
+
+function categoryFor(name: string) {
+  if (name.includes("_push_")) return "Push";
+  if (name.includes("_history") || name.includes("_recovery")) return "History & recovery";
+  if (name.includes("_ai_")) return "AI transport";
+  if (name.includes("_queue_")) return "Queue";
+  if (
+    name.startsWith("process_") ||
+    name.includes("_process_") ||
+    name.includes("_tokio_")
+  ) {
+    return "Runtime";
+  }
+  if (name.includes("_annotation")) return "Annotations";
+  if (name.includes("_presence")) return "Presence";
+  if (name.includes("_delta")) return "Delta compression";
+  return "Realtime";
+}
+
+function prettyMetricName(name: string) {
+  return name
+    .replace(/^sockudo_/, "")
+    .replace(/_total$/, "")
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function formatValue(panel: PanelConfig, value?: number) {
+  if (value === undefined) return "—";
+  if (panel.metric.endsWith("_bytes")) {
+    const units = ["B", "KiB", "MiB", "GiB"];
+    let amount = value;
+    let unit = 0;
+    while (Math.abs(amount) >= 1024 && unit < units.length - 1) {
+      amount /= 1024;
+      unit += 1;
+    }
+    return `${amount.toFixed(amount >= 10 ? 1 : 2)} ${units[unit]}`;
+  }
+  const formatted = new Intl.NumberFormat(undefined, {
+    notation: Math.abs(value) >= 10_000 ? "compact" : "standard",
+    maximumFractionDigits: Math.abs(value) < 10 ? 2 : 1,
+  }).format(value);
+  return panel.view === "rate" ? `${formatted}/s` : formatted;
+}
+
+function lastScrapeLabel() {
+  if (!lastScrape.value) return "Not scraped yet";
+  const date = new Date(lastScrape.value);
+  return Number.isNaN(date.getTime()) ? "Just now" : date.toLocaleTimeString();
 }
 </script>
 
 <template>
   <div>
-    <div class="flex items-center justify-between mb-6">
+    <header class="page-header">
       <div>
-        <h1 class="text-2xl font-semibold text-surface-100">Metrics</h1>
-        <p class="text-sm text-surface-400 mt-1">
-          Live Prometheus summary from Sockudo (refreshes every 15s).
+        <div class="flex items-center gap-2 text-brand-300 mb-2">
+          <Activity class="w-4 h-4" />
+          <span class="eyebrow !mb-0">Observability workbench</span>
+        </div>
+        <h1 class="page-title">Metrics</h1>
+        <p class="page-subtitle">
+          Build a live dashboard from every Prometheus family exported by Sockudo.
         </p>
       </div>
-      <button class="btn-secondary flex items-center gap-2" @click="load">
-        <RefreshCw class="w-4 h-4" />
-        Refresh
-      </button>
+      <div class="flex flex-wrap items-center gap-2">
+        <select
+          v-model.number="intervalSeconds"
+          class="input-field !w-auto"
+          aria-label="Scrape interval"
+        >
+          <option :value="5">5 second scrape</option>
+          <option :value="15">15 second scrape</option>
+          <option :value="30">30 second scrape</option>
+          <option :value="60">60 second scrape</option>
+        </select>
+        <button class="btn-secondary flex items-center gap-2" :disabled="refreshing" @click="load">
+          <RefreshCw class="w-4 h-4" :class="{ 'animate-spin': refreshing }" />
+          Refresh
+        </button>
+        <button class="btn-primary flex items-center gap-2" @click="showPicker = true">
+          <Plus class="w-4 h-4" />
+          Add panel
+        </button>
+      </div>
+    </header>
+
+    <div v-if="error" class="alert alert-warning mb-5">
+      {{ error }} — ensure the Sockudo metrics listener is reachable. Existing chart history is
+      preserved.
     </div>
 
-    <p v-if="error" class="text-amber-400 text-sm mb-4">
-      {{ error }} — ensure Sockudo metrics are enabled on port 9601.
-    </p>
-
-    <div v-if="loading && !summary" class="text-surface-400">Loading metrics...</div>
-
-    <template v-else-if="summary">
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        <div class="panel p-4">
-          <p class="text-xs text-surface-500">Connected sockets</p>
-          <p class="text-2xl font-semibold mt-1">{{ formatNum(summary.connected_sockets) }}</p>
+    <section class="panel p-4 mb-5">
+      <div class="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
+        <div class="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs">
+          <span class="inline-flex items-center gap-2 text-surface-300">
+            <span
+              class="w-2 h-2 rounded-full"
+              :class="error ? 'bg-amber-400' : 'bg-emerald-400 animate-pulse'"
+            />
+            {{ error ? "Datasource degraded" : "Scraping live" }}
+          </span>
+          <span class="text-surface-500">{{ families.length }} metric families discovered</span>
+          <span class="text-surface-500">Last scrape {{ lastScrapeLabel() }}</span>
+          <span v-if="isHidden" class="inline-flex items-center gap-1 text-surface-500">
+            <Pause class="w-3 h-3" />
+            Paused while hidden
+          </span>
         </div>
-        <div class="panel p-4">
-          <p class="text-xs text-surface-500">WS messages in</p>
-          <p class="text-2xl font-semibold mt-1">
-            {{ formatNum(summary.ws_messages_received_total) }}
-          </p>
-        </div>
-        <div class="panel p-4">
-          <p class="text-xs text-surface-500">WS messages out</p>
-          <p class="text-2xl font-semibold mt-1">
-            {{ formatNum(summary.ws_messages_sent_total) }}
-          </p>
-        </div>
-        <div class="panel p-4">
-          <p class="text-xs text-surface-500">HTTP API calls</p>
-          <p class="text-2xl font-semibold mt-1">
-            {{ formatNum(summary.http_calls_received_total) }}
-          </p>
-        </div>
-        <div class="panel p-4">
-          <p class="text-xs text-surface-500">Subscriptions</p>
-          <p class="text-2xl font-semibold mt-1">
-            {{ formatNum(summary.channel_subscriptions_total) }}
-          </p>
-        </div>
-        <div class="panel p-4">
-          <p class="text-xs text-surface-500">Connection errors</p>
-          <p class="text-2xl font-semibold mt-1 text-red-400">
-            {{ formatNum(summary.connection_errors_total) }}
-          </p>
-        </div>
-        <div class="panel p-4">
-          <p class="text-xs text-surface-500">Rate limits hit</p>
-          <p class="text-2xl font-semibold mt-1 text-amber-400">
-            {{ formatNum(summary.rate_limit_triggered_total) }}
-          </p>
-        </div>
-        <div class="panel p-4">
-          <p class="text-xs text-surface-500">Total connections (lifetime)</p>
-          <p class="text-2xl font-semibold mt-1">
-            {{ formatNum(summary.new_connections_total) }}
-          </p>
+        <div class="flex items-center gap-2">
+          <label class="text-xs text-surface-500">App</label>
+          <select
+            v-model="appFilter"
+            class="input-field !w-auto min-w-36"
+            aria-label="Filter metrics by app"
+          >
+            <option value="*">All apps</option>
+            <option v-for="id in availableApps" :key="id" :value="id">{{ id }}</option>
+          </select>
+          <button class="icon-button" title="Reset dashboard" @click="resetDashboard">
+            <Settings2 class="w-4 h-4" />
+          </button>
         </div>
       </div>
+    </section>
 
-      <div class="panel p-6">
-        <h2 class="font-medium text-surface-200 mb-4">Connections by app</h2>
-        <div v-if="summary.by_app.length === 0" class="text-surface-500 text-sm">
-          No per-app socket metrics yet.
-        </div>
-        <table v-else class="w-full text-sm">
-          <thead class="text-surface-400 text-left">
-            <tr>
-              <th class="pb-2 font-medium">App ID</th>
-              <th class="pb-2 font-medium text-right">Connected sockets</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="row in summary.by_app"
-              :key="row.app_id"
-              class="border-t border-surface-800"
+    <div v-if="loading && families.length === 0" class="empty-state">
+      Discovering Prometheus metrics…
+    </div>
+
+    <div v-else-if="panels.length === 0" class="empty-state">
+      <Gauge class="w-8 h-8 text-surface-600 mx-auto mb-3" />
+      <p class="text-surface-300 font-medium">Your workbench is empty</p>
+      <p class="mt-1">Add any observed Sockudo, runtime, queue, history, AI, or push metric.</p>
+      <button class="btn-primary mt-4" @click="showPicker = true">Add first panel</button>
+    </div>
+
+    <div v-else class="grid md:grid-cols-2 xl:grid-cols-3 gap-4">
+      <article v-for="panel in panels" :key="panel.id" class="metric-panel">
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0">
+            <p class="text-sm font-medium text-surface-200 truncate">{{ panel.title }}</p>
+            <p class="font-mono text-[0.65rem] text-surface-600 truncate mt-1">
+              {{ panel.metric }}
+            </p>
+          </div>
+          <div class="flex items-center gap-1 shrink-0">
+            <select
+              v-model="panel.view"
+              class="panel-select"
+              :aria-label="`View mode for ${panel.title}`"
+              @change="changeView(panel)"
             >
-              <td class="py-2 font-mono text-brand-300">{{ row.app_id }}</td>
-              <td class="py-2 text-right">{{ formatNum(row.connected_sockets) }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </template>
+              <option value="value">Value</option>
+              <option value="rate">Rate</option>
+              <option value="average">Average</option>
+            </select>
+            <button
+              class="icon-button !w-7 !h-7 danger"
+              :aria-label="`Remove ${panel.title} panel`"
+              @click="removePanel(panel.id)"
+            >
+              <Trash2 class="w-3.5 h-3.5" />
+            </button>
+          </div>
+        </div>
+        <p class="text-3xl font-semibold tracking-tight text-surface-50 mt-5">
+          {{ formatValue(panel, currentValues[panel.id]) }}
+        </p>
+        <p class="text-[0.68rem] text-surface-600 mt-1">
+          {{ panelScopeLabel(panel) }}
+        </p>
+        <MetricChart
+          :id="panel.id"
+          :points="history[panel.id] ?? []"
+          :color="panel.color"
+          class="mt-3"
+        />
+      </article>
+    </div>
+
+    <div v-if="showPicker" class="modal-backdrop" @click.self="showPicker = false">
+      <section class="metric-picker panel">
+        <div class="flex items-start justify-between gap-4 p-5 border-b border-surface-800">
+          <div>
+            <p class="eyebrow">Panel library</p>
+            <h2 class="text-lg font-semibold">Add a Prometheus metric</h2>
+            <p class="text-xs text-surface-500 mt-1">
+              Includes core, runtime, history, queue, AI transport, and push families.
+            </p>
+          </div>
+          <button
+            class="icon-button"
+            aria-label="Close metric library"
+            @click="showPicker = false"
+          >
+            <X class="w-4 h-4" />
+          </button>
+        </div>
+        <div class="p-4 border-b border-surface-800">
+          <div class="relative">
+            <Search class="absolute left-3 top-2.5 w-4 h-4 text-surface-500" />
+            <input
+              v-model="pickerSearch"
+              class="input-field !pl-9"
+              autofocus
+              placeholder="Search metric name, description, or category…"
+            />
+          </div>
+        </div>
+        <div class="metric-family-list">
+          <button
+            v-for="family in filteredFamilies"
+            :key="family.name"
+            class="metric-family-row"
+            @click="addPanel(family)"
+          >
+            <span class="min-w-0">
+              <span class="block font-mono text-xs text-brand-200 truncate">
+                {{ family.name }}
+              </span>
+              <span class="block text-xs text-surface-500 truncate mt-1">
+                {{ family.help || "No exporter description" }}
+              </span>
+            </span>
+            <span class="flex items-center gap-2 shrink-0">
+              <span class="metric-tag">{{ categoryFor(family.name) }}</span>
+              <span class="metric-tag">{{ family.type ?? "untyped" }}</span>
+              <Plus class="w-4 h-4 text-surface-500" />
+            </span>
+          </button>
+          <div v-if="filteredFamilies.length === 0" class="empty-state !border-0 !rounded-none">
+            No matching metric families.
+          </div>
+        </div>
+      </section>
+    </div>
   </div>
 </template>
+
+<style scoped>
+.metric-panel {
+  border: 1px solid rgb(51 65 85 / 0.45);
+  border-radius: 1rem;
+  background: rgb(15 23 42 / 0.72);
+  padding: 1rem;
+  box-shadow: 0 16px 50px rgb(2 6 23 / 0.15);
+  overflow: hidden;
+}
+
+.panel-select {
+  border: 1px solid rgb(51 65 85 / 0.7);
+  border-radius: 0.45rem;
+  background: rgb(30 41 59 / 0.75);
+  color: #94a3b8;
+  padding: 0.28rem 0.4rem;
+  font-size: 0.65rem;
+  outline: none;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgb(2 6 23 / 0.78);
+  backdrop-filter: blur(10px);
+}
+
+.metric-picker {
+  width: min(48rem, 100%);
+  max-height: min(44rem, calc(100vh - 2rem));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.metric-family-list {
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.metric-family-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-radius: 0.7rem;
+  padding: 0.75rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.metric-family-row:hover {
+  background: rgb(30 41 59 / 0.65);
+}
+
+.metric-tag {
+  border: 1px solid rgb(51 65 85 / 0.6);
+  border-radius: 999px;
+  padding: 0.2rem 0.45rem;
+  color: #64748b;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+</style>

--- a/dashboard/web/src/router/index.ts
+++ b/dashboard/web/src/router/index.ts
@@ -25,6 +25,11 @@ const router = createRouter({
           component: () => import("@/pages/AppDetailPage.vue"),
         },
         {
+          path: "apps/:id/push",
+          name: "app-push",
+          component: () => import("@/pages/AppPushPage.vue"),
+        },
+        {
           path: "metrics",
           name: "metrics",
           component: () => import("@/pages/MetricsPage.vue"),

--- a/dashboard/web/src/style.css
+++ b/dashboard/web/src/style.css
@@ -31,10 +31,28 @@
 
 body {
   @apply bg-surface-950 text-surface-100 antialiased font-sans;
+  min-width: 320px;
+  background-image:
+    radial-gradient(circle at 20% -10%, rgb(76 110 245 / 0.16), transparent 32rem),
+    radial-gradient(circle at 100% 20%, rgb(14 165 233 / 0.08), transparent 28rem);
+  background-attachment: fixed;
 }
 
 * {
   @apply border-surface-700/50;
+}
+
+button,
+input,
+select,
+textarea {
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    color 150ms ease,
+    box-shadow 150ms ease,
+    opacity 150ms ease,
+    transform 150ms ease;
 }
 
 @utility panel {
@@ -42,6 +60,7 @@ body {
   backdrop-filter: blur(24px);
   border: 1px solid oklch(from var(--color-surface-700) l c h / 0.4);
   border-radius: 1rem;
+  box-shadow: 0 18px 50px rgb(2 6 23 / 0.16);
 }
 
 @utility input-field {
@@ -58,6 +77,10 @@ body {
     box-shadow: 0 0 0 2px oklch(from var(--color-brand-500) l c h / 0.4);
     border-color: oklch(from var(--color-brand-500) l c h / 0.6);
   }
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
 }
 
 @utility btn-primary {
@@ -68,7 +91,11 @@ body {
   font-weight: 500;
   border-radius: 0.5rem;
   cursor: pointer;
-  &:hover { background: var(--color-brand-500); }
+  box-shadow: 0 8px 24px rgb(76 110 245 / 0.18);
+  &:hover {
+    background: var(--color-brand-500);
+    transform: translateY(-1px);
+  }
   &:disabled { opacity: 0.4; cursor: not-allowed; }
 }
 
@@ -109,4 +136,219 @@ body {
   letter-spacing: 0.05em;
   color: var(--color-surface-400);
   margin-bottom: 0.75rem;
+}
+
+@utility page-header {
+  @apply flex flex-col lg:flex-row lg:items-center justify-between gap-4 mb-6;
+}
+
+@utility page-title {
+  @apply text-2xl lg:text-3xl font-semibold tracking-tight text-surface-50;
+}
+
+@utility page-subtitle {
+  @apply text-sm text-surface-400 mt-1;
+}
+
+@utility eyebrow {
+  @apply text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-brand-400 mb-1;
+}
+
+@utility field-label {
+  @apply block text-xs font-semibold uppercase tracking-[0.08em] text-surface-400 mb-2;
+}
+
+@utility field-hint {
+  @apply block text-xs leading-5 text-surface-500 mt-1.5;
+}
+
+@utility settings-card {
+  @apply panel p-5 lg:p-6;
+}
+
+@utility card-heading {
+  @apply flex items-start justify-between gap-4 pb-5 mb-5 border-b border-surface-800;
+  h2 {
+    @apply text-base font-semibold text-surface-100;
+  }
+  p:not(.eyebrow) {
+    @apply text-xs leading-5 text-surface-500 mt-1;
+  }
+}
+
+@utility setting-row {
+  @apply flex items-center justify-between gap-4 py-3.5 border-b border-surface-800/80 last:border-b-0;
+}
+
+@utility subcard {
+  @apply rounded-xl border border-surface-700/60 bg-surface-950/35 p-4;
+}
+
+@utility nested-policy {
+  @apply rounded-lg border border-surface-800 bg-surface-900/60 p-4;
+}
+
+@utility inherit-state {
+  @apply rounded-xl border border-dashed border-surface-700 bg-surface-950/25 px-4 py-7 text-center text-sm text-surface-500;
+}
+
+@utility empty-state {
+  @apply panel px-5 py-12 text-center text-sm text-surface-400;
+}
+
+@utility back-link {
+  @apply inline-flex items-center gap-2 text-sm text-surface-400 hover:text-surface-100 mb-5 cursor-pointer;
+}
+
+@utility status-pill {
+  @apply inline-flex items-center rounded-full px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-wide;
+}
+
+@utility status-positive {
+  @apply bg-emerald-500/12 text-emerald-300 ring-1 ring-inset ring-emerald-400/20;
+}
+
+@utility status-negative {
+  @apply bg-red-500/12 text-red-300 ring-1 ring-inset ring-red-400/20;
+}
+
+@utility app-avatar {
+  @apply w-11 h-11 shrink-0 rounded-xl bg-gradient-to-br from-brand-500/30 to-sky-500/10 border border-brand-400/20 flex items-center justify-center text-sm font-bold text-brand-200;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.06);
+}
+
+@utility alert {
+  @apply rounded-xl border px-4 py-3 text-sm leading-5;
+}
+
+@utility alert-error {
+  @apply border-red-400/20 bg-red-500/10 text-red-300;
+}
+
+@utility alert-warning {
+  @apply border-amber-400/20 bg-amber-500/8 text-amber-200/85;
+}
+
+@utility toggle-input {
+  width: 2.5rem;
+  height: 1.35rem;
+  accent-color: var(--color-brand-500);
+  cursor: pointer;
+}
+
+@utility segmented {
+  @apply inline-flex rounded-lg border border-surface-700 bg-surface-950/50 p-0.5;
+  button {
+    @apply rounded-md px-2.5 py-1.5 text-[0.7rem] font-medium text-surface-500 cursor-pointer;
+  }
+  button:hover {
+    @apply text-surface-200;
+  }
+  button.active {
+    @apply bg-surface-700 text-surface-100 shadow-sm;
+  }
+}
+
+@utility icon-button {
+  @apply inline-flex h-8 w-8 items-center justify-center rounded-lg border border-surface-700 bg-surface-800/70 text-surface-400 hover:text-surface-100 cursor-pointer;
+  &.danger:hover {
+    @apply border-red-400/30 bg-red-500/10 text-red-300;
+  }
+}
+
+@utility text-button {
+  @apply text-xs font-medium text-brand-300 hover:text-brand-200 cursor-pointer;
+}
+
+@utility event-chip {
+  @apply rounded-lg border border-surface-700 bg-surface-900/70 px-2.5 py-1.5 text-[0.7rem] text-surface-400 cursor-pointer;
+  &:hover {
+    @apply border-surface-500 text-surface-200;
+  }
+  &.active {
+    @apply border-brand-400/35 bg-brand-500/12 text-brand-200;
+  }
+}
+
+@utility rule-row {
+  @apply grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 rounded-lg border border-surface-800 bg-surface-950/30 p-2;
+  code {
+    @apply truncate px-2 text-xs text-brand-200;
+  }
+}
+
+@utility webhook-row {
+  @apply flex items-center justify-between gap-4 rounded-xl border border-surface-800 bg-surface-950/25 p-4 hover:border-surface-700;
+}
+
+.app-settings-layout {
+  display: grid;
+  grid-template-columns: 15rem minmax(0, 1fr);
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.settings-nav {
+  position: sticky;
+  top: 1.5rem;
+  padding: 0.5rem;
+}
+
+.settings-nav button {
+  @apply flex w-full items-center justify-between gap-2 rounded-xl px-3 py-3 text-left text-surface-400 cursor-pointer;
+}
+
+.settings-nav button:hover {
+  @apply bg-surface-800/60 text-surface-200;
+}
+
+.settings-nav button.active {
+  @apply bg-brand-500/12 text-brand-200;
+}
+
+.settings-nav strong,
+.settings-nav small {
+  display: block;
+}
+
+.settings-nav strong {
+  @apply text-sm font-medium;
+}
+
+.settings-nav small {
+  @apply mt-0.5 text-[0.68rem] leading-4 text-surface-600;
+}
+
+.settings-nav button.active small {
+  @apply text-brand-300/60;
+}
+
+@media (max-width: 900px) {
+  .app-settings-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .settings-nav {
+    position: static;
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0.125rem;
+  }
+
+  .settings-nav button {
+    min-width: 0;
+    width: auto;
+    justify-content: center;
+    padding: 0.7rem 0.25rem;
+    text-align: center;
+  }
+
+  .settings-nav strong {
+    font-size: 0.68rem;
+  }
+
+  .settings-nav small,
+  .settings-nav svg {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Summary

- refresh the operator dashboard with a polished responsive shell, application registry, login, and app settings experience
- expose the complete per-app policy surface, including limits, namespaces, delta rules, reliability, history, presence, and advanced webhooks
- preserve advanced and legacy application policy fields across PostgreSQL, MySQL, and DynamoDB reads and updates
- add a Prometheus workbench with family discovery, searchable panels, rates, averages, histograms, app filtering, and bounded local history
- add an app-scoped Push Manager for provider credentials, devices, subscriptions, publishing/status, and dead-letter replay through a signed, redacted dashboard proxy

## Why

The managing-apps dashboard exposed only a small subset of Sockudo's application policy and lacked flexible operational metrics and push administration. This brings those operator workflows into one consistent control plane while keeping credentials and signed requests protected.

## Validation

- `cd dashboard/api && bun run test` — 33 tests passed
- `cd dashboard/api && bun run typecheck`
- `cd dashboard/web && bun run typecheck`
- `cd dashboard/web && bun run build`
- real PostgreSQL policy creation, legacy reconstruction, replacement, deletion, webhook, and browser-driven persistence checks
- desktop and 390px responsive browser QA with no console errors
- signed push proxy and dynamic Prometheus checks against safe local QA upstreams

## Operational notes

- no live APNs or FCM provider delivery was attempted because provider credentials were not supplied
- some stored credential changes require worker restart, and the dashboard explicitly communicates provider activation caveats
- metrics history is intentionally browser-local and bounded; Prometheus/Grafana remains the durable cluster-wide alerting path
- running Sockudo nodes can retain app policy until the configured app-manager cache TTL expires
