### PR TITLE
Fix React Native client entrypoint

### DIFF
--- a/client-sdks/sockudo-js/react-native/index.js
+++ b/client-sdks/sockudo-js/react-native/index.js
@@ -1,3 +1,3 @@
-import Pusher from "../dist/react-native/pusher.js";
+import Pusher from "../dist/react-native/sockudo.js";
 
 export default Pusher;

--- a/client-sdks/sockudo-js/test/esm-only.test.ts
+++ b/client-sdks/sockudo-js/test/esm-only.test.ts
@@ -22,4 +22,20 @@ describe("esm-only packaging", () => {
     expect(JSON.stringify(packageJson.exports).includes(".cjs")).toBe(false);
     expect(JSON.stringify(packageJson.exports).includes('"require"')).toBe(false);
   });
+
+  it("points explicit mobile entrypoints at their Sockudo builds", () => {
+    const reactNativeEntry = readFileSync(
+      join(currentDir, "..", "react-native", "index.js"),
+      "utf8",
+    );
+    const nativeScriptEntry = readFileSync(
+      join(currentDir, "..", "nativescript", "index.js"),
+      "utf8",
+    );
+
+    expect(reactNativeEntry).toContain('from "../dist/react-native/sockudo.js"');
+    expect(nativeScriptEntry).toContain('from "../dist/nativescript/sockudo.js"');
+    expect(reactNativeEntry).not.toContain("pusher.js");
+    expect(nativeScriptEntry).not.toContain("pusher.js");
+  });
 });


### PR DESCRIPTION
## Summary

- point the explicit React Native entrypoint at the generated `dist/react-native/sockudo.js` bundle
- add regression coverage for both React Native and NativeScript mobile entrypoints
- confirm NativeScript already targets `dist/nativescript/sockudo.js` and does not have the same bug

## Root cause

The React Native build was renamed to `sockudo.js`, but the explicit `@sockudo/client/react-native` wrapper still imported the old `pusher.js` filename. Consumers using that subpath therefore resolved a file that is not included in the package.

## Validation

- `bun run test test/esm-only.test.ts test/nativescript-runtime.test.ts`
- `bun run format:check`
- `bun run check` (53 tests)
- `bun run build:all`
- `npm pack --dry-run`

Fixes #351
