### PR TITLE
Fix: don't hold DashMap shard guard across `.await` in `/stats` handler

### DIFF
--- a/crates/sockudo-server/src/http_handler/system.rs
+++ b/crates/sockudo-server/src/http_handler/system.rs
@@ -182,11 +182,18 @@ pub async fn stats(
         app_stat.occupancy.channels = channel_names.len();
         app_stat.occupancy.subscriptions = namespace.channels.iter().map(|entry| entry.len()).sum();
 
-        for socket in namespace.sockets.iter() {
-            if socket.value().get_user_id().await.is_some() {
+        // Snapshotted first: holding this iter's shard guard across the awaits below
+        // can deadlock against add_socket()'s insert on the same shard.
+        let socket_refs: Vec<_> = namespace
+            .sockets
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect();
+        for socket in socket_refs {
+            if socket.get_user_id().await.is_some() {
                 app_stat.authenticated_connections += 1;
             }
-            if socket.value().get_connection_meta().await.is_some() {
+            if socket.get_connection_meta().await.is_some() {
                 app_stat.connections_with_meta += 1;
             }
         }


### PR DESCRIPTION
Closes #366.

## Problem

`stats()` iterates `namespace.sockets.iter()` and awaits inside the loop. The `DashMap` shard read-guard from `.iter()` stays alive across those awaits. Under connection load, an incoming connection's `add_socket` does `self.sockets.insert(...)` that needs a write lock on the same shard and blocks behind it. Since `stats()` won't drop the guard until every socket in that shard has been awaited, this can freeze the accept loop entirely on runtimes with few worker threads.

## Fix

Collect the socket refs into a `Vec` first (cheap `WebSocketRef` clone), then iterate the snapshot. The shard guard from `.iter()` is dropped as soon as the `.collect()` finishes, before any `.await`.

No behavior change: same sockets are checked, same counts computed. Purely a lock-scope fix.

## Testing

- `cargo check -p sockudo` clean.
- Not yet load-tested against this exact upstream revision (we validated the same fix pattern against our own fork previously, under a connection ramp with `/stats` polled every 300ms, which is what originally triggered this). Happy to re-run against `master` if useful before merge.

## Scope

This PR only fixes the guard-across-await pattern in `stats()`. `stats()` is still O(N) `DashMap`-mutex-locks per poll - a separate, non-deadlocking perf concern or a follow-up.