### PR TITLE
Fix step-start-serial compatibility

### DIFF
--- a/crates/sockudo-ably-compat/src/runtime/tests.rs
+++ b/crates/sockudo-ably-compat/src/runtime/tests.rs
@@ -97,6 +97,51 @@ fn publish_validation_accepts_empty_ai_step_owner() {
 }
 
 #[test]
+fn publish_validation_accepts_step_start_serial() {
+    let message = AblyMessage {
+        name: Some("ai-step-end".to_string()),
+        extras: Some(json!({
+            "ai": {
+                "transport": {
+                    "run-id": "run-1",
+                    "step-id": "step-1",
+                    "step-start-serial": "serial-1"
+                }
+            }
+        })),
+        ..AblyMessage::default()
+    };
+
+    validate_ably_publish_message(&message, false)
+        .expect("step-start-serial is the current Ably AI Transport header");
+}
+
+#[test]
+fn publish_validation_rejects_obsolete_start_serial() {
+    let message = AblyMessage {
+        name: Some("ai-step-end".to_string()),
+        extras: Some(json!({
+            "ai": {
+                "transport": {
+                    "run-id": "run-1",
+                    "step-id": "step-1",
+                    "start-serial": "serial-1"
+                }
+            }
+        })),
+        ..AblyMessage::default()
+    };
+
+    let error = validate_ably_publish_message(&message, false).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("unknown extras.ai.transport key 'start-serial'"),
+        "unexpected validation error: {error}"
+    );
+}
+
+#[test]
 fn publish_validation_rejects_reserved_and_unknown_fields() {
     let reserved = AblyMessage {
         connection_id: Some("client-supplied".to_string()),

--- a/crates/sockudo-protocol/src/messages.rs
+++ b/crates/sockudo-protocol/src/messages.rs
@@ -33,7 +33,7 @@ pub const AI_HEADER_CODEC_MESSAGE_ID: &str = "codec-message-id";
 pub const AI_HEADER_INVOCATION_ID: &str = "invocation-id";
 pub const AI_HEADER_EVENT_ID: &str = "event-id";
 pub const AI_HEADER_STEP_ID: &str = "step-id";
-pub const AI_HEADER_START_SERIAL: &str = "start-serial";
+pub const AI_HEADER_STEP_START_SERIAL: &str = "step-start-serial";
 pub const AI_HEADER_STEP_REASON: &str = "step-reason";
 pub const AI_HEADER_STEP_CLIENT_ID: &str = "step-client-id";
 pub const AI_HEADER_MSG_REGENERATE: &str = "msg-regenerate";
@@ -332,8 +332,8 @@ impl<'a> AiTransportHeaders<'a> {
     }
 
     #[inline]
-    pub fn start_serial(&self) -> Option<&'a str> {
-        self.get(AI_HEADER_START_SERIAL)
+    pub fn step_start_serial(&self) -> Option<&'a str> {
+        self.get(AI_HEADER_STEP_START_SERIAL)
     }
 
     #[inline]
@@ -592,7 +592,7 @@ fn validate_transport_key_domain(key: &str, value: &str) -> Result<(), AiHeaderV
         | AI_HEADER_INVOCATION_ID
         | AI_HEADER_EVENT_ID
         | AI_HEADER_STEP_ID
-        | AI_HEADER_START_SERIAL
+        | AI_HEADER_STEP_START_SERIAL
         | AI_HEADER_MSG_REGENERATE
         | "error-code"
         | "model" => {

--- a/crates/sockudo-protocol/tests/protocol_compliance.rs
+++ b/crates/sockudo-protocol/tests/protocol_compliance.rs
@@ -4,8 +4,8 @@ use sockudo_protocol::messages::{
     AI_EVENT_LEGACY_TURN_START, AI_EVENT_OUTPUT, AI_EVENT_RUN_END, AI_EVENT_RUN_RESUME,
     AI_EVENT_RUN_START, AI_EVENT_RUN_SUSPEND, AI_HEADER_LEGACY_TURN_ID, AI_HEADER_MSG_REGENERATE,
     AI_HEADER_RUN_CLIENT_ID, AI_HEADER_RUN_ID, AI_HEADER_STEP_CLIENT_ID,
-    AI_TRANSPORT_VALUE_MAX_BYTES, AiExtras, ExtrasValue, MessageData, MessageExtras, PusherMessage,
-    is_ai_event,
+    AI_HEADER_STEP_START_SERIAL, AI_TRANSPORT_VALUE_MAX_BYTES, AiExtras, ExtrasValue, MessageData,
+    MessageExtras, PusherMessage, is_ai_event,
 };
 use sonic_rs::prelude::*;
 use sonic_rs::{Value, json};
@@ -128,6 +128,10 @@ fn test_ai_transport_headers_are_borrowed_views() {
     transport.insert("status".to_string(), "streaming".to_string());
     transport.insert("parent".to_string(), "msg-0".to_string());
     transport.insert("fork-of".to_string(), "msg-old".to_string());
+    transport.insert(
+        AI_HEADER_STEP_START_SERIAL.to_string(),
+        "serial-1".to_string(),
+    );
 
     let extras = sockudo_protocol::messages::MessageExtras {
         ai: Some(AiExtras {
@@ -146,6 +150,7 @@ fn test_ai_transport_headers_are_borrowed_views() {
     assert_eq!(headers.status(), Some("streaming"));
     assert_eq!(headers.parent(), Some("msg-0"));
     assert_eq!(headers.fork_of(), Some("msg-old"));
+    assert_eq!(headers.step_start_serial(), Some("serial-1"));
     assert_eq!(
         extras
             .ai_codec_headers()
@@ -353,7 +358,7 @@ fn test_ai_transport_identity_keys_reject_empty_except_native_unknown_owners() {
         ("event-id", false),
         ("step-id", false),
         (AI_HEADER_STEP_CLIENT_ID, true),
-        ("start-serial", false),
+        (AI_HEADER_STEP_START_SERIAL, false),
         ("msg-regenerate", false),
         ("model", false),
     ];
@@ -369,6 +374,27 @@ fn test_ai_transport_identity_keys_reject_empty_except_native_unknown_owners() {
 
         assert_eq!(extras.validate_ai_headers().is_ok(), allowed, "key={key}");
     }
+}
+
+#[test]
+fn test_ai_transport_rejects_obsolete_start_serial_header() {
+    let extras = MessageExtras {
+        ai: Some(AiExtras {
+            transport: Some(HashMap::from([(
+                "start-serial".to_string(),
+                "serial-1".to_string(),
+            )])),
+            codec: None,
+        }),
+        ..Default::default()
+    };
+
+    let error = extras.validate_ai_headers().unwrap_err();
+    assert_eq!(error.code, AI_ERROR_INVALID_TRANSPORT_HEADER);
+    assert_eq!(
+        error.message,
+        "unknown extras.ai.transport key 'start-serial'"
+    );
 }
 
 #[test]

--- a/docs/specs/ai-transport-wire-protocol.md
+++ b/docs/specs/ai-transport-wire-protocol.md
@@ -167,7 +167,7 @@ Transport keys:
 | `event-id` | Non-empty opaque string |
 | `input-client-id` | Verified client identity string |
 | `step-id` | Non-empty opaque string; stable logical step identity across attempts |
-| `start-serial` | Non-empty serial of the corresponding `ai-step-start` attempt |
+| `step-start-serial` | Non-empty serial of the corresponding `ai-step-start` attempt |
 | `step-reason` | `complete`, `failed`, `cancelled` |
 | `step-client-id` | Verified client identity string, or the empty native wire sentinel when the step participant is unknown |
 | `role` | `user`, `assistant`, `system`, `tool`, `agent` |


### PR DESCRIPTION
## Summary

- rename the step-attempt header from `start-serial` to `step-start-serial` in Sockudo's native Protocol V2 contract
- rename the public Rust constant and typed transport accessor so stale callers fail at compile time
- apply the shared validator to both native Sockudo and Ably-compatible publishing paths
- add regressions that accept `step-start-serial` and reject the obsolete `start-serial` spelling
- update the AI Transport wire specification

## Why

Current `ably-ai-transport-js` publishes the attempt identity as `step-start-serial`. Sockudo still whitelisted `start-serial`, so current agents and demos were rejected before publish. This is the intended pre-1.0 wire/API break with no backward-compatibility alias; agents and clients must use matching versions.

## Impact

The wire header changes to `step-start-serial`. The Rust API changes from `AI_HEADER_START_SERIAL` / `start_serial()` to `AI_HEADER_STEP_START_SERIAL` / `step_start_serial()`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sockudo-protocol` (97 passed)
- `cargo test -p sockudo-ably-compat publish_validation_` (5 passed)
- `cargo test -p sockudo-ai-transport` (40 passed)
- `cargo clippy -p sockudo-protocol -p sockudo-ably-compat -p sockudo-ai-transport --all-targets -- -D warnings`
