### PR TITLE
fix(webhook): skip count queries for channels excluded by webhook filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8016,6 +8016,7 @@ dependencies = [
  "sockudo-filter",
  "sockudo-metrics",
  "sockudo-protocol",
+ "sockudo-queue",
  "sockudo-webhook",
  "sockudo-ws",
  "sonic-rs",

--- a/crates/sockudo-adapter/Cargo.toml
+++ b/crates/sockudo-adapter/Cargo.toml
@@ -70,6 +70,7 @@ chrono = { workspace = true }
 md5 = { workspace = true }
 sockudo-app = { workspace = true }
 sockudo-cache = { workspace = true, features = ["redis"] }
+sockudo-queue = { workspace = true }
 num_cpus = { workspace = true }
 papaya = { workspace = true }
 criterion = { workspace = true }

--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -160,10 +160,17 @@ impl ConnectionHandler {
 
         // Skip count reads entirely when this leave cannot produce an observable
         // count-derived event.
-        let wants_channel_vacated_webhook =
-            self.subscription_count_webhook_configured(app_config, "channel_vacated");
-        let wants_subscription_count_webhook =
-            self.subscription_count_webhook_configured(app_config, "subscription_count");
+        let wants_channel_vacated_webhook = self.subscription_count_webhook_configured_for_channel(
+            app_config,
+            "channel_vacated",
+            channel_name,
+        );
+        let wants_subscription_count_webhook = self
+            .subscription_count_webhook_configured_for_channel(
+                app_config,
+                "subscription_count",
+                channel_name,
+            );
         let wants_meta_channel = self
             .subscription_count_meta_channel_has_local_subscriber(app_config, channel_name)
             .await;
@@ -231,14 +238,17 @@ impl ConnectionHandler {
         Ok(())
     }
 
-    pub(crate) fn subscription_count_webhook_configured(
+    pub(crate) fn subscription_count_webhook_configured_for_channel(
         &self,
         app_config: &App,
         event_type: &str,
+        channel: &str,
     ) -> bool {
         self.webhook_integration
             .as_ref()
-            .is_some_and(|integration| integration.webhook_configured(app_config, event_type))
+            .is_some_and(|integration| {
+                integration.wants_channel_count_webhook(app_config, event_type, channel)
+            })
     }
 
     /// Returns true when this node has local subscribers for the channel's
@@ -850,7 +860,11 @@ impl ConnectionHandler {
         // Per Pusher spec: delay prevents spurious webhooks from momentary disconnects
         if current_sub_count == 0
             && let Some(webhook_integration) = &self.webhook_integration
-            && webhook_integration.webhook_configured(app_config, "channel_vacated")
+            && webhook_integration.wants_channel_count_webhook(
+                app_config,
+                "channel_vacated",
+                channel_str,
+            )
         {
             let wi = Arc::clone(webhook_integration);
             let cm = Arc::clone(&self.connection_manager);

--- a/crates/sockudo-adapter/src/handler/subscription_management.rs
+++ b/crates/sockudo-adapter/src/handler/subscription_management.rs
@@ -423,10 +423,18 @@ impl ConnectionHandler {
 
         // Skip count reads entirely when this join cannot produce an observable
         // count-derived event.
-        let wants_channel_occupied_webhook =
-            self.subscription_count_webhook_configured(app_config, "channel_occupied");
-        let wants_subscription_count_webhook =
-            self.subscription_count_webhook_configured(app_config, "subscription_count");
+        let wants_channel_occupied_webhook = self
+            .subscription_count_webhook_configured_for_channel(
+                app_config,
+                "channel_occupied",
+                channel,
+            );
+        let wants_subscription_count_webhook = self
+            .subscription_count_webhook_configured_for_channel(
+                app_config,
+                "subscription_count",
+                channel,
+            );
         let wants_meta_channel = self
             .subscription_count_meta_channel_has_local_subscriber(app_config, channel)
             .await;

--- a/crates/sockudo-adapter/tests/adapter/handler/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/mod.rs
@@ -8,3 +8,4 @@ pub mod presence_user_id_guard_test;
 pub mod runtime_rewind_recovery_e2e_test;
 pub mod signin_test;
 pub mod validation_test;
+pub mod webhook_count_gate_test;

--- a/crates/sockudo-adapter/tests/adapter/handler/webhook_count_gate_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/webhook_count_gate_test.rs
@@ -1,0 +1,404 @@
+use ahash::AHashMap;
+use async_trait::async_trait;
+use sockudo_adapter::ConnectionManager;
+use sockudo_adapter::connection_manager::{ChannelSocketCount, HorizontalAdapterInterface};
+use sockudo_adapter::handler::ConnectionHandler;
+use sockudo_adapter::handler::subscription_management::SubscriptionResult;
+use sockudo_adapter::handler::types::SubscriptionRequest;
+use sockudo_app::memory_app_manager::MemoryAppManager;
+use sockudo_core::app::{App, AppManager, AppPolicy};
+use sockudo_core::channel::PresenceMemberInfo;
+use sockudo_core::error::Result;
+use sockudo_core::namespace::Namespace;
+use sockudo_core::options::ServerOptions;
+use sockudo_core::webhook_types::{Webhook, WebhookFilter};
+use sockudo_core::websocket::{SocketId, WebSocketRef};
+use sockudo_protocol::messages::{MessageData, PusherMessage};
+use sockudo_queue::manager::QueueManagerFactory;
+use sockudo_webhook::integration::{QueueManager, WebhookConfig, WebhookIntegration};
+use sockudo_ws::axum_integration::WebSocketWriter;
+use std::any::Any;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// No-op [`ConnectionManager`] that counts calls to the channel-socket-count
+/// methods. Everything else delegates to [`crate::mocks::connection_handler_mock::MockAdapter`]'s
+/// behavior (all no-ops) without importing it, keeping this file self-contained.
+struct CountingAdapter {
+    count_query_calls: Arc<AtomicUsize>,
+}
+
+impl CountingAdapter {
+    fn new() -> Self {
+        Self {
+            count_query_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+#[async_trait]
+impl ConnectionManager for CountingAdapter {
+    async fn init(&self) {}
+    async fn get_namespace(&self, _app_id: &str) -> Option<Arc<Namespace>> {
+        None
+    }
+    async fn add_socket(
+        &self,
+        _socket_id: SocketId,
+        _socket: WebSocketWriter,
+        _app_id: &str,
+        _app_manager: Arc<dyn AppManager + Send + Sync>,
+        _buffer_config: sockudo_core::websocket::WebSocketBufferConfig,
+        _protocol_version: sockudo_protocol::ProtocolVersion,
+        _wire_format: sockudo_protocol::WireFormat,
+        _echo_messages: bool,
+        _append_mode: sockudo_protocol::AppendMode,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn get_connection(&self, _socket_id: &SocketId, _app_id: &str) -> Option<WebSocketRef> {
+        None
+    }
+    async fn remove_connection(&self, _socket_id: &SocketId, _app_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn send_message(
+        &self,
+        _app_id: &str,
+        _socket_id: &SocketId,
+        _message: PusherMessage,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn send(
+        &self,
+        _channel: &str,
+        _message: PusherMessage,
+        _except: Option<&SocketId>,
+        _app_id: &str,
+        _start_time_ms: Option<f64>,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn get_channel_members(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+    ) -> Result<AHashMap<String, PresenceMemberInfo>> {
+        Ok(AHashMap::new())
+    }
+    async fn get_channel_sockets(&self, _app_id: &str, _channel: &str) -> Result<Vec<SocketId>> {
+        Ok(Vec::new())
+    }
+    async fn remove_channel(&self, _app_id: &str, _channel: &str) {}
+    async fn is_in_channel(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+    async fn get_user_sockets(&self, _user_id: &str, _app_id: &str) -> Result<Vec<WebSocketRef>> {
+        Ok(Vec::new())
+    }
+    async fn cleanup_connection(&self, _app_id: &str, _ws: WebSocketRef) {}
+    async fn terminate_connection(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn add_channel_to_sockets(&self, _app_id: &str, _channel: &str, _socket_id: &SocketId) {}
+    async fn get_channel_socket_count_info(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+    ) -> ChannelSocketCount {
+        self.count_query_calls.fetch_add(1, Ordering::SeqCst);
+        ChannelSocketCount {
+            count: 0,
+            complete: true,
+        }
+    }
+    async fn get_channel_socket_count(&self, _app_id: &str, _channel: &str) -> usize {
+        self.count_query_calls.fetch_add(1, Ordering::SeqCst);
+        0
+    }
+    async fn get_local_channel_socket_count(&self, _app_id: &str, _channel: &str) -> usize {
+        0
+    }
+    async fn add_to_channel(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Result<(bool, bool)> {
+        Ok((false, false))
+    }
+    async fn remove_from_channel(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Result<(bool, bool)> {
+        Ok((false, false))
+    }
+    async fn get_presence_member(
+        &self,
+        _app_id: &str,
+        _channel: &str,
+        _socket_id: &SocketId,
+    ) -> Option<PresenceMemberInfo> {
+        None
+    }
+    async fn terminate_user_connections(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn force_reconnect_user(&self, _app_id: &str, _user_id: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn add_user(&self, _ws: WebSocketRef) -> Result<()> {
+        Ok(())
+    }
+    async fn remove_user(&self, _ws: WebSocketRef) -> Result<()> {
+        Ok(())
+    }
+    async fn get_channels_with_socket_count(
+        &self,
+        _app_id: &str,
+    ) -> Result<AHashMap<String, usize>> {
+        Ok(AHashMap::new())
+    }
+    async fn get_sockets_count(&self, _app_id: &str) -> Result<usize> {
+        Ok(0)
+    }
+    async fn get_namespaces(&self) -> Result<Vec<(String, Arc<Namespace>)>> {
+        Ok(Vec::new())
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    async fn remove_user_socket(
+        &self,
+        _user_id: &str,
+        _socket_id: &SocketId,
+        _app_id: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
+    async fn count_user_connections_in_channel(
+        &self,
+        _user_id: &str,
+        _app_id: &str,
+        _channel: &str,
+        _excluding_socket: Option<&SocketId>,
+    ) -> Result<usize> {
+        Ok(0)
+    }
+    async fn check_health(&self) -> Result<()> {
+        Ok(())
+    }
+    fn get_node_id(&self) -> String {
+        "counting-mock".to_string()
+    }
+    fn as_horizontal_adapter(&self) -> Option<&dyn HorizontalAdapterInterface> {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_presence_filtered_app(app_id: &str) -> App {
+    App::from_policy(
+        app_id.to_string(),
+        format!("{app_id}-key"),
+        format!("{app_id}-secret"),
+        true,
+        AppPolicy {
+            webhooks: Some(vec![Webhook {
+                event_types: vec![
+                    "channel_occupied".to_string(),
+                    "channel_vacated".to_string(),
+                    "subscription_count".to_string(),
+                ],
+                filter: Some(WebhookFilter {
+                    channel_prefix: Some("presence-".to_string()),
+                    ..Default::default()
+                }),
+                ..Webhook::default()
+            }]),
+            ..AppPolicy::default()
+        },
+    )
+}
+
+struct Harness {
+    handler: ConnectionHandler,
+    counting_cm: Arc<CountingAdapter>,
+    app: App,
+}
+
+async fn build_harness(app_id: &str) -> Harness {
+    let app = make_presence_filtered_app(app_id);
+    let app_manager = Arc::new(MemoryAppManager::new());
+    app_manager.create_app(app.clone()).await.unwrap();
+
+    let counting_cm = Arc::new(CountingAdapter::new());
+
+    let driver = QueueManagerFactory::create("memory", None, None, None, None)
+        .await
+        .expect("failed to create memory queue for test");
+    let queue_manager = Arc::new(QueueManager::new(driver));
+    let webhook_integration = Arc::new(
+        WebhookIntegration::new(
+            WebhookConfig {
+                enabled: true,
+                ..Default::default()
+            },
+            app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+            Some(queue_manager),
+        )
+        .await
+        .expect("failed to create webhook integration for test"),
+    );
+
+    let handler = ConnectionHandler::builder(
+        app_manager as Arc<dyn AppManager + Send + Sync>,
+        counting_cm.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(crate::mocks::connection_handler_mock::MockCacheManager::new()),
+        ServerOptions::default(),
+    )
+    .webhook_integration(webhook_integration)
+    .build();
+
+    Harness {
+        handler,
+        counting_cm,
+        app,
+    }
+}
+
+fn make_subscription_result() -> SubscriptionResult {
+    SubscriptionResult {
+        success: true,
+        auth_error: None,
+        member: None,
+        channel_connections: Some(1),
+    }
+}
+
+fn make_subscription_request(channel: &str) -> SubscriptionRequest {
+    SubscriptionRequest {
+        channel: channel.to_string(),
+        auth: None,
+        channel_data: None,
+        #[cfg(feature = "tag-filtering")]
+        tags_filter: None,
+        #[cfg(feature = "tag-filtering")]
+        predicate: None,
+        #[cfg(feature = "delta")]
+        delta: None,
+        rewind: None,
+        event_name_filter: None,
+        annotation_subscribe: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn non_presence_subscribe_skips_count_query() {
+    let harness = build_harness("non-presence-sub").await;
+    let socket_id = SocketId::new();
+
+    let before = harness.counting_cm.count_query_calls.load(Ordering::SeqCst);
+
+    for channel in &["private-orders", "orders", "private-updates"] {
+        harness
+            .handler
+            .handle_post_subscription(
+                &socket_id,
+                &harness.app,
+                &make_subscription_request(channel),
+                &make_subscription_result(),
+                None,
+            )
+            .await
+            .ok();
+    }
+
+    let after = harness.counting_cm.count_query_calls.load(Ordering::SeqCst);
+    assert_eq!(
+        after, before,
+        "count queries must be zero for non-presence channels with presence-only webhook filter"
+    );
+}
+
+#[tokio::test]
+async fn presence_subscribe_triggers_count_query() {
+    let harness = build_harness("presence-sub").await;
+    let socket_id = SocketId::new();
+
+    let before = harness.counting_cm.count_query_calls.load(Ordering::SeqCst);
+
+    harness
+        .handler
+        .handle_post_subscription(
+            &socket_id,
+            &harness.app,
+            &make_subscription_request("presence-lobby"),
+            &make_subscription_result(),
+            None,
+        )
+        .await
+        .ok();
+
+    let after = harness.counting_cm.count_query_calls.load(Ordering::SeqCst);
+    assert!(
+        after > before,
+        "at least one count query must fire for presence-lobby (got {} calls)",
+        after - before
+    );
+}
+
+#[tokio::test]
+async fn non_presence_unsubscribe_skips_count_query() {
+    let harness = build_harness("non-presence-unsub").await;
+    let socket_id = SocketId::new();
+
+    for channel in &["private-orders", "orders"] {
+        let msg = PusherMessage {
+            channel: Some(channel.to_string()),
+            event: Some("pusher:unsubscribe".to_string()),
+            data: Some(MessageData::String(
+                sonic_rs::json!({"channel": channel}).to_string(),
+            )),
+            name: None,
+            user_id: None,
+            tags: None,
+            sequence: None,
+            conflation_key: None,
+            message_id: None,
+            stream_id: None,
+            serial: None,
+            idempotency_key: None,
+            extras: None,
+            delta_sequence: None,
+            delta_conflation_key: None,
+        };
+
+        harness
+            .handler
+            .handle_unsubscribe(&socket_id, &msg, &harness.app)
+            .await
+            .ok();
+    }
+
+    let after = harness.counting_cm.count_query_calls.load(Ordering::SeqCst);
+    assert_eq!(
+        after, 0,
+        "count queries must be zero for non-presence unsubscribe with presence-only webhook filter"
+    );
+}

--- a/crates/sockudo-core/src/webhook_types.rs
+++ b/crates/sockudo-core/src/webhook_types.rs
@@ -28,13 +28,67 @@ pub struct WebhookEventType {
     pub name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct WebhookFilter {
     pub channel_prefix: Option<String>,
     pub channel_suffix: Option<String>,
     pub channel_pattern: Option<String>,
     pub channel_namespace: Option<String>,
     pub channel_namespaces: Option<Vec<String>>,
+}
+
+impl WebhookFilter {
+    /// Returns `true` if `channel` passes every constraint in this filter.
+    /// Absent fields always pass. Invalid `channel_pattern` returns `false`.
+    ///
+    /// Compiles the pattern on every call; prefer
+    /// [`Self::matches_channel_with_pattern`] when evaluating many channels.
+    pub fn matches_channel(&self, channel: &str) -> bool {
+        let pattern = match &self.channel_pattern {
+            Some(pattern) => match regex::Regex::new(pattern) {
+                Ok(re) => Some(re),
+                Err(_) => return false,
+            },
+            None => None,
+        };
+        self.matches_channel_with_pattern(channel, pattern.as_ref())
+    }
+
+    /// Pre-compiled variant of [`Self::matches_channel`].
+    /// `pattern` is the compiled `channel_pattern`, or `None` when absent.
+    pub fn matches_channel_with_pattern(
+        &self,
+        channel: &str,
+        pattern: Option<&regex::Regex>,
+    ) -> bool {
+        if let Some(prefix) = &self.channel_prefix
+            && !channel.starts_with(prefix)
+        {
+            return false;
+        }
+        if let Some(suffix) = &self.channel_suffix
+            && !channel.ends_with(suffix)
+        {
+            return false;
+        }
+        if let Some(regex) = pattern
+            && !regex.is_match(channel)
+        {
+            return false;
+        }
+        let namespace = crate::utils::channel_namespace_name(channel);
+        if let Some(expected) = &self.channel_namespace
+            && namespace != Some(expected.as_str())
+        {
+            return false;
+        }
+        if let Some(expected) = &self.channel_namespaces
+            && !expected.iter().any(|c| namespace == Some(c.as_str()))
+        {
+            return false;
+        }
+        true
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -125,5 +179,201 @@ mod tests {
         let legacy = r#"{"app_key":"key","app_id":"app","app_secret":"secret","payload":{"time_ms":1,"events":[]},"original_signature":"signature"}"#;
         let job: JobData = sonic_rs::from_str(legacy).expect("legacy job data should deserialize");
         assert_eq!(job.job_id, None);
+    }
+
+    fn empty_filter() -> WebhookFilter {
+        WebhookFilter {
+            channel_prefix: None,
+            channel_suffix: None,
+            channel_pattern: None,
+            channel_namespace: None,
+            channel_namespaces: None,
+        }
+    }
+
+    #[test]
+    fn matches_channel_all_none_always_true() {
+        let f = empty_filter();
+        assert!(f.matches_channel("anything"));
+        assert!(f.matches_channel("private-foo:bar"));
+        assert!(f.matches_channel(""));
+    }
+
+    #[test]
+    fn matches_channel_prefix_match() {
+        let f = WebhookFilter {
+            channel_prefix: Some("orders-".into()),
+            ..empty_filter()
+        };
+        assert!(f.matches_channel("orders-123"));
+    }
+
+    #[test]
+    fn matches_channel_prefix_mismatch() {
+        let f = WebhookFilter {
+            channel_prefix: Some("orders-".into()),
+            ..empty_filter()
+        };
+        assert!(!f.matches_channel("invoices-123"));
+    }
+
+    #[test]
+    fn matches_channel_suffix_match() {
+        let f = WebhookFilter {
+            channel_suffix: Some("-live".into()),
+            ..empty_filter()
+        };
+        assert!(f.matches_channel("chat-live"));
+    }
+
+    #[test]
+    fn matches_channel_suffix_mismatch() {
+        let f = WebhookFilter {
+            channel_suffix: Some("-live".into()),
+            ..empty_filter()
+        };
+        assert!(!f.matches_channel("chat-staging"));
+    }
+
+    #[test]
+    fn matches_channel_valid_pattern_match() {
+        let f = WebhookFilter {
+            channel_pattern: Some(r"^orders-\d+$".into()),
+            ..empty_filter()
+        };
+        assert!(f.matches_channel("orders-42"));
+    }
+
+    #[test]
+    fn matches_channel_valid_pattern_no_match() {
+        let f = WebhookFilter {
+            channel_pattern: Some(r"^orders-\d+$".into()),
+            ..empty_filter()
+        };
+        assert!(!f.matches_channel("orders-abc"));
+    }
+
+    #[test]
+    fn matches_channel_invalid_regex_returns_false() {
+        let f = WebhookFilter {
+            channel_pattern: Some("[invalid".into()),
+            ..empty_filter()
+        };
+        assert!(!f.matches_channel("any-channel"));
+    }
+
+    #[test]
+    fn matches_channel_with_pattern_applies_supplied_pattern() {
+        let f = WebhookFilter {
+            channel_prefix: Some("presence-".into()),
+            channel_pattern: Some("^presence-lobby$".into()),
+            ..empty_filter()
+        };
+        let pattern = regex::Regex::new("^presence-lobby$").unwrap();
+
+        // Prefix + supplied pattern both match.
+        assert!(f.matches_channel_with_pattern("presence-lobby", Some(&pattern)));
+        // Prefix matches but supplied pattern rejects.
+        assert!(!f.matches_channel_with_pattern("presence-other", Some(&pattern)));
+        // Supplied pattern would match but prefix rejects.
+        assert!(!f.matches_channel_with_pattern("private-lobby", Some(&pattern)));
+    }
+
+    #[test]
+    fn matches_channel_with_pattern_none_skips_pattern_check() {
+        // Passing None skips the channel_pattern constraint entirely, even
+        // though the filter declares one — the caller owns the pattern check.
+        let f = WebhookFilter {
+            channel_prefix: Some("presence-".into()),
+            channel_pattern: Some("^never-matches$".into()),
+            ..empty_filter()
+        };
+        assert!(f.matches_channel_with_pattern("presence-lobby", None));
+        assert!(!f.matches_channel_with_pattern("private-lobby", None));
+    }
+
+    #[test]
+    fn matches_channel_namespace_singular_match() {
+        let f = WebhookFilter {
+            channel_namespace: Some("chat".into()),
+            ..empty_filter()
+        };
+        assert!(f.matches_channel("chat:room-1"));
+    }
+
+    #[test]
+    fn matches_channel_namespace_singular_mismatch() {
+        let f = WebhookFilter {
+            channel_namespace: Some("chat".into()),
+            ..empty_filter()
+        };
+        assert!(!f.matches_channel("orders:123"));
+    }
+
+    #[test]
+    fn matches_channel_namespaces_plural_in_list() {
+        let f = WebhookFilter {
+            channel_namespaces: Some(vec!["chat".into(), "orders".into()]),
+            ..empty_filter()
+        };
+        assert!(f.matches_channel("chat:room-1"));
+        assert!(f.matches_channel("orders:456"));
+    }
+
+    #[test]
+    fn matches_channel_namespaces_plural_not_in_list() {
+        let f = WebhookFilter {
+            channel_namespaces: Some(vec!["chat".into(), "orders".into()]),
+            ..empty_filter()
+        };
+        assert!(!f.matches_channel("invoices:789"));
+    }
+
+    #[test]
+    fn matches_channel_combined_prefix_and_namespace_both_pass() {
+        let f = WebhookFilter {
+            channel_prefix: Some("private-".into()),
+            channel_namespace: Some("orders".into()),
+            ..empty_filter()
+        };
+        assert!(f.matches_channel("private-orders:123"));
+    }
+
+    #[test]
+    fn matches_channel_combined_prefix_and_namespace_prefix_fails() {
+        let f = WebhookFilter {
+            channel_prefix: Some("private-".into()),
+            channel_namespace: Some("orders".into()),
+            ..empty_filter()
+        };
+        assert!(!f.matches_channel("orders:123"));
+    }
+
+    #[test]
+    fn matches_channel_combined_prefix_and_namespace_namespace_fails() {
+        let f = WebhookFilter {
+            channel_prefix: Some("private-".into()),
+            channel_namespace: Some("orders".into()),
+            ..empty_filter()
+        };
+        assert!(!f.matches_channel("private-chat:room-1"));
+    }
+
+    #[test]
+    fn matches_channel_presence_prefix_namespace_extraction() {
+        let f = WebhookFilter {
+            channel_namespace: Some("orders".into()),
+            ..empty_filter()
+        };
+        assert!(f.matches_channel("presence-orders:123"));
+    }
+
+    #[test]
+    fn matches_channel_no_prefix_with_namespace() {
+        let f = WebhookFilter {
+            channel_namespace: Some("chat".into()),
+            ..empty_filter()
+        };
+        assert!(f.matches_channel("chat:room-1"));
     }
 }

--- a/crates/sockudo-webhook/src/integration.rs
+++ b/crates/sockudo-webhook/src/integration.rs
@@ -373,6 +373,21 @@ impl WebhookIntegration {
             || self.webhook_configured(app, "subscription_count")
     }
 
+    /// Like [`Self::webhook_configured`] but also checks the webhook's filter
+    /// against `channel`. No filter matches all channels.
+    pub fn wants_channel_count_webhook(&self, app: &App, event_type: &str, channel: &str) -> bool {
+        self.is_enabled()
+            && app.webhooks_ref().is_some_and(|webhooks| {
+                webhooks.iter().any(|wh| {
+                    wh.event_types.iter().any(|e| e.as_str() == event_type)
+                        && wh
+                            .filter
+                            .as_ref()
+                            .is_none_or(|f| f.matches_channel(channel))
+                })
+            })
+    }
+
     pub async fn send_channel_occupied(&self, app: &App, channel: &str) -> Result<()> {
         if !self.should_send_webhook(app, "channel_occupied") {
             return Ok(());
@@ -806,7 +821,7 @@ mod tests {
     use super::*;
     use sockudo_app::memory_app_manager::MemoryAppManager;
     use sockudo_core::app::{AppFeaturesPolicy, AppLimitsPolicy, AppPolicy};
-    use sockudo_core::webhook_types::{JobData, JobPayload, Webhook};
+    use sockudo_core::webhook_types::{JobData, JobPayload, Webhook, WebhookFilter};
     use sockudo_queue::manager::QueueManagerFactory;
 
     async fn create_test_queue_manager() -> Arc<QueueManager> {
@@ -1246,6 +1261,161 @@ mod tests {
         assert_eq!(merged[0].payload.events.len(), 2);
         assert_eq!(merged[1].app_id, "app-b");
         assert_eq!(merged[1].payload.events.len(), 1);
+    }
+
+    async fn make_integration(enabled: bool) -> WebhookIntegration {
+        let app_manager = Arc::new(MemoryAppManager::new());
+        let queue_manager = create_test_queue_manager().await;
+        WebhookIntegration::new(
+            WebhookConfig {
+                enabled,
+                ..Default::default()
+            },
+            app_manager,
+            Some(queue_manager),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn wants_channel_count_webhook_no_webhooks_configured() {
+        let integration = make_integration(true).await;
+        let app = test_app();
+        assert!(!integration.wants_channel_count_webhook(
+            &app,
+            "channel_occupied",
+            "presence-lobby"
+        ));
+    }
+
+    #[tokio::test]
+    async fn wants_channel_count_webhook_event_type_mismatch() {
+        let integration = make_integration(true).await;
+        let mut app = test_app();
+        app.policy.webhooks = Some(vec![Webhook {
+            event_types: vec!["channel_vacated".to_string()],
+            ..Webhook::default()
+        }]);
+        assert!(!integration.wants_channel_count_webhook(
+            &app,
+            "channel_occupied",
+            "presence-lobby"
+        ));
+    }
+
+    #[tokio::test]
+    async fn wants_channel_count_webhook_match_no_filter() {
+        let integration = make_integration(true).await;
+        let mut app = test_app();
+        app.policy.webhooks = Some(vec![Webhook {
+            event_types: vec!["channel_occupied".to_string()],
+            ..Webhook::default()
+        }]);
+        assert!(integration.wants_channel_count_webhook(&app, "channel_occupied", "public-room"));
+        assert!(integration.wants_channel_count_webhook(&app, "channel_occupied", "private-x"));
+        assert!(integration.wants_channel_count_webhook(
+            &app,
+            "channel_occupied",
+            "presence-lobby"
+        ));
+    }
+
+    #[tokio::test]
+    async fn wants_channel_count_webhook_filter_prefix_match() {
+        let integration = make_integration(true).await;
+        let mut app = test_app();
+        app.policy.webhooks = Some(vec![Webhook {
+            event_types: vec!["channel_occupied".to_string()],
+            filter: Some(WebhookFilter {
+                channel_prefix: Some("presence-".to_string()),
+                ..Default::default()
+            }),
+            ..Webhook::default()
+        }]);
+        assert!(integration.wants_channel_count_webhook(
+            &app,
+            "channel_occupied",
+            "presence-lobby"
+        ));
+    }
+
+    #[tokio::test]
+    async fn wants_channel_count_webhook_filter_prefix_no_match() {
+        let integration = make_integration(true).await;
+        let mut app = test_app();
+        app.policy.webhooks = Some(vec![Webhook {
+            event_types: vec!["channel_occupied".to_string()],
+            filter: Some(WebhookFilter {
+                channel_prefix: Some("presence-".to_string()),
+                ..Default::default()
+            }),
+            ..Webhook::default()
+        }]);
+        assert!(!integration.wants_channel_count_webhook(&app, "channel_occupied", "private-x"));
+    }
+
+    #[tokio::test]
+    async fn wants_channel_count_webhook_two_webhooks_second_filter_matches() {
+        let integration = make_integration(true).await;
+        let mut app = test_app();
+        app.policy.webhooks = Some(vec![
+            Webhook {
+                event_types: vec!["channel_occupied".to_string()],
+                filter: Some(WebhookFilter {
+                    channel_prefix: Some("presence-".to_string()),
+                    ..Default::default()
+                }),
+                ..Webhook::default()
+            },
+            Webhook {
+                event_types: vec!["channel_occupied".to_string()],
+                filter: Some(WebhookFilter {
+                    channel_prefix: Some("private-".to_string()),
+                    ..Default::default()
+                }),
+                ..Webhook::default()
+            },
+        ]);
+        assert!(integration.wants_channel_count_webhook(&app, "channel_occupied", "private-x"));
+    }
+
+    #[tokio::test]
+    async fn wants_channel_count_webhook_no_filter_webhook_matches_all() {
+        let integration = make_integration(true).await;
+        let mut app = test_app();
+        app.policy.webhooks = Some(vec![
+            Webhook {
+                event_types: vec!["channel_occupied".to_string()],
+                filter: None,
+                ..Webhook::default()
+            },
+            Webhook {
+                event_types: vec!["channel_occupied".to_string()],
+                filter: Some(WebhookFilter {
+                    channel_prefix: Some("presence-".to_string()),
+                    ..Default::default()
+                }),
+                ..Webhook::default()
+            },
+        ]);
+        assert!(integration.wants_channel_count_webhook(&app, "channel_occupied", "public-room"));
+        assert!(integration.wants_channel_count_webhook(&app, "channel_occupied", "private-x"));
+    }
+
+    #[tokio::test]
+    async fn wants_channel_count_webhook_disabled_integration() {
+        let integration = make_integration(false).await;
+        let mut app = test_app();
+        app.policy.webhooks = Some(vec![Webhook {
+            event_types: vec!["channel_occupied".to_string()],
+            ..Webhook::default()
+        }]);
+        assert!(!integration.wants_channel_count_webhook(
+            &app,
+            "channel_occupied",
+            "presence-lobby"
+        ));
     }
 
     #[test]

--- a/crates/sockudo-webhook/src/sender.rs
+++ b/crates/sockudo-webhook/src/sender.rs
@@ -9,7 +9,6 @@ use ahash::AHashMap;
 use reqwest::{Client, header};
 use serde::Serialize;
 use sockudo_core::token::Token;
-use sockudo_core::utils::channel_namespace_name;
 use sockudo_core::webhook_types::{JobData, Webhook, WebhookFilter, WebhookRetryPolicy};
 use sonic_rs::Value;
 #[cfg(feature = "lambda")]
@@ -105,41 +104,7 @@ impl WebhookSender {
             .and_then(Value::as_str)
             .unwrap_or_default();
 
-        if let Some(prefix) = &filter.channel_prefix
-            && !channel.starts_with(prefix)
-        {
-            return false;
-        }
-
-        if let Some(suffix) = &filter.channel_suffix
-            && !channel.ends_with(suffix)
-        {
-            return false;
-        }
-
-        if let Some(regex) = channel_pattern
-            && !regex.is_match(channel)
-        {
-            return false;
-        }
-
-        let namespace = channel_namespace_name(channel);
-
-        if let Some(expected_namespace) = &filter.channel_namespace
-            && namespace != Some(expected_namespace.as_str())
-        {
-            return false;
-        }
-
-        if let Some(expected_namespaces) = &filter.channel_namespaces
-            && !expected_namespaces
-                .iter()
-                .any(|candidate| namespace == Some(candidate.as_str()))
-        {
-            return false;
-        }
-
-        true
+        filter.matches_channel_with_pattern(channel, channel_pattern)
     }
 
     fn filter_events_for_webhook(&self, events: &[Value], webhook_config: &Webhook) -> Vec<Value> {
@@ -848,5 +813,88 @@ mod tests {
         assert_eq!(relevant.len(), 2);
         assert_eq!(relevant.get("http://localhost/prefix").unwrap().1.len(), 1);
         assert_eq!(relevant.get("http://localhost/all").unwrap().1.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_events_for_webhook_respects_channel_pattern() {
+        let webhook_sender = WebhookSender::new(
+            Arc::new(MemoryAppManager::new()),
+            WebhookRetryConfig::default(),
+            10_000,
+        );
+        let webhook = Webhook {
+            url: Some(url::Url::parse("http://localhost/webhook").unwrap()),
+            lambda_function: None,
+            lambda: None,
+            event_types: vec!["channel_occupied".to_string()],
+            filter: Some(WebhookFilter {
+                channel_prefix: None,
+                channel_suffix: None,
+                channel_pattern: Some("^presence-.*$".to_string()),
+                channel_namespace: None,
+                channel_namespaces: None,
+            }),
+            headers: None,
+            retry: None,
+            request_timeout_ms: None,
+        };
+
+        let filtered = webhook_sender.filter_events_for_webhook(
+            &[
+                sonic_rs::json!({
+                    "name": "channel_occupied",
+                    "channel": "presence-lobby"
+                }),
+                sonic_rs::json!({
+                    "name": "channel_occupied",
+                    "channel": "private-conversation.123"
+                }),
+            ],
+            &webhook,
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(
+            filtered[0].get("channel").and_then(Value::as_str),
+            Some("presence-lobby")
+        );
+    }
+
+    #[test]
+    fn test_filter_events_for_webhook_invalid_pattern_drops_all_events() {
+        let webhook_sender = WebhookSender::new(
+            Arc::new(MemoryAppManager::new()),
+            WebhookRetryConfig::default(),
+            10_000,
+        );
+        let webhook = Webhook {
+            url: Some(url::Url::parse("http://localhost/webhook").unwrap()),
+            lambda_function: None,
+            lambda: None,
+            event_types: vec!["channel_occupied".to_string()],
+            filter: Some(WebhookFilter {
+                channel_prefix: None,
+                channel_suffix: None,
+                channel_pattern: Some("[invalid".to_string()),
+                channel_namespace: None,
+                channel_namespaces: None,
+            }),
+            headers: None,
+            retry: None,
+            request_timeout_ms: None,
+        };
+
+        let filtered = webhook_sender.filter_events_for_webhook(
+            &[sonic_rs::json!({
+                "name": "channel_occupied",
+                "channel": "presence-lobby"
+            })],
+            &webhook,
+        );
+
+        assert!(
+            filtered.is_empty(),
+            "invalid channel_pattern must drop every event for the webhook"
+        );
     }
 }


### PR DESCRIPTION
The subscription-count webhook gate (`channel_occupied`, `channel_vacated`, `subscription_count`) was channel-blind: any configured webhook triggered an expensive cluster-wide count fetch on every subscribe/unsubscribe, regardless of whether the webhook's filter matched the channel.

This MR makes the gate channel-aware. If every webhook for a given event type has a filter and none matches the channel, the count query is skipped entirely.

Changes:
- Move channel-matching logic from `WebhookSender` into `WebhookFilter::matches_channel` / `matches_channel_with_pattern`
- Add `WebhookIntegration::wants_channel_count_webhook` (filter-aware gate)
- Replace channel-blind call sites in `ConnectionHandler` with the new gate
- Add `Default` derive to `WebhookFilter`
- Remove unused `subscription_count_webhook_configured` method

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
