### PR TITLE
fix(memory): clean up socket rate limiters on disconnect

### DIFF
--- a/crates/sockudo-adapter/src/handler/core.rs
+++ b/crates/sockudo-adapter/src/handler/core.rs
@@ -516,10 +516,8 @@ impl ConnectionHandler {
             .await
             .ok();
 
-        // Step 3: Clean up client event rate limiter (lock-free)
-        if self.client_event_limiters.remove(socket_id).is_some() {
-            debug!(socket_id = %socket_id, "client event rate limiter removed");
-        }
+        // Step 3: Clean up socket-scoped rate limiters (lock-free)
+        self.remove_socket_limiters(socket_id);
 
         // Step 3.5: MEMORY LEAK FIX - Clean up delta compression state for this socket
         #[cfg(feature = "delta")]
@@ -607,10 +605,7 @@ impl ConnectionHandler {
         self.clear_user_authentication_timeout(app_id, socket_id)
             .await?;
 
-        // Clean up client event rate limiter
-        if self.client_event_limiters.remove(socket_id).is_some() {
-            debug!(socket_id = %socket_id, "client event rate limiter removed");
-        }
+        self.remove_socket_limiters(socket_id);
 
         // MEMORY LEAK FIX: Clean up delta compression state for this socket
         #[cfg(feature = "delta")]

--- a/crates/sockudo-adapter/src/handler/mod.rs
+++ b/crates/sockudo-adapter/src/handler/mod.rs
@@ -483,6 +483,13 @@ fn start_ai_stream_orphan_worker(
 }
 
 impl ConnectionHandler {
+    fn remove_socket_limiters(&self, socket_id: &SocketId) {
+        self.client_event_limiters.remove(socket_id);
+        self.message_limiters.remove(socket_id);
+        self.presence_update_limiters.remove(socket_id);
+        self.history_request_limits.remove(socket_id);
+    }
+
     /// Stop AI background workers and wait for the bounded rollup shutdown drain.
     pub async fn shutdown_ai_workers(&self) {
         #[cfg(feature = "ai-transport")]
@@ -1199,10 +1206,7 @@ impl ConnectionHandler {
     }
 
     async fn cleanup_socket(&self, socket_id: &SocketId, app_config: &App) {
-        // Remove rate limiters
-        self.client_event_limiters.remove(socket_id);
-        self.message_limiters.remove(socket_id);
-        self.history_request_limits.remove(socket_id);
+        self.remove_socket_limiters(socket_id);
 
         // MEMORY LEAK FIX: Clean up delta compression state for this socket
         #[cfg(feature = "delta")]

--- a/crates/sockudo-adapter/src/handler/rate_limiting.rs
+++ b/crates/sockudo-adapter/src/handler/rate_limiting.rs
@@ -127,3 +127,50 @@ impl ConnectionHandler {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::local_adapter::LocalAdapter;
+    use sockudo_app::memory_app_manager::MemoryAppManager;
+    use sockudo_cache::MemoryCacheManager;
+    use sockudo_core::options::{MemoryCacheOptions, ServerOptions};
+    use tokio::sync::Semaphore;
+
+    #[test]
+    fn socket_cleanup_removes_all_socket_scoped_limiters() {
+        let app_manager = Arc::new(MemoryAppManager::new());
+        let adapter = Arc::new(LocalAdapter::new());
+        let handler = ConnectionHandler::builder(
+            app_manager,
+            adapter.clone(),
+            Arc::new(MemoryCacheManager::new(
+                "limiter-cleanup-test".to_string(),
+                MemoryCacheOptions::default(),
+            )),
+            ServerOptions::default(),
+        )
+        .local_adapter(adapter)
+        .build();
+        let socket_id = SocketId::new();
+        handler
+            .client_event_limiters
+            .insert(socket_id, Arc::new(MemoryRateLimiter::new(10, 1)));
+        handler
+            .message_limiters
+            .insert(socket_id, Arc::new(MemoryRateLimiter::new(10, 1)));
+        handler
+            .presence_update_limiters
+            .insert(socket_id, Arc::new(MemoryRateLimiter::new(10, 1)));
+        handler
+            .history_request_limits
+            .insert(socket_id, Arc::new(Semaphore::new(1)));
+
+        handler.remove_socket_limiters(&socket_id);
+
+        assert!(!handler.client_event_limiters.contains_key(&socket_id));
+        assert!(!handler.message_limiters.contains_key(&socket_id));
+        assert!(!handler.presence_update_limiters.contains_key(&socket_id));
+        assert!(!handler.history_request_limits.contains_key(&socket_id));
+    }
+}


### PR DESCRIPTION
Socket-scoped rate limiters were not fully removed when a WebSocket disconnected.

Only the client-event limiter was cleaned up in the main disconnect paths, leaving message, presence-update, and history-request limiter entries keyed by old socket IDs. These entries accumulated as connections turned over and caused memory usage to grow.

This change centralizes socket limiter cleanup and uses it from every disconnect path.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
