### PR TITLE
Fix Ably auth and presence compatibility

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -437,6 +437,8 @@ max_member_size_in_kb = 2
 update_rate_limit_per_member_per_second = 10
 # 0 preserves legacy immediate member_removed timing. AI agent channels commonly use 15.
 ungraceful_timeout_seconds = 0
+# Protocol V2 separates a short presence lease from its longer recovery state.
+v2_ungraceful_timeout_seconds = 15
 
 [http_api]
 request_limit_in_mb = 10

--- a/crates/sockudo-ably-compat/src/protocol.rs
+++ b/crates/sockudo-ably-compat/src/protocol.rs
@@ -35,10 +35,13 @@ pub(crate) const FLAG_RESUMED: u64 = 1 << 2;
 pub(crate) const FLAG_ATTACH_RESUME: u64 = 1 << 5;
 pub(crate) const DEFAULT_CONNECTION_STATE_TTL_MS: u64 = 120_000;
 pub(crate) const DEFAULT_MAX_IDLE_INTERVAL_MS: u64 = 15_000;
+pub(crate) const DEFAULT_REMAIN_PRESENT_FOR_MS: u64 = 15_000;
+pub(crate) const MIN_REMAIN_PRESENT_FOR_MS: u64 = 1_000;
 pub(crate) const DEFAULT_MAX_MESSAGE_SIZE: u64 = 64 * 1024;
 pub(crate) const DEFAULT_TOKEN_TTL_MS: i64 = 60 * 60 * 1000;
 pub(crate) const ABLY_COMPAT_MAX_REPLAY_MESSAGES: usize = 4096;
 pub(crate) const ABLY_COMPAT_MAX_SESSIONS: usize = 100_000;
+pub(crate) const ABLY_COMPAT_MAX_PENDING_PRESENCE_REMOVALS: usize = 100_000;
 pub(crate) const ABLY_COMPAT_MAX_TOKENS: usize = 100_000;
 pub(crate) const ABLY_COMPAT_EXPIRY_SWEEP_MS: u64 = 30_000;
 

--- a/crates/sockudo-ably-compat/src/runtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime.rs
@@ -103,10 +103,17 @@ use sonic_rs::{JsonContainerTrait, JsonValueTrait, Value, json};
 #[cfg(feature = "delta")]
 use std::time::Instant;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     future::Future,
-    sync::{Arc, Mutex, OnceLock, RwLock, Weak, atomic::Ordering},
+    sync::{
+        Arc, Mutex, OnceLock, RwLock, Weak,
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+    },
     time::Duration,
+};
+use tokio::{
+    sync::{Mutex as AsyncMutex, Notify},
+    time::Instant as TokioInstant,
 };
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -488,6 +495,29 @@ struct AblyLiveSession {
     app_id: String,
     authorization: Arc<RwLock<ConnectionAuthorization>>,
     command_tx: crossfire::MAsyncTx<crossfire::mpsc::Array<AblySessionCommand>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AblyPresenceConnectionKey {
+    app_id: String,
+    connection_id: String,
+}
+
+#[derive(Debug)]
+struct AblyPendingPresenceRemoval {
+    key: AblyPresenceConnectionKey,
+    session_id: String,
+    generation: u64,
+}
+
+#[derive(Default)]
+struct AblyPresenceRemovalQueue {
+    deadlines: AsyncMutex<BTreeMap<TokioInstant, VecDeque<AblyPendingPresenceRemoval>>>,
+    pending_generations: DashMap<AblyPresenceConnectionKey, u64>,
+    next_generation: AtomicU64,
+    pending_count: AtomicUsize,
+    worker_started: AtomicBool,
+    notify: Notify,
 }
 
 #[derive(Clone)]
@@ -1029,6 +1059,7 @@ pub struct AblyCompatHub {
     revocations: Mutex<AblyRevocationStore>,
     live_sessions: DashMap<String, AblyLiveSession>,
     session_echo: DashMap<String, bool>,
+    presence_removals: Arc<AblyPresenceRemovalQueue>,
     presence_registry: Arc<PresenceRegistry>,
     handler: OnceLock<Weak<ConnectionHandler>>,
     nonces: DashMap<String, i64>,
@@ -1835,6 +1866,273 @@ impl AblyCompatHub {
         Ok(Some(compiled))
     }
 
+    async fn schedule_pending_presence_removal(
+        self: &Arc<Self>,
+        app_id: &str,
+        connection_id: &str,
+        session_id: &str,
+        delay_ms: u64,
+    ) -> SockudoResult<()> {
+        if self
+            .presence_removals
+            .pending_count
+            .fetch_add(1, Ordering::AcqRel)
+            >= ABLY_COMPAT_MAX_PENDING_PRESENCE_REMOVALS
+        {
+            self.presence_removals
+                .pending_count
+                .fetch_sub(1, Ordering::AcqRel);
+            return Err(SockudoError::OverCapacity);
+        }
+
+        let key = AblyPresenceConnectionKey {
+            app_id: app_id.to_string(),
+            connection_id: connection_id.to_string(),
+        };
+        let generation = self
+            .presence_removals
+            .next_generation
+            .fetch_add(1, Ordering::Relaxed);
+        self.presence_removals
+            .pending_generations
+            .insert(key.clone(), generation);
+        let deadline = TokioInstant::now() + Duration::from_millis(delay_ms);
+        {
+            let mut deadlines = self.presence_removals.deadlines.lock().await;
+            deadlines
+                .entry(deadline)
+                .or_default()
+                .push_back(AblyPendingPresenceRemoval {
+                    key,
+                    session_id: session_id.to_string(),
+                    generation,
+                });
+        }
+        self.ensure_presence_removal_worker();
+        self.presence_removals.notify.notify_one();
+        Ok(())
+    }
+
+    fn ensure_presence_removal_worker(self: &Arc<Self>) {
+        if self
+            .presence_removals
+            .worker_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let weak_hub = Arc::downgrade(self);
+        let queue = Arc::clone(&self.presence_removals);
+        tokio::spawn(async move {
+            Self::run_presence_removal_worker(weak_hub, queue).await;
+        });
+    }
+
+    async fn run_presence_removal_worker(
+        weak_hub: Weak<Self>,
+        queue: Arc<AblyPresenceRemovalQueue>,
+    ) {
+        loop {
+            let next_deadline = {
+                let deadlines = queue.deadlines.lock().await;
+                let next_deadline = deadlines.keys().next().copied();
+                if next_deadline.is_none() {
+                    // This store happens while holding the queue lock. A producer
+                    // therefore either observes the running worker and leaves a
+                    // visible deadline, or observes false and starts a new worker.
+                    queue.worker_started.store(false, Ordering::Release);
+                }
+                next_deadline
+            };
+            let Some(deadline) = next_deadline else {
+                return;
+            };
+
+            tokio::select! {
+                _ = tokio::time::sleep_until(deadline) => {}
+                _ = queue.notify.notified() => continue,
+            }
+
+            let due = {
+                let mut deadlines = queue.deadlines.lock().await;
+                let now = TokioInstant::now();
+                let mut due = Vec::new();
+                while let Some((&deadline, _)) = deadlines.first_key_value() {
+                    if deadline > now {
+                        break;
+                    }
+                    if let Some((_, mut bucket)) = deadlines.pop_first() {
+                        due.reserve(bucket.len());
+                        due.extend(bucket.drain(..));
+                    }
+                }
+                due
+            };
+            let Some(hub) = weak_hub.upgrade() else {
+                return;
+            };
+            for removal in due {
+                queue.pending_count.fetch_sub(1, Ordering::AcqRel);
+                hub.process_pending_presence_removal(removal).await;
+            }
+        }
+    }
+
+    async fn process_pending_presence_removal(&self, removal: AblyPendingPresenceRemoval) {
+        if self
+            .presence_removals
+            .pending_generations
+            .remove_if(&removal.key, |_, generation| {
+                *generation == removal.generation
+            })
+            .is_none()
+        {
+            return;
+        }
+        if !self
+            .claim_pending_presence_removal(&removal.key, &removal.session_id)
+            .await
+        {
+            return;
+        }
+        self.remove_presence_connection(
+            &removal.key.app_id,
+            &removal.key.connection_id,
+            PresenceHistoryEventCause::Timeout,
+        )
+        .await;
+    }
+
+    async fn claim_pending_presence_removal(
+        &self,
+        key: &AblyPresenceConnectionKey,
+        session_id: &str,
+    ) -> bool {
+        let Some(cache) = &self.cache else {
+            return true;
+        };
+        match cache
+            .compare_and_remove(
+                &session_owner_cache_key(&key.app_id, &key.connection_id),
+                session_id,
+            )
+            .await
+        {
+            Ok(claimed) => claimed,
+            Err(error) => {
+                self.metrics.mark_backend_failure();
+                warn!(
+                    protocol = "ably",
+                    app_id = %key.app_id,
+                    connection_id = %key.connection_id,
+                    error = %error,
+                    "presence removal session owner claim failed"
+                );
+                // The connection-state expiry sweep is the bounded fallback when
+                // distributed ownership cannot be claimed safely.
+                false
+            }
+        }
+    }
+
+    async fn remove_presence_connection(
+        &self,
+        app_id: &str,
+        connection_id: &str,
+        cause: PresenceHistoryEventCause,
+    ) {
+        let handler = self.handler.get().and_then(Weak::upgrade);
+        let removals = if let Some(handler) = handler.as_ref() {
+            match handler.app_manager().find_by_id(app_id).await {
+                Ok(Some(app)) => PresenceService::new(Arc::clone(handler))
+                    .unregister_connection(&app, connection_id, cause)
+                    .await
+                    .map(|removals| {
+                        let mut grouped = BTreeMap::<String, Vec<PresenceChange>>::new();
+                        for removal in removals {
+                            grouped
+                                .entry(removal.channel)
+                                .or_default()
+                                .push(PresenceChange {
+                                    action: PresenceChangeAction::Leave,
+                                    member: removal.member,
+                                    // Server-generated disconnect leaves are
+                                    // synthesized. Omitting the item ID makes
+                                    // Ably SDKs order them by timestamp instead
+                                    // of rejecting the reused enter serial.
+                                    wire_id: None,
+                                });
+                        }
+                        grouped
+                    }),
+                Ok(None) => Ok(self.remove_connection_presence(app_id, connection_id)),
+                Err(error) => Err(error),
+            }
+        } else {
+            Ok(self.remove_connection_presence(app_id, connection_id))
+        };
+        let removals = match removals {
+            Ok(removals) => removals,
+            Err(error) => {
+                warn!(
+                    protocol = "ably",
+                    app_id = %app_id,
+                    connection_id = %connection_id,
+                    error = %error,
+                    "failed to persist timed out ably presence leaves"
+                );
+                self.remove_connection_presence(app_id, connection_id)
+            }
+        };
+        for (channel, changes) in removals {
+            let replication = PresenceReplication {
+                changes,
+                unregister_connection: None,
+            };
+            if let Some(handler) = handler.as_ref() {
+                if let Err(error) = handler.fanout_presence(app_id, &channel, replication).await {
+                    warn!(
+                        protocol = "ably",
+                        app_id = %app_id,
+                        channel = %channel,
+                        error = %error,
+                        "failed to replicate timed out presence leaves"
+                    );
+                }
+            } else if let Err(error) = self.deliver_presence(app_id, &channel, &replication) {
+                warn!(
+                    protocol = "ably",
+                    app_id = %app_id,
+                    channel = %channel,
+                    error = %error,
+                    "failed to deliver timed out presence leaves"
+                );
+            }
+        }
+        if let Some(handler) = handler.as_ref()
+            && let Err(error) = handler
+                .fanout_presence(
+                    app_id,
+                    "",
+                    PresenceReplication {
+                        changes: Vec::new(),
+                        unregister_connection: Some(connection_id.to_string()),
+                    },
+                )
+                .await
+        {
+            warn!(
+                protocol = "ably",
+                app_id = %app_id,
+                connection_id = %connection_id,
+                error = %error,
+                "failed to replicate timed out presence connection removal"
+            );
+        }
+    }
+
     async fn expire(&self, now: i64) {
         let expired_connections = self
             .sessions
@@ -1875,98 +2173,12 @@ impl AblyCompatHub {
             self.metrics.expiry.fetch_add(1, Ordering::Relaxed);
         }
         for (connection_id, app_id) in expired_connections {
-            let handler = self.handler.get().and_then(Weak::upgrade);
-            let removals = if let Some(handler) = handler.as_ref() {
-                match handler.app_manager().find_by_id(&app_id).await {
-                    Ok(Some(app)) => PresenceService::new(Arc::clone(handler))
-                        .unregister_connection(
-                            &app,
-                            &connection_id,
-                            PresenceHistoryEventCause::Timeout,
-                        )
-                        .await
-                        .map(|removals| {
-                            let mut grouped = BTreeMap::<String, Vec<PresenceChange>>::new();
-                            for removal in removals {
-                                let wire_id = Some(removal.member.id.clone());
-                                grouped
-                                    .entry(removal.channel)
-                                    .or_default()
-                                    .push(PresenceChange {
-                                        action: PresenceChangeAction::Leave,
-                                        member: removal.member,
-                                        wire_id,
-                                    });
-                            }
-                            grouped
-                        }),
-                    Ok(None) => Ok(self.remove_connection_presence(&app_id, &connection_id)),
-                    Err(error) => Err(error),
-                }
-            } else {
-                Ok(self.remove_connection_presence(&app_id, &connection_id))
-            };
-            let removals = match removals {
-                Ok(removals) => removals,
-                Err(error) => {
-                    warn!(
-                        protocol = "ably",
-                        app_id = %app_id,
-                        connection_id = %connection_id,
-                        error = %error,
-                        "failed to persist expired Ably presence leaves"
-                    );
-                    self.remove_connection_presence(&app_id, &connection_id)
-                }
-            };
-            for (channel, changes) in removals {
-                let replication = PresenceReplication {
-                    changes,
-                    unregister_connection: None,
-                };
-                if let Some(handler) = handler.as_ref() {
-                    if let Err(error) = handler
-                        .fanout_presence(&app_id, &channel, replication)
-                        .await
-                    {
-                        warn!(
-                            protocol = "ably",
-                            app_id = %app_id,
-                            channel = %channel,
-                            error = %error,
-                            "failed to replicate expired presence leaves"
-                        );
-                    }
-                } else if let Err(error) = self.deliver_presence(&app_id, &channel, &replication) {
-                    warn!(
-                        protocol = "ably",
-                        app_id = %app_id,
-                        channel = %channel,
-                        error = %error,
-                        "failed to deliver expired presence leaves"
-                    );
-                }
-            }
-            if let Some(handler) = handler.as_ref()
-                && let Err(error) = handler
-                    .fanout_presence(
-                        &app_id,
-                        "",
-                        PresenceReplication {
-                            changes: Vec::new(),
-                            unregister_connection: Some(connection_id.clone()),
-                        },
-                    )
-                    .await
-            {
-                warn!(
-                    protocol = "ably",
-                    app_id = %app_id,
-                    connection_id = %connection_id,
-                    error = %error,
-                    "failed to replicate expired presence connection removal"
-                );
-            }
+            self.remove_presence_connection(
+                &app_id,
+                &connection_id,
+                PresenceHistoryEventCause::Timeout,
+            )
+            .await;
         }
     }
 
@@ -2241,14 +2453,13 @@ impl AblyCompatHub {
         {
             let mut member = removal.member;
             member.timestamp_ms = now_ms();
-            let wire_id = Some(member.id.clone());
             leaves
                 .entry(removal.channel)
                 .or_default()
                 .push(PresenceChange {
                     action: PresenceChangeAction::Leave,
                     member,
-                    wire_id,
+                    wire_id: None,
                 });
         }
         leaves
@@ -3043,9 +3254,19 @@ impl AblyCompatHub {
         connection_id: String,
         session: AblyLiveSession,
     ) -> Option<crossfire::MAsyncTx<crossfire::mpsc::Array<AblySessionCommand>>> {
+        self.cancel_pending_presence_removal(&session.app_id, &connection_id);
         self.live_sessions
             .insert(connection_id, session)
             .map(|previous| previous.command_tx)
+    }
+
+    fn cancel_pending_presence_removal(&self, app_id: &str, connection_id: &str) {
+        self.presence_removals
+            .pending_generations
+            .remove(&AblyPresenceConnectionKey {
+                app_id: app_id.to_string(),
+                connection_id: connection_id.to_string(),
+            });
     }
 
     async fn claim_session_owner(

--- a/crates/sockudo-ably-compat/src/runtime/auth_runtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime/auth_runtime.rs
@@ -222,6 +222,7 @@ pub(super) fn parse_token_request_integer(
         .map(|value| {
             value
                 .as_i64()
+                .or_else(|| value.as_str()?.parse::<i64>().ok())
                 .ok_or_else(|| format!("TokenRequest {field} must be an integer"))
         })
         .transpose()
@@ -741,6 +742,19 @@ pub(super) struct VerifiedAblyJwt {
     pub(super) embedded_token: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct EmbeddedAblyTokenClaims {
+    #[serde(default)]
+    exp: Option<i64>,
+    #[serde(default, rename = "x-ably-token")]
+    embedded_token: Option<String>,
+}
+
+pub(super) struct EmbeddedAblyTokenEnvelope {
+    pub(super) token: String,
+    pub(super) expires_ms: Option<i64>,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn resolve_ably_auth_with_expiry(
     hub: &AblyCompatHub,
@@ -865,6 +879,21 @@ pub(super) async fn resolve_ably_jwt(
         return Err(AblyAuthError::unauthorized("JWT exceeds 8 KiB"));
     }
     let original_token = token;
+    if let Some(envelope) = parse_embedded_ably_token_envelope(token)?
+        && let Some(resolved) = resolve_embedded_ably_token(
+            hub,
+            handler,
+            &envelope.token,
+            requested_client_id,
+            allow_expired,
+            envelope.expires_ms,
+            original_token,
+        )
+        .await?
+    {
+        return Ok(resolved);
+    }
+
     let mut jwe_key = None;
     let signed_token = if token.split('.').count() == 5 {
         let header = parse_ably_jose_header(token)?;
@@ -960,6 +989,63 @@ pub(super) async fn resolve_ably_jwt(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn resolve_embedded_ably_token(
+    hub: &AblyCompatHub,
+    handler: &Arc<ConnectionHandler>,
+    embedded_token: &str,
+    requested_client_id: Option<&str>,
+    allow_expired: bool,
+    outer_expires_ms: Option<i64>,
+    credential: &str,
+) -> Result<Option<ResolvedAblyAuth>, AblyAuthError> {
+    let Some(record) = hub.resolve_token(embedded_token).await else {
+        return Ok(None);
+    };
+    let now_ms = now_ms();
+    if record.revocable && !token_key_is_current(hub, &record, now_ms) {
+        return Err(AblyAuthError::unauthorized("Token has been revoked"));
+    }
+    if !allow_expired && record.expires_ms <= now_ms {
+        return Err(AblyAuthError::expired());
+    }
+    let expires_ms = if let Some(outer_expires_ms) = outer_expires_ms {
+        if !allow_expired && outer_expires_ms <= now_ms {
+            return Err(AblyAuthError::expired());
+        }
+        if outer_expires_ms > record.expires_ms {
+            return Err(AblyAuthError::unauthorized(
+                "Embedded Ably token expires before its outer JWT",
+            ));
+        }
+        outer_expires_ms
+    } else {
+        record.expires_ms
+    };
+    let app = find_enabled_app_by_id(handler, &record.app_id).await?;
+    let token_client_id = record.client_id.clone();
+    let client_id = resolve_ably_token_client_id(record.client_id, requested_client_id)?;
+    let connection_client_id =
+        if token_client_id.as_deref() == Some("*") && requested_client_id.is_none() {
+            Some("*".to_string())
+        } else {
+            client_id.clone()
+        };
+    Ok(Some(ResolvedAblyAuth {
+        app,
+        client_id,
+        connection_client_id,
+        capabilities: record.capabilities,
+        issued_ms: record.issued_ms,
+        expires_ms: Some(expires_ms),
+        credential_id: credential_id(credential),
+        revocable: record.revocable,
+        revocation_key: record.revocation_key,
+        #[cfg(feature = "push")]
+        push_device_id: None,
+    }))
+}
+
 pub(super) async fn resolve_ably_jwt_key(
     hub: &AblyCompatHub,
     handler: &Arc<ConnectionHandler>,
@@ -992,13 +1078,66 @@ pub(super) fn parse_ably_jose_header(token: &str) -> Result<AblyJoseHeader, Ably
     if protected.len() > 4 * 1024 {
         return Err(AblyAuthError::unauthorized("JOSE header exceeds 4 KiB"));
     }
-    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(protected)
-        .map_err(|_| AblyAuthError::invalid_credentials())?;
+    let bytes = decode_ably_base64_segment(protected)?;
     if bytes.len() > 4 * 1024 {
         return Err(AblyAuthError::unauthorized("JOSE header exceeds 4 KiB"));
     }
     serde_json::from_slice(&bytes).map_err(|_| AblyAuthError::invalid_credentials())
+}
+
+pub(super) fn parse_embedded_ably_token_envelope(
+    token: &str,
+) -> Result<Option<EmbeddedAblyTokenEnvelope>, AblyAuthError> {
+    if token.len() > 8 * 1024 {
+        return Err(AblyAuthError::unauthorized("JWT exceeds 8 KiB"));
+    }
+    let header = parse_ably_jose_header(token)?;
+    let segment_count = token.split('.').count();
+    let (claims_token, expires_ms) = match segment_count {
+        3 => {
+            let payload = token
+                .split('.')
+                .nth(1)
+                .filter(|payload| !payload.is_empty())
+                .ok_or_else(AblyAuthError::invalid_credentials)?;
+            if payload.len() > 8 * 1024 {
+                return Err(AblyAuthError::unauthorized("JWT payload exceeds 8 KiB"));
+            }
+            let bytes = decode_ably_base64_segment(payload)?;
+            if bytes.len() > 8 * 1024 {
+                return Err(AblyAuthError::unauthorized("JWT payload exceeds 8 KiB"));
+            }
+            let claims: EmbeddedAblyTokenClaims =
+                serde_json::from_slice(&bytes).map_err(|_| AblyAuthError::invalid_credentials())?;
+            let expires_ms = claims.exp.map(jwt_seconds_to_millis).transpose()?;
+            (claims.embedded_token, expires_ms)
+        }
+        5 => (None, None),
+        _ => return Ok(None),
+    };
+    let Some(embedded_token) = header.embedded_token.or(claims_token) else {
+        return Ok(None);
+    };
+    if embedded_token.is_empty() || embedded_token.len() > 8 * 1024 {
+        return Err(AblyAuthError::unauthorized(
+            "Embedded Ably token is invalid",
+        ));
+    }
+    Ok(Some(EmbeddedAblyTokenEnvelope {
+        token: embedded_token,
+        expires_ms,
+    }))
+}
+
+fn decode_ably_base64_segment(segment: &str) -> Result<Vec<u8>, AblyAuthError> {
+    use base64::engine::general_purpose::{STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD};
+
+    URL_SAFE_NO_PAD
+        .decode(segment)
+        .or_else(|_| URL_SAFE.decode(segment))
+        .or_else(|_| STANDARD_NO_PAD.decode(segment))
+        .or_else(|_| STANDARD.decode(segment))
+        .map_err(|_| AblyAuthError::invalid_credentials())
 }
 
 pub(super) fn verify_ably_signed_jwt(

--- a/crates/sockudo-ably-compat/src/runtime/realtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime/realtime.rs
@@ -188,6 +188,7 @@ pub async fn handle_ably_realtime_upgrade(
     let resume = params.resume.clone();
     let recover = params.recover.clone();
     let replace_presence_on_reenter = params.remain_present_for.is_some();
+    let remain_present_for_ms = normalized_remain_present_for_ms(params.remain_present_for);
     let initial_error = credential_error.or_else(|| {
         resolved
             .expires_ms
@@ -219,6 +220,7 @@ pub async fn handle_ably_realtime_upgrade(
                     format,
                     echo: params.echo,
                     replace_presence_on_reenter,
+                    remain_present_for_ms,
                     stats_transport,
                 },
             )
@@ -295,6 +297,7 @@ pub(super) struct AblyRealtimeSocketContext {
     format: AblyFormat,
     echo: bool,
     replace_presence_on_reenter: bool,
+    remain_present_for_ms: u64,
     stats_transport: &'static str,
 }
 
@@ -312,6 +315,7 @@ pub(super) async fn run_ably_realtime_socket(
         format,
         echo,
         replace_presence_on_reenter,
+        remain_present_for_ms,
         stats_transport,
     } = context;
     let app = resolved.app.clone();
@@ -704,8 +708,8 @@ pub(super) async fn run_ably_realtime_socket(
                 .or_default()
                 .push(PresenceChange {
                     action: PresenceChangeAction::Leave,
-                    wire_id: Some(removal.member.id.clone()),
                     member: removal.member,
+                    wire_id: None,
                 });
         }
         for (channel, changes) in leaves {
@@ -795,8 +799,47 @@ pub(super) async fn run_ably_realtime_socket(
         // Cleanup from this stale socket must not recreate its recovery key.
         hub.forget_connection(&final_connection_key).await;
     }
-    hub.release_session_owner(&app.id, &connection_id, &session_id)
-        .await;
+    let defer_owner_release = if owns_session
+        && !graceful_close
+        && hub
+            .presence_registry
+            .connection_has_members(&app.id, &connection_id)
+    {
+        match hub
+            .schedule_pending_presence_removal(
+                &app.id,
+                &connection_id,
+                &session_id,
+                remain_present_for_ms,
+            )
+            .await
+        {
+            Ok(()) if hub.live_sessions.contains_key(&connection_id) => {
+                // Recovery may win between the original ownership check and
+                // scheduling. Cancel here; a later local recovery cancels from
+                // register_live_session instead.
+                hub.cancel_pending_presence_removal(&app.id, &connection_id);
+                false
+            }
+            Ok(()) => true,
+            Err(error) => {
+                warn!(
+                    protocol = "ably",
+                    app_id = %app.id,
+                    connection_id = %connection_id,
+                    error = %error,
+                    "failed to schedule presence removal"
+                );
+                false
+            }
+        }
+    } else {
+        false
+    };
+    if !defer_owner_release {
+        hub.release_session_owner(&app.id, &connection_id, &session_id)
+            .await;
+    }
     heartbeat_task.abort();
     let _ = heartbeat_task.await;
     drop(sender);
@@ -822,6 +865,12 @@ pub(super) async fn run_ably_realtime_socket(
         "socket disconnected"
     );
     Ok(())
+}
+
+pub(super) fn normalized_remain_present_for_ms(requested_ms: Option<u64>) -> u64 {
+    requested_ms
+        .unwrap_or(DEFAULT_REMAIN_PRESENT_FOR_MS)
+        .clamp(MIN_REMAIN_PRESENT_FOR_MS, DEFAULT_REMAIN_PRESENT_FOR_MS)
 }
 
 pub(super) fn authorization_deadline(

--- a/crates/sockudo-ably-compat/src/runtime/tests.rs
+++ b/crates/sockudo-ably-compat/src/runtime/tests.rs
@@ -892,6 +892,23 @@ fn close_and_disconnect_actions_have_distinct_terminal_outcomes() {
 }
 
 #[test]
+fn remain_present_for_uses_ably_default_and_bounds() {
+    assert_eq!(
+        normalized_remain_present_for_ms(None),
+        DEFAULT_REMAIN_PRESENT_FOR_MS
+    );
+    assert_eq!(
+        normalized_remain_present_for_ms(Some(0)),
+        MIN_REMAIN_PRESENT_FOR_MS
+    );
+    assert_eq!(normalized_remain_present_for_ms(Some(5_000)), 5_000);
+    assert_eq!(
+        normalized_remain_present_for_ms(Some(u64::MAX)),
+        DEFAULT_REMAIN_PRESENT_FOR_MS
+    );
+}
+
+#[test]
 fn presence_reentry_preserves_only_valid_same_connection_ids() {
     let connection_id = "connection-a";
     assert_eq!(
@@ -910,6 +927,282 @@ fn presence_reentry_preserves_only_valid_same_connection_ids() {
         ably_presence_message_id(None, connection_id, 9, 1),
         "connection-a:9:1"
     );
+}
+
+#[test]
+fn synthesized_disconnect_leave_omits_the_enter_message_id() {
+    let hub = AblyCompatHub::default();
+    hub.presence_registry
+        .register_connection("app", "connection-a");
+    hub.presence_registry
+        .enter(
+            "app",
+            "room",
+            PresenceRecord {
+                connection_id: "connection-a".to_string(),
+                client_id: "client-a".to_string(),
+                id: "connection-a:1:0".to_string(),
+                data: None,
+                encoding: None,
+                extras: None,
+                timestamp_ms: 1,
+            },
+        )
+        .expect("presence entry succeeds");
+
+    let removals = hub.remove_connection_presence("app", "connection-a");
+    let change = removals
+        .get("room")
+        .and_then(|changes| changes.first())
+        .expect("disconnect produces a leave");
+    let wire = ably_presence_from_change(change);
+
+    assert_eq!(wire.action, Some(3));
+    assert!(wire.id.is_none());
+    assert!(wire.timestamp.is_some_and(|timestamp| timestamp > 1));
+}
+
+#[tokio::test]
+async fn abrupt_disconnect_presence_removal_runs_after_its_deadline() {
+    let hub = Arc::new(AblyCompatHub::default());
+    hub.presence_registry
+        .register_connection("app", "connection-a");
+    hub.presence_registry
+        .enter(
+            "app",
+            "room",
+            PresenceRecord {
+                connection_id: "connection-a".to_string(),
+                client_id: "client-a".to_string(),
+                id: "connection-a:1:0".to_string(),
+                data: None,
+                encoding: None,
+                extras: None,
+                timestamp_ms: 1,
+            },
+        )
+        .expect("presence entry succeeds");
+
+    hub.schedule_pending_presence_removal("app", "connection-a", "disconnected-session", 1)
+        .await
+        .expect("presence removal is scheduled");
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while hub
+            .presence_registry
+            .connection_has_members("app", "connection-a")
+        {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("presence removal worker completes");
+
+    assert!(hub.presence_snapshot("app", "room").is_empty());
+    assert_eq!(
+        hub.presence_removals.pending_count.load(Ordering::Acquire),
+        0
+    );
+}
+
+#[tokio::test]
+async fn recovered_live_session_cancels_pending_presence_removal() {
+    let hub = Arc::new(AblyCompatHub::default());
+    hub.presence_registry
+        .register_connection("app", "connection-a");
+    hub.presence_registry
+        .enter(
+            "app",
+            "room",
+            PresenceRecord {
+                connection_id: "connection-a".to_string(),
+                client_id: "client-a".to_string(),
+                id: "connection-a:1:0".to_string(),
+                data: None,
+                encoding: None,
+                extras: None,
+                timestamp_ms: 1,
+            },
+        )
+        .expect("presence entry succeeds");
+    hub.schedule_pending_presence_removal("app", "connection-a", "disconnected-session", 20)
+        .await
+        .expect("presence removal is scheduled");
+    let (command_tx, _command_rx) = crossfire::mpsc::bounded_async(1);
+    assert!(
+        hub.register_live_session(
+            "connection-a".to_string(),
+            AblyLiveSession {
+                session_id: "recovered-session".to_string(),
+                app_id: "app".to_string(),
+                authorization: Arc::new(RwLock::new(ConnectionAuthorization {
+                    generation: 1,
+                    client_id: Some("client-a".to_string()),
+                    connection_client_id: Some("client-a".to_string()),
+                    capabilities: None,
+                    issued_ms: now_ms(),
+                    expires_ms: None,
+                    credential_id: "test".to_string(),
+                    revocable: false,
+                    revocation_key: None,
+                })),
+                command_tx,
+            },
+        )
+        .is_none()
+    );
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while hub.presence_removals.pending_count.load(Ordering::Acquire) != 0 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("cancelled removal reaches its deadline");
+
+    assert!(
+        hub.presence_registry
+            .connection_has_members("app", "connection-a")
+    );
+}
+
+#[tokio::test]
+async fn second_disconnect_uses_a_new_presence_removal_deadline() {
+    let hub = Arc::new(AblyCompatHub::default());
+    hub.presence_registry
+        .register_connection("app", "connection-a");
+    hub.presence_registry
+        .enter(
+            "app",
+            "room",
+            PresenceRecord {
+                connection_id: "connection-a".to_string(),
+                client_id: "client-a".to_string(),
+                id: "connection-a:1:0".to_string(),
+                data: None,
+                encoding: None,
+                extras: None,
+                timestamp_ms: 1,
+            },
+        )
+        .expect("presence entry succeeds");
+    hub.schedule_pending_presence_removal("app", "connection-a", "first-session", 20)
+        .await
+        .expect("first removal is scheduled");
+    let (command_tx, _command_rx) = crossfire::mpsc::bounded_async(1);
+    hub.register_live_session(
+        "connection-a".to_string(),
+        AblyLiveSession {
+            session_id: "second-session".to_string(),
+            app_id: "app".to_string(),
+            authorization: Arc::new(RwLock::new(ConnectionAuthorization {
+                generation: 1,
+                client_id: Some("client-a".to_string()),
+                connection_client_id: Some("client-a".to_string()),
+                capabilities: None,
+                issued_ms: now_ms(),
+                expires_ms: None,
+                credential_id: "test".to_string(),
+                revocable: false,
+                revocation_key: None,
+            })),
+            command_tx,
+        },
+    );
+    hub.unregister_live_session("connection-a", "second-session");
+    hub.schedule_pending_presence_removal("app", "connection-a", "second-session", 100)
+        .await
+        .expect("second removal is scheduled");
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        hub.presence_registry
+            .connection_has_members("app", "connection-a"),
+        "the first session deadline must not remove the recovered session"
+    );
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while hub
+            .presence_registry
+            .connection_has_members("app", "connection-a")
+        {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("the second session deadline removes presence");
+}
+
+#[tokio::test]
+async fn recovered_shared_owner_cancels_the_old_nodes_presence_deadline() {
+    let cache: Arc<dyn CacheManager> = Arc::new(MemoryCacheManager::new(
+        "presence-owner-handoff".to_string(),
+        MemoryCacheOptions::default(),
+    ));
+    let presence_registry = Arc::new(PresenceRegistry::default());
+    let dependencies = AblyCompatDependencies {
+        cache: Some(cache),
+        presence_registry: Arc::clone(&presence_registry),
+        ..Default::default()
+    };
+    let first = AblyCompatRuntime::new(dependencies.clone());
+    let second = AblyCompatRuntime::new(dependencies);
+    presence_registry.register_connection("app", "connection-a");
+    presence_registry
+        .enter(
+            "app",
+            "room",
+            PresenceRecord {
+                connection_id: "connection-a".to_string(),
+                client_id: "client-a".to_string(),
+                id: "connection-a:1:0".to_string(),
+                data: None,
+                encoding: None,
+                extras: None,
+                timestamp_ms: 1,
+            },
+        )
+        .expect("presence entry succeeds");
+    first
+        .hub
+        .claim_session_owner("app", "connection-a", "first-session")
+        .await
+        .expect("first node claims the session");
+    first
+        .hub
+        .schedule_pending_presence_removal("app", "connection-a", "first-session", 20)
+        .await
+        .expect("first removal is scheduled");
+
+    second
+        .hub
+        .claim_session_owner("app", "connection-a", "second-session")
+        .await
+        .expect("second node claims the recovered session");
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while first
+            .hub
+            .presence_removals
+            .pending_count
+            .load(Ordering::Acquire)
+            != 0
+        {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("the old node reaches its cancelled deadline");
+    assert!(presence_registry.connection_has_members("app", "connection-a"));
+
+    second
+        .hub
+        .schedule_pending_presence_removal("app", "connection-a", "second-session", 20)
+        .await
+        .expect("second removal is scheduled");
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while presence_registry.connection_has_members("app", "connection-a") {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("the recovered owner's deadline removes presence");
 }
 
 #[test]
@@ -1911,6 +2204,20 @@ fn token_request_mac_uses_canonical_newline_terminated_input() {
 }
 
 #[test]
+fn token_request_integer_accepts_decimal_json_strings() {
+    assert_eq!(
+        parse_token_request_integer(Some(&serde_json::json!("1785332178132")), "timestamp")
+            .unwrap(),
+        Some(1_785_332_178_132)
+    );
+    assert_eq!(
+        parse_token_request_integer(Some(&serde_json::json!(1234)), "ttl").unwrap(),
+        Some(1234)
+    );
+    assert!(parse_token_request_integer(Some(&serde_json::json!("12.5")), "ttl").is_err());
+}
+
+#[test]
 fn jwt_timestamp_conversion_rejects_seconds_that_overflow_milliseconds() {
     let maximum_valid = i64::MAX / 1_000;
     let minimum_valid = i64::MIN / 1_000;
@@ -1966,6 +2273,44 @@ fn embedded_jwt_verifies_signature_key_and_inner_credential() {
     assert_eq!(verified.embedded_token.as_deref(), Some(inner.as_str()));
     assert!(verify_ably_signed_jwt(&outer, "other.key", "secret").is_err());
     assert!(verify_ably_signed_jwt(&outer, "app.key", "wrong").is_err());
+}
+
+#[test]
+fn unsigned_embedded_token_envelope_accepts_token_from_jws_claims() {
+    let outer = sign_test_jwt(
+        serde_json::json!({"typ":"JWT","alg":"HS256"}),
+        serde_json::json!({
+            "iat":1_700_000_000_i64,
+            "exp":1_700_000_600_i64,
+            "x-ably-token":"sockudo-ably-token",
+        }),
+        "irrelevant",
+    );
+
+    let envelope = parse_embedded_ably_token_envelope(&outer)
+        .unwrap()
+        .expect("embedded token envelope");
+    assert_eq!(envelope.token, "sockudo-ably-token");
+    assert_eq!(envelope.expires_ms, Some(1_700_000_600_000));
+}
+
+#[test]
+fn unsigned_embedded_token_envelope_accepts_token_from_jwe_header() {
+    let protected = general_purpose::STANDARD.encode(
+        serde_json::to_vec(&serde_json::json!({
+            "alg":"HS256",
+            "enc":"A256GCM",
+            "x-ably-token":"sockudo-ably-token",
+        }))
+        .unwrap(),
+    );
+    let outer = format!("{protected}.encrypted-key.iv.ciphertext.tag");
+
+    let envelope = parse_embedded_ably_token_envelope(&outer)
+        .unwrap()
+        .expect("embedded token envelope");
+    assert_eq!(envelope.token, "sockudo-ably-token");
+    assert_eq!(envelope.expires_ms, None);
 }
 
 #[test]

--- a/crates/sockudo-adapter/src/cleanup.rs
+++ b/crates/sockudo-adapter/src/cleanup.rs
@@ -1,5 +1,7 @@
 use crossfire::mpsc;
+use sockudo_core::channel::PresenceMemberInfo;
 use sockudo_core::websocket::{DisconnectCause, SocketId};
+use std::collections::HashMap;
 use std::time::Instant;
 
 pub type CleanupChannelFlavor = mpsc::Array<DisconnectTask>;
@@ -53,6 +55,7 @@ pub struct DisconnectTask {
 #[derive(Debug, Clone)]
 pub struct ConnectionCleanupInfo {
     pub presence_channels: Vec<String>,
+    pub presence_members: HashMap<String, PresenceMemberInfo>,
     pub auth_info: Option<AuthInfo>,
 }
 

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -4,6 +4,7 @@ use crate::channel_manager::ChannelManager;
 use crate::cleanup::{AuthInfo, ConnectionCleanupInfo, DisconnectTask};
 use crate::horizontal_adapter::DeadNodeEvent;
 use sockudo_core::app::App;
+use sockudo_core::channel::PresenceMemberInfo;
 use sockudo_core::error::{Error, Result};
 use sockudo_core::presence_registry::{
     PresenceChange, PresenceChangeAction, PresenceRecord, PresenceReplication,
@@ -18,6 +19,11 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, info, warn};
+
+struct DisconnectPresenceLease<'a> {
+    member: Option<&'a PresenceMemberInfo>,
+    timeout_seconds: u64,
+}
 
 impl ConnectionHandler {
     pub async fn send_connection_established(
@@ -331,10 +337,22 @@ impl ConnectionHandler {
         app_id: &str,
         socket_id: &SocketId,
     ) -> Result<()> {
+        let presence_ungraceful_timeout_seconds = match self
+            .connection_manager
+            .get_connection(socket_id, app_id)
+            .await
+        {
+            Some(connection) => self
+                .server_options()
+                .presence
+                .ungraceful_timeout_for_protocol(connection.protocol_version),
+            None => 0,
+        };
+
         self.handle_disconnect_with_presence_timeout(
             app_id,
             socket_id,
-            self.server_options().presence.ungraceful_timeout_seconds,
+            presence_ungraceful_timeout_seconds,
         )
         .await
     }
@@ -417,7 +435,7 @@ impl ConnectionHandler {
         // Retain the WebSocketRef outside the lock scope so we can call shutdown()
         // before queuing the cleanup task — cleanup queue latency must not extend
         // the reader/writer task lifetime.
-        let (disconnect_task, connection) = {
+        let (mut disconnect_task, connection) = {
             let connection_manager = &self.connection_manager;
             let conn_ref =
                 if let Some(c) = connection_manager.get_connection(socket_id, app_id).await {
@@ -460,6 +478,7 @@ impl ConnectionHandler {
                 connection_info: if !presence_channels.is_empty() {
                     Some(ConnectionCleanupInfo {
                         presence_channels,
+                        presence_members: HashMap::new(),
                         auth_info: user_id.map(|uid| AuthInfo {
                             user_id: uid,
                             user_info: None,
@@ -474,6 +493,12 @@ impl ConnectionHandler {
             drop(conn_locked);
             (task, conn_ref)
         };
+
+        if let Some(connection_info) = disconnect_task.connection_info.as_mut() {
+            connection_info.presence_members = self
+                .capture_presence_members(app_id, socket_id, &connection_info.presence_channels)
+                .await;
+        }
 
         // Step 2: Clear immediate timeouts (these should be fast)
         self.clear_activity_timeout(app_id, socket_id).await.ok();
@@ -596,6 +621,14 @@ impl ConnectionHandler {
         let (subscribed_channels, user_id, user_watchlist) = self
             .extract_connection_state_for_disconnect(socket_id, &app_config)
             .await?;
+        let presence_channels: Vec<String> = subscribed_channels
+            .iter()
+            .filter(|channel| channel.starts_with("presence-"))
+            .cloned()
+            .collect();
+        let presence_members = self
+            .capture_presence_members(&app_config.id, socket_id, &presence_channels)
+            .await;
 
         // Handle watchlist offline events
         if let Some(ref user_id_str) = user_id {
@@ -620,6 +653,7 @@ impl ConnectionHandler {
                 &app_config,
                 &subscribed_channels,
                 &user_id,
+                &presence_members,
                 presence_ungraceful_timeout_seconds,
             )
             .await
@@ -686,6 +720,7 @@ impl ConnectionHandler {
         app_config: &App,
         subscribed_channels: &HashSet<String>,
         user_id: &Option<String>,
+        presence_members: &HashMap<String, PresenceMemberInfo>,
         presence_ungraceful_timeout_seconds: u64,
     ) -> Result<()> {
         if subscribed_channels.is_empty() {
@@ -730,7 +765,10 @@ impl ConnectionHandler {
                                     user_id,
                                     *remaining_connections,
                                     socket_id,
-                                    presence_ungraceful_timeout_seconds,
+                                    DisconnectPresenceLease {
+                                        member: presence_members.get(channel_name),
+                                        timeout_seconds: presence_ungraceful_timeout_seconds,
+                                    },
                                 )
                                 .await?;
                             }
@@ -767,7 +805,7 @@ impl ConnectionHandler {
         user_id: &Option<String>,
         current_sub_count: usize,
         socket_id: &SocketId,
-        presence_ungraceful_timeout_seconds: u64,
+        presence_lease: DisconnectPresenceLease<'_>,
     ) -> Result<()> {
         if channel_str.starts_with("presence-") {
             if let Some(disconnected_user_id) = user_id {
@@ -777,7 +815,7 @@ impl ConnectionHandler {
                 );
                 // Use centralized presence member removal logic (instance method for race safety)
                 self.presence_manager
-                    .handle_member_removed(
+                    .handle_member_removed_with_info(
                         &self.connection_manager,
                         Arc::clone(self.presence_history_store()),
                         presence_history_policy.enabled,
@@ -789,7 +827,10 @@ impl ConnectionHandler {
                         Some(socket_id),
                         sockudo_core::presence_history::PresenceHistoryEventCause::Disconnect,
                         None,
-                        presence_ungraceful_timeout_seconds,
+                        presence_lease
+                            .member
+                            .and_then(|member| member.user_info.clone()),
+                        presence_lease.timeout_seconds,
                         Some(presence_history_policy.retention()),
                     )
                     .await
@@ -825,6 +866,25 @@ impl ConnectionHandler {
         }
 
         Ok(())
+    }
+
+    async fn capture_presence_members(
+        &self,
+        app_id: &str,
+        socket_id: &SocketId,
+        presence_channels: &[String],
+    ) -> HashMap<String, PresenceMemberInfo> {
+        let mut members = HashMap::with_capacity(presence_channels.len());
+        for channel in presence_channels {
+            if let Some(member) = self
+                .connection_manager
+                .get_presence_member(app_id, channel, socket_id)
+                .await
+            {
+                members.insert(channel.clone(), member);
+            }
+        }
+        members
     }
 
     async fn handle_disconnect_watchlist_events(

--- a/crates/sockudo-adapter/src/handler/mod.rs
+++ b/crates/sockudo-adapter/src/handler/mod.rs
@@ -200,6 +200,7 @@ pub struct ConnectionHandlerBuilder {
     annotation_store: Option<Arc<dyn AnnotationStore + Send + Sync>>,
     version_store: Option<Arc<dyn VersionStore + Send + Sync>>,
     presence_history_store: Option<Arc<dyn PresenceHistoryStore + Send + Sync>>,
+    presence_manager: Option<Arc<PresenceManager>>,
     presence_registry: Option<Arc<PresenceRegistry>>,
     realtime_egress_tap: Option<Arc<dyn RealtimeEgressTap>>,
     webhook_integration: Option<Arc<WebhookIntegration>>,
@@ -227,6 +228,7 @@ impl ConnectionHandlerBuilder {
             annotation_store: None,
             version_store: None,
             presence_history_store: None,
+            presence_manager: None,
             presence_registry: None,
             realtime_egress_tap: None,
             webhook_integration: None,
@@ -271,6 +273,11 @@ impl ConnectionHandlerBuilder {
         presence_history_store: Arc<dyn PresenceHistoryStore + Send + Sync>,
     ) -> Self {
         self.presence_history_store = Some(presence_history_store);
+        self
+    }
+
+    pub fn presence_manager(mut self, presence_manager: Arc<PresenceManager>) -> Self {
+        self.presence_manager = Some(presence_manager);
         self
     }
 
@@ -398,7 +405,9 @@ impl ConnectionHandlerBuilder {
             cleanup_circuit_breaker_opened_at: Arc::new(AtomicU64::new(0)),
             #[cfg(feature = "delta")]
             delta_compression,
-            presence_manager: Arc::new(PresenceManager::new()),
+            presence_manager: self
+                .presence_manager
+                .unwrap_or_else(|| Arc::new(PresenceManager::new())),
             presence_registry: self
                 .presence_registry
                 .unwrap_or_else(|| Arc::new(PresenceRegistry::default())),

--- a/crates/sockudo-adapter/src/presence.rs
+++ b/crates/sockudo-adapter/src/presence.rs
@@ -19,6 +19,7 @@ use tokio::time::{Duration, Instant};
 use tracing::{debug, error, warn};
 
 const MAX_PENDING_PRESENCE_REMOVALS: usize = 100_000;
+static PRESENCE_REMOVAL_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 /// Lock key for presence operations to prevent TOCTOU races
 /// Format: "app_id:channel:user_id"
@@ -49,7 +50,6 @@ pub struct PresenceManager {
     /// Per-user locks to prevent TOCTOU races during presence operations
     /// Maps "app_id:channel:user_id" -> async mutex for true per-key exclusivity
     presence_locks: PresenceLockMap,
-    removal_generation: AtomicU64,
     pending_removal_deadlines: Arc<Mutex<BTreeMap<Instant, VecDeque<PendingRemovalTask>>>>,
     pending_removal_count: Arc<AtomicUsize>,
     pending_removal_worker_started: AtomicBool,
@@ -66,7 +66,6 @@ impl PresenceManager {
     pub fn new() -> Self {
         Self {
             presence_locks: DashMap::with_hasher(ahash::RandomState::new()),
-            removal_generation: AtomicU64::new(1),
             pending_removal_deadlines: Arc::new(Mutex::new(BTreeMap::new())),
             pending_removal_count: Arc::new(AtomicUsize::new(0)),
             pending_removal_worker_started: AtomicBool::new(false),
@@ -448,6 +447,43 @@ impl PresenceManager {
         ungraceful_timeout_seconds: u64,
         retention: Option<sockudo_core::presence_history::PresenceHistoryRetentionPolicy>,
     ) -> Result<()> {
+        self.handle_member_removed_with_info(
+            connection_manager,
+            presence_history_store,
+            presence_history_enabled,
+            webhook_integration,
+            metrics,
+            app_config,
+            channel,
+            user_id,
+            excluding_socket,
+            cause,
+            dead_node_id,
+            None,
+            ungraceful_timeout_seconds,
+            retention,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn handle_member_removed_with_info(
+        &self,
+        connection_manager: &Arc<dyn ConnectionManager + Send + Sync>,
+        presence_history_store: Arc<dyn PresenceHistoryStore + Send + Sync>,
+        presence_history_enabled: bool,
+        webhook_integration: Option<&Arc<WebhookIntegration>>,
+        metrics: Option<&Arc<dyn MetricsInterface + Send + Sync>>,
+        app_config: &App,
+        channel: &str,
+        user_id: &str,
+        excluding_socket: Option<&SocketId>,
+        cause: PresenceHistoryEventCause,
+        dead_node_id: Option<&str>,
+        pending_user_info: Option<sonic_rs::Value>,
+        ungraceful_timeout_seconds: u64,
+        retention: Option<sockudo_core::presence_history::PresenceHistoryRetentionPolicy>,
+    ) -> Result<()> {
         debug!(user_id = %user_id, channel = %channel, app_id = %app_config.id, "processing presence member removal");
 
         let lock_key = presence_lock_key(&app_config.id, channel, user_id);
@@ -475,16 +511,18 @@ impl PresenceManager {
             if !has_other_connections {
                 if cause == PresenceHistoryEventCause::Disconnect && ungraceful_timeout_seconds > 0
                 {
-                    let generation = self.removal_generation.fetch_add(1, Ordering::Relaxed);
-                    let user_info = if let Some(socket_id) = excluding_socket {
-                        connection_manager
-                            .get_presence_member(&app_config.id, channel, socket_id)
-                            .await
-                            .and_then(|member| member.user_info)
-                    } else {
-                        None
+                    let generation = PRESENCE_REMOVAL_GENERATION.fetch_add(1, Ordering::Relaxed);
+                    let user_info = match pending_user_info {
+                        Some(ref user_info) => Some(user_info.clone()),
+                        None => match excluding_socket {
+                            Some(socket_id) => connection_manager
+                                .get_presence_member(&app_config.id, channel, socket_id)
+                                .await
+                                .and_then(|member| member.user_info),
+                            None => None,
+                        },
                     };
-                    connection_manager
+                    let pending_result = connection_manager
                         .mark_presence_member_pending(
                             &app_config.id,
                             channel,
@@ -495,28 +533,72 @@ impl PresenceManager {
                             user_info,
                             generation,
                         )
-                        .await?;
+                        .await;
 
-                    self.schedule_pending_removal(
-                        ungraceful_timeout_seconds,
-                        PendingRemovalTask {
-                            connection_manager: Arc::clone(connection_manager),
-                            presence_history_store: Arc::clone(&presence_history_store),
-                            presence_history_enabled,
-                            webhook_integration: webhook_integration.cloned(),
-                            metrics: metrics.cloned(),
-                            app_config: app_config.clone(),
-                            channel: channel.to_string(),
-                            user_id: user_id.to_string(),
-                            socket_for_leave: excluding_socket.map(ToString::to_string),
-                            generation,
-                            retention: retention.clone(),
-                        },
-                    )
-                    .await?;
+                    match pending_result {
+                        Ok(()) => {
+                            let schedule_result = self
+                                .schedule_pending_removal(
+                                    ungraceful_timeout_seconds,
+                                    PendingRemovalTask {
+                                        connection_manager: Arc::clone(connection_manager),
+                                        presence_history_store: Arc::clone(&presence_history_store),
+                                        presence_history_enabled,
+                                        webhook_integration: webhook_integration.cloned(),
+                                        metrics: metrics.cloned(),
+                                        app_config: app_config.clone(),
+                                        channel: channel.to_string(),
+                                        user_id: user_id.to_string(),
+                                        socket_for_leave: excluding_socket.map(ToString::to_string),
+                                        generation,
+                                        retention: retention.clone(),
+                                    },
+                                )
+                                .await;
 
-                    self.cleanup_stale_locks();
-                    return Ok(());
+                            match schedule_result {
+                                Ok(()) => {
+                                    self.cleanup_stale_locks();
+                                    return Ok(());
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        app_id = %app_config.id,
+                                        channel = %channel,
+                                        user_id = %user_id,
+                                        error = %e,
+                                        "presence removal scheduling failed, removing member immediately"
+                                    );
+                                    if let Err(remove_error) = connection_manager
+                                        .remove_pending_presence_member(
+                                            &app_config.id,
+                                            channel,
+                                            user_id,
+                                            generation,
+                                        )
+                                        .await
+                                    {
+                                        error!(
+                                            app_id = %app_config.id,
+                                            channel = %channel,
+                                            user_id = %user_id,
+                                            error = %remove_error,
+                                            "pending presence rollback failed"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(
+                                app_id = %app_config.id,
+                                channel = %channel,
+                                user_id = %user_id,
+                                error = %e,
+                                "pending presence creation failed, removing member immediately"
+                            );
+                        }
+                    }
                 }
 
                 debug!(user_id = %user_id, channel = %channel, "user has no other connections, sending member_removed events");

--- a/crates/sockudo-adapter/tests/cleanup_fallback_tests.rs
+++ b/crates/sockudo-adapter/tests/cleanup_fallback_tests.rs
@@ -17,6 +17,7 @@ mod tests {
             timestamp: Instant::now(),
             connection_info: Some(ConnectionCleanupInfo {
                 presence_channels: vec!["presence-room1".to_string()],
+                presence_members: std::collections::HashMap::new(),
                 auth_info: Some(AuthInfo {
                     user_id: "user123".to_string(),
                     user_info: None,

--- a/crates/sockudo-ai-transport/tests/ait_s_conformance.rs
+++ b/crates/sockudo-ai-transport/tests/ait_s_conformance.rs
@@ -528,12 +528,15 @@ fn ait_s069_to_s073_rollup_table_and_reduced_state_are_deterministic() {
 fn ait_s084_085_presence_timeout_defaults_off_and_can_be_configured() {
     let default = PresenceConfig::default();
     assert_eq!(default.ungraceful_timeout_seconds, 0);
+    assert_eq!(default.v2_ungraceful_timeout_seconds, 15);
 
     let enabled = PresenceConfig {
         ungraceful_timeout_seconds: 15,
+        v2_ungraceful_timeout_seconds: 30,
         ..PresenceConfig::default()
     };
     assert_eq!(enabled.ungraceful_timeout_seconds, 15);
+    assert_eq!(enabled.v2_ungraceful_timeout_seconds, 30);
 }
 
 #[test]

--- a/crates/sockudo-core/src/options/channels.rs
+++ b/crates/sockudo-core/src/options/channels.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use sockudo_protocol::ProtocolVersion;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -22,7 +23,10 @@ pub struct PresenceConfig {
     pub max_members_per_channel: u32,
     pub max_member_size_in_kb: u32,
     pub update_rate_limit_per_member_per_second: u32,
+    /// Protocol V1/Pusher-compatible abrupt-disconnect presence lease.
     pub ungraceful_timeout_seconds: u64,
+    /// Protocol V2 abrupt-disconnect presence lease.
+    pub v2_ungraceful_timeout_seconds: u64,
 }
 
 impl Default for ChannelLimits {
@@ -52,6 +56,53 @@ impl Default for PresenceConfig {
             max_member_size_in_kb: 2,
             update_rate_limit_per_member_per_second: 10,
             ungraceful_timeout_seconds: 0,
+            v2_ungraceful_timeout_seconds: 15,
         }
+    }
+}
+
+impl PresenceConfig {
+    pub fn ungraceful_timeout_for_protocol(&self, protocol_version: ProtocolVersion) -> u64 {
+        match protocol_version {
+            ProtocolVersion::V1 => self.ungraceful_timeout_seconds,
+            ProtocolVersion::V2 => self.v2_ungraceful_timeout_seconds,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presence_timeout_defaults_preserve_v1_and_protect_v2_recovery() {
+        let config = PresenceConfig::default();
+
+        assert_eq!(
+            config.ungraceful_timeout_for_protocol(ProtocolVersion::V1),
+            0
+        );
+        assert_eq!(
+            config.ungraceful_timeout_for_protocol(ProtocolVersion::V2),
+            15
+        );
+    }
+
+    #[test]
+    fn presence_timeout_can_be_overridden_per_protocol() {
+        let config = PresenceConfig {
+            ungraceful_timeout_seconds: 4,
+            v2_ungraceful_timeout_seconds: 9,
+            ..PresenceConfig::default()
+        };
+
+        assert_eq!(
+            config.ungraceful_timeout_for_protocol(ProtocolVersion::V1),
+            4
+        );
+        assert_eq!(
+            config.ungraceful_timeout_for_protocol(ProtocolVersion::V2),
+            9
+        );
     }
 }

--- a/crates/sockudo-core/src/options/env/runtime.rs
+++ b/crates/sockudo-core/src/options/env/runtime.rs
@@ -113,6 +113,10 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
         "PRESENCE_UNGRACEFUL_TIMEOUT_SECONDS",
         options.presence.ungraceful_timeout_seconds,
     );
+    options.presence.v2_ungraceful_timeout_seconds = parse_env::<u64>(
+        "PRESENCE_V2_UNGRACEFUL_TIMEOUT_SECONDS",
+        options.presence.v2_ungraceful_timeout_seconds,
+    );
     if let Ok(prefix) = std::env::var("RATE_LIMITER_REDIS_PREFIX") {
         options.rate_limiter.redis.prefix = Some(prefix);
     }

--- a/crates/sockudo-core/src/presence_registry.rs
+++ b/crates/sockudo-core/src/presence_registry.rs
@@ -295,6 +295,23 @@ impl PresenceRegistry {
         self.has_connection(app_id, connection_id)
     }
 
+    /// Return whether a connection currently owns at least one presence member.
+    #[must_use]
+    pub fn connection_has_members(&self, app_id: &str, connection_id: &str) -> bool {
+        let apps = self.apps.pin();
+        let Some(app) = apps.get(app_id) else {
+            return false;
+        };
+        let connections = app.connections.pin();
+        let Some(connection) = connections.get(connection_id) else {
+            return false;
+        };
+        connection
+            .channels
+            .iter()
+            .any(|channel| channel.value().contains_connection(connection_id))
+    }
+
     fn capacity_shard(app_id: &str, channel: &str, client_id: &str) -> usize {
         Self::coordination_shard((app_id, channel, client_id))
     }
@@ -734,6 +751,21 @@ mod tests {
         assert_eq!(snapshot.len(), 2);
         assert_eq!(snapshot[0].id, "connection-a:1:0");
         assert_eq!(snapshot[1].id, "connection-a:2:0");
+    }
+
+    #[test]
+    fn connection_has_members_distinguishes_registration_from_presence_entry() {
+        let registry = PresenceRegistry::new(128);
+        registry.register_connection("app", "connection-a");
+        assert!(!registry.connection_has_members("app", "connection-a"));
+
+        registry
+            .enter("app", "room", member("connection-a", "client-a", 1))
+            .expect("presence entry succeeds");
+        assert!(registry.connection_has_members("app", "connection-a"));
+
+        registry.unregister_connection("app", "connection-a");
+        assert!(!registry.connection_has_members("app", "connection-a"));
     }
 
     #[test]

--- a/crates/sockudo-server/src/bootstrap/server.rs
+++ b/crates/sockudo-server/src/bootstrap/server.rs
@@ -3,14 +3,15 @@ use super::push::workers::start_push_monolith_workers;
 #[cfg(feature = "push")]
 use super::push::{PushAdmissionSnapshot, create_push_queue, create_push_store};
 use super::{MetricsFactory, ServerState, SockudoServer};
-use crate::cleanup::CleanupSender;
 use crate::cleanup::multi_worker::MultiWorkerCleanupSystem;
+use crate::cleanup::{CleanupSender, PresenceCleanupContext};
 use crate::history::create_history_store;
 #[cfg(feature = "versioned-messages")]
 use crate::history::{create_annotation_store, create_version_store};
 use crate::presence_history::create_presence_history_store;
 use sockudo_adapter::ConnectionHandler;
 use sockudo_adapter::factory::AdapterFactory;
+use sockudo_adapter::presence::PresenceManager;
 use sockudo_app::AppManagerFactory;
 use sockudo_cache::CacheManagerFactory;
 use sockudo_core::auth::AuthValidator;
@@ -581,6 +582,7 @@ impl SockudoServer {
 
         // Initialize cleanup queue if enabled
         let cleanup_config = config.cleanup.clone();
+        let presence_manager = Arc::new(PresenceManager::new());
 
         // Validate cleanup configuration
         if let Err(e) = cleanup_config.validate() {
@@ -592,12 +594,16 @@ impl SockudoServer {
         }
 
         let (cleanup_queue, cleanup_worker_handles) = if cleanup_config.async_enabled {
+            let presence_cleanup = PresenceCleanupContext {
+                history_store: Arc::clone(&presence_history_store),
+                history_config: config.presence_history.clone(),
+                manager: Arc::clone(&presence_manager),
+            };
             let multi_worker_system = MultiWorkerCleanupSystem::new(
                 connection_manager.clone(),
                 app_manager.clone(),
                 Some(webhook_integration.clone()),
-                presence_history_store.clone(),
-                config.presence_history.clone(),
+                presence_cleanup,
                 cleanup_config.clone(),
                 metrics.clone(),
             );
@@ -946,6 +952,7 @@ impl SockudoServer {
             builder = builder.version_store(version_store);
         }
         builder = builder.presence_history_store(presence_history_store);
+        builder = builder.presence_manager(presence_manager);
         #[cfg(feature = "versioned-messages")]
         {
             builder = builder.annotation_store(annotation_store);

--- a/crates/sockudo-server/src/cleanup/mod.rs
+++ b/crates/sockudo-server/src/cleanup/mod.rs
@@ -8,8 +8,12 @@ pub use sockudo_adapter::cleanup::{
 };
 
 // Re-export CleanupConfig and WorkerThreadsConfig from sockudo-core options
+use sockudo_adapter::presence::PresenceManager;
+use sockudo_core::options::PresenceHistoryConfig;
 pub use sockudo_core::options::{CleanupConfig, WorkerThreadsConfig};
+use sockudo_core::presence_history::PresenceHistoryStore;
 use sockudo_core::websocket::SocketId;
+use std::sync::Arc;
 
 // Re-export CancellationToken for use by callers who want graceful shutdown
 pub use tokio_util::sync::CancellationToken;
@@ -106,5 +110,13 @@ pub struct WebhookEvent {
     pub user_id: Option<String>,
     pub socket_id: Option<SocketId>,
     pub data: sonic_rs::Value,
+    pub presence_user_info: Option<sonic_rs::Value>,
     pub presence_ungraceful_timeout_seconds: u64,
+}
+
+#[derive(Clone)]
+pub struct PresenceCleanupContext {
+    pub history_store: Arc<dyn PresenceHistoryStore + Send + Sync>,
+    pub history_config: PresenceHistoryConfig,
+    pub manager: Arc<PresenceManager>,
 }

--- a/crates/sockudo-server/src/cleanup/multi_worker.rs
+++ b/crates/sockudo-server/src/cleanup/multi_worker.rs
@@ -1,10 +1,11 @@
-use super::{CleanupConfig, CleanupSenderHandle, WorkerThreadsResolve, worker::CleanupWorker};
+use super::{
+    CleanupConfig, CleanupSenderHandle, PresenceCleanupContext, WorkerThreadsResolve,
+    worker::CleanupWorker,
+};
 use crossfire::mpsc;
 use sockudo_adapter::connection_manager::ConnectionManager;
 use sockudo_core::app::AppManager;
 use sockudo_core::metrics::MetricsInterface;
-use sockudo_core::options::PresenceHistoryConfig;
-use sockudo_core::presence_history::PresenceHistoryStore;
 use sockudo_webhook::WebhookIntegration;
 use std::sync::Arc;
 use tracing::{error, info};
@@ -21,8 +22,7 @@ impl MultiWorkerCleanupSystem {
         connection_manager: Arc<dyn ConnectionManager + Send + Sync>,
         app_manager: Arc<dyn AppManager + Send + Sync>,
         webhook_integration: Option<Arc<WebhookIntegration>>,
-        presence_history_store: Arc<dyn PresenceHistoryStore + Send + Sync>,
-        presence_history_config: PresenceHistoryConfig,
+        presence: PresenceCleanupContext,
         config: CleanupConfig,
         metrics: Option<Arc<dyn MetricsInterface + Send + Sync>>,
     ) -> Self {
@@ -45,8 +45,7 @@ impl MultiWorkerCleanupSystem {
                 connection_manager.clone(),
                 app_manager.clone(),
                 webhook_integration.clone(),
-                presence_history_store.clone(),
-                presence_history_config.clone(),
+                presence.clone(),
                 worker_config.clone(),
                 metrics.clone(),
             );

--- a/crates/sockudo-server/src/cleanup/worker.rs
+++ b/crates/sockudo-server/src/cleanup/worker.rs
@@ -1,13 +1,13 @@
-use super::{CleanupConfig, ConnectionCleanupInfo, DisconnectTask, WebhookEvent};
+use super::{
+    CleanupConfig, ConnectionCleanupInfo, DisconnectTask, PresenceCleanupContext, WebhookEvent,
+};
 use ahash::AHashMap;
 use sockudo_adapter::channel_manager::ChannelManager;
 use sockudo_adapter::connection_manager::ConnectionManager;
-use sockudo_adapter::presence::global_presence_manager;
 use sockudo_core::app::AppManager;
 use sockudo_core::channel::ChannelType;
 use sockudo_core::metrics::MetricsInterface;
-use sockudo_core::options::PresenceHistoryConfig;
-use sockudo_core::presence_history::{PresenceHistoryEventCause, PresenceHistoryStore};
+use sockudo_core::presence_history::PresenceHistoryEventCause;
 use sockudo_core::websocket::SocketId;
 use sockudo_webhook::WebhookIntegration;
 use std::sync::Arc;
@@ -20,8 +20,7 @@ pub struct CleanupWorker {
     connection_manager: Arc<dyn ConnectionManager + Send + Sync>,
     app_manager: Arc<dyn AppManager + Send + Sync>,
     webhook_integration: Option<Arc<WebhookIntegration>>,
-    presence_history_store: Arc<dyn PresenceHistoryStore + Send + Sync>,
-    presence_history_config: PresenceHistoryConfig,
+    presence: PresenceCleanupContext,
     config: CleanupConfig,
     metrics: Option<Arc<dyn MetricsInterface + Send + Sync>>,
 }
@@ -31,8 +30,7 @@ impl CleanupWorker {
         connection_manager: Arc<dyn ConnectionManager + Send + Sync>,
         app_manager: Arc<dyn AppManager + Send + Sync>,
         webhook_integration: Option<Arc<WebhookIntegration>>,
-        presence_history_store: Arc<dyn PresenceHistoryStore + Send + Sync>,
-        presence_history_config: PresenceHistoryConfig,
+        presence: PresenceCleanupContext,
         config: CleanupConfig,
         metrics: Option<Arc<dyn MetricsInterface + Send + Sync>>,
     ) -> Self {
@@ -40,8 +38,7 @@ impl CleanupWorker {
             connection_manager,
             app_manager,
             webhook_integration,
-            presence_history_store,
-            presence_history_config,
+            presence,
             config,
             metrics,
         }
@@ -153,7 +150,7 @@ impl CleanupWorker {
         }
 
         if !webhook_events.is_empty() {
-            self.process_webhooks_async(webhook_events).await;
+            self.process_cleanup_events(webhook_events).await;
         }
 
         batch.clear();
@@ -281,6 +278,10 @@ impl CleanupWorker {
                         "user_id": user_id,
                         "socket_id": task.socket_id.to_string()
                     }),
+                    presence_user_info: info
+                        .presence_members
+                        .get(channel)
+                        .and_then(|member| member.user_info.clone()),
                     presence_ungraceful_timeout_seconds: task.presence_ungraceful_timeout_seconds,
                 });
             }
@@ -302,6 +303,7 @@ impl CleanupWorker {
                     data: sonic_rs::json!({
                         "channel": channel
                     }),
+                    presence_user_info: None,
                     presence_ungraceful_timeout_seconds: 0,
                 });
             }
@@ -310,79 +312,82 @@ impl CleanupWorker {
         events
     }
 
-    async fn process_webhooks_async(&self, webhook_events: Vec<WebhookEvent>) {
-        if let Some(webhook_integration) = &self.webhook_integration {
-            debug!(
-                event_count = webhook_events.len(),
-                "processing cleanup webhook events"
-            );
+    async fn process_cleanup_events(&self, cleanup_events: Vec<WebhookEvent>) {
+        debug!(
+            event_count = cleanup_events.len(),
+            "processing disconnect cleanup events"
+        );
 
-            let mut events_by_app: AHashMap<String, Vec<WebhookEvent>> = AHashMap::new();
-            for event in webhook_events {
-                events_by_app
-                    .entry(event.app_id.clone())
-                    .or_default()
-                    .push(event);
-            }
+        let mut events_by_app: AHashMap<String, Vec<WebhookEvent>> = AHashMap::new();
+        for event in cleanup_events {
+            events_by_app
+                .entry(event.app_id.clone())
+                .or_default()
+                .push(event);
+        }
 
-            let mut webhook_handles = Vec::new();
+        let mut cleanup_handles = Vec::new();
 
-            for (app_id, events) in events_by_app {
-                let webhook_integration = webhook_integration.clone();
-                let app_manager = self.app_manager.clone();
-                let connection_manager = self.connection_manager.clone();
-                let presence_history_store = self.presence_history_store.clone();
-                let presence_history_config = self.presence_history_config.clone();
-                let handle = tokio::spawn(async move {
-                    let app_config = match app_manager.find_by_id(&app_id).await {
-                        Ok(Some(app)) => app,
-                        Ok(None) => {
-                            warn!(app_id = %app_id, "app not found for cleanup webhook events");
-                            return;
-                        }
-                        Err(e) => {
-                            error!(app_id = %app_id, error = %e, "app lookup failed for cleanup webhook events");
-                            return;
-                        }
-                    };
-
-                    for event in events {
-                        if let Err(e) = Self::send_webhook_event(
-                            &connection_manager,
-                            &webhook_integration,
-                            &presence_history_store,
-                            &presence_history_config,
-                            &app_config,
-                            &event,
-                        )
-                        .await
-                        {
-                            error!(
-                                app_id = %app_id,
-                                event = %event.event_type,
-                                error = %e,
-                                "cleanup webhook event send failed"
-                            );
-                        }
+        for (app_id, events) in events_by_app {
+            let webhook_integration = self.webhook_integration.clone();
+            let app_manager = self.app_manager.clone();
+            let connection_manager = self.connection_manager.clone();
+            let presence_history_store = Arc::clone(&self.presence.history_store);
+            let presence_history_config = self.presence.history_config.clone();
+            let presence_manager = Arc::clone(&self.presence.manager);
+            let handle = tokio::spawn(async move {
+                let app_config = match app_manager.find_by_id(&app_id).await {
+                    Ok(Some(app)) => app,
+                    Ok(None) => {
+                        warn!(app_id = %app_id, "app not found for disconnect cleanup events");
+                        return;
                     }
-                });
+                    Err(e) => {
+                        error!(app_id = %app_id, error = %e, "app lookup failed for disconnect cleanup events");
+                        return;
+                    }
+                };
 
-                webhook_handles.push(handle);
-            }
-
-            for handle in webhook_handles {
-                if let Err(e) = handle.await {
-                    error!(error = %e, "cleanup webhook task failed");
+                for event in events {
+                    if let Err(e) = Self::process_cleanup_event(
+                        &connection_manager,
+                        &presence_manager,
+                        webhook_integration.as_ref(),
+                        &presence_history_store,
+                        &presence_history_config,
+                        &app_config,
+                        &event,
+                    )
+                    .await
+                    {
+                        error!(
+                            app_id = %app_id,
+                            event = %event.event_type,
+                            error = %e,
+                            "disconnect cleanup event processing failed"
+                        );
+                    }
                 }
+            });
+
+            cleanup_handles.push(handle);
+        }
+
+        for handle in cleanup_handles {
+            if let Err(e) = handle.await {
+                error!(error = %e, "disconnect cleanup task failed");
             }
         }
     }
 
-    async fn send_webhook_event(
+    async fn process_cleanup_event(
         connection_manager: &Arc<dyn ConnectionManager + Send + Sync>,
-        webhook_integration: &Arc<WebhookIntegration>,
-        presence_history_store: &Arc<dyn PresenceHistoryStore + Send + Sync>,
-        presence_history_config: &PresenceHistoryConfig,
+        presence_manager: &sockudo_adapter::presence::PresenceManager,
+        webhook_integration: Option<&Arc<WebhookIntegration>>,
+        presence_history_store: &Arc<
+            dyn sockudo_core::presence_history::PresenceHistoryStore + Send + Sync,
+        >,
+        presence_history_config: &sockudo_core::options::PresenceHistoryConfig,
         app_config: &sockudo_core::app::App,
         event: &WebhookEvent,
     ) -> sockudo_core::error::Result<()> {
@@ -390,20 +395,20 @@ impl CleanupWorker {
             app_id = %app_config.id,
             channel = %event.channel,
             event = %event.event_type,
-            "sending cleanup webhook"
+            "processing disconnect cleanup event"
         );
 
         match event.event_type.as_str() {
             "member_removed" => {
                 if let Some(user_id) = &event.user_id {
-                    global_presence_manager()
-                        .handle_member_removed(
+                    presence_manager
+                        .handle_member_removed_with_info(
                             connection_manager,
                             Arc::clone(presence_history_store),
                             app_config
                                 .resolved_presence_history(&event.channel, presence_history_config)
                                 .enabled,
-                            Some(webhook_integration),
+                            webhook_integration,
                             None,
                             app_config,
                             &event.channel,
@@ -411,6 +416,7 @@ impl CleanupWorker {
                             event.socket_id.as_ref(),
                             PresenceHistoryEventCause::Disconnect,
                             None,
+                            event.presence_user_info.clone(),
                             event.presence_ungraceful_timeout_seconds,
                             Some(
                                 app_config
@@ -431,15 +437,17 @@ impl CleanupWorker {
                 }
             }
             "channel_vacated" => {
-                webhook_integration
-                    .send_channel_vacated(app_config, &event.channel)
-                    .await?;
-                debug!(
-                    app_id = %app_config.id,
-                    channel = %event.channel,
-                    event = "channel_vacated",
-                    "cleanup webhook sent"
-                );
+                if let Some(webhook_integration) = webhook_integration {
+                    webhook_integration
+                        .send_channel_vacated(app_config, &event.channel)
+                        .await?;
+                    debug!(
+                        app_id = %app_config.id,
+                        channel = %event.channel,
+                        event = "channel_vacated",
+                        "cleanup webhook sent"
+                    );
+                }
             }
             _ => {
                 warn!(event = %event.event_type, "unknown cleanup webhook event type");
@@ -454,6 +462,7 @@ impl CleanupWorker {
 mod tests {
     use super::*;
     use crossfire::mpsc;
+    use futures_util::StreamExt;
     use sockudo_adapter::cleanup::{CleanupSender, DisconnectTask};
     use sockudo_adapter::handler::ConnectionHandler;
     use sockudo_adapter::local_adapter::LocalAdapter;
@@ -467,7 +476,10 @@ mod tests {
     use sockudo_protocol::{ProtocolVersion, WireFormat};
     use sockudo_ws::axum_integration::{WebSocket, WebSocketWriter};
     use sockudo_ws::client::WebSocketClient;
-    use sockudo_ws::{Config as WsConfig, Http1, Stream as WsStream, WebSocketStream};
+    use sockudo_ws::{
+        Config as WsConfig, Http1, Message as WsMessage, Stream as WsStream, WebSocketStream,
+    };
+    use sonic_rs::JsonValueTrait;
     use std::time::{Duration, Instant};
     use tokio::net::{TcpListener, TcpStream};
 
@@ -517,12 +529,22 @@ mod tests {
 
     fn make_worker(adapter: Arc<dyn ConnectionManager + Send + Sync>) -> CleanupWorker {
         let app_manager = Arc::new(MemoryAppManager::new()) as Arc<dyn AppManager + Send + Sync>;
+        make_worker_with_app_manager(adapter, app_manager)
+    }
+
+    fn make_worker_with_app_manager(
+        adapter: Arc<dyn ConnectionManager + Send + Sync>,
+        app_manager: Arc<dyn AppManager + Send + Sync>,
+    ) -> CleanupWorker {
         CleanupWorker::new(
             adapter,
             app_manager,
             None,
-            Arc::new(NoopPresenceHistoryStore),
-            PresenceHistoryConfig::default(),
+            PresenceCleanupContext {
+                history_store: Arc::new(NoopPresenceHistoryStore),
+                history_config: PresenceHistoryConfig::default(),
+                manager: Arc::new(sockudo_adapter::presence::PresenceManager::new()),
+            },
             CleanupConfig {
                 batch_size: 64,
                 batch_timeout_ms: 50,
@@ -530,6 +552,205 @@ mod tests {
             },
             None,
         )
+    }
+
+    #[tokio::test]
+    async fn disconnect_cleanup_retains_then_emits_presence_leave_without_webhooks() {
+        let adapter = Arc::new(LocalAdapter::new());
+        adapter.init().await;
+
+        let app_manager = Arc::new(MemoryAppManager::new());
+        app_manager.create_app(make_app()).await.unwrap();
+
+        let observer_socket = SocketId::new();
+        let (observer_writer, mut observer_client) = make_ws_pair().await;
+        adapter
+            .add_socket(
+                observer_socket,
+                observer_writer,
+                APP_ID,
+                app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+                WebSocketBufferConfig::default(),
+                ProtocolVersion::V1,
+                WireFormat::Json,
+                true,
+                sockudo_protocol::AppendMode::Delta,
+            )
+            .await
+            .unwrap();
+        adapter
+            .add_to_channel(APP_ID, "presence-room", &observer_socket)
+            .await
+            .unwrap();
+
+        let leaving_socket = SocketId::new();
+        let (leaving_writer, _leaving_client) = make_ws_pair().await;
+        adapter
+            .add_socket(
+                leaving_socket,
+                leaving_writer,
+                APP_ID,
+                app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+                WebSocketBufferConfig::default(),
+                ProtocolVersion::V1,
+                WireFormat::Json,
+                true,
+                sockudo_protocol::AppendMode::Delta,
+            )
+            .await
+            .unwrap();
+        adapter
+            .add_to_channel(APP_ID, "presence-room", &leaving_socket)
+            .await
+            .unwrap();
+
+        let leaving_connection = adapter
+            .get_connection(&leaving_socket, APP_ID)
+            .await
+            .unwrap();
+        {
+            let mut guard = leaving_connection.inner.lock().await;
+            guard.state.user_id = Some("leaving-user".to_string());
+        }
+        adapter.add_user(leaving_connection).await.unwrap();
+
+        let namespace = adapter.get_namespace(APP_ID).await.unwrap();
+        namespace
+            .presence_data
+            .entry(leaving_socket)
+            .or_default()
+            .insert(
+                "presence-room".to_string(),
+                PresenceMemberInfo {
+                    user_id: "leaving-user".to_string(),
+                    user_info: Some(sonic_rs::json!({"status": "busy"})),
+                },
+            );
+
+        let mut presence_members = std::collections::HashMap::new();
+        presence_members.insert(
+            "presence-room".to_string(),
+            PresenceMemberInfo {
+                user_id: "leaving-user".to_string(),
+                user_info: Some(sonic_rs::json!({"status": "busy"})),
+            },
+        );
+        let task = DisconnectTask {
+            socket_id: leaving_socket,
+            app_id: APP_ID.to_string(),
+            subscribed_channels: vec!["presence-room".to_string()],
+            user_id: Some("leaving-user".to_string()),
+            cause: sockudo_core::websocket::DisconnectCause::TransportError,
+            timestamp: Instant::now(),
+            connection_info: Some(ConnectionCleanupInfo {
+                presence_channels: vec!["presence-room".to_string()],
+                presence_members,
+                auth_info: None,
+            }),
+            presence_ungraceful_timeout_seconds: 1,
+        };
+
+        let worker = make_worker_with_app_manager(
+            adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+            app_manager as Arc<dyn AppManager + Send + Sync>,
+        );
+        let mut batch = vec![task];
+        worker.process_batch(&mut batch).await;
+
+        let retained = adapter
+            .get_channel_members(APP_ID, "presence-room")
+            .await
+            .unwrap();
+        assert_eq!(
+            retained
+                .get("leaving-user")
+                .and_then(|member| member.user_info.as_ref())
+                .and_then(|info| info.get("status"))
+                .and_then(sonic_rs::Value::as_str),
+            Some("busy")
+        );
+
+        let frame = tokio::time::timeout(Duration::from_secs(2), observer_client.next())
+            .await
+            .expect("observer must receive member_removed")
+            .expect("observer websocket must remain open")
+            .expect("observer frame must be readable");
+        let message: sockudo_protocol::messages::PusherMessage = match frame {
+            WsMessage::Text(bytes) => sonic_rs::from_slice(bytes.as_ref()).unwrap(),
+            WsMessage::Binary(bytes) => sonic_rs::from_slice(&bytes).unwrap(),
+            other => panic!("unexpected websocket frame: {other:?}"),
+        };
+
+        assert_eq!(
+            message.event.as_deref(),
+            Some("pusher_internal:member_removed")
+        );
+        assert_eq!(message.channel.as_deref(), Some("presence-room"));
+        assert!(
+            message
+                .data
+                .as_ref()
+                .is_some_and(|data| sonic_rs::to_string(data).unwrap().contains("leaving-user"))
+        );
+    }
+
+    #[tokio::test]
+    async fn v2_ungraceful_disconnect_uses_recovery_presence_lease() {
+        let adapter = Arc::new(LocalAdapter::new());
+        adapter.init().await;
+
+        let app_manager = Arc::new(MemoryAppManager::new());
+        app_manager.create_app(make_app()).await.unwrap();
+
+        let socket_id = SocketId::new();
+        let (writer, _client) = make_ws_pair().await;
+        adapter
+            .add_socket(
+                socket_id,
+                writer,
+                APP_ID,
+                app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+                WebSocketBufferConfig::default(),
+                ProtocolVersion::V2,
+                WireFormat::Json,
+                true,
+                sockudo_protocol::AppendMode::Delta,
+            )
+            .await
+            .unwrap();
+
+        let (tx, rx) = mpsc::bounded_async::<DisconnectTask>(8);
+        let cache = Arc::new(MemoryCacheManager::new(
+            "cleanup-worker-v2-presence-test".to_string(),
+            MemoryCacheOptions::default(),
+        ));
+        let handler = ConnectionHandler::builder(
+            app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+            cache,
+            ServerOptions::default(),
+        )
+        .local_adapter(adapter.clone())
+        .cleanup_queue(CleanupSender::Direct(tx))
+        .build();
+
+        handler
+            .handle_ungraceful_disconnect(APP_ID, &socket_id)
+            .await
+            .unwrap();
+        let task = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("disconnect task must be queued")
+            .expect("cleanup queue must remain open");
+
+        assert_eq!(task.presence_ungraceful_timeout_seconds, 15);
+
+        let worker = make_worker_with_app_manager(
+            adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+            app_manager as Arc<dyn AppManager + Send + Sync>,
+        );
+        let mut batch = vec![task];
+        worker.process_batch(&mut batch).await;
     }
 
     #[tokio::test]

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -65,10 +65,12 @@ new key authentication. Tokens from a key with `revocable_tokens = true` are
 also rejected after that key is disabled, revoked, expired, or replaced with a
 different `rotation_id`. Secrets and bearer tokens are never written to logs.
 
-TokenRequest timestamps are accepted only within the configured skew. Nonces
-are claimed atomically in the configured cache for `nonce_ttl_seconds`, and
-issued token records use the same cache, allowing issuance on one node and use
-on another. Use a shared cache driver such as Redis in multi-node deployments.
+TokenRequest `timestamp` and `ttl` values accept JSON integers or decimal
+integer strings, matching values commonly forwarded from auth URL query
+parameters. Timestamps are accepted only within the configured skew. Nonces are
+claimed atomically in the configured cache for `nonce_ttl_seconds`, and issued
+token records use the same cache, allowing issuance on one node and use on
+another. Use a shared cache driver such as Redis in multi-node deployments.
 
 The server's `ably-compat` Cargo feature explicitly enables native AI Transport,
 recovery, delta, and push support. Runtime `[ably_compat].enabled` and the key

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -372,6 +372,14 @@ See [Logging](/docs/reference/logging) for level policy, stable lifecycle fields
 | `EVENT_NAME_FILTERING_MAX_EVENTS_PER_FILTER` | Maximum event names in one subscription filter. |
 | `EVENT_NAME_FILTERING_MAX_EVENT_NAME_LENGTH` | Maximum event name length inside a filter. |
 
+## Presence
+
+| Variable | Purpose |
+| --- | --- |
+| `PRESENCE_UPDATE_RATE_LIMIT_PER_MEMBER_PER_SECOND` | Maximum presence updates accepted per member per second. |
+| `PRESENCE_UNGRACEFUL_TIMEOUT_SECONDS` | Protocol V1/Pusher presence lease after an abrupt disconnect. Defaults to immediate removal. |
+| `PRESENCE_V2_UNGRACEFUL_TIMEOUT_SECONDS` | Protocol V2 presence lease after an abrupt disconnect. Defaults to 15 seconds. |
+
 ## History, idempotency, versioning, and annotations
 
 | Variable | Purpose |

--- a/docs/content/docs/server/ably-ai-transport-compatibility.mdx
+++ b/docs/content/docs/server/ably-ai-transport-compatibility.mdx
@@ -65,7 +65,7 @@ coordination backend to private memory.
 | WebSocket writer, auth timer, channel gate, negotiated attachment | Local connection state | The node owning the socket. Gates and queues have count and byte bounds and end with the transport. | The socket closes when safe local delivery cannot continue; another node never fabricates ownership. |
 | Session owner and recovery key | Replicated ephemeral | Compare-and-swap owner lease in shared cache, bounded by the connection-state TTL. Recovery keys are single-use and key rotation invalidates the previous key. | Resume fails closed when the owner lease or continuity record cannot be verified. A successful claim on another node supersedes the old owner. |
 | Publish idempotency claim and acknowledgement | Replicated ephemeral plus durable repair | Atomic cache claim/receipt for the idempotency TTL; canonical history/version records repair an ambiguous post-commit receipt. | A backend error does not permit a second winner. A retry is acknowledged only after its canonical commit is proven. |
-| Current presence | Replicated ephemeral | Per-connection typed membership, replicated by the horizontal adapter and tied to the node-health lease. | Duplicate leave/dead-node notifications are idempotent. Node death removes every orphan connection; failure to coordinate cleanup is degraded and observable rather than reported as a clean snapshot. |
+| Current presence | Replicated ephemeral | Per-connection typed membership, replicated by the horizontal adapter and tied to the node-health lease. Abrupt transport loss starts a bounded 15-second removal lease, independently of the two-minute connection-state lease. | A recovered live owner cancels pending removal. Duplicate leave/dead-node notifications are idempotent. Node death removes every orphan connection; failure to coordinate cleanup is degraded and observable rather than reported as a clean snapshot. |
 | Presence transitions | Durable | Configured durable history backend and its retention policy. | Current membership can remain available, but continuity-sensitive history fails closed while degraded. |
 | Attachment high-water and reconnect continuity | Local attachment plus durable canonical position | The live attachment owner captures the high-water; durable history/version streams prove reconnect ranges. | `untilAttach` requires routing affinity to the attachment owner. Resume/recover returns reset-required when stream identity or a contiguous range cannot be proven. |
 | Remote delivery suppression | Local bounded projection state | Each subscriber node keeps a contiguous per-stream delivery high-water plus a bounded set of out-of-order serials; Redis fanout carries the complete canonical envelope. | Serials at or below proven continuity remain suppressed without retaining an unbounded ledger. Missing canonical identity is not guessed; reorder-window overflow is counted and fails reset-required instead of evicting duplicate evidence. |
@@ -128,12 +128,15 @@ messages.
 ### Presence across reconnects
 
 Ably `DISCONNECT` and `CLOSE` have different presence lifecycles. `DISCONNECT`
-ends the current WebSocket transport but retains the connection's presence
-members until the bounded connection-state lease expires, allowing a short
-disconnect or a suspended-channel resync to preserve the authoritative member
-set. `CLOSE` is terminal: it removes the connection's members immediately and
-fans out their leave transitions. Both paths still unsubscribe the terminated
-transport session from local channel delivery.
+ends the current WebSocket transport and starts the Ably presence grace period.
+The default is 15 seconds; the `remainPresentFor` transport parameter may reduce
+it to a minimum of one second. Recovery during that window keeps the
+authoritative member set and cancels the pending removal. After the grace period,
+Sockudo removes the members and fans out their leave transitions while retaining
+the connection recovery state for its independent two-minute lease. `CLOSE` is
+terminal: it removes the connection's members immediately and invalidates its
+recovery state. Both paths still unsubscribe the terminated transport session
+from local channel delivery.
 
 On automatic presence re-entry, Sockudo preserves a supplied member ID only
 when it is a valid `connectionId:msgSerial:index` ID owned by the current

--- a/docs/content/docs/server/agent-presence.mdx
+++ b/docs/content/docs/server/agent-presence.mdx
@@ -37,6 +37,10 @@ Limits and access:
 
 Late joiners see the latest member data in the presence snapshot returned with `subscription_succeeded`.
 
-`[presence].ungraceful_timeout_seconds` controls abnormal disconnect grace. The default is `0`, preserving legacy immediate `member_removed` timing. For agent channels, use `15` seconds so transient transport loss does not produce a leave/enter flap. Clean unsubscribe and clean WebSocket close still remove immediately.
+`[presence].ungraceful_timeout_seconds` controls Protocol V1 abnormal disconnect
+grace and defaults to `0`, preserving legacy immediate `member_removed` timing.
+Protocol V2 uses `[presence].v2_ungraceful_timeout_seconds`, which defaults to
+`15` seconds so transient transport loss does not produce a leave/enter flap.
+Clean unsubscribe and clean WebSocket close still remove immediately.
 
 Presence update ordering is independent from channel message ordering. Treat presence status as latest-known member state, not as a causal marker for `ai-output` or mutable-message delivery.

--- a/docs/content/docs/server/ai-transport-troubleshooting.mdx
+++ b/docs/content/docs/server/ai-transport-troubleshooting.mdx
@@ -14,7 +14,7 @@ icon: Wrench
 | Rollup latency too high | Window too high or slow flush under load | Compare `sockudo_flush_latency` to the configured window and lower `default_window_ms`. |
 | Rollup savings too low | Window too low or terminal flushes dominate | Compare `sockudo_appends_received_total`, `sockudo_appends_delivered_total`, and `sockudo_rollup_ratio`. |
 | Push channel misses user | Device not registered or not subscribed to the notification channel | Inspect push channel subscriptions and provider token state. |
-| Presence flaps during transient loss | Ungraceful timeout is zero or too low | Raise `[presence].ungraceful_timeout_seconds` for agent presence channels. |
+| Presence flaps during transient loss | Ungraceful timeout is zero or too low | Raise `[presence].v2_ungraceful_timeout_seconds` for Protocol V2 agent presence channels. |
 | Recovery fails after node loss | Durable state degraded/reset-required or shared cache/store unavailable | Inspect `sockudo_history_recovery_failures_total`, degraded/reset-required gauges, and store health. |
 
 For scale and chaos-specific playbooks, see [AI Transport production operations](/docs/server/ai-transport-production-ops).

--- a/docs/content/docs/server/configuration.mdx
+++ b/docs/content/docs/server/configuration.mdx
@@ -179,9 +179,14 @@ max_members_per_channel = 100
 max_member_size_in_kb = 2
 update_rate_limit_per_member_per_second = 10
 ungraceful_timeout_seconds = 0
+v2_ungraceful_timeout_seconds = 15
 ```
 
-`ungraceful_timeout_seconds = 0` preserves legacy immediate `member_removed` behavior. Set it to `15` for agent presence channels that should tolerate short abnormal reconnects without leave/enter flaps.
+`ungraceful_timeout_seconds = 0` preserves Protocol V1/Pusher's legacy immediate
+`member_removed` behavior. Protocol V2 defaults
+`v2_ungraceful_timeout_seconds` to `15`, retaining presence through short abnormal
+disconnects without leave/enter flaps. Clean unsubscribe and clean WebSocket close
+remove presence immediately for both protocol versions.
 
 ## Webhooks
 


### PR DESCRIPTION
## Summary

- Accept Sockudo-issued opaque tokens inside signed Ably JWT/JWE envelopes instead of requiring the embedded `x-ably-token` value to be another JWT.
- Coerce decimal-string `TokenRequest` timestamps and TTLs while preserving integer and range validation.
- Align Ably abrupt-disconnect presence cleanup with `remainPresentFor`, keeping presence retention independent from connection-state recovery.
- Fix native Protocol V2 presence cleanup across graceful closes, abrupt disconnects, reconnect races, and multi-worker cleanup while preserving Protocol V1 behavior.
- Add regression tests and document the new native V2 abrupt-presence timeout configuration.

## Root cause

The embedded-token path verified the outer JWT/JWE and then unconditionally parsed `x-ably-token` as a JWT. Tokens returned by the Sockudo `requestToken` endpoint are opaque (`sockudo-ably-<uuid>`), so otherwise valid authenticated requests failed with `401 / 40101`. `TokenRequest` deserialization also required JSON numbers even though auth URL services commonly construct the request from query parameters and therefore send decimal strings.

Presence cleanup coupled membership removal too closely to connection recovery and did not consistently preserve enough ownership and generation state for race-safe delayed cleanup. Native V2 cleanup also used immediate-removal behavior inherited from Protocol V1 and did not share the same presence manager across all cleanup paths.

## Impact

- Sockudo opaque Ably tokens now work through signed JWT and JWE embedding.
- Ably-compatible auth URL implementations can send decimal-string timestamp and TTL values.
- Ably presence remains for the configured `remainPresentFor` window after an ungraceful disconnect, then emits a leave without reusing the enter message ID.
- Native V2 defaults to a 15-second ungraceful presence timeout; graceful closes still remove immediately, and V1 keeps its existing immediate-removal default.
- Operators can configure native V2 cleanup with `presence.v2_ungraceful_timeout_seconds` or `PRESENCE_V2_UNGRACEFUL_TIMEOUT_SECONDS`.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `REDIS_URL=redis://127.0.0.1:6379 cargo test --workspace --quiet`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cd docs && npm run types:check && npm run build`
- Live Ably CLI validation with ably/ably-cli#437: abrupt exit emitted leave after approximately 15 seconds and presence became empty.
- Live native Protocol V2 validation: graceful close emitted `member_removed` immediately; forced termination emitted it after approximately 15 seconds.

## References

- https://github.com/ably-labs/sockudo-compatibility/blob/main/scope/known-failures.json
- https://github.com/ably/ably-cli/pull/437
- https://gist.github.com/lmars/0efd5f62d6246838ef3786308b98c942