### PR TITLE
Align client SDK reconnection behavior

### DIFF
--- a/client-sdks/sockudo-ai-transport-js/src/realtime/types.ts
+++ b/client-sdks/sockudo-ai-transport-js/src/realtime/types.ts
@@ -235,6 +235,7 @@ export interface ChannelLike {
 export type ConnectionState =
   | "initialized"
   | "connecting"
+  | "reconnecting"
   | "connected"
   | "disconnected"
   | "unavailable"

--- a/client-sdks/sockudo-dotnet/README.md
+++ b/client-sdks/sockudo-dotnet/README.md
@@ -414,20 +414,30 @@ await client.User.SignInAsync();
 ### Connection State Events
 
 ```csharp
-client.Connection.StateChanged += (sender, change) =>
+var client = new SockudoClient(
+    "app-key",
+    new SockudoOptions(
+        Cluster: "local",
+        MaxReconnectAttempts: 10,
+        MaxReconnectGapInSeconds: 60
+    )
+);
+
+client.Bind("state_change", (value, _) =>
+{
+    var change = (StateChange)value!;
     Console.WriteLine($"connection: {change.Previous} -> {change.Current}");
-
-client.Connection.Connected += (sender, data) =>
-    Console.WriteLine($"connected, socket id: {data.SocketId}");
-
-client.Connection.Disconnected += (sender, _) =>
-    Console.WriteLine("disconnected");
-
-client.Connection.Reconnecting += (sender, _) =>
-    Console.WriteLine("reconnecting...");
+});
+client.Bind("reconnecting", (_, _) => Console.WriteLine("reconnecting..."));
 
 await client.ConnectAsync();
 ```
+
+Unexpected disconnects retry with a quadratic delay of 0s, 1s, 4s, 9s, up to
+120s by default. Protocol retry and TLS-upgrade close codes reconnect
+immediately. The default limit is six attempts; set `MaxReconnectAttempts` to
+`null` for unlimited retries. The counter resets after a successful connection
+and on explicit connect or disconnect calls.
 
 ### Protocol V2
 

--- a/client-sdks/sockudo-dotnet/src/Sockudo.Client/Models.cs
+++ b/client-sdks/sockudo-dotnet/src/Sockudo.Client/Models.cs
@@ -30,6 +30,7 @@ public enum ConnectionState
 {
     Initialized,
     Connecting,
+    Reconnecting,
     Connected,
     Disconnected,
     Unavailable,
@@ -610,6 +611,8 @@ public sealed record SockudoOptions(
     SockudoWireFormat WireFormat = SockudoWireFormat.Json,
     SockudoAppendMode AppendMode = SockudoAppendMode.Delta,
     int? AppendRollupWindow = null,
+    int? MaxReconnectAttempts = 6,
+    double MaxReconnectGapInSeconds = 120.0,
     TokenAuthenticationOptions? TokenAuthentication = null
 )
 {

--- a/client-sdks/sockudo-dotnet/src/Sockudo.Client/SockudoClient.cs
+++ b/client-sdks/sockudo-dotnet/src/Sockudo.Client/SockudoClient.cs
@@ -89,6 +89,8 @@ public sealed class SockudoClient : IAsyncDisposable
     private bool _manuallyDisconnected;
     private SockudoTransport? _currentTransport;
     private bool _attemptedFallback;
+    private bool _useTls;
+    private int _reconnectAttempts;
     private string? _authToken;
 
     public SockudoClient(string key, SockudoOptions options, HttpClient? httpClient = null)
@@ -104,6 +106,7 @@ public sealed class SockudoClient : IAsyncDisposable
 
         Key = key;
         Options = options;
+        _useTls = options.ForceTls is not false;
         _httpClient = httpClient ?? new HttpClient();
         _prefix = new ProtocolPrefix(options.ProtocolVersion);
         _deduplicator = options.MessageDeduplication ? new MessageDeduplicator(options.MessageDeduplicationCapacity) : null;
@@ -234,6 +237,7 @@ public sealed class SockudoClient : IAsyncDisposable
 
             _manuallyDisconnected = false;
             _attemptedFallback = false;
+            _reconnectAttempts = 0;
             UpdateState(ConnectionState.Connecting);
             await OpenWebSocketAsync(transports[0], cancellationToken).ConfigureAwait(false);
             SetUnavailableTimer();
@@ -247,6 +251,7 @@ public sealed class SockudoClient : IAsyncDisposable
     public async Task DisconnectAsync(CancellationToken cancellationToken = default)
     {
         _manuallyDisconnected = true;
+        _reconnectAttempts = 0;
         CancelTimers();
 
         var socket = _socket;
@@ -537,7 +542,15 @@ public sealed class SockudoClient : IAsyncDisposable
             _dispatcher.Emit("error", exception);
         }
 
-        await HandleSocketClosedAsync().ConfigureAwait(false);
+        int? closeCode = null;
+        try
+        {
+            closeCode = socket.CloseStatus is null ? null : (int)socket.CloseStatus.Value;
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        await HandleSocketClosedAsync(closeCode).ConfigureAwait(false);
     }
 
     private static async Task<(byte[] Payload, WebSocketMessageType Type)> ReceiveMessageAsync(ClientWebSocket socket, CancellationToken cancellationToken)
@@ -589,6 +602,8 @@ public sealed class SockudoClient : IAsyncDisposable
             {
                 var payloadData = @event.Data as Dictionary<string, object?> ?? new Dictionary<string, object?>(StringComparer.Ordinal);
                 SocketId = payloadData.Get("socket_id") as string ?? throw new SockudoException("Invalid handshake");
+                _reconnectAttempts = 0;
+                ClearUnavailableTimer();
                 UpdateState(ConnectionState.Connected, new Dictionary<string, object?> { ["socket_id"] = SocketId });
 
                 foreach (var channel in _channels.Values)
@@ -745,7 +760,7 @@ public sealed class SockudoClient : IAsyncDisposable
         }
     }
 
-    private async Task HandleSocketClosedAsync()
+    private async Task HandleSocketClosedAsync(int? code)
     {
         _socket?.Dispose();
         _socket = null;
@@ -761,14 +776,51 @@ public sealed class SockudoClient : IAsyncDisposable
 
         User.Cleanup();
 
-        if (!_manuallyDisconnected)
+        var action = CloseActionFor(code);
+        switch (action)
         {
-            await ScheduleRetryAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+            case CloseAction.TlsOnly:
+                _useTls = true;
+                await ScheduleRetryAsync(ReconnectDelay(action)).ConfigureAwait(false);
+                break;
+            case CloseAction.Backoff:
+            case CloseAction.Retry:
+                await ScheduleRetryAsync(ReconnectDelay(action)).ConfigureAwait(false);
+                break;
+            case CloseAction.Refused:
+                UpdateState(ConnectionState.Disconnected);
+                break;
+            case null when !_manuallyDisconnected:
+                await ScheduleRetryAsync(ReconnectDelay(null)).ConfigureAwait(false);
+                break;
         }
     }
 
-    private async Task ScheduleRetryAsync(TimeSpan delay)
+    private TimeSpan ReconnectDelay(CloseAction? action)
     {
+        if (action is CloseAction.Retry or CloseAction.TlsOnly)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var intervalSeconds = (double)_reconnectAttempts * _reconnectAttempts;
+        return TimeSpan.FromSeconds(Math.Min(intervalSeconds, Options.MaxReconnectGapInSeconds));
+    }
+
+    private Task ScheduleRetryAsync(TimeSpan delay)
+    {
+        if (_manuallyDisconnected)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (Options.MaxReconnectAttempts is int maxAttempts && _reconnectAttempts >= maxAttempts)
+        {
+            UpdateState(ConnectionState.Disconnected);
+            return Task.CompletedTask;
+        }
+        _reconnectAttempts += 1;
+
         _retryLoop?.DisposeSafe();
         _retryLoop = Task.Run(async () =>
         {
@@ -780,13 +832,13 @@ public sealed class SockudoClient : IAsyncDisposable
                     return;
                 }
 
-                UpdateState(ConnectionState.Connecting);
+                UpdateState(ConnectionState.Reconnecting);
                 var transports = TransportSequence();
                 var nextTransport = _currentTransport == SockudoTransport.Ws &&
                                     !_attemptedFallback &&
                                     transports.Contains(SockudoTransport.Wss)
                     ? SockudoTransport.Wss
-                    : (transports.FirstOrDefault());
+                    : (transports.Count > 0 ? transports[0] : SockudoTransport.Wss);
                 _attemptedFallback = nextTransport == SockudoTransport.Wss && _currentTransport == SockudoTransport.Ws;
                 await OpenWebSocketAsync(nextTransport, CancellationToken.None).ConfigureAwait(false);
                 SetUnavailableTimer();
@@ -796,13 +848,43 @@ public sealed class SockudoClient : IAsyncDisposable
                 _dispatcher.Emit("error", exception);
             }
         });
+        return Task.CompletedTask;
+    }
+
+    private static CloseAction? CloseActionFor(int? code)
+    {
+        if (code is null)
+        {
+            return null;
+        }
+        if (code < 4000)
+        {
+            return code is >= 1002 and <= 1004 ? CloseAction.Backoff : null;
+        }
+        if (code == 4000)
+        {
+            return CloseAction.TlsOnly;
+        }
+        if (code < 4100)
+        {
+            return CloseAction.Refused;
+        }
+        if (code < 4200)
+        {
+            return CloseAction.Backoff;
+        }
+        if (code < 4300)
+        {
+            return CloseAction.Retry;
+        }
+        return CloseAction.Refused;
     }
 
     private List<SockudoTransport> TransportSequence()
     {
-        var transports = (Options.ForceTls is false
-            ? new[] { SockudoTransport.Ws, SockudoTransport.Wss }
-            : new[] { SockudoTransport.Wss }).ToList();
+        var transports = (_useTls
+            ? new[] { SockudoTransport.Wss }
+            : new[] { SockudoTransport.Ws, SockudoTransport.Wss }).ToList();
 
         if (Options.EnabledTransports is not null)
         {
@@ -887,6 +969,14 @@ public sealed class SockudoClient : IAsyncDisposable
         ClearUnavailableTimer();
         _retryLoop?.DisposeSafe();
         _retryLoop = null;
+    }
+
+    private enum CloseAction
+    {
+        TlsOnly,
+        Refused,
+        Backoff,
+        Retry,
     }
 
     private static string StripDeltaMetadata(string rawMessage) => rawMessage;

--- a/client-sdks/sockudo-dotnet/tests/Sockudo.Client.Tests/ReconnectionTests.cs
+++ b/client-sdks/sockudo-dotnet/tests/Sockudo.Client.Tests/ReconnectionTests.cs
@@ -38,20 +38,23 @@ public sealed class ReconnectionTests
     public async Task RetryEmitsReconnectingAndStopsAtConfiguredLimit()
     {
         await using var client = TestClient(maxReconnectAttempts: 1);
-        var states = new List<string>();
-        client.Bind("state_change", (data, _) => states.Add(((StateChange)data!).Current));
+        var reconnecting = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.Bind("state_change", (data, _) =>
+        {
+            if (((StateChange)data!).Current == "reconnecting")
+            {
+                reconnecting.TrySetResult(true);
+            }
+        });
 
         await InvokeScheduleRetryAsync(client, TimeSpan.Zero);
-        var retryLoop = (Task?)Field("_retryLoop").GetValue(client);
-        Assert.NotNull(retryLoop);
-        await retryLoop!.WaitAsync(TimeSpan.FromSeconds(2));
+        await reconnecting.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
-        Assert.Contains("reconnecting", states);
+        Assert.Equal(ConnectionState.Reconnecting, client.ConnectionState);
 
         await InvokeScheduleRetryAsync(client, TimeSpan.Zero);
 
         Assert.Equal(ConnectionState.Disconnected, client.ConnectionState);
-        Assert.Equal("disconnected", states[^1]);
     }
 
     [Fact]

--- a/client-sdks/sockudo-dotnet/tests/Sockudo.Client.Tests/ReconnectionTests.cs
+++ b/client-sdks/sockudo-dotnet/tests/Sockudo.Client.Tests/ReconnectionTests.cs
@@ -1,0 +1,120 @@
+using System.Net.WebSockets;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace Sockudo.Client.Tests;
+
+public sealed class ReconnectionTests
+{
+    [Fact]
+    public void ReconnectionOptionsAndStateHaveParityDefaults()
+    {
+        var options = new SockudoOptions(Cluster: "local");
+        var unlimited = new SockudoOptions(Cluster: "local", MaxReconnectAttempts: null);
+
+        Assert.Equal("reconnecting", ConnectionState.Reconnecting.ToString().ToLowerInvariant());
+        Assert.Equal(6, options.MaxReconnectAttempts);
+        Assert.Equal(120.0, options.MaxReconnectGapInSeconds);
+        Assert.Null(unlimited.MaxReconnectAttempts);
+    }
+
+    [Fact]
+    public void CloseActionsUseQuadraticCappedDelay()
+    {
+        var client = TestClient(maxReconnectGapInSeconds: 5.0);
+        SetReconnectAttempts(client, 3);
+
+        Assert.Equal("Backoff", InvokeCloseAction(4100)?.ToString());
+        Assert.Equal("Retry", InvokeCloseAction(4200)?.ToString());
+        Assert.Equal("TlsOnly", InvokeCloseAction(4000)?.ToString());
+        Assert.Equal("Refused", InvokeCloseAction(4300)?.ToString());
+        Assert.Equal(TimeSpan.FromSeconds(5), InvokeReconnectDelay(client, null));
+        Assert.Equal(TimeSpan.Zero, InvokeReconnectDelay(client, InvokeCloseAction(4200)));
+        Assert.Equal(TimeSpan.Zero, InvokeReconnectDelay(client, InvokeCloseAction(4000)));
+    }
+
+    [Fact]
+    public async Task RetryEmitsReconnectingAndStopsAtConfiguredLimit()
+    {
+        await using var client = TestClient(maxReconnectAttempts: 1);
+        var states = new List<string>();
+        client.Bind("state_change", (data, _) => states.Add(((StateChange)data!).Current));
+
+        await InvokeScheduleRetryAsync(client, TimeSpan.Zero);
+        var retryLoop = (Task?)Field("_retryLoop").GetValue(client);
+        Assert.NotNull(retryLoop);
+        await retryLoop!.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Contains("reconnecting", states);
+
+        await InvokeScheduleRetryAsync(client, TimeSpan.Zero);
+
+        Assert.Equal(ConnectionState.Disconnected, client.ConnectionState);
+        Assert.Equal("disconnected", states[^1]);
+    }
+
+    [Fact]
+    public async Task SuccessfulHandshakeAndDisconnectResetReconnectAttempts()
+    {
+        await using var client = TestClient();
+        SetReconnectAttempts(client, 4);
+
+        await InvokeRawMessageAsync(
+            client,
+            """{"event":"sockudo:connection_established","data":{"socket_id":"1.1","activity_timeout":120}}"""
+        );
+
+        Assert.Equal(0, GetReconnectAttempts(client));
+
+        SetReconnectAttempts(client, 5);
+        await client.DisconnectAsync();
+
+        Assert.Equal(0, GetReconnectAttempts(client));
+    }
+
+    private static SockudoClient TestClient(
+        int? maxReconnectAttempts = 6,
+        double maxReconnectGapInSeconds = 120.0
+    ) => new(
+        "app-key",
+        new SockudoOptions(
+            Cluster: "local",
+            ForceTls: false,
+            EnabledTransports: new[] { SockudoTransport.Ws },
+            WsHost: "127.0.0.1",
+            WsPort: 1,
+            MaxReconnectAttempts: maxReconnectAttempts,
+            MaxReconnectGapInSeconds: maxReconnectGapInSeconds
+        )
+    );
+
+    private static object? InvokeCloseAction(int code) =>
+        Method("CloseActionFor").Invoke(null, new object?[] { code });
+
+    private static TimeSpan InvokeReconnectDelay(SockudoClient client, object? action) =>
+        (TimeSpan)Method("ReconnectDelay").Invoke(client, new[] { action })!;
+
+    private static async Task InvokeScheduleRetryAsync(SockudoClient client, TimeSpan delay) =>
+        await (Task)Method("ScheduleRetryAsync").Invoke(client, new object[] { delay })!;
+
+    private static async Task InvokeRawMessageAsync(SockudoClient client, string raw) =>
+        await (Task)Method("HandleRawMessageAsync").Invoke(
+            client,
+            new object[] { Encoding.UTF8.GetBytes(raw), WebSocketMessageType.Text }
+        )!;
+
+    private static int GetReconnectAttempts(SockudoClient client) =>
+        (int)Field("_reconnectAttempts").GetValue(client)!;
+
+    private static void SetReconnectAttempts(SockudoClient client, int attempts) =>
+        Field("_reconnectAttempts").SetValue(client, attempts);
+
+    private static MethodInfo Method(string name) =>
+        typeof(SockudoClient).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+        ?? throw new MissingMethodException(typeof(SockudoClient).FullName, name);
+
+    private static FieldInfo Field(string name) =>
+        typeof(SockudoClient).GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new MissingFieldException(typeof(SockudoClient).FullName, name);
+}

--- a/client-sdks/sockudo-flutter/README.md
+++ b/client-sdks/sockudo-flutter/README.md
@@ -348,6 +348,29 @@ final page = await push.listChannelSubscriptions(
 print(page['next_cursor']);
 ```
 
+### Reconnection
+
+Unexpected disconnects emit `ConnectionState.reconnecting` and retry with a
+bounded quadratic delay of 0s, 1s, 4s, 9s, up to 120s. Protocol retry and
+TLS-upgrade close codes reconnect immediately. The default limit is six
+attempts; `null` enables unlimited retries.
+
+```dart
+final client = SockudoClient(
+  'app-key',
+  const SockudoOptions(
+    cluster: 'local',
+    maxReconnectAttempts: 10,
+    maxReconnectGapInSeconds: 60,
+  ),
+);
+
+client.bind('reconnecting', (_, _) => print('reconnecting'));
+```
+
+The attempt counter resets after a successful connection and on explicit
+`connect()` or `disconnect()` calls.
+
 ### Encrypted Channels
 
 `private-encrypted-*` channels use the `sharedSecret` returned by your auth endpoint or custom handler. Payload decryption is handled automatically.

--- a/client-sdks/sockudo-flutter/lib/src/client.dart
+++ b/client-sdks/sockudo-flutter/lib/src/client.dart
@@ -86,6 +86,8 @@ class SockudoOptions {
     this.wireFormat = SockudoWireFormat.json,
     this.appendMode = SockudoAppendMode.delta,
     this.appendRollupWindow,
+    this.maxReconnectAttempts = 6,
+    this.maxReconnectGapInSeconds = 120.0,
     this.channelAuthorization = const ChannelAuthorizationOptions(),
     this.userAuthentication = const UserAuthenticationOptions(),
     this.presenceHistory,
@@ -121,6 +123,8 @@ class SockudoOptions {
   final SockudoWireFormat wireFormat;
   final SockudoAppendMode appendMode;
   final int? appendRollupWindow;
+  final int? maxReconnectAttempts;
+  final double maxReconnectGapInSeconds;
   final ChannelAuthorizationOptions channelAuthorization;
   final UserAuthenticationOptions userAuthentication;
   final PresenceHistoryOptions? presenceHistory;
@@ -184,6 +188,7 @@ class SockudoClient {
   SockudoTransport? _currentTransport;
   bool _attemptedFallback = false;
   bool _manuallyDisconnected = false;
+  int _reconnectAttempts = 0;
   Future<void>? _authRefreshFuture;
   Timer? _authRefreshTimer;
   int _openAttempt = 0;
@@ -270,6 +275,7 @@ class SockudoClient {
     }
     _manuallyDisconnected = false;
     _attemptedFallback = false;
+    _reconnectAttempts = 0;
     _updateState(ConnectionState.connecting);
     _openWebSocket(transports.first);
     _setUnavailableTimer();
@@ -277,6 +283,7 @@ class SockudoClient {
 
   void disconnect() {
     _manuallyDisconnected = true;
+    _reconnectAttempts = 0;
     _openAttempt += 1;
     _cancelAuthRefreshTimer();
     _invalidateTimers();
@@ -548,6 +555,7 @@ class SockudoClient {
           throw const SockudoException('Invalid handshake');
         }
         socketId = newSocketId;
+        _reconnectAttempts = 0;
         _clearUnavailableTimer();
         _updateState(
           ConnectionState.connected,
@@ -779,19 +787,20 @@ class SockudoClient {
       channel._disconnect();
     }
 
-    switch (_closeAction(code)) {
+    final action = _closeAction(code);
+    switch (action) {
       case _CloseAction.tlsOnly:
         _config.useTls = true;
-        _scheduleRetry(Duration.zero);
+        _scheduleRetry(_reconnectDelay(action));
       case _CloseAction.backoff:
-        _scheduleRetry(const Duration(seconds: 1));
+        _scheduleRetry(_reconnectDelay(action));
       case _CloseAction.retry:
-        _scheduleRetry(Duration.zero);
+        _scheduleRetry(_reconnectDelay(action));
       case _CloseAction.refused:
         _updateState(ConnectionState.disconnected);
       case null:
         if (!_manuallyDisconnected) {
-          _scheduleRetry(const Duration(seconds: 1));
+          _scheduleRetry(_reconnectDelay(null));
         }
     }
 
@@ -821,6 +830,20 @@ class SockudoClient {
       return _CloseAction.retry;
     }
     return _CloseAction.refused;
+  }
+
+  Duration _reconnectDelay(_CloseAction? action) {
+    if (action == _CloseAction.retry || action == _CloseAction.tlsOnly) {
+      return Duration.zero;
+    }
+    final attempts = _reconnectAttempts.toDouble();
+    final intervalSeconds = attempts * attempts;
+    final cappedSeconds = intervalSeconds < _config.maxReconnectGapInSeconds
+        ? intervalSeconds
+        : _config.maxReconnectGapInSeconds;
+    return Duration(
+      microseconds: (cappedSeconds * Duration.microsecondsPerSecond).round(),
+    );
   }
 
   Uri _socketUri(SockudoTransport transport, {String? token}) {
@@ -906,12 +929,18 @@ class SockudoClient {
     if (_manuallyDisconnected) {
       return;
     }
+    final maxAttempts = _config.maxReconnectAttempts;
+    if (maxAttempts != null && _reconnectAttempts >= maxAttempts) {
+      _updateState(ConnectionState.disconnected);
+      return;
+    }
+    _reconnectAttempts += 1;
     _retryTimer?.cancel();
     _retryTimer = Timer(after, () {
       _socketSubscription?.cancel();
       _socketSubscription = null;
       _webSocket = null;
-      _updateState(ConnectionState.connecting);
+      _updateState(ConnectionState.reconnecting);
       final transports = _transportSequence();
       if (_currentTransport == SockudoTransport.ws &&
           !_attemptedFallback &&
@@ -1659,6 +1688,8 @@ class ResolvedConfiguration {
       httpPath = options.httpPath,
       pongTimeout = options.pongTimeout,
       unavailableTimeout = options.unavailableTimeout,
+      maxReconnectAttempts = options.maxReconnectAttempts,
+      maxReconnectGapInSeconds = options.maxReconnectGapInSeconds,
       enableStats = options.enableStats,
       statsHost = options.statsHost,
       timelineParams = options.timelineParams,
@@ -1680,6 +1711,8 @@ class ResolvedConfiguration {
   final String httpPath;
   final Duration pongTimeout;
   final Duration unavailableTimeout;
+  final int? maxReconnectAttempts;
+  final double maxReconnectGapInSeconds;
   final bool enableStats;
   final String statsHost;
   final Map<String, AuthValue> timelineParams;

--- a/client-sdks/sockudo-flutter/lib/src/models.dart
+++ b/client-sdks/sockudo-flutter/lib/src/models.dart
@@ -34,6 +34,7 @@ const Set<int> allowedAppendRollupWindows = <int>{0, 20, 40, 100, 500};
 enum ConnectionState {
   initialized,
   connecting,
+  reconnecting,
   connected,
   disconnected,
   unavailable,

--- a/client-sdks/sockudo-flutter/test/sockudo_flutter_test.dart
+++ b/client-sdks/sockudo-flutter/test/sockudo_flutter_test.dart
@@ -381,7 +381,7 @@ void main() {
       final request = await server.first;
       queryBox.value = request.uri.queryParameters;
       final socket = await WebSocketTransformer.upgrade(request);
-      await socket.close();
+      await socket.done;
     }());
 
     final client = SockudoClient(
@@ -410,6 +410,7 @@ void main() {
     expect(query['append_mode'], 'full');
     expect(query['append_rollup_window'], '40');
     expect(query['token'], 'initial-token');
+    client.disconnect();
   });
 
   test('validates append rollup window values locally', () {
@@ -426,6 +427,61 @@ void main() {
     );
   });
 
+  test('reconnection options and state have parity defaults', () {
+    const options = SockudoOptions(cluster: 'local');
+
+    expect(ConnectionState.reconnecting.name, 'reconnecting');
+    expect(options.maxReconnectAttempts, 6);
+    expect(options.maxReconnectGapInSeconds, 120.0);
+  });
+
+  test('retries emit reconnecting and stop at the configured limit', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    var acceptedConnections = 0;
+    final serverSubscription = server.listen((request) async {
+      acceptedConnections += 1;
+      final socket = await WebSocketTransformer.upgrade(request);
+      await socket.close(4200, 'retry immediately');
+    });
+
+    final client = SockudoClient(
+      'app-key',
+      SockudoOptions(
+        cluster: 'local',
+        forceTls: false,
+        enabledTransports: const <SockudoTransport>[SockudoTransport.ws],
+        wsHost: '127.0.0.1',
+        wsPort: server.port,
+        maxReconnectAttempts: 2,
+        maxReconnectGapInSeconds: 0.0,
+      ),
+    );
+    final states = <String>[];
+    client.bind('state_change', (data, _) {
+      states.add((data as Map<Object?, Object?>)['current']! as String);
+    });
+    addTearDown(() async {
+      client.close();
+      await serverSubscription.cancel();
+      await server.close(force: true);
+    });
+
+    client.connect();
+    await _waitFor(() => states.contains('disconnected'));
+
+    expect(states.where((state) => state == 'reconnecting').length, 2);
+    expect(acceptedConnections, 3);
+
+    final connectionsBeforeExplicitConnect = acceptedConnections;
+    client.connect();
+    await _waitFor(
+      () => acceptedConnections > connectionsBeforeExplicitConnect,
+    );
+    await _waitFor(
+      () => states.where((state) => state == 'reconnecting').length > 2,
+    );
+  });
+
   test('uses v1 by default and omits the format query', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(() async {
@@ -437,7 +493,7 @@ void main() {
       final request = await server.first;
       queryBox.value = request.uri.queryParameters;
       final socket = await WebSocketTransformer.upgrade(request);
-      await socket.close();
+      await socket.done;
     }());
 
     final client = SockudoClient(
@@ -460,6 +516,7 @@ void main() {
     expect(query['protocol'], '7');
     expect(query.containsKey('format'), isFalse);
     expect(query.containsKey('append_mode'), isFalse);
+    client.disconnect();
   });
 
   test(

--- a/client-sdks/sockudo-js/README.md
+++ b/client-sdks/sockudo-js/README.md
@@ -103,6 +103,28 @@ Protocol V2 also supports `wireFormat: "messagepack"` and
 binary values. The MessagePack representation is the additive tagged variant
 `["binary", <bin>]`; existing wire variants remain unchanged.
 
+## Reconnection
+
+Unexpected disconnects emit the distinct `reconnecting` state and retry with a
+bounded quadratic delay: 0s, 1s, 4s, 9s, up to 120s. Protocol retry and
+TLS-upgrade close codes reconnect immediately. The default retry limit is six;
+set `maxReconnectAttempts: null` for unlimited retries.
+
+```ts
+const client = new Sockudo("app-key", {
+  cluster: "local",
+  maxReconnectAttempts: 10,
+  maxReconnectGapInSeconds: 60,
+});
+
+client.connection.bind("reconnecting", () => {
+  console.log("reconnecting");
+});
+```
+
+The attempt counter resets after a successful connection and on explicit
+`connect()` or `disconnect()` calls.
+
 ## Features
 
 Protocol V2 subscriptions can combine event names, tag filters, and a bounded

--- a/client-sdks/sockudo-js/src/core/config.ts
+++ b/client-sdks/sockudo-js/src/core/config.ts
@@ -26,6 +26,8 @@ export interface Config {
   pongTimeout: number;
   statsHost: string;
   unavailableTimeout: number;
+  maxReconnectAttempts: number | null;
+  maxReconnectGapInSeconds: number;
   useTLS: boolean;
   wsHost: string;
   wsPath: string;
@@ -61,6 +63,11 @@ export function getConfig(opts: Options, sockudo): Config {
     pongTimeout: opts.pongTimeout || Defaults.pongTimeout,
     statsHost: opts.statsHost || Defaults.stats_host,
     unavailableTimeout: opts.unavailableTimeout || Defaults.unavailableTimeout,
+    maxReconnectAttempts:
+      opts.maxReconnectAttempts === undefined
+        ? Defaults.maxReconnectAttempts
+        : opts.maxReconnectAttempts,
+    maxReconnectGapInSeconds: opts.maxReconnectGapInSeconds ?? Defaults.maxReconnectGapInSeconds,
     wsPath: opts.wsPath || Defaults.wsPath,
     wsPort: opts.wsPort || Defaults.wsPort,
     wssPort: opts.wssPort || Defaults.wssPort,

--- a/client-sdks/sockudo-js/src/core/connection/connection_manager.ts
+++ b/client-sdks/sockudo-js/src/core/connection/connection_manager.ts
@@ -27,6 +27,7 @@ import { prefixedEvent } from "../protocol_prefix";
  * States:
  * - initialized - initial state, never transitioned to
  * - connecting - connection is being established
+ * - reconnecting - a connection retry is being established
  * - connected - connection has been fully established
  * - disconnected - on requested disconnection
  * - unavailable - after connection timeout or when there's no network
@@ -36,6 +37,8 @@ import { prefixedEvent } from "../protocol_prefix";
  * - unavailableTimeout - time to transition to unavailable state
  * - activityTimeout - time after which ping message should be sent
  * - pongTimeout - time for server to respond with pong before reconnecting
+ * - maxReconnectAttempts - maximum retries before disconnecting; null is unlimited
+ * - maxReconnectGapInSeconds - cap for quadratic reconnect delay
  *
  * @param {String} key application key
  * @param {Object} options
@@ -57,6 +60,7 @@ export default class ConnectionManager extends EventsDispatcher {
   errorCallbacks: ErrorCallbacks;
   handshakeCallbacks: HandshakeCallbacks;
   connectionCallbacks: ConnectionCallbacks;
+  private reconnectAttempts: number;
 
   constructor(key: string, options: ConnectionManagerOptions) {
     super();
@@ -67,6 +71,7 @@ export default class ConnectionManager extends EventsDispatcher {
     this.options = options;
     this.timeline = this.options.timeline;
     this.usingTLS = this.options.useTLS;
+    this.reconnectAttempts = 0;
 
     this.errorCallbacks = this.buildErrorCallbacks();
     this.connectionCallbacks = this.buildConnectionCallbacks(this.errorCallbacks);
@@ -96,6 +101,10 @@ export default class ConnectionManager extends EventsDispatcher {
    * to find events emitted on connection attempts.
    */
   connect() {
+    this.connectWithState("connecting", true);
+  }
+
+  private connectWithState(state: "connecting" | "reconnecting", resetAttempts: boolean) {
     if (this.connection || this.runner) {
       return;
     }
@@ -103,7 +112,10 @@ export default class ConnectionManager extends EventsDispatcher {
       this.updateState("failed");
       return;
     }
-    this.updateState("connecting");
+    if (resetAttempts) {
+      this.reconnectAttempts = 0;
+    }
+    this.updateState(state);
     this.startConnecting();
     this.setUnavailableTimer();
   }
@@ -137,6 +149,7 @@ export default class ConnectionManager extends EventsDispatcher {
 
   /** Closes the connection. */
   disconnect() {
+    this.reconnectAttempts = 0;
     this.disconnectInternally();
     this.updateState("disconnected");
   }
@@ -191,14 +204,32 @@ export default class ConnectionManager extends EventsDispatcher {
   }
 
   private retryIn(delay) {
+    if (
+      this.options.maxReconnectAttempts !== null &&
+      this.reconnectAttempts >= this.options.maxReconnectAttempts
+    ) {
+      this.disconnectInternally();
+      this.updateState("disconnected");
+      return;
+    }
+    this.reconnectAttempts += 1;
+    this.clearRetryTimer();
     this.timeline.info({ action: "retry", delay: delay });
     if (delay > 0) {
       this.emit("connecting_in", Math.round(delay / 1000));
     }
     this.retryTimer = new Timer(delay || 0, () => {
       this.disconnectInternally();
-      this.connect();
+      this.connectWithState("reconnecting", false);
     });
+  }
+
+  private reconnectDelay(action?: "tls_only" | "backoff" | "retry"): number {
+    if (action === "retry" || action === "tls_only") {
+      return 0;
+    }
+    const intervalSeconds = this.reconnectAttempts * this.reconnectAttempts;
+    return Math.min(intervalSeconds, this.options.maxReconnectGapInSeconds) * 1000;
   }
 
   private clearRetryTimer() {
@@ -265,8 +296,8 @@ export default class ConnectionManager extends EventsDispatcher {
       },
       closed: () => {
         this.abandonConnection();
-        if (this.shouldRetry()) {
-          this.retryIn(1000);
+        if (this.shouldRetry() && !this.retryTimer) {
+          this.retryIn(this.reconnectDelay());
         }
       },
     });
@@ -281,6 +312,7 @@ export default class ConnectionManager extends EventsDispatcher {
           handshake.connection.activityTimeout || Infinity,
         );
         this.clearUnavailableTimer();
+        this.reconnectAttempts = 0;
         this.setConnection(handshake.connection);
         this.socket_id = this.connection.id;
         this.updateState("connected", { socket_id: this.socket_id });
@@ -302,16 +334,16 @@ export default class ConnectionManager extends EventsDispatcher {
       tls_only: withErrorEmitted(() => {
         this.usingTLS = true;
         this.updateStrategy();
-        this.retryIn(0);
+        this.retryIn(this.reconnectDelay("tls_only"));
       }),
       refused: withErrorEmitted(() => {
         this.disconnect();
       }),
       backoff: withErrorEmitted(() => {
-        this.retryIn(1000);
+        this.retryIn(this.reconnectDelay("backoff"));
       }),
       retry: withErrorEmitted(() => {
-        this.retryIn(0);
+        this.retryIn(this.reconnectDelay("retry"));
       }),
     };
   }
@@ -353,6 +385,8 @@ export default class ConnectionManager extends EventsDispatcher {
   }
 
   private shouldRetry(): boolean {
-    return this.state === "connecting" || this.state === "connected";
+    return (
+      this.state === "connecting" || this.state === "reconnecting" || this.state === "connected"
+    );
   }
 }

--- a/client-sdks/sockudo-js/src/core/connection/connection_manager_options.ts
+++ b/client-sdks/sockudo-js/src/core/connection/connection_manager_options.ts
@@ -9,6 +9,8 @@ interface ConnectionManagerOptions {
   pongTimeout: number;
   activityTimeout: number;
   useTLS: boolean;
+  maxReconnectAttempts: number | null;
+  maxReconnectGapInSeconds: number;
 }
 
 export default ConnectionManagerOptions;

--- a/client-sdks/sockudo-js/src/core/defaults.ts
+++ b/client-sdks/sockudo-js/src/core/defaults.ts
@@ -18,6 +18,8 @@ export interface DefaultConfig {
   activityTimeout: number;
   pongTimeout: number;
   unavailableTimeout: number;
+  maxReconnectAttempts: number;
+  maxReconnectGapInSeconds: number;
   userAuthentication: UserAuthenticationOptions;
   channelAuthorization: ChannelAuthorizationOptions;
 
@@ -47,6 +49,8 @@ const Defaults: DefaultConfig = {
   activityTimeout: 120000,
   pongTimeout: 30000,
   unavailableTimeout: 10000,
+  maxReconnectAttempts: 6,
+  maxReconnectGapInSeconds: 120,
   userAuthentication: {
     endpoint: "/sockudo/user-auth",
     transport: "fetch",

--- a/client-sdks/sockudo-js/src/core/options.ts
+++ b/client-sdks/sockudo-js/src/core/options.ts
@@ -43,6 +43,8 @@ export interface Options {
   messageDeduplication?: boolean;
   messageDeduplicationCapacity?: number;
   connectionRecovery?: boolean;
+  maxReconnectAttempts?: number | null;
+  maxReconnectGapInSeconds?: number;
   echoMessages?: boolean;
   enableStats?: boolean;
   disableStats?: boolean;

--- a/client-sdks/sockudo-js/src/core/sockudo.ts
+++ b/client-sdks/sockudo-js/src/core/sockudo.ts
@@ -139,6 +139,8 @@ export default class Sockudo {
       pongTimeout: this.config.pongTimeout,
       unavailableTimeout: this.config.unavailableTimeout,
       useTLS: Boolean(this.config.useTLS),
+      maxReconnectAttempts: this.config.maxReconnectAttempts,
+      maxReconnectGapInSeconds: this.config.maxReconnectGapInSeconds,
     });
 
     // Initialize message deduplication (enabled by default)
@@ -322,9 +324,11 @@ export default class Sockudo {
         this.global_emitter.emit(event.event, event.data);
       }
     });
-    this.connection.bind("connecting", () => {
+    const disconnectChannels = () => {
       this.channels.disconnect();
-    });
+    };
+    this.connection.bind("connecting", disconnectChannels);
+    this.connection.bind("reconnecting", disconnectChannels);
     this.connection.bind("disconnected", () => {
       this.channels.disconnect();
     });

--- a/client-sdks/sockudo-js/test/connection-manager-reconnection.test.ts
+++ b/client-sdks/sockudo-js/test/connection-manager-reconnection.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getConfig } from "../src/core/config";
+import ConnectionManager from "../src/core/connection/connection_manager";
+import EventsDispatcher from "../src/core/events/dispatcher";
+import type Strategy from "../src/core/strategies/strategy";
+import type Timeline from "../src/core/timeline/timeline";
+
+describe("connection manager reconnection", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses parity defaults and preserves null as unlimited", () => {
+    const defaults = getConfig({ cluster: "local" }, {});
+    const unlimited = getConfig({ cluster: "local", maxReconnectAttempts: null }, {});
+
+    expect(defaults.maxReconnectAttempts).toBe(6);
+    expect(defaults.maxReconnectGapInSeconds).toBe(120);
+    expect(unlimited.maxReconnectAttempts).toBeNull();
+  });
+
+  it("emits reconnecting and stops at the configured attempt limit", async () => {
+    vi.useFakeTimers();
+    const { callbacks, manager } = createManager({ maxReconnectAttempts: 1 });
+    const states: string[] = [];
+    manager.bind("state_change", ({ current }) => states.push(current));
+
+    manager.connect();
+    callbacks[0](null, { action: "backoff" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(states).toEqual(["connecting", "reconnecting"]);
+
+    callbacks[1](null, { action: "backoff" });
+
+    expect(manager.state).toBe("disconnected");
+    expect(states.at(-1)).toBe("disconnected");
+  });
+
+  it("uses quadratic capped delays and resets attempts after success", async () => {
+    vi.useFakeTimers();
+    const { callbacks, manager, timeline } = createManager({
+      maxReconnectAttempts: null,
+      maxReconnectGapInSeconds: 5,
+    });
+    const internals = manager as unknown as { reconnectAttempts: number };
+    internals.reconnectAttempts = 3;
+
+    manager.errorCallbacks.backoff({ action: "backoff" });
+
+    expect(timeline.info).toHaveBeenLastCalledWith({ action: "retry", delay: 5000 });
+
+    await vi.advanceTimersByTimeAsync(5000);
+    const connection = fakeConnection();
+    callbacks[0](null, {
+      action: "connected",
+      activityTimeout: 120_000,
+      connection,
+    });
+
+    expect(manager.state).toBe("connected");
+    expect(internals.reconnectAttempts).toBe(0);
+
+    timeline.info.mockClear();
+    manager.errorCallbacks.retry({ action: "retry" });
+    manager.connectionCallbacks.closed();
+
+    expect(timeline.info).toHaveBeenCalledTimes(1);
+    expect(timeline.info).toHaveBeenLastCalledWith({ action: "retry", delay: 0 });
+
+    manager.disconnect();
+    internals.reconnectAttempts = 4;
+    manager.connect();
+
+    expect(internals.reconnectAttempts).toBe(0);
+  });
+});
+
+function createManager(
+  overrides: Partial<{
+    maxReconnectAttempts: number | null;
+    maxReconnectGapInSeconds: number;
+  }> = {},
+) {
+  const callbacks: Array<(error: unknown, handshake: any) => void> = [];
+  const strategy: Strategy = {
+    isSupported: () => true,
+    connect: (_priority, callback) => {
+      callbacks.push(callback);
+      return { abort: vi.fn(), forceMinPriority: vi.fn() };
+    },
+  };
+  const timeline = {
+    info: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Timeline & { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+  const manager = new ConnectionManager("app-key", {
+    timeline,
+    getStrategy: () => strategy,
+    unavailableTimeout: 10_000,
+    pongTimeout: 30_000,
+    activityTimeout: 120_000,
+    useTLS: false,
+    maxReconnectAttempts:
+      overrides.maxReconnectAttempts === undefined ? 6 : overrides.maxReconnectAttempts,
+    maxReconnectGapInSeconds: overrides.maxReconnectGapInSeconds ?? 120,
+  });
+
+  return { callbacks, manager, timeline };
+}
+
+function fakeConnection() {
+  const connection = new EventsDispatcher() as EventsDispatcher & {
+    id: string;
+    activityTimeout: number;
+    handlesActivityChecks: () => boolean;
+    close: () => void;
+  };
+  connection.id = "1.1";
+  connection.activityTimeout = 120_000;
+  connection.handlesActivityChecks = () => true;
+  connection.close = vi.fn();
+  return connection;
+}

--- a/client-sdks/sockudo-js/types/core/config.d.ts
+++ b/client-sdks/sockudo-js/types/core/config.d.ts
@@ -13,6 +13,8 @@ export interface Config {
     pongTimeout: number;
     statsHost: string;
     unavailableTimeout: number;
+    maxReconnectAttempts: number | null;
+    maxReconnectGapInSeconds: number;
     useTLS: boolean;
     wsHost: string;
     wsPath: string;

--- a/client-sdks/sockudo-js/types/core/connection/connection_manager.d.ts
+++ b/client-sdks/sockudo-js/types/core/connection/connection_manager.d.ts
@@ -23,8 +23,10 @@ export default class ConnectionManager extends EventsDispatcher {
     errorCallbacks: ErrorCallbacks;
     handshakeCallbacks: HandshakeCallbacks;
     connectionCallbacks: ConnectionCallbacks;
+    private reconnectAttempts;
     constructor(key: string, options: ConnectionManagerOptions);
     connect(): void;
+    private connectWithState;
     send(data: any): boolean;
     send_event(name: string, data: any, channel?: string): boolean;
     disconnect(): void;
@@ -34,6 +36,7 @@ export default class ConnectionManager extends EventsDispatcher {
     private disconnectInternally;
     private updateStrategy;
     private retryIn;
+    private reconnectDelay;
     private clearRetryTimer;
     private setUnavailableTimer;
     private clearUnavailableTimer;

--- a/client-sdks/sockudo-js/types/core/connection/connection_manager_options.d.ts
+++ b/client-sdks/sockudo-js/types/core/connection/connection_manager_options.d.ts
@@ -7,5 +7,7 @@ interface ConnectionManagerOptions {
     pongTimeout: number;
     activityTimeout: number;
     useTLS: boolean;
+    maxReconnectAttempts: number | null;
+    maxReconnectGapInSeconds: number;
 }
 export default ConnectionManagerOptions;

--- a/client-sdks/sockudo-js/types/core/defaults.d.ts
+++ b/client-sdks/sockudo-js/types/core/defaults.d.ts
@@ -16,6 +16,8 @@ export interface DefaultConfig {
     activityTimeout: number;
     pongTimeout: number;
     unavailableTimeout: number;
+    maxReconnectAttempts: number;
+    maxReconnectGapInSeconds: number;
     userAuthentication: UserAuthenticationOptions;
     channelAuthorization: ChannelAuthorizationOptions;
     cdn_http?: string;

--- a/client-sdks/sockudo-js/types/core/options.d.ts
+++ b/client-sdks/sockudo-js/types/core/options.d.ts
@@ -19,6 +19,8 @@ export interface Options {
     messageDeduplication?: boolean;
     messageDeduplicationCapacity?: number;
     connectionRecovery?: boolean;
+    maxReconnectAttempts?: number | null;
+    maxReconnectGapInSeconds?: number;
     echoMessages?: boolean;
     enableStats?: boolean;
     disableStats?: boolean;

--- a/client-sdks/sockudo-js/vitest.config.ts
+++ b/client-sdks/sockudo-js/vitest.config.ts
@@ -2,6 +2,13 @@ import { defineConfig } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
+  define: {
+    RUNTIME: JSON.stringify("node"),
+    VERSION: JSON.stringify("2.1.0"),
+    CDN_HTTP: JSON.stringify("//js.pusher.com/"),
+    CDN_HTTPS: JSON.stringify("//js.pusher.com/"),
+    DEPENDENCY_SUFFIX: JSON.stringify(""),
+  },
   resolve: {
     alias: {
       runtime: path.resolve(__dirname, "src/runtimes/node/runtime.ts"),

--- a/client-sdks/sockudo-kotlin/README.md
+++ b/client-sdks/sockudo-kotlin/README.md
@@ -319,6 +319,30 @@ runBlocking {
 }
 ```
 
+### Reconnection
+
+Unexpected disconnects emit `ConnectionState.RECONNECTING` and retry with a
+bounded quadratic delay of 0s, 1s, 4s, 9s, up to 120s. Protocol retry and
+TLS-upgrade close codes reconnect immediately. The default limit is six
+attempts; `null` enables unlimited retries.
+
+```kotlin
+val client =
+    SockudoClient(
+        "app-key",
+        SockudoOptions(
+            cluster = "local",
+            maxReconnectAttempts = 10,
+            maxReconnectGapInSeconds = 60.0,
+        ),
+    )
+
+client.bind("reconnecting") { _, _ -> println("reconnecting") }
+```
+
+The attempt counter resets after a successful connection and on explicit
+`connect()` or `disconnect()` calls.
+
 ### Encrypted Channels
 
 `private-encrypted-*` channels use the `shared_secret` returned by your auth handler. Payload decryption is handled automatically.

--- a/client-sdks/sockudo-kotlin/lib/src/test/kotlin/io/sockudo/client/ReconnectionTest.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/test/kotlin/io/sockudo/client/ReconnectionTest.kt
@@ -79,10 +79,8 @@ class ReconnectionTest {
                 """{"event":"sockudo:connection_established","data":{"socket_id":"1.1","activity_timeout":120}}""",
             )
 
-            repeat(3) {
-                invokeHandleSocketClosed(client, 4100, null)
-                delay(50)
-            }
+            setReconnectAttempts(client, 2)
+            invokeHandleSocketClosed(client, 4100, null)
 
             waitFor { "disconnected" in stateChanges }
             assertTrue("disconnected" in stateChanges, "Expected DISCONNECTED after max attempts, got: $stateChanges")
@@ -165,6 +163,12 @@ class ReconnectionTest {
         val field = SockudoClient::class.java.getDeclaredField("reconnectAttempts")
         field.isAccessible = true
         return field.getInt(client)
+    }
+
+    private fun setReconnectAttempts(client: SockudoClient, attempts: Int) {
+        val field = SockudoClient::class.java.getDeclaredField("reconnectAttempts")
+        field.isAccessible = true
+        field.setInt(client, attempts)
     }
 
     private suspend fun waitFor(timeoutMs: Long = 2_000, condition: () -> Boolean) {

--- a/client-sdks/sockudo-python/README.md
+++ b/client-sdks/sockudo-python/README.md
@@ -362,19 +362,27 @@ await client.user.sign_in()
 Bind to connection state changes to react to connect, disconnect, and reconnect events:
 
 ```python
-def on_state_change(change) -> None:
-    print(f"connection: {change.previous} -> {change.current}")
+def on_state_change(change, _) -> None:
+    print(f"connection: {change['previous']} -> {change['current']}")
 
 
-client.connection.bind("state_change", on_state_change)
-client.connection.bind(
+client.bind("state_change", on_state_change)
+client.bind(
     "connected", lambda data, _: print("socket id:", data.get("socket_id"))
 )
-client.connection.bind("disconnected", lambda data, _: print("disconnected"))
-client.connection.bind("error", lambda data, _: print("error:", data))
+client.bind("reconnecting", lambda *_: print("reconnecting"))
+client.bind("disconnected", lambda *_: print("disconnected"))
+client.bind("error", lambda data, _: print("error:", data))
 
 await client.connect()
 ```
+
+Unexpected disconnects retry with a quadratic delay of 0s, 1s, 4s, 9s, up to
+120s by default. Protocol retry and TLS-upgrade close codes reconnect
+immediately. Configure `max_reconnect_attempts` (default `6`, `None` for
+unlimited) and `max_reconnect_gap_in_seconds` in `SockudoOptions`. The attempt
+counter resets after a successful connection and on explicit connect or
+disconnect calls.
 
 ### Protocol V2
 

--- a/client-sdks/sockudo-python/README.md
+++ b/client-sdks/sockudo-python/README.md
@@ -367,9 +367,7 @@ def on_state_change(change, _) -> None:
 
 
 client.bind("state_change", on_state_change)
-client.bind(
-    "connected", lambda data, _: print("socket id:", data.get("socket_id"))
-)
+client.bind("connected", lambda data, _: print("socket id:", data.get("socket_id")))
 client.bind("reconnecting", lambda *_: print("reconnecting"))
 client.bind("disconnected", lambda *_: print("disconnected"))
 client.bind("error", lambda data, _: print("error:", data))

--- a/client-sdks/sockudo-python/src/sockudo_python/client.py
+++ b/client-sdks/sockudo-python/src/sockudo_python/client.py
@@ -68,10 +68,18 @@ _TOKEN_REFRESH_CODES = {40142, 40160}
 class ConnectionState(str, Enum):
     INITIALIZED = "initialized"
     CONNECTING = "connecting"
+    RECONNECTING = "reconnecting"
     CONNECTED = "connected"
     DISCONNECTED = "disconnected"
     UNAVAILABLE = "unavailable"
     FAILED = "failed"
+
+
+class _CloseAction(str, Enum):
+    TLS_ONLY = "tls_only"
+    REFUSED = "refused"
+    BACKOFF = "backoff"
+    RETRY = "retry"
 
 
 class SockudoTransport(str, Enum):
@@ -488,6 +496,8 @@ class SockudoOptions:
     wire_format: SockudoWireFormat = SockudoWireFormat.JSON
     append_mode: AppendMode = AppendMode.DELTA
     append_rollup_window: Optional[int] = None
+    max_reconnect_attempts: Optional[int] = 6
+    max_reconnect_gap_in_seconds: float = 120.0
     token: Optional[str] = None
     auth_callback: Optional[TokenAuthCallback] = None
     auth_refresh_leeway_seconds: float = 30.0
@@ -1926,6 +1936,8 @@ class _ResolvedConfiguration:
         self.http_path = options.http_path
         self.pong_timeout = options.pong_timeout
         self.unavailable_timeout = options.unavailable_timeout
+        self.max_reconnect_attempts = options.max_reconnect_attempts
+        self.max_reconnect_gap_in_seconds = options.max_reconnect_gap_in_seconds
         self.enabled_transports = options.enabled_transports
         self.disabled_transports = options.disabled_transports
         self.channel_options = options.channel_authorization
@@ -2497,6 +2509,7 @@ class SockudoClient:
         self._manually_disconnected = False
         self._current_transport: Optional[SockudoTransport] = None
         self._attempted_fallback = False
+        self._reconnect_attempts = 0
         self._auth_token: Optional[str] = options.token
         (
             self._auth_token_expires_at,
@@ -2570,12 +2583,14 @@ class SockudoClient:
             return
         self._manually_disconnected = False
         self._attempted_fallback = False
+        self._reconnect_attempts = 0
         self._update_state(ConnectionState.CONNECTING)
         await self._open_websocket(transports[0])
         self._set_unavailable_timer()
 
     async def disconnect(self) -> None:
         self._manually_disconnected = True
+        self._reconnect_attempts = 0
         self._cancel_timers()
         if self.socket is not None:
             await self.socket.close()
@@ -2644,6 +2659,8 @@ class SockudoClient:
                 self.socket_id = payload.get("socket_id")
                 if not isinstance(self.socket_id, str):
                     raise SockudoException("Invalid handshake")
+                self._reconnect_attempts = 0
+                self._clear_unavailable_timer()
                 self._update_state(
                     ConnectionState.CONNECTED, {"socket_id": self.socket_id}
                 )
@@ -2785,20 +2802,41 @@ class SockudoClient:
         self._cancel_auth_refresh_task()
         for channel in self.channels.values():
             channel.disconnect()
-        if not self._manually_disconnected:
-            await self._schedule_retry(1.0)
+        action = self._close_action(code)
+        if action is _CloseAction.TLS_ONLY:
+            self.config.use_tls = True
+            await self._schedule_retry(self._reconnect_delay(action))
+        elif action is _CloseAction.BACKOFF:
+            await self._schedule_retry(self._reconnect_delay(action))
+        elif action is _CloseAction.RETRY:
+            await self._schedule_retry(self._reconnect_delay(action))
+        elif action is _CloseAction.REFUSED:
+            self._update_state(ConnectionState.DISCONNECTED)
+        elif not self._manually_disconnected:
+            await self._schedule_retry(self._reconnect_delay(None))
         if reason:
             self.dispatcher.emit("error", reason)
+
+    def _reconnect_delay(self, action: Optional[_CloseAction]) -> float:
+        if action in {_CloseAction.RETRY, _CloseAction.TLS_ONLY}:
+            return 0.0
+        interval_seconds = float(self._reconnect_attempts**2)
+        return min(interval_seconds, self.config.max_reconnect_gap_in_seconds)
 
     async def _schedule_retry(self, after_seconds: float) -> None:
         if self._manually_disconnected:
             return
+        max_attempts = self.config.max_reconnect_attempts
+        if max_attempts is not None and self._reconnect_attempts >= max_attempts:
+            self._update_state(ConnectionState.DISCONNECTED)
+            return
+        self._reconnect_attempts += 1
         if self._retry_task:
             self._retry_task.cancel()
 
         async def _retry() -> None:
             await asyncio.sleep(after_seconds)
-            self._update_state(ConnectionState.CONNECTING)
+            self._update_state(ConnectionState.RECONNECTING)
             transports = self._transport_sequence()
             if (
                 self._current_transport is SockudoTransport.WS
@@ -2815,6 +2853,20 @@ class SockudoClient:
             self._set_unavailable_timer()
 
         self._retry_task = asyncio.create_task(_retry())
+
+    @staticmethod
+    def _close_action(code: int) -> Optional[_CloseAction]:
+        if code < 4000:
+            return _CloseAction.BACKOFF if 1002 <= code <= 1004 else None
+        if code == 4000:
+            return _CloseAction.TLS_ONLY
+        if code < 4100:
+            return _CloseAction.REFUSED
+        if code < 4200:
+            return _CloseAction.BACKOFF
+        if code < 4300:
+            return _CloseAction.RETRY
+        return _CloseAction.REFUSED
 
     def _socket_url(self, transport: SockudoTransport) -> str:
         scheme = "wss" if transport is SockudoTransport.WSS else "ws"

--- a/client-sdks/sockudo-python/tests/test_client.py
+++ b/client-sdks/sockudo-python/tests/test_client.py
@@ -168,6 +168,102 @@ def test_rejects_invalid_append_rollup_window() -> None:
         )
 
 
+def test_reconnection_options_and_state_defaults() -> None:
+    options = SockudoOptions(cluster="local")
+
+    assert ConnectionState.RECONNECTING.value == "reconnecting"
+    assert options.max_reconnect_attempts == 6
+    assert options.max_reconnect_gap_in_seconds == 120.0
+
+
+@pytest.mark.asyncio
+async def test_retry_emits_reconnecting_and_stops_at_max_attempts() -> None:
+    client = SockudoClient(
+        "app-key",
+        SockudoOptions(
+            cluster="local",
+            force_tls=False,
+            enabled_transports=[SockudoTransport.WS],
+            max_reconnect_attempts=1,
+        ),
+    )
+    states: list[str] = []
+    opened: list[SockudoTransport] = []
+
+    async def fake_open_websocket(transport: SockudoTransport) -> None:
+        opened.append(transport)
+
+    client._open_websocket = fake_open_websocket  # type: ignore[method-assign]
+    client.bind("state_change", lambda change, _: states.append(change["current"]))
+
+    await client._schedule_retry(0)
+    assert client._retry_task is not None
+    await client._retry_task
+
+    assert states == ["reconnecting"]
+    assert opened == [SockudoTransport.WS]
+
+    await client._schedule_retry(0)
+
+    assert client.connection_state is ConnectionState.DISCONNECTED
+    assert states[-1] == "disconnected"
+    client._cancel_timers()
+    await client.config.close()
+
+
+@pytest.mark.asyncio
+async def test_close_actions_use_quadratic_capped_delay() -> None:
+    client = SockudoClient(
+        "app-key",
+        SockudoOptions(
+            cluster="local",
+            force_tls=False,
+            max_reconnect_attempts=None,
+            max_reconnect_gap_in_seconds=5.0,
+        ),
+    )
+    delays: list[float] = []
+
+    async def capture_retry(delay: float) -> None:
+        delays.append(delay)
+
+    client._schedule_retry = capture_retry  # type: ignore[method-assign]
+    client._reconnect_attempts = 3
+
+    await client._handle_socket_closed(4100, "")
+    await client._handle_socket_closed(4200, "")
+    await client._handle_socket_closed(4000, "")
+
+    assert delays == [5.0, 0.0, 0.0]
+    assert client.config.use_tls is True
+    await client.config.close()
+
+
+@pytest.mark.asyncio
+async def test_connect_and_disconnect_reset_reconnect_attempts() -> None:
+    client = SockudoClient(
+        "app-key",
+        SockudoOptions(
+            cluster="local",
+            force_tls=False,
+            enabled_transports=[SockudoTransport.WS],
+        ),
+    )
+
+    async def fake_open_websocket(_: SockudoTransport) -> None:
+        return None
+
+    client._open_websocket = fake_open_websocket  # type: ignore[method-assign]
+    client._reconnect_attempts = 3
+
+    await client.connect()
+    assert client._reconnect_attempts == 0
+
+    client._reconnect_attempts = 4
+    await client.disconnect()
+    assert client._reconnect_attempts == 0
+
+
 def test_subscribe_tracks_event_filters() -> None:
     client = SockudoClient("app-key", SockudoOptions(cluster="local", force_tls=False))
 
@@ -341,6 +437,7 @@ def test_connection_recovery_uses_channel_positions_payload() -> None:
         stream_id="stream-1",
         last_message_id="msg-42",
     )
+    client._reconnect_attempts = 4
 
     payload = json.dumps(
         {
@@ -351,6 +448,7 @@ def test_connection_recovery_uses_channel_positions_payload() -> None:
 
     asyncio.run(client._handle_raw_message(payload))
 
+    assert client._reconnect_attempts == 0
     resume_event = next(item for item in sent if item[0] == "sockudo:resume")
     assert resume_event[1] == {
         "channel_positions": {

--- a/client-sdks/sockudo-swift/README.md
+++ b/client-sdks/sockudo-swift/README.md
@@ -442,12 +442,12 @@ dispatch is needed — it already runs off-main.
 
 ### Reconnection
 
-On disconnect, the client reconnects automatically using exponential backoff:
+On disconnect, the client reconnects automatically using quadratic backoff:
 
-- Delay formula: `attempt² seconds` (1s, 4s, 9s, 16s, 25s, ...)
+- Delay formula: `attempt² seconds` (0s, 1s, 4s, 9s, 16s, ...)
 - Maximum delay: 120 seconds (configurable via `Options.maxReconnectGapInSeconds`)
 - Maximum attempts: 6 (configurable via `Options.maxReconnectAttempts`, `nil` = unlimited)
-- Counter resets on successful connection
+- Counter resets on a successful connection and on explicit `connect()` or `disconnect()` calls
 
 ```swift
 let client = try SockudoClient(

--- a/docs/content/docs/clients/dotnet.mdx
+++ b/docs/content/docs/clients/dotnet.mdx
@@ -64,6 +64,8 @@ client.Bind("connected", (_, _) =>
     Console.WriteLine($"socket id: {client.SocketId}"));
 client.Bind("connecting", (_, _) =>
     Console.WriteLine("connecting"));
+client.Bind("reconnecting", (_, _) =>
+    Console.WriteLine("reconnecting"));
 client.Bind("error", (error, _) =>
     Console.Error.WriteLine(error));
 
@@ -81,6 +83,12 @@ client.Unbind("state_change", stateToken);
 await client.UnsubscribeAsync("public-updates");
 await client.DisconnectAsync();
 ```
+
+Unexpected disconnects use quadratic backoff (0s, 1s, 4s, 9s) capped at 120
+seconds and emit `ConnectionState.Reconnecting`. Set `MaxReconnectAttempts`
+(default `6`, `null` for unlimited) and `MaxReconnectGapInSeconds` in
+`SockudoOptions`. Protocol retry and TLS-upgrade close codes reconnect
+immediately.
 
 ## Auth
 

--- a/docs/content/docs/clients/flutter.mdx
+++ b/docs/content/docs/clients/flutter.mdx
@@ -77,6 +77,20 @@ live. Unsubscribe in the owning service or controller's disposal path, and
 disconnect on explicit sign-out or process shutdown. Let the SDK handle
 temporary transport failures and resubscription.
 
+Unexpected disconnects emit `ConnectionState.reconnecting` and use quadratic
+backoff (0s, 1s, 4s, 9s) capped at 120 seconds. Configure
+`maxReconnectAttempts` (default `6`, `null` for unlimited) and
+`maxReconnectGapInSeconds`; protocol retry and TLS-upgrade close codes remain
+immediate.
+
+```dart
+const options = SockudoOptions(
+  cluster: 'local',
+  maxReconnectAttempts: 10,
+  maxReconnectGapInSeconds: 60,
+);
+```
+
 ## Auth
 
 ```dart

--- a/docs/content/docs/clients/javascript.mdx
+++ b/docs/content/docs/clients/javascript.mdx
@@ -100,6 +100,21 @@ client.disconnect();
 Framework hooks clean up their own bindings when components unmount. When using
 the core client directly, lifecycle cleanup is your responsibility.
 
+Unexpected disconnects emit `reconnecting` and use quadratic backoff (0s, 1s,
+4s, 9s) capped at 120 seconds. Configure `maxReconnectAttempts` (default `6`,
+`null` for unlimited) and `maxReconnectGapInSeconds`; protocol retry and
+TLS-upgrade close codes remain immediate.
+
+```ts
+const client = new Sockudo("app-key", {
+  cluster: "local",
+  maxReconnectAttempts: 10,
+  maxReconnectGapInSeconds: 60,
+});
+
+client.connection.bind("reconnecting", () => console.log("reconnecting"));
+```
+
 ## Binary wire formats
 
 Protocol V2 can negotiate JSON, MessagePack, or Protobuf with `wireFormat`.

--- a/docs/content/docs/clients/kotlin.mdx
+++ b/docs/content/docs/clients/kotlin.mdx
@@ -90,6 +90,12 @@ as live. Unsubscribe and unbind when an Android lifecycle owner no longer needs
 updates; disconnect on explicit sign-out. A temporary network loss should be
 left to the SDK's reconnect path.
 
+Unexpected disconnects emit `ConnectionState.RECONNECTING` and use quadratic
+backoff (0s, 1s, 4s, 9s) capped at 120 seconds. Configure
+`maxReconnectAttempts` (default `6`, `null` for unlimited) and
+`maxReconnectGapInSeconds`; protocol retry and TLS-upgrade close codes remain
+immediate.
+
 ## Auth
 
 ```kotlin

--- a/docs/content/docs/clients/python.mdx
+++ b/docs/content/docs/clients/python.mdx
@@ -74,6 +74,8 @@ inside a callback. Schedule or await that work in an async task instead.
 | `force_tls` | Select `wss://` when true | Enable outside local development |
 | `protocol_version` | `2` for Sockudo-native features; `1` for Pusher compatibility | Prefer `2` for new applications |
 | `connection_recovery` | Resume from the last `stream_id` and `serial` | Enable when missed events matter |
+| `max_reconnect_attempts` | Retry limit; `None` means unlimited | Defaults to `6` |
+| `max_reconnect_gap_in_seconds` | Maximum quadratic backoff delay | Defaults to `120.0` seconds |
 | `wire_format` | JSON, MessagePack, or Protobuf | Use a binary format only when every endpoint supports it |
 
 `cluster` remains required by the options type, but a custom `ws_host` is the
@@ -94,6 +96,7 @@ client.bind(
     lambda data, _: print("socket id:", data.get("socket_id")),
 )
 client.bind("connecting", lambda *_: print("connecting"))
+client.bind("reconnecting", lambda *_: print("reconnecting"))
 client.bind("error", lambda error, _: print("error:", error))
 ```
 
@@ -106,7 +109,9 @@ await client.unsubscribe("public-updates")
 
 `await client.close()` is an alias for `disconnect()`. A manual disconnect
 stops reconnect timers; an unexpected transport failure uses the client's
-reconnect policy.
+reconnect policy. Retries emit `reconnecting` and use quadratic backoff (0s,
+1s, 4s, 9s) capped by `max_reconnect_gap_in_seconds`; protocol retry and
+TLS-upgrade close codes remain immediate.
 
 ## Private and presence authorization
 

--- a/docs/content/docs/clients/swift.mdx
+++ b/docs/content/docs/clients/swift.mdx
@@ -89,11 +89,12 @@ Keep the `EventBindingToken` returned by `bind` when you want to remove one
 handler with `unbind(eventName:token:)`; call `unbindAll()` only when the
 channel owner is being torn down.
 
-Unexpected disconnects reconnect with bounded exponential backoff. Tune
+Unexpected disconnects reconnect with bounded quadratic backoff. Tune
 `maxReconnectAttempts` and `maxReconnectGapInSeconds` for the app's foreground
-and background policy. Client events emitted while disconnected are buffered
-up to 50 per channel and replayed after subscription; unsubscribing clears that
-buffer.
+and background policy. The attempt counter resets after a successful connection
+and on explicit `connect()` or `disconnect()` calls. Client events emitted while
+disconnected are buffered up to 50 per channel and replayed after subscription;
+unsubscribing clears that buffer.
 
 ## Auth
 


### PR DESCRIPTION
## Summary

- align the .NET, Flutter, JavaScript, and Python realtime clients with the reconnection contract introduced in #338
- expose the `reconnecting` state, six-attempt default (`null`/`None` for unlimited), quadratic capped delay, immediate retry/TLS close actions, and counter resets
- update the AI Transport connection-state union, SDK documentation, and client docs
- add focused regression coverage and stabilize the existing Kotlin reconnection boundary test

## Impact

All official realtime clients now expose consistent reconnection states and retry controls. Unexpected disconnects retry at 0s, 1s, 4s, 9s, and so on, capped at 120 seconds by default, while protocol retry and TLS-upgrade close actions remain immediate.

## Validation

- .NET: 47 tests passed
- Flutter: 36 tests passed; `flutter analyze` passed
- JavaScript: 52 tests passed; typecheck/lint and all builds passed
- Python: 46 tests passed; Ruff formatting and checks passed
- Kotlin: 9 reconnection tests passed
- Swift: 8 reconnection tests passed
- AI Transport: 209 tests passed; typecheck, formatting, and all builds passed
- Docs: typecheck passed and all 205 pages built

## Known existing check failure

`pnpm api:snapshot` in `sockudo-ai-transport-js` already fails on the base branch because the checked-in declaration still has the old generic `unrespondedSteerIds<TMessage>` signature. Commit `d34f649c` removed that unused generic from the source without regenerating the snapshot; this PR does not touch that API.
