### PR TITLE
feat(core): add ${VAR} substitution in config files

### DIFF
--- a/crates/sockudo-core/src/options/server.rs
+++ b/crates/sockudo-core/src/options/server.rs
@@ -113,6 +113,8 @@ impl Default for ServerOptions {
 impl ServerOptions {
     pub async fn load_from_file(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let content = tokio::fs::read_to_string(path).await?;
+        let content =
+            crate::utils::substitute_env_vars(&content).map_err(crate::error::Error::ConfigFile)?;
         let options: Self = if path.ends_with(".toml") {
             toml::from_str(&content)?
         } else {

--- a/crates/sockudo-core/src/utils.rs
+++ b/crates/sockudo-core/src/utils.rs
@@ -21,6 +21,46 @@ static CACHING_CHANNEL_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
         .collect()
 });
 
+// Matches ${VAR} and ${VAR:-default} placeholders.
+static ENV_VAR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}").unwrap());
+
+/// Substitutes `${VAR}` and `${VAR:-default}` placeholders with values from
+/// the process environment. Returns an error listing all unresolved variables.
+pub fn substitute_env_vars(input: &str) -> Result<String, String> {
+    substitute_env_vars_with(input, |name| {
+        std::env::var(name).ok().filter(|v| !v.is_empty())
+    })
+}
+
+fn substitute_env_vars_with(
+    input: &str,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Result<String, String> {
+    let mut missing = Vec::new();
+
+    let result = ENV_VAR_RE.replace_all(input, |caps: &regex::Captures| {
+        let var_name = &caps[1];
+        if let Some(val) = lookup(var_name) {
+            val
+        } else if let Some(default) = caps.get(2) {
+            default.as_str().to_owned()
+        } else {
+            missing.push(var_name.to_owned());
+            caps[0].to_owned()
+        }
+    });
+
+    if missing.is_empty() {
+        Ok(result.into_owned())
+    } else {
+        Err(format!(
+            "unresolved environment variables in config: {}",
+            missing.join(", ")
+        ))
+    }
+}
+
 pub fn is_cache_channel(channel: &str) -> bool {
     // Use the pre-compiled regexes
     for regex in CACHING_CHANNEL_REGEXES.iter() {
@@ -705,5 +745,129 @@ mod tests {
         assert!(validate_wildcard_subscription_pattern("private-news.*").is_err());
         assert!(validate_wildcard_subscription_pattern("news.*.*").is_err());
         assert!(validate_wildcard_subscription_pattern("news.*#user-1").is_err());
+    }
+}
+
+#[cfg(test)]
+mod substitute_env_vars_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn lookup_from<'a>(map: &'a HashMap<&'a str, &'a str>) -> impl Fn(&str) -> Option<String> + 'a {
+        move |name| map.get(name).map(|v| v.to_string())
+    }
+
+    #[test]
+    fn resolves_known_var() {
+        let vars = HashMap::from([("DB_HOST", "localhost")]);
+        let result = substitute_env_vars_with(r#"host = "${DB_HOST}""#, lookup_from(&vars));
+        assert_eq!(result.unwrap(), r#"host = "localhost""#);
+    }
+
+    #[test]
+    fn errors_on_missing_var() {
+        let result = substitute_env_vars_with(r#"secret = "${MISSING}""#, |_| None);
+        let err = result.unwrap_err();
+        assert!(err.contains("MISSING"));
+    }
+
+    #[test]
+    fn collects_all_missing_vars() {
+        let result = substitute_env_vars_with("${A} ${B} ${C:-ok}", |_| None);
+        let err = result.unwrap_err();
+        assert!(err.contains("A"), "should list A");
+        assert!(err.contains("B"), "should list B");
+        assert!(!err.contains('C'), "C has a default, should not be listed");
+    }
+
+    #[test]
+    fn default_used_when_missing() {
+        let result = substitute_env_vars_with(r#"port = "${PORT:-6001}""#, |_| None);
+        assert_eq!(result.unwrap(), r#"port = "6001""#);
+    }
+
+    #[test]
+    fn default_ignored_when_present() {
+        let vars = HashMap::from([("PORT", "8080")]);
+        let result = substitute_env_vars_with(r#"port = "${PORT:-6001}""#, lookup_from(&vars));
+        assert_eq!(result.unwrap(), r#"port = "8080""#);
+    }
+
+    #[test]
+    fn empty_default_produces_empty_string() {
+        let result = substitute_env_vars_with(r#"val = "${UNSET:-}""#, |_| None);
+        assert_eq!(result.unwrap(), r#"val = """#);
+    }
+
+    #[test]
+    fn default_with_colons_preserved() {
+        let result = substitute_env_vars_with(r#"url = "${DB:-host:5432}""#, |_| None);
+        assert_eq!(result.unwrap(), r#"url = "host:5432""#);
+    }
+
+    #[test]
+    fn no_placeholders_unchanged() {
+        let input = r#"plain text $dollar and $(parens) and $100"#;
+        let result = substitute_env_vars_with(input, |_| None);
+        assert_eq!(result.unwrap(), input);
+    }
+
+    #[test]
+    fn adjacent_interpolations() {
+        let vars = HashMap::from([("A", "hello"), ("B", "world")]);
+        let result = substitute_env_vars_with("${A}${B}", lookup_from(&vars));
+        assert_eq!(result.unwrap(), "helloworld");
+    }
+
+    #[test]
+    fn mixed_resolved_and_default() {
+        let vars = HashMap::from([("HOST", "db.internal")]);
+        let result =
+            substitute_env_vars_with(r#"url = "${HOST}:${PORT:-5432}""#, lookup_from(&vars));
+        assert_eq!(result.unwrap(), r#"url = "db.internal:5432""#);
+    }
+
+    #[test]
+    fn toml_integration_round_trip() {
+        #[derive(serde::Deserialize, PartialEq, Debug)]
+        struct Cfg {
+            secret: String,
+            name: String,
+        }
+
+        let vars = HashMap::from([("MY_SECRET", "s3cr3t")]);
+        let toml_input = "secret = \"${MY_SECRET}\"\nname = \"${LABEL:-default-name}\"";
+        let resolved = substitute_env_vars_with(toml_input, lookup_from(&vars)).unwrap();
+        let cfg: Cfg = toml::from_str(&resolved).unwrap();
+        assert_eq!(cfg.secret, "s3cr3t");
+        assert_eq!(cfg.name, "default-name");
+    }
+
+    #[test]
+    fn json_integration_round_trip() {
+        let vars = HashMap::from([("APP_SECRET", "json-secret")]);
+        let json_input = r#"{"secret": "${APP_SECRET}", "port": "${PORT:-9000}"}"#;
+        let resolved = substitute_env_vars_with(json_input, lookup_from(&vars)).unwrap();
+        let parsed: sonic_rs::Value = sonic_rs::from_str(&resolved).unwrap();
+        assert_eq!(parsed["secret"], "json-secret");
+        assert_eq!(parsed["port"], "9000");
+    }
+
+    #[test]
+    fn backward_compat_no_interpolation() {
+        let input = concat!(
+            "[app_manager.array]\n",
+            "[[app_manager.array.apps]]\n",
+            "id = \"my-app\"\n",
+            "key = \"app-key\"\n",
+            "secret = \"plain-secret\"\n",
+            "enabled = true\n",
+        );
+        let result = substitute_env_vars_with(input, |_| None);
+        assert_eq!(
+            result.unwrap(),
+            input,
+            "input without ${{}} must be unchanged"
+        );
     }
 }

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -16,6 +16,78 @@ the server parser and accept common true/false forms.
 
 This page lists every runtime environment variable referenced by the server, core configuration loader, push subsystem, app managers, adapters, queues, and provider workers.
 
+## Config File Interpolation
+
+Sockudo supports `${VAR}` environment variable interpolation in TOML and JSON
+configuration files. Variables are resolved from the process environment at
+startup, before the config file is parsed.
+
+### Syntax
+
+| Pattern | Behavior |
+|---------|----------|
+| `${VAR}` | Replaced with the value of `VAR`. **Startup error if unset or empty.** |
+| `${VAR:-default}` | Replaced with the value of `VAR`, or `default` if unset or empty. |
+
+### Examples
+
+Inject a secret from the environment (e.g. from AWS Secrets Manager via a pod environment variable):
+
+```toml
+[[app_manager.array.apps]]
+id = "my-app"
+key = "app-key"
+secret = "${SOCKUDO_APP_SECRET}"
+enabled = true
+```
+
+Use defaults for optional values:
+
+```toml
+port = 6001
+
+[adapter]
+driver = "${ADAPTER_DRIVER:-local}"
+
+[adapter.redis.redis_pub_options]
+url = "${REDIS_URL:-redis://localhost:6379}"
+```
+
+### Behavior
+
+- **Missing variables**: If a `${VAR}` reference has no default and the
+  variable is unset or empty, sockudo prints an error listing **all**
+  unresolved variables and exits. This is fail-fast by design — you see
+  every missing variable at once, not one at a time.
+
+- **Empty values**: An environment variable set to an empty string (`VAR=""`)
+  is treated as unset. The `:-default` fallback will activate.
+
+- **Single pass**: Interpolation runs once on the raw file text. If a
+  resolved value itself contains `${…}`, it is **not** re-expanded. This
+  prevents accidental recursion and injection.
+
+- **No bare `$VAR`**: Only the braced `${VAR}` syntax is recognized. A bare
+  `$` character (e.g., in regex patterns or currency symbols) is never
+  matched.
+
+### Limitations
+
+- **Comments**: Interpolation operates on raw text before TOML/JSON parsing.
+  A `${VAR}` reference inside a TOML comment (`# secret = "${MISSING}"`)
+  will still be resolved — and will cause a startup error if the variable
+  is missing. Remove or replace `${…}` patterns in comments if they
+  reference variables that are not set.
+
+- **Typed fields**: Interpolation produces string replacements. For string
+  config values (secrets, URLs, connection strings), this works naturally.
+  For numeric or boolean fields, prefer the existing environment variable
+  overrides instead.
+
+- **Defaults cannot contain `}`**: The default value in `${VAR:-default}`
+  ends at the first `}` character. This is sufficient for most values
+  (strings, URLs, ports) but not for JSON fragments.
+
 ## Process and listener
 
 | Variable | Purpose |


### PR DESCRIPTION
Adds `${VAR}` and `${VAR:-default}` environment variable substitution to TOML and JSON config file loading. Variables are resolved from the process environment at startup, between file read and parsing.

Supports injecting secrets (e.g. from AWS Secrets Manager) without duplicating full app config in environment variables:

```toml
[[app_manager.array.apps]]
id = "my-app"
key = "app-key"
secret = "${SOCKUDO_APP_SECRET}"
```

Behavior:
- Fail-fast: collects all missing vars, reports them in a single error
- Empty env var treated as unset
- Single-pass, non-recursive (resolved values never re-expanded)
- Only ${VAR} braced syntax — bare $ is never matched

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
