### PR TITLE
Simplify Linux distribution, repair CI, and test latest Ably SDKs

### DIFF
--- a/.github/MANUAL_BUILDS.md
+++ b/.github/MANUAL_BUILDS.md
@@ -5,18 +5,16 @@
 ### For Pull Requests
 1. **Automatic Instructions**: When you create a PR, a bot comment will appear with a direct link
 2. **Click the link** in the bot comment to go to the Manual Build workflow
-3. **Select platforms** you want to build
+3. **Select Linux architectures** you want to build
 4. **Artifacts** will be posted back to the PR when complete
 
 ### For Any Branch
 1. Go to [Actions → Manual Build](../actions/workflows/manual-build.yml)
 2. Click **"Run workflow"** (green button)
 3. Select your branch from the dropdown
-4. Choose platforms to build:
-   - ☑️ **Linux x64** (GNU) - Standard Linux binary
-   - ☑️ **macOS x64** (Intel Macs) - x86_64 binary for Intel Macs
-   - ☑️ **macOS ARM64** (Apple Silicon) - Native M1/M2/M3 binary
-   - ☑️ **Windows x64** - Standard Windows executable
+4. Choose artifacts to build:
+   - ☑️ **Linux x64** (GNU + musl)
+   - ☑️ **Linux ARM64** (GNU + musl)
    - ☑️ **Docker image** - Containerized application
 5. Click **"Run workflow"**
 
@@ -29,9 +27,9 @@
 ## Artifact Downloads
 
 ### Binaries
-- **Format**: `sockudo-{platform}` (e.g., `sockudo-linux-x64`)
-- **Usage**: Direct execution after download
-- **Platforms**: Linux, macOS, Windows
+- **Format**: `sockudo-{target}` (e.g., `sockudo-x86_64-unknown-linux-gnu`)
+- **Usage**: Verify the adjacent `.sha256` file, extract, and run
+- **Platforms**: Linux x86_64 and ARM64, with GNU and musl variants
 
 ### Docker Images
 - **Format**: `sockudo-docker-{branch}-{timestamp}.tar.gz`
@@ -50,9 +48,7 @@
 | Platform | Typical Time | Cache Hit |
 |----------|--------------|-----------|
 | Linux x64 | ~8 minutes | ~3 minutes |
-| macOS x64 | ~12 minutes | ~5 minutes |
-| macOS ARM64 | ~10 minutes | ~4 minutes |
-| Windows x64 | ~15 minutes | ~6 minutes |
+| Linux ARM64 | ~8 minutes | ~3 minutes |
 | Docker | ~10 minutes | ~4 minutes |
 
 ## FAQ

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:15"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(actions)"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(docker)"

--- a/.github/workflows/ably-upstream-compat.yml
+++ b/.github/workflows/ably-upstream-compat.yml
@@ -1,0 +1,323 @@
+name: Ably upstream compatibility
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ably-upstream-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build-sockudo:
+    name: Build Sockudo compatibility binary
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
+      - name: Cache Rust build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-ably-upstream-${{ hashFiles('Cargo.lock') }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            libcurl4-openssl-dev \
+            libpq-dev \
+            libprotobuf-dev \
+            libssl-dev \
+            pkg-config \
+            protobuf-compiler
+
+      - name: Build compatibility server
+        run: >-
+          cargo build --locked -p sockudo
+          --features v2,ai-transport,ably-compat,redis,postgres,push,monolith
+
+      - name: Package server binary
+        run: |
+          ldd target/debug/sockudo
+          tar -czf sockudo-ably-compat.tar.gz target/debug/sockudo
+
+      - name: Upload server binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sockudo-ably-compat-${{ github.run_id }}
+          path: sockudo-ably-compat.tar.gz
+          compression-level: 0
+          retention-days: 1
+
+  ably-js:
+    name: ably-js main (WebSocket)
+    needs: build-sockudo
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout latest ably-js main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ably/ably-js
+          ref: main
+          path: .upstream/ably-js
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: .upstream/ably-js/package-lock.json
+
+      - name: Download server binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sockudo-ably-compat-${{ github.run_id }}
+          path: .artifacts
+
+      - name: Test local compatibility provisioner
+        run: node --test tests/ably-compat/upstream-sandbox.test.mjs
+
+      - name: Prepare server and SDK
+        shell: bash
+        run: |
+          tar -xzf "${GITHUB_WORKSPACE}/.artifacts/sockudo-ably-compat.tar.gz" -C "${GITHUB_WORKSPACE}"
+          npm ci --ignore-scripts
+          npm run build:node
+          npm run build:push
+        working-directory: .upstream/ably-js
+
+      - name: Record source revisions
+        run: |
+          {
+            echo "# Ably upstream compatibility"
+            echo
+            echo "| Source | Revision |"
+            echo "| --- | --- |"
+            echo "| sockudo PR merge | \`${GITHUB_SHA}\` |"
+            echo "| ably/ably-js main | \`$(git -C .upstream/ably-js rev-parse HEAD)\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          {
+            echo "sockudo ${GITHUB_SHA}"
+            echo "ably-js $(git -C .upstream/ably-js rev-parse HEAD)"
+          } > "${RUNNER_TEMP}/ably-js-revisions.txt"
+
+      - name: Run latest WebSocket compatibility suite
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sandbox_log="${RUNNER_TEMP}/ably-js-sandbox.log"
+          server_log_dir="${RUNNER_TEMP}/ably-js-servers"
+          mkdir -p "${server_log_dir}"
+
+          node tests/ably-compat/upstream-sandbox.mjs \
+            --sockudo-bin "${GITHUB_WORKSPACE}/target/debug/sockudo" \
+            --config "${GITHUB_WORKSPACE}/config/config.toml" \
+            --listen 127.0.0.1:9080 \
+            --log-dir "${server_log_dir}" >"${sandbox_log}" 2>&1 &
+          sandbox_pid=$!
+          cleanup() {
+            kill "${sandbox_pid}" 2>/dev/null || true
+            wait "${sandbox_pid}" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --output /dev/null http://127.0.0.1:9080/; then
+              break
+            fi
+            if ! kill -0 "${sandbox_pid}" 2>/dev/null; then
+              tail -n 100 "${sandbox_log}"
+              exit 1
+            fi
+            sleep 1
+          done
+          curl --fail --silent --output /dev/null http://127.0.0.1:9080/ || {
+            tail -n 100 "${sandbox_log}"
+            exit 1
+          }
+
+          cd .upstream/ably-js
+          mapfile -d '' test_files < <(
+            find test/unit test/rest test/realtime \
+              -type f -name '*.test.js' \
+              ! -name 'liveobjects.test.js' \
+              ! -name 'transports.test.js' \
+              -print0 | sort -z
+          )
+          printf 'Selected %s ably-js files from main\n' "${#test_files[@]}"
+          printf '%s\n' "${test_files[@]}"
+
+          harness_only_excludes='realtime/init node_transports|rest/fallbacks Should use the primary domain as the first attempted for every connection attempt|rest/init Init without any tls key should enable tls'
+          CI=true \
+          ABLY_LOCAL_SANDBOX_URL=http://127.0.0.1:9080 \
+          ABLY_TEST_TRANSPORTS=web_socket \
+          ./node_modules/.bin/mocha \
+            --exit \
+            --grep "${harness_only_excludes}" \
+            --invert \
+            "${test_files[@]}" 2>&1 | tee "${RUNNER_TEMP}/ably-js.log"
+
+      - name: Upload compatibility diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ably-js-main-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/ably-js.log
+            ${{ runner.temp }}/ably-js-revisions.txt
+            ${{ runner.temp }}/ably-js-sandbox.log
+            ${{ runner.temp }}/ably-js-servers
+          if-no-files-found: warn
+          retention-days: 7
+
+  ably-ai-transport-js:
+    name: ably-ai-transport-js main
+    needs: build-sockudo
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout latest ably-ai-transport-js main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ably/ably-ai-transport-js
+          ref: main
+          path: .upstream/ably-ai-transport-js
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: .upstream/ably-ai-transport-js/pnpm-lock.yaml
+
+      - name: Download server binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sockudo-ably-compat-${{ github.run_id }}
+          path: .artifacts
+
+      - name: Prepare server and SDK
+        shell: bash
+        run: |
+          tar -xzf "${GITHUB_WORKSPACE}/.artifacts/sockudo-ably-compat.tar.gz" -C "${GITHUB_WORKSPACE}"
+          pnpm install --frozen-lockfile
+        working-directory: .upstream/ably-ai-transport-js
+
+      - name: Record source revisions
+        run: |
+          {
+            echo "# Ably AI Transport upstream compatibility"
+            echo
+            echo "| Source | Revision |"
+            echo "| --- | --- |"
+            echo "| sockudo PR merge | \`${GITHUB_SHA}\` |"
+            echo "| ably/ably-ai-transport-js main | \`$(git -C .upstream/ably-ai-transport-js rev-parse HEAD)\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          {
+            echo "sockudo ${GITHUB_SHA}"
+            echo "ably-ai-transport-js $(git -C .upstream/ably-ai-transport-js rev-parse HEAD)"
+          } > "${RUNNER_TEMP}/ably-ai-transport-js-revisions.txt"
+
+      - name: Run complete upstream unit suite
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm test 2>&1 | tee "${RUNNER_TEMP}/ably-ai-transport-js-unit.log"
+        working-directory: .upstream/ably-ai-transport-js
+
+      - name: Run complete upstream integration suite
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          sandbox_log="${RUNNER_TEMP}/ably-ai-transport-js-sandbox.log"
+          server_log_dir="${RUNNER_TEMP}/ably-ai-transport-js-servers"
+          mkdir -p "${server_log_dir}"
+
+          node tests/ably-compat/upstream-sandbox.mjs \
+            --sockudo-bin "${GITHUB_WORKSPACE}/target/debug/sockudo" \
+            --config "${GITHUB_WORKSPACE}/config/config.toml" \
+            --listen 127.0.0.1:9080 \
+            --log-dir "${server_log_dir}" >"${sandbox_log}" 2>&1 &
+          sandbox_pid=$!
+          cleanup() {
+            kill "${sandbox_pid}" 2>/dev/null || true
+            wait "${sandbox_pid}" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --output /dev/null http://127.0.0.1:9080/; then
+              break
+            fi
+            if ! kill -0 "${sandbox_pid}" 2>/dev/null; then
+              tail -n 100 "${sandbox_log}"
+              exit 1
+            fi
+            sleep 1
+          done
+          curl --fail --silent --output /dev/null http://127.0.0.1:9080/ || {
+            tail -n 100 "${sandbox_log}"
+            exit 1
+          }
+
+          cd .upstream/ably-ai-transport-js
+          CI=true \
+          ABLY_LOCAL_SANDBOX_URL=http://127.0.0.1:9080 \
+          ABLY_TEST_TRANSPORTS=web_socket \
+          pnpm run test:integration 2>&1 | tee "${RUNNER_TEMP}/ably-ai-transport-js-integration.log"
+
+      - name: Upload compatibility diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ably-ai-transport-js-main-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/ably-ai-transport-js-integration.log
+            ${{ runner.temp }}/ably-ai-transport-js-revisions.txt
+            ${{ runner.temp }}/ably-ai-transport-js-sandbox.log
+            ${{ runner.temp }}/ably-ai-transport-js-servers
+            ${{ runner.temp }}/ably-ai-transport-js-unit.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/ably-upstream-compat.yml
+++ b/.github/workflows/ably-upstream-compat.yml
@@ -90,10 +90,10 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - name: Use Node.js 24
+      - name: Use Node.js 20
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 20
           cache: npm
           cache-dependency-path: .upstream/ably-js/package-lock.json
 
@@ -143,6 +143,7 @@ jobs:
             --sockudo-bin "${GITHUB_WORKSPACE}/target/debug/sockudo" \
             --config "${GITHUB_WORKSPACE}/config/config.toml" \
             --listen 127.0.0.1:9080 \
+            --ws-package-root "${GITHUB_WORKSPACE}/.upstream/ably-js" \
             --log-dir "${server_log_dir}" >"${sandbox_log}" 2>&1 &
           sandbox_pid=$!
           cleanup() {
@@ -223,6 +224,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+        with:
+          package_json_file: .upstream/ably-ai-transport-js/package.json
 
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,4 +1,4 @@
-name: Reusable Build Binary Workflow
+name: Reusable Linux Binary Build
 
 on:
   workflow_call:
@@ -10,24 +10,16 @@ on:
       target_triple:
         required: true
         type: string
-        description: "Rust target triple"
+        description: "Linux Rust target triple"
       runner_os:
         required: true
         type: string
-        description: "Runner OS to use"
-      archive_ext:
-        required: true
-        type: string
-        description: "Archive extension (tgz, zip)"
-      binary_name:
-        required: true
-        type: string
-        description: "Binary filename"
-      cross_compile:
+        description: "Linux runner to use"
+      git_ref:
         required: false
-        type: boolean
-        default: false
-        description: "Whether this is a cross-compilation build"
+        type: string
+        default: ""
+        description: "Git ref to build; defaults to the triggering ref"
       version:
         required: false
         type: string
@@ -48,10 +40,16 @@ jobs:
   build:
     name: Build ${{ inputs.target_name }}
     runs-on: ${{ inputs.runner_os }}
+    env:
+      CARGO_PROFILE_RELEASE_LTO: thin
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "8"
+      CARGO_BUILD_JOBS: "2"
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref || github.ref }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -67,18 +65,24 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-release-${{ inputs.target_triple }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install system dependencies (Linux x86_64 GNU)
-        if: runner.os == 'Linux' && runner.arch == 'X64' && !contains(inputs.target_triple, 'musl')
+      - name: Install GNU build dependencies
+        if: ${{ !contains(inputs.target_triple, 'musl') }}
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libpq-dev libmariadb-dev cmake protobuf-compiler libprotobuf-dev
           sudo apt-get install -y libssl-dev libcurl4-openssl-dev
 
-      - name: Build musl binary (Linux x86_64)
-        if: runner.os == 'Linux' && runner.arch == 'X64' && contains(inputs.target_triple, 'musl')
+      - name: Build musl binary
+        if: ${{ contains(inputs.target_triple, 'musl') }}
+        env:
+          TARGET_TRIPLE: ${{ inputs.target_triple }}
         run: |
           RUST_VERSION=$(grep "^rust-version" Cargo.toml | head -1 | cut -d'"' -f2)
           docker run --rm \
+            -e TARGET_TRIPLE \
+            -e CARGO_PROFILE_RELEASE_LTO \
+            -e CARGO_PROFILE_RELEASE_CODEGEN_UNITS \
+            -e CARGO_BUILD_JOBS \
             -v "$PWD":/src \
             -v "$HOME/.cargo/registry":/root/.cargo/registry \
             -v "$HOME/.cargo/git":/root/.cargo/git \
@@ -88,95 +92,41 @@ jobs:
               apk add --no-cache musl-dev pkgconf \
                 postgresql-dev mariadb-dev cmake make gcc g++ openssl-dev openssl-libs-static curl-dev zlib-dev zlib-static perl linux-headers protoc protobuf-dev
               mkdir -p .cargo
-              printf "[build]\nrustflags = [\"--cfg\", \"tokio_unstable\"]\n\n[target.x86_64-unknown-linux-musl]\nlinker = \"gcc\"\n" > .cargo/config.toml
+              printf "[build]\nrustflags = [\"--cfg\", \"tokio_unstable\"]\n\n[target.%s]\nlinker = \"gcc\"\n" "$TARGET_TRIPLE" > .cargo/config.toml
               export PROTOC_INCLUDE=/usr/include
-              cargo build -p sockudo --release --features full --target x86_64-unknown-linux-musl
+              cargo build -p sockudo --release --features full --target "$TARGET_TRIPLE"
             '
 
-      - name: Install system dependencies (Linux ARM64 GNU)
-        if: runner.os == 'Linux' && runner.arch == 'ARM64' && !contains(inputs.target_triple, 'musl')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libpq-dev libmariadb-dev cmake protobuf-compiler libprotobuf-dev
-          sudo apt-get install -y libssl-dev libcurl4-openssl-dev
+      - name: Build GNU binary
+        if: ${{ !contains(inputs.target_triple, 'musl') }}
+        run: cargo build -p sockudo --release --features full --target ${{ inputs.target_triple }}
 
-      - name: Install system dependencies (Windows x86_64)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          choco install protoc -y
-          $protoc = (Get-Command protoc).Source
-          "PROTOC=$protoc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          brew install protobuf
-          echo "PROTOC=$(command -v protoc)" >> "$GITHUB_ENV"
-
-      - name: Build musl binary (Linux ARM64)
-        if: runner.os == 'Linux' && runner.arch == 'ARM64' && contains(inputs.target_triple, 'musl')
-        run: |
-          RUST_VERSION=$(grep "^rust-version" Cargo.toml | head -1 | cut -d'"' -f2)
-          docker run --rm --platform linux/arm64 \
-            -v "$PWD":/src \
-            -v "$HOME/.cargo/registry":/root/.cargo/registry \
-            -v "$HOME/.cargo/git":/root/.cargo/git \
-            -w /src \
-            "rust:${RUST_VERSION}-alpine" \
-            sh -c '
-              apk add --no-cache musl-dev pkgconf \
-                postgresql-dev mariadb-dev cmake make gcc g++ openssl-dev openssl-libs-static curl-dev zlib-dev zlib-static perl linux-headers protoc protobuf-dev
-              mkdir -p .cargo
-              printf "[build]\nrustflags = [\"--cfg\", \"tokio_unstable\"]\n\n[target.aarch64-unknown-linux-musl]\nlinker = \"gcc\"\n" > .cargo/config.toml
-              export PROTOC_INCLUDE=/usr/include
-              cargo build -p sockudo --release --features full --target aarch64-unknown-linux-musl
-            '
-
-      - name: Build release binary
-        if: "!contains(inputs.target_triple, 'musl')"
-        shell: bash
-        run: |
-          cargo build -p sockudo --release --features full --target ${{ inputs.target_triple }}
-
-      - name: Prepare binary and create archive
+      - name: Package binary and checksum
         id: prepare_artifact
-        shell: bash
+        env:
+          TARGET_TRIPLE: ${{ inputs.target_triple }}
+          VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
-          TARGET_TRIPLE="${{ inputs.target_triple }}"
-          ARCHIVE_EXT="${{ inputs.archive_ext }}"
-          BINARY_NAME="${{ inputs.binary_name }}"
+          SOURCE_PATH="./target/${TARGET_TRIPLE}/release/sockudo"
 
-          SOURCE_PATH="./target/${TARGET_TRIPLE}/release/${BINARY_NAME}"
-
-          # Use different naming for release vs manual builds
           if [[ "$VERSION" == "dev" ]]; then
-            ARCHIVE_NAME="sockudo-${TARGET_TRIPLE}.${ARCHIVE_EXT}"
+            ARCHIVE_NAME="sockudo-${TARGET_TRIPLE}.tgz"
           else
-            ARCHIVE_NAME="sockudo-v${VERSION}-${TARGET_TRIPLE}.${ARCHIVE_EXT}"
+            ARCHIVE_NAME="sockudo-v${VERSION}-${TARGET_TRIPLE}.tgz"
           fi
 
-          # Strip binary on Unix systems
-          if [[ "$RUNNER_OS" == "Linux" || "$RUNNER_OS" == "macOS" ]]; then
-            strip "${SOURCE_PATH}" || echo "Strip failed, continuing..."
-          fi
+          strip "$SOURCE_PATH" || echo "Strip failed, continuing..."
+          tar -C "$(dirname "$SOURCE_PATH")" -czf "$ARCHIVE_NAME" sockudo
+          sha256sum "$ARCHIVE_NAME" > "${ARCHIVE_NAME}.sha256"
 
-          # Create archive
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            powershell Compress-Archive -Path "${SOURCE_PATH}" -DestinationPath "${ARCHIVE_NAME}"
-          else
-            cd $(dirname "${SOURCE_PATH}")
-            tar -czf "${GITHUB_WORKSPACE}/${ARCHIVE_NAME}" "${BINARY_NAME}"
-          fi
-
-          echo "archive_name=${ARCHIVE_NAME}" >> $GITHUB_OUTPUT
+          echo "archive_name=${ARCHIVE_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
         if: inputs.upload_artifact
         uses: actions/upload-artifact@v4
         with:
           name: sockudo-${{ inputs.target_triple }}
-          path: ${{ steps.prepare_artifact.outputs.archive_name }}
+          path: |
+            ${{ steps.prepare_artifact.outputs.archive_name }}
+            ${{ steps.prepare_artifact.outputs.archive_name }}.sha256
           retention-days: ${{ inputs.artifact_retention_days }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,15 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev libcurl4-openssl-dev cmake protobuf-compiler libprotobuf-dev
+          sudo apt-get install -y pkg-config libssl-dev libcurl4-openssl-dev cmake protobuf-compiler libprotobuf-dev shellcheck
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+      - name: Check Linux installer
+        run: |
+          sh -n install.sh
+          shellcheck install.sh
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
@@ -667,11 +672,9 @@ jobs:
                 `1. **Click here:** [🚀 Trigger Manual Build](${runUrl})`,
                 '2. Click **"Run workflow"** (green button)',
                 `3. Select branch: \`${branchName}\``,
-                '4. Choose platforms to build:',
-                '   - ☑️ Linux x64 (GNU)',
-                '   - ☑️ macOS x64 (Intel)',
-                '   - ☑️ macOS ARM64 (Apple Silicon)',
-                '   - ☑️ Windows x64',
+                '4. Choose artifacts to build:',
+                '   - ☑️ Linux x64 (GNU + musl)',
+                '   - ☑️ Linux ARM64 (GNU + musl)',
                 '   - ☑️ Docker image',
                 '5. Click **"Run workflow"**',
                 '',

--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -55,3 +55,12 @@ jobs:
 
       - name: Mutation request parser smoke
         run: cargo fuzz run mutation_request -- -max_total_time=10
+
+      - name: Upload fuzz crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crashes-${{ github.run_id }}
+          path: fuzz/artifacts/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,161 +1,37 @@
-name: Maintenance - Dependency Updates
+name: Maintenance - Security and Cleanup
 
 on:
   schedule:
-    # Run every Monday at 6 AM UTC
-    - cron: "0 6 * * 1"
-  workflow_dispatch:
-    inputs:
-      update_type:
-        description: "Type of update to perform"
-        required: true
-        type: choice
-        options:
-          - "dependencies"
-          - "security"
-          - "all"
-        default: "dependencies"
-      create_pr:
-        description: "Create pull request for updates"
-        required: false
-        type: boolean
-        default: true
+    - cron: "0 7 * * 1"
+  workflow_dispatch: {}
 
 permissions:
-  contents: write
-  pull-requests: write
-  security-events: write
+  contents: read
+  issues: write
+  actions: write
 
 jobs:
-  # =============================================================================
-  # Dependency Updates
-  # =============================================================================
-  update-dependencies:
-    name: Update Dependencies
+  security-audit:
+    name: Security Audit
     runs-on: ubuntu-24.04
-    if: github.event.inputs.update_type == 'dependencies' || github.event.inputs.update_type == 'all' || github.event_name == 'schedule'
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-edit
-        run: cargo install cargo-edit
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev libpq-dev libmariadb-dev cmake protobuf-compiler libprotobuf-dev
-
-      - name: Update Cargo dependencies
-        run: |
-          echo "📦 Checking for dependency updates..."
-
-          # Update dependencies
-          cargo update
-
-          # Check if Cargo.lock was modified
-          if git diff --quiet Cargo.lock; then
-            echo "✅ No dependency updates available"
-            echo "updates_available=false" >> $GITHUB_ENV
-          else
-            echo "📝 Dependencies updated"
-            echo "updates_available=true" >> $GITHUB_ENV
-
-            # Show what changed
-            echo "## Updated Dependencies" > dependency_changes.md
-            echo "" >> dependency_changes.md
-            git diff --no-index /dev/null Cargo.lock | grep "^+" | grep -E "name|version" | head -20 >> dependency_changes.md || true
-          fi
-
-      - name: Run tests after update
-        if: env.updates_available == 'true'
-        run: |
-          echo "🧪 Running tests with updated dependencies..."
-          cargo test --all-features
-
-      - name: Check for security advisories
-        run: |
-          echo "🔒 Checking for security advisories..."
-          cargo install cargo-audit
-          cargo audit --json > audit_results.json || true
-
-          # Check if there are any vulnerabilities
-          if [ -s audit_results.json ] && jq -e '.vulnerabilities.found | length > 0' audit_results.json > /dev/null; then
-            echo "⚠️ Security vulnerabilities found!"
-            echo "security_issues=true" >> $GITHUB_ENV
-            jq -r '.vulnerabilities.list[] | "- \(.advisory.title) (\(.advisory.id))"' audit_results.json > security_issues.md
-          else
-            echo "✅ No security vulnerabilities found"
-            echo "security_issues=false" >> $GITHUB_ENV
-          fi
-
-      - name: Create pull request
-        if: env.updates_available == 'true' && (github.event.inputs.create_pr != 'false' || github.event_name == 'schedule')
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: |
-            chore: update dependencies
-
-            Automated dependency update by GitHub Actions.
-          title: "chore: automated dependency updates"
-          body: |
-            ## 🤖 Automated Dependency Updates
-
-            This PR contains automated dependency updates performed by GitHub Actions.
-
-            ### Changes
-            - Updated Cargo.lock with latest compatible versions
-            - All tests pass with updated dependencies
-
-            ### Security Status
-            ${{ env.security_issues == 'true' && '⚠️ Security issues detected - see details below' || '✅ No security vulnerabilities detected' }}
-
-            ${{ env.security_issues == 'true' && 'See security_issues.md for details' || '' }}
-
-            ### Dependency Changes
-            $(cat dependency_changes.md 2>/dev/null || echo "See commit for details")
-
-            ---
-
-            **Note:** This PR was automatically created. Please review the changes and run additional tests if necessary.
-          branch: automated/dependency-updates
-          delete-branch: true
-          draft: false
-
-  # =============================================================================
-  # Security Updates
-  # =============================================================================
-  security-updates:
-    name: Security Updates
-    runs-on: ubuntu-24.04
-    if: github.event.inputs.update_type == 'security' || github.event.inputs.update_type == 'all' || github.event_name == 'schedule'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --locked
 
       - name: Run security audit
         run: |
-          echo "🔒 Running comprehensive security audit..."
+          set -euo pipefail
           cargo audit \
             --ignore RUSTSEC-2026-0049 \
             --ignore RUSTSEC-2025-0134 \
-            --json > security_audit.json
+            --json > security_audit.json || true
 
-          # Generate human-readable report
           cargo audit \
             --ignore RUSTSEC-2026-0049 \
             --ignore RUSTSEC-2025-0134 \
@@ -164,59 +40,59 @@ jobs:
       - name: Check for security issues
         id: security_check
         run: |
-          if [ -s security_audit.json ] && jq -e '.vulnerabilities.found | . > 0' security_audit.json > /dev/null; then
-            VULN_COUNT=$(jq -r '.vulnerabilities.found' security_audit.json)
-            echo "found_vulnerabilities=true" >> $GITHUB_OUTPUT
-            echo "vulnerability_count=${VULN_COUNT}" >> $GITHUB_OUTPUT
-
-            # Create summary
-            echo "## 🚨 Security Vulnerabilities Found" > security_summary.md
-            echo "" >> security_summary.md
-            echo "Found ${VULN_COUNT} security vulnerabilities:" >> security_summary.md
-            echo "" >> security_summary.md
-            jq -r '.vulnerabilities.list[] | "### \(.advisory.title)\n- **ID:** \(.advisory.id)\n- **Severity:** \(.advisory.severity // "Unknown")\n- **Package:** \(.package.name)@\(.package.version)\n- **Description:** \(.advisory.description)\n- **Solution:** \(.advisory.solution // "Update to a patched version")\n"' security_audit.json >> security_summary.md
-          else
-            echo "found_vulnerabilities=false" >> $GITHUB_OUTPUT
-            echo "vulnerability_count=0" >> $GITHUB_OUTPUT
-            echo "✅ No security vulnerabilities found"
+          set -euo pipefail
+          if ! jq -e '.vulnerabilities.count | numbers' security_audit.json > /dev/null; then
+            echo "cargo-audit did not produce a valid vulnerability report" >&2
+            exit 1
           fi
 
-      - name: Create security issue
+          if jq -e '.vulnerabilities.count > 0' security_audit.json > /dev/null; then
+            vulnerability_count="$(jq -r '.vulnerabilities.count' security_audit.json)"
+            echo "found_vulnerabilities=true" >> "$GITHUB_OUTPUT"
+            echo "vulnerability_count=${vulnerability_count}" >> "$GITHUB_OUTPUT"
+
+            {
+              echo "## Security vulnerabilities found"
+              echo
+              echo "Found ${vulnerability_count} security vulnerabilities:"
+              echo
+              jq -r '.vulnerabilities.list[] | "### \(.advisory.title)\n- **ID:** \(.advisory.id)\n- **Severity:** \(.advisory.severity // \"Unknown\")\n- **Package:** \(.package.name)@\(.package.version)\n- **Description:** \(.advisory.description)\n- **Solution:** \(.advisory.solution // \"Update to a patched version\")\n"' security_audit.json
+            } > security_summary.md
+          else
+            echo "found_vulnerabilities=false" >> "$GITHUB_OUTPUT"
+            echo "vulnerability_count=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update security issue
         if: steps.security_check.outputs.found_vulnerabilities == 'true'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const securitySummary = fs.readFileSync('security_summary.md', 'utf8');
+            const titlePrefix = 'Security vulnerabilities detected';
 
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'security,automated',
-              state: 'open'
+              state: 'open',
+              per_page: 100
             });
 
-            // Check if there's already an open security issue
-            const existingIssue = issues.find(issue =>
-              issue.title.includes('Security Vulnerabilities Detected')
-            );
-
+            const existingIssue = issues.find((issue) => issue.title.startsWith(titlePrefix));
             if (existingIssue) {
-              // Update existing issue
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: existingIssue.number,
-                body: `## Updated Security Scan Results\n\n${securitySummary}\n\n---\n*Updated: ${new Date().toISOString()}*`
+                body: `## Updated security scan\n\n${securitySummary}\n\nUpdated: ${new Date().toISOString()}`
               });
             } else {
-              // Create new issue
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `🚨 Security Vulnerabilities Detected (${{ steps.security_check.outputs.vulnerability_count }} found)`,
-                body: `${securitySummary}\n\n---\n\n**Action Required:** Please review and address these security vulnerabilities as soon as possible.\n\n*Created: ${new Date().toISOString()}*`,
-                labels: ['security', 'automated', 'high-priority']
+                title: `${titlePrefix} (${{ steps.security_check.outputs.vulnerability_count }})`,
+                body: `${securitySummary}\n\nCreated: ${new Date().toISOString()}`
               });
             }
 
@@ -224,117 +100,44 @@ jobs:
         if: steps.security_check.outputs.found_vulnerabilities == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: security-audit-report
+          name: security-audit-${{ github.run_id }}
           path: |
             security_audit.json
             security_report.txt
             security_summary.md
           retention-days: 30
 
-  # =============================================================================
-  # Dockerfile Updates
-  # =============================================================================
-  dockerfile-updates:
-    name: Dockerfile Base Image Updates
-    runs-on: ubuntu-24.04
-    if: github.event.inputs.update_type == 'all' || github.event_name == 'schedule'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check for base image updates
+      - name: Write security summary
+        if: always()
+        env:
+          VULNERABILITY_COUNT: ${{ steps.security_check.outputs.vulnerability_count || 'unknown' }}
         run: |
-          echo "🐳 Checking for Docker base image updates..."
+          {
+            echo "## Security audit"
+            echo
+            echo "Vulnerabilities found: ${VULNERABILITY_COUNT}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          # Get current base images from Dockerfile
-          RUST_IMAGE=$(grep "^FROM rust:" Dockerfile | head -1 | awk '{print $2}')
-          DEBIAN_IMAGE=$(grep "^FROM debian:" Dockerfile | tail -1 | awk '{print $2}')
-
-          echo "Current Rust image: $RUST_IMAGE"
-          echo "Current Debian image: $DEBIAN_IMAGE"
-
-          # Check if images have updates (this is a simplified check)
-          docker pull $RUST_IMAGE
-          docker pull $DEBIAN_IMAGE
-
-          # For a more sophisticated check, you could compare digests
-          echo "base_images_checked=true" >> $GITHUB_ENV
-
-      - name: Test Dockerfile with updated images
-        run: |
-          echo "🧪 Testing Dockerfile with current base images..."
-          docker build -t sockudo:test . --no-cache --pull
-
-          # Basic functionality test
-          docker run --rm sockudo:test --version || echo "Version check completed"
-
-  # =============================================================================
-  # GitHub Actions Updates
-  # =============================================================================
-  actions-updates:
-    name: GitHub Actions Updates
-    runs-on: ubuntu-24.04
-    if: github.event.inputs.update_type == 'all' || github.event_name == 'schedule'
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check for GitHub Actions updates
-        run: |
-          echo "⚙️ Checking for GitHub Actions updates..."
-
-          # List all workflow files
-          find .github/workflows -name "*.yml" -o -name "*.yaml" | while read -r workflow; do
-            echo "Checking $workflow for action updates..."
-
-            # Extract action references (simplified)
-            grep -E "uses: [^@]+@v[0-9]+" "$workflow" | while read -r line; do
-              ACTION=$(echo "$line" | sed -E 's/.*uses: ([^@]+)@(v[0-9]+).*/\1@\2/')
-              echo "  Found action: $ACTION"
-            done
-          done
-
-          echo "actions_checked=true" >> $GITHUB_ENV
-
-  # =============================================================================
-  # Cleanup and Maintenance
-  # =============================================================================
   cleanup:
     name: Repository Cleanup
     runs-on: ubuntu-24.04
-    if: github.event.inputs.update_type == 'all' || github.event_name == 'schedule'
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Clean up old artifacts
+      - name: Delete old artifacts
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: artifacts } = await github.rest.actions.listArtifactsForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              per_page: 100
-            });
-
-            const thirtyDaysAgo = new Date();
-            thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-
-            const oldArtifacts = artifacts.artifacts.filter(artifact =>
-              new Date(artifact.created_at) < thirtyDaysAgo
+            const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+            const artifacts = await github.paginate(
+              github.rest.actions.listArtifactsForRepo,
+              { owner: context.repo.owner, repo: context.repo.repo, per_page: 100 }
+            );
+            const oldArtifacts = artifacts.filter(
+              (artifact) => Date.parse(artifact.created_at) < thirtyDaysAgo
             );
 
-            console.log(`Found ${oldArtifacts.length} artifacts older than 30 days`);
-
-            for (const artifact of oldArtifacts.slice(0, 10)) { // Limit to 10 to avoid rate limits
-              console.log(`Deleting artifact: ${artifact.name} (${artifact.created_at})`);
+            core.info(`Found ${oldArtifacts.length} artifacts older than 30 days`);
+            for (const artifact of oldArtifacts.slice(0, 50)) {
+              core.info(`Deleting artifact ${artifact.name} from ${artifact.created_at}`);
               await github.rest.actions.deleteArtifact({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -342,75 +145,11 @@ jobs:
               });
             }
 
-      - name: Generate maintenance report
+      - name: Write cleanup summary
         run: |
-          echo "## 🔧 Maintenance Report - $(date)" > maintenance_report.md
-          echo "" >> maintenance_report.md
-          echo "### Actions Performed" >> maintenance_report.md
-          echo "- ✅ Dependency updates checked" >> maintenance_report.md
-          echo "- ✅ Security audit completed" >> maintenance_report.md
-          echo "- ✅ Dockerfile base images checked" >> maintenance_report.md
-          echo "- ✅ GitHub Actions versions checked" >> maintenance_report.md
-          echo "- ✅ Old artifacts cleaned up" >> maintenance_report.md
-          echo "" >> maintenance_report.md
-          echo "### Next Steps" >> maintenance_report.md
-          echo "- Review any created pull requests" >> maintenance_report.md
-          echo "- Address any security issues found" >> maintenance_report.md
-          echo "- Monitor CI/CD pipeline health" >> maintenance_report.md
-
-      - name: Upload maintenance report
-        uses: actions/upload-artifact@v4
-        with:
-          name: maintenance-report-${{ github.run_number }}
-          path: maintenance_report.md
-          retention-days: 90
-
-  # =============================================================================
-  # Summary
-  # =============================================================================
-  summary:
-    name: Maintenance Summary
-    runs-on: ubuntu-24.04
-    needs:
-      [
-        update-dependencies,
-        security-updates,
-        dockerfile-updates,
-        actions-updates,
-        cleanup,
-      ]
-    if: always()
-
-    steps:
-      - name: Create summary
-        run: |
-          echo "## 🛠️ Maintenance Workflow Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Date:** $(date -u)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Job Results" >> $GITHUB_STEP_SUMMARY
-          echo "- Dependencies: ${{ needs.update-dependencies.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Security: ${{ needs.security-updates.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Dockerfile: ${{ needs.dockerfile-updates.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Actions: ${{ needs.actions-updates.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Cleanup: ${{ needs.cleanup.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Add status indicators
-          if [[ "${{ needs.security-updates.result }}" == "success" ]]; then
-            echo "### 🔒 Security Status" >> $GITHUB_STEP_SUMMARY
-            echo "Security audit completed successfully." >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          if [[ "${{ needs.update-dependencies.result }}" == "success" ]]; then
-            echo "### 📦 Dependencies Status" >> $GITHUB_STEP_SUMMARY
-            echo "Dependency updates checked and processed." >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          echo "### 📋 Next Actions" >> $GITHUB_STEP_SUMMARY
-          echo "1. Review any automatically created pull requests" >> $GITHUB_STEP_SUMMARY
-          echo "2. Check for any security issues that need immediate attention" >> $GITHUB_STEP_SUMMARY
-          echo "3. Monitor the next scheduled maintenance run" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Repository cleanup"
+            echo
+            echo "Artifacts older than 30 days were checked and up to 50 were removed."
+            echo "Dependency updates are managed by Dependabot."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -1,4 +1,4 @@
-name: Manual Build - Cross Platform Artifacts
+name: Manual Build - Linux Artifacts
 
 on:
   workflow_dispatch:
@@ -10,21 +10,6 @@ on:
         default: false
       build_linux_arm64:
         description: "Build Linux ARM64 (GNU + musl)"
-        required: false
-        type: boolean
-        default: false
-      build_macos_x64:
-        description: "Build macOS x86_64 (Intel)"
-        required: false
-        type: boolean
-        default: false
-      build_macos_arm64:
-        description: "Build macOS ARM64 (Apple Silicon)"
-        required: false
-        type: boolean
-        default: false
-      build_windows_x64:
-        description: "Build Windows x86_64"
         required: false
         type: boolean
         default: false
@@ -54,8 +39,6 @@ jobs:
       target_name: Linux x86_64 (GNU)
       target_triple: x86_64-unknown-linux-gnu
       runner_os: ubuntu-24.04
-      archive_ext: tgz
-      binary_name: sockudo
       artifact_retention_days: 30
 
   build-linux-x64-musl:
@@ -65,8 +48,6 @@ jobs:
       target_name: Linux x86_64 (musl)
       target_triple: x86_64-unknown-linux-musl
       runner_os: ubuntu-24.04
-      archive_ext: tgz
-      binary_name: sockudo
       artifact_retention_days: 30
 
   build-linux-arm64-gnu:
@@ -76,8 +57,6 @@ jobs:
       target_name: Linux ARM64 (GNU)
       target_triple: aarch64-unknown-linux-gnu
       runner_os: ubuntu-24.04-arm
-      archive_ext: tgz
-      binary_name: sockudo
       artifact_retention_days: 30
 
   build-linux-arm64-musl:
@@ -87,41 +66,6 @@ jobs:
       target_name: Linux ARM64 (musl)
       target_triple: aarch64-unknown-linux-musl
       runner_os: ubuntu-24.04-arm
-      archive_ext: tgz
-      binary_name: sockudo
-      artifact_retention_days: 30
-
-  build-macos-x64:
-    if: inputs.build_macos_x64
-    uses: ./.github/workflows/build-binary.yml
-    with:
-      target_name: macOS x86_64
-      target_triple: x86_64-apple-darwin
-      runner_os: macos-15-intel
-      archive_ext: tgz
-      binary_name: sockudo
-      artifact_retention_days: 30
-
-  build-macos-arm64:
-    if: inputs.build_macos_arm64
-    uses: ./.github/workflows/build-binary.yml
-    with:
-      target_name: macOS ARM64
-      target_triple: aarch64-apple-darwin
-      runner_os: macos-latest
-      archive_ext: tgz
-      binary_name: sockudo
-      artifact_retention_days: 30
-
-  build-windows-x64:
-    if: inputs.build_windows_x64
-    uses: ./.github/workflows/build-binary.yml
-    with:
-      target_name: Windows x86_64
-      target_triple: x86_64-pc-windows-msvc
-      runner_os: windows-latest
-      archive_ext: zip
-      binary_name: sockudo.exe
       artifact_retention_days: 30
 
   # =============================================================================
@@ -202,9 +146,6 @@ jobs:
         build-linux-x64-musl,
         build-linux-arm64-gnu,
         build-linux-arm64-musl,
-        build-macos-x64,
-        build-macos-arm64,
-        build-windows-x64,
         docker,
       ]
     permissions:
@@ -242,9 +183,6 @@ jobs:
 
             if ('${{ inputs.build_linux_x64 }}' === 'true') artifacts.push('Linux x64 (GNU + musl)');
             if ('${{ inputs.build_linux_arm64 }}' === 'true') artifacts.push('Linux ARM64 (GNU + musl)');
-            if ('${{ inputs.build_macos_x64 }}' === 'true') artifacts.push('macOS x64');
-            if ('${{ inputs.build_macos_arm64 }}' === 'true') artifacts.push('macOS ARM64');
-            if ('${{ inputs.build_windows_x64 }}' === 'true') artifacts.push('Windows x64');
             if ('${{ inputs.build_docker }}' === 'true') artifacts.push('Docker image');
 
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/.github/workflows/mirror-swift-sdks.yml
+++ b/.github/workflows/mirror-swift-sdks.yml
@@ -85,6 +85,29 @@ jobs:
 
           echo "selected=${selected}" >> "$GITHUB_OUTPUT"
 
+      - name: Verify mirror token access
+        if: steps.select.outputs.selected == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SWIFT_SDK_MIRROR_TOKEN }}
+          MIRROR_REPOSITORY: ${{ matrix.mirror_repository }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "SWIFT_SDK_MIRROR_TOKEN is not configured." >&2
+            exit 1
+          fi
+
+          if ! can_push="$(gh api "repos/${MIRROR_REPOSITORY}" --jq '.permissions.push')"; then
+            echo "SWIFT_SDK_MIRROR_TOKEN is invalid, expired, or cannot access ${MIRROR_REPOSITORY}." >&2
+            exit 1
+          fi
+
+          if [ "${can_push}" != "true" ]; then
+            echo "SWIFT_SDK_MIRROR_TOKEN needs Contents: Read and write access to ${MIRROR_REPOSITORY}." >&2
+            exit 1
+          fi
+
       - name: Checkout source
         if: steps.select.outputs.selected == 'true'
         uses: actions/checkout@v6
@@ -142,7 +165,7 @@ jobs:
 
           mirror_tag="${MANUAL_MIRROR_TAG}"
           if [ "${EVENT_NAME}" = "push" ] && [ "${REF_TYPE}" = "tag" ]; then
-            mirror_tag="${REF_NAME#${TAG_PREFIX}}"
+            mirror_tag="${REF_NAME#"${TAG_PREFIX}"}"
           fi
 
           if [ -n "${mirror_tag}" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,14 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "prerelease=${PRERELEASE}" >> $GITHUB_OUTPUT
 
+      - name: Checkout requested release tag
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+          fetch-depth: 0
+
       - name: Verify version matches Cargo.toml
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: |
           TAG="${{ steps.version.outputs.tag }}"
 
@@ -103,7 +109,7 @@ jobs:
           echo "suffix=${SUFFIX}" >> $GITHUB_OUTPUT
 
   # =============================================================================
-  # Build Cross-Platform Binaries
+  # Build Linux Binaries
   # =============================================================================
   build-linux-x64-musl:
     needs: prepare
@@ -112,8 +118,7 @@ jobs:
       target_name: Linux x86_64 (musl)
       target_triple: x86_64-unknown-linux-musl
       runner_os: ubuntu-24.04
-      archive_ext: tgz
-      binary_name: sockudo
+      git_ref: ${{ needs.prepare.outputs.tag }}
       version: ${{ needs.prepare.outputs.version }}
 
   build-linux-x64-gnu:
@@ -123,8 +128,7 @@ jobs:
       target_name: Linux x86_64 (GNU)
       target_triple: x86_64-unknown-linux-gnu
       runner_os: ubuntu-24.04
-      archive_ext: tgz
-      binary_name: sockudo
+      git_ref: ${{ needs.prepare.outputs.tag }}
       version: ${{ needs.prepare.outputs.version }}
 
   build-linux-arm64-gnu:
@@ -134,8 +138,7 @@ jobs:
       target_name: Linux ARM64 (GNU)
       target_triple: aarch64-unknown-linux-gnu
       runner_os: ubuntu-24.04-arm
-      archive_ext: tgz
-      binary_name: sockudo
+      git_ref: ${{ needs.prepare.outputs.tag }}
       version: ${{ needs.prepare.outputs.version }}
 
   build-linux-arm64-musl:
@@ -145,41 +148,7 @@ jobs:
       target_name: Linux ARM64 (musl)
       target_triple: aarch64-unknown-linux-musl
       runner_os: ubuntu-24.04-arm
-      archive_ext: tgz
-      binary_name: sockudo
-      version: ${{ needs.prepare.outputs.version }}
-
-  build-macos-x64:
-    needs: prepare
-    uses: ./.github/workflows/build-binary.yml
-    with:
-      target_name: macOS x86_64
-      target_triple: x86_64-apple-darwin
-      runner_os: macos-15-intel
-      archive_ext: tgz
-      binary_name: sockudo
-      version: ${{ needs.prepare.outputs.version }}
-
-  build-macos-arm64:
-    needs: prepare
-    uses: ./.github/workflows/build-binary.yml
-    with:
-      target_name: macOS ARM64
-      target_triple: aarch64-apple-darwin
-      runner_os: macos-latest
-      archive_ext: tgz
-      binary_name: sockudo
-      version: ${{ needs.prepare.outputs.version }}
-
-  build-windows-x64:
-    needs: prepare
-    uses: ./.github/workflows/build-binary.yml
-    with:
-      target_name: Windows x86_64
-      target_triple: x86_64-pc-windows-msvc
-      runner_os: windows-latest
-      archive_ext: zip
-      binary_name: sockudo.exe
+      git_ref: ${{ needs.prepare.outputs.tag }}
       version: ${{ needs.prepare.outputs.version }}
 
   # =============================================================================
@@ -203,6 +172,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -327,15 +298,14 @@ jobs:
         build-linux-x64-gnu,
         build-linux-arm64-gnu,
         build-linux-arm64-musl,
-        build-macos-x64,
-        build-macos-arm64,
-        build-windows-x64,
       ]
     if: needs.prepare.outputs.prerelease != 'true'
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -421,9 +391,6 @@ jobs:
         build-linux-x64-gnu,
         build-linux-arm64-gnu,
         build-linux-arm64-musl,
-        build-macos-x64,
-        build-macos-arm64,
-        build-windows-x64,
         docker-manifest,
         publish-crates,
       ]
@@ -431,13 +398,17 @@ jobs:
       always() && !cancelled() &&
       needs.build-linux-x64-musl.result == 'success' &&
       needs.build-linux-x64-gnu.result == 'success' &&
-      needs.build-macos-x64.result == 'success' &&
-      needs.build-macos-arm64.result == 'success' &&
-      needs.build-windows-x64.result == 'success' &&
+      needs.build-linux-arm64-gnu.result == 'success' &&
+      needs.build-linux-arm64-musl.result == 'success' &&
       needs.docker-manifest.result == 'success' &&
       (needs.publish-crates.result == 'success' || needs.publish-crates.result == 'skipped')
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -446,7 +417,7 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           name: "Sockudo ${{ needs.prepare.outputs.tag }}"
@@ -454,9 +425,11 @@ jobs:
           body: |
             ## Installation
 
-            ### Using cargo-binstall (Recommended)
+            ### Linux installer (Recommended)
             ```bash
-            cargo binstall sockudo --version ${{ needs.prepare.outputs.version }}
+            curl --proto '=https' --tlsv1.2 -sSfL \
+              https://sockudo.io/install.sh \
+              | sh -s -- --version ${{ needs.prepare.outputs.version }}
             ```
 
             ### Using cargo
@@ -471,18 +444,18 @@ jobs:
             ```
 
             ### Direct Download
-            Download the appropriate binary for your platform from the assets below.
+            Linux archives and their SHA-256 checksums are attached below.
 
             ## Platform Support
             - ✅ Linux x86_64 (GNU)
             - ✅ Linux x86_64 (musl)
             - ✅ Linux ARM64 (GNU)
             - ✅ Linux ARM64 (musl)
-            - ✅ macOS x86_64 (Intel)
-            - ✅ macOS ARM64 (Apple Silicon)
-            - ✅ Windows x86_64
             - ✅ Docker linux/amd64
             - ✅ Docker linux/arm64
-          files: ./release-artifacts/*
+            - 🛠️ Other platforms via `cargo install sockudo`
+          files: |
+            ./release-artifacts/*
+            ./install.sh
           draft: false
           prerelease: ${{ needs.prepare.outputs.prerelease }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ RUN for dir in protocol filter core app cache queue rate-limiter metrics webhook
     done && \
     mkdir -p crates/sockudo-push/examples && \
     echo "fn main() {}" > crates/sockudo-push/examples/webpush_send.rs && \
+    mkdir -p crates/sockudo-queue/examples && \
+    echo "fn main() {}" > crates/sockudo-queue/examples/queue_bench.rs && \
     mkdir -p crates/sockudo-ably-compat/benches && \
     for bench in wire_codec compatibility_hot_paths fanout_grouping realtime_retry_id stats_recording ably_vcdiff; do \
         echo "fn main() {}" > crates/sockudo-ably-compat/benches/$bench.rs; \
@@ -78,22 +80,26 @@ RUN for dir in protocol filter core app cache queue rate-limiter metrics webhook
 RUN test -f Cargo.lock || cargo generate-lockfile
 
 ARG SOCKUDO_FEATURES=full
-ARG CARGO_PROFILE_RELEASE_LTO=true
-ARG CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+# The full feature graph exceeds the standard ARM64 runner's memory with fat LTO.
+# Thin LTO keeps cross-architecture images optimized while bounding link memory.
+ARG CARGO_PROFILE_RELEASE_LTO=thin
+ARG CARGO_PROFILE_RELEASE_CODEGEN_UNITS=8
+ARG CARGO_BUILD_JOBS=2
 ENV CARGO_PROFILE_RELEASE_LTO=${CARGO_PROFILE_RELEASE_LTO}
 ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 
 # Set jemalloc's page size to 4KB (use 16 for 64KB-page hosts)
 ARG JEMALLOC_SYS_WITH_LG_PAGE=12
 ENV JEMALLOC_SYS_WITH_LG_PAGE=${JEMALLOC_SYS_WITH_LG_PAGE}
 
 # Build dependencies only (this layer is cached unless Cargo.toml files change)
-RUN cargo build -p sockudo --release --features "${SOCKUDO_FEATURES}" || true
+RUN cargo build -p sockudo --release --features "${SOCKUDO_FEATURES}"
 # Clean up dummy sources but keep compiled deps
 RUN for dir in protocol filter core app cache queue rate-limiter metrics webhook delta push ai-transport ably-compat adapter server simulator; do \
         rm -rf crates/sockudo-$dir/src; \
     done && \
-    rm -rf crates/sockudo-push/examples && \
+    rm -rf crates/sockudo-push/examples crates/sockudo-queue/examples && \
     rm -rf crates/sockudo-ably-compat/benches && \
     rm -rf benches/ai/src benches/ai/benches && \
     rm -f target/release/deps/sockudo* target/release/deps/libsockudo* target/release/sockudo

--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ Default local services:
 | Dashboard UI | `http://localhost:5174` |
 | Dashboard API | `http://localhost:3460` |
 
+### Linux Binary
+
+Install the latest verified x86_64 or ARM64 release into `~/.local/bin`:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://sockudo.io/install.sh | sh
+```
+
+The installer detects GNU libc or musl and verifies the archive's SHA-256 checksum. See the
+[installation guide](docs/content/docs/getting-started/installation.mdx) for version pinning and
+custom installation paths.
+
 ### From Source
 
 ```bash

--- a/crates/sockudo-protocol/src/messages.rs
+++ b/crates/sockudo-protocol/src/messages.rs
@@ -45,6 +45,12 @@ pub const AI_HEADER_STEER_CODEC_MESSAGE_IDS: &str = "steer-codec-message-ids";
 pub const AI_HEADER_STEP_REASON: &str = "step-reason";
 pub const AI_HEADER_STEP_CLIENT_ID: &str = "step-client-id";
 pub const AI_HEADER_MSG_REGENERATE: &str = "msg-regenerate";
+/// Run id of the suspended reply that a client tool-result fork replaces.
+///
+/// Unlike `fork-of` and `msg-regenerate`, which keep both branches navigable,
+/// `supersedes` lets clients hide the dead suspended trunk from branch
+/// selection after its tool result continues in a new run.
+pub const AI_HEADER_SUPERSEDES: &str = "supersedes";
 pub const AI_HEADER_LEGACY_TURN_ID: &str = "turn-id";
 pub const AI_HEADER_LEGACY_TURN_CLIENT_ID: &str = "turn-client-id";
 pub const AI_HEADER_LEGACY_TURN_REASON: &str = "turn-reason";
@@ -346,6 +352,11 @@ impl<'a> AiTransportHeaders<'a> {
     #[inline]
     pub fn msg_regenerate(&self) -> Option<&'a str> {
         self.get(AI_HEADER_MSG_REGENERATE)
+    }
+
+    #[inline]
+    pub fn supersedes(&self) -> Option<&'a str> {
+        self.get(AI_HEADER_SUPERSEDES)
     }
 
     #[inline]
@@ -675,6 +686,7 @@ fn validate_transport_key_domain(key: &str, value: &str) -> Result<(), AiHeaderV
         | AI_HEADER_STEP_START_SERIAL
         | AI_HEADER_STEER_CODEC_MESSAGE_IDS
         | AI_HEADER_MSG_REGENERATE
+        | AI_HEADER_SUPERSEDES
         | "error-code"
         | "model" => {
             if value.is_empty() {

--- a/crates/sockudo-protocol/tests/protocol_compliance.rs
+++ b/crates/sockudo-protocol/tests/protocol_compliance.rs
@@ -5,8 +5,9 @@ use sockudo_protocol::messages::{
     AI_EVENT_RUN_START, AI_EVENT_RUN_SUSPEND, AI_HEADER_LEGACY_TURN_ID, AI_HEADER_MSG_REGENERATE,
     AI_HEADER_RUN_CLIENT_ID, AI_HEADER_RUN_CONTINUE, AI_HEADER_RUN_ID,
     AI_HEADER_STEER_CODEC_MESSAGE_IDS, AI_HEADER_STEER_CODEC_MESSAGE_IDS_MAX_BYTES,
-    AI_HEADER_STEP_CLIENT_ID, AI_HEADER_STEP_START_SERIAL, AI_TRANSPORT_VALUE_MAX_BYTES, AiExtras,
-    AiHeaderLimits, ExtrasValue, MessageData, MessageExtras, PusherMessage, is_ai_event,
+    AI_HEADER_STEP_CLIENT_ID, AI_HEADER_STEP_START_SERIAL, AI_HEADER_SUPERSEDES,
+    AI_TRANSPORT_VALUE_MAX_BYTES, AiExtras, AiHeaderLimits, ExtrasValue, MessageData,
+    MessageExtras, PusherMessage, is_ai_event,
 };
 use sonic_rs::prelude::*;
 use sonic_rs::{Value, json};
@@ -674,6 +675,48 @@ fn test_ai_transport_msg_regenerate_rejects_empty() {
             transport: Some(HashMap::from([(
                 AI_HEADER_MSG_REGENERATE.to_string(),
                 "".to_string(),
+            )])),
+            codec: None,
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        extras.validate_ai_headers().unwrap_err().code,
+        AI_ERROR_INVALID_TRANSPORT_HEADER
+    );
+}
+
+#[test]
+fn test_ai_transport_supersedes_accepts_run_id() {
+    let extras = MessageExtras {
+        ai: Some(AiExtras {
+            transport: Some(HashMap::from([
+                (AI_HEADER_RUN_ID.to_string(), "run-fork".to_string()),
+                (AI_HEADER_SUPERSEDES.to_string(), "run-trunk".to_string()),
+            ])),
+            codec: None,
+        }),
+        ..Default::default()
+    };
+
+    assert!(extras.validate_ai_headers().is_ok());
+    assert_eq!(
+        extras
+            .ai_transport_headers()
+            .expect("transport headers")
+            .supersedes(),
+        Some("run-trunk")
+    );
+}
+
+#[test]
+fn test_ai_transport_supersedes_rejects_empty() {
+    let extras = MessageExtras {
+        ai: Some(AiExtras {
+            transport: Some(HashMap::from([(
+                AI_HEADER_SUPERSEDES.to_string(),
+                String::new(),
             )])),
             codec: None,
         }),

--- a/crates/sockudo-server/Cargo.toml
+++ b/crates/sockudo-server/Cargo.toml
@@ -169,10 +169,4 @@ supported-targets = [
   "x86_64-unknown-linux-musl",
   "aarch64-unknown-linux-gnu",
   "aarch64-unknown-linux-musl",
-  "x86_64-apple-darwin",
-  "aarch64-apple-darwin",
-  "x86_64-pc-windows-msvc",
 ]
-
-[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
-pkg-fmt = "zip"

--- a/docs/ably-compat/TEST_PLAN.md
+++ b/docs/ably-compat/TEST_PLAN.md
@@ -23,6 +23,35 @@ make ably-ai-transport-test
 make ably-ai-demo
 ```
 
+## Pull Request Latest-Upstream Gate
+
+Every pull request runs `.github/workflows/ably-upstream-compat.yml`. The workflow checks out the
+current `main` heads of `ably/ably-js` and `ably/ably-ai-transport-js` at job start, records the
+resolved commit IDs in the GitHub step summary and diagnostic artifact, and tests the pull request's
+Sockudo merge commit. No Ably credentials or long-lived test app are required. Sockudo's public
+`tests/ably-compat/upstream-sandbox.mjs` provisioner creates isolated, randomly keyed Sockudo
+children locally from the repository's own config template. This keeps the pull request workflow
+usable from forks without a private-repository token.
+
+The `ably-js` job runs every Node `test/unit`, `test/rest`, and `test/realtime` file discovered on
+upstream `main`, except:
+
+- `test/rest/liveobjects.test.js` and `test/realtime/liveobjects.test.js`, because Live Objects is
+  outside Sockudo's advertised compatibility surface;
+- `test/realtime/transports.test.js`, because Sockudo realtime is WebSocket-only;
+- the exact `node_transports` assertion, which requires the SDK's Comet inventory; and
+- two SDK-default TLS/port assertions whose expected defaults are necessarily replaced by the
+  local sandbox routing. The remaining connectivity, REST fallback, and init assertions still run.
+
+`ABLY_TEST_TRANSPORTS=web_socket` forces all parameterized realtime cases onto WebSocket. New files
+are included automatically; the file list is printed so an upstream rename cannot silently shrink
+coverage. Upstream-default pending tests remain pending, matching Ably's own Node command.
+
+The `ably-ai-transport-js` job has no test exclusions. It runs the complete unit suite followed by
+the complete integration suite against the same local Sockudo sandbox. The two jobs are deliberately
+separate from pinned release evidence: latest-upstream CI detects drift, while a release claim must
+still cite immutable source revisions and retained reports.
+
 Release evidence uses the pinned harness directly and keeps each lane separate:
 
 ```bash

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -4,9 +4,9 @@ description: Run Sockudo locally or build a production binary with the right fea
 icon: Download
 ---
 
-The fastest way to evaluate Sockudo is Docker Compose. For a single binary, use `cargo-binstall`
-or `cargo install`. For container platforms, pull the published image from GitHub Container Registry
-or Docker Hub. The most controlled production path is a Cargo build with only the features you need.
+The fastest way to evaluate Sockudo is Docker Compose. On Linux, the release installer downloads a
+verified prebuilt binary. For container platforms, pull the published image from GitHub Container
+Registry or Docker Hub. Other operating systems can build from crates.io or source.
 
 ## Docker Compose
 
@@ -25,20 +25,33 @@ The default server listens on:
 
 Use Compose when you want Redis, local configuration, and repeatable development infrastructure without compiling Rust first.
 
-## Install a prebuilt binary
+## Install a Linux binary
 
-Use `cargo-binstall` when you want the released Sockudo binary without cloning the repository or
-compiling the server locally.
+The installer supports x86_64 and ARM64 Linux, detects GNU libc or musl, and verifies the release
+archive against its published SHA-256 checksum. It installs to `~/.local/bin` by default.
 
 ```bash
-cargo install cargo-binstall
-cargo binstall sockudo
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://sockudo.io/install.sh | sh
 ```
 
-Pin a release when your deployment needs repeatable installs:
+`sockudo.io/install.sh` is the stable public URL. It redirects to the installer attached to the
+latest GitHub release; the installer then downloads and verifies the selected version from GitHub.
+
+Pin the binary version in deployments:
 
 ```bash
-cargo binstall sockudo --version 4.7.0
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://sockudo.io/install.sh \
+  | sh -s -- --version 4.7.0
+```
+
+Choose another writable installation directory with `--bin-dir`:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSfL \
+  https://sockudo.io/install.sh \
+  | sh -s -- --bin-dir "$HOME/bin"
 ```
 
 Run the installed binary with a local configuration file:
@@ -47,9 +60,13 @@ Run the installed binary with a local configuration file:
 sockudo --config ./config/config.toml
 ```
 
+Only Linux binaries are published. `cargo binstall sockudo` remains available for the same Linux
+release assets; use a source build on macOS, Windows, and other platforms.
+
 ## Install from crates.io
 
-Use `cargo install` when you prefer building the published crate on the target host:
+Use `cargo install` when you prefer building the published crate on the target host or need a
+platform without a prebuilt binary:
 
 ```bash
 cargo install sockudo --locked

--- a/docs/content/docs/reference/compatibility.mdx
+++ b/docs/content/docs/reference/compatibility.mdx
@@ -69,12 +69,16 @@ AI Transport is additive and default-off. The server release order is:
 
 Sockudo does not claim full Ably platform compatibility. The evidence-backed wording is **Ably REST
 and WebSocket compatibility, excluding Live Objects**. The opt-in `ably-compat` surface is validated
-against pinned Node, browser, strict-upstream-pending, and AI Transport manifests in
-`sockudo-compatibility/`. Exactly the two Live Objects files and the multiple/non-WebSocket
-transport file are excluded. `testExcludes` and the selected-lane known-failure entries are empty;
-upstream-default pending results are audited and executed separately, without changing their bodies,
-assertions, or expected values. A default-lane pass is not reported as a strict-completeness or
-browser pass.
+in two layers. Pull requests fetch the current `main` heads of `ably-js` and
+`ably-ai-transport-js`, record their resolved commit IDs, and run the Node REST/WebSocket and complete
+AI Transport suites against the pull request. Realtime is forced to WebSocket; Live Objects and
+multiple/non-WebSocket transport coverage are excluded. Three named SDK/harness-only assertions are
+also excluded: the Comet inventory and two default TLS/port checks overridden by local routing.
+
+Pinned Node, browser, strict-upstream-pending, and AI Transport manifests remain the source of
+reproducible release evidence. Upstream-default pending results are audited and executed separately,
+without changing their bodies, assertions, or expected values. A latest-upstream or default-lane
+pass is not reported as a strict-completeness, browser, or immutable release-evidence pass.
 
 The current dated evidence is not release-complete: Node defaults are green at 575 passes and AIT
 is 50/50, while strict completeness and all browser release lanes remain red. The authoritative

--- a/docs/content/docs/server/ably-ai-transport-compatibility.mdx
+++ b/docs/content/docs/server/ably-ai-transport-compatibility.mdx
@@ -27,6 +27,15 @@ no per-test exclusions. Node defaults, browser execution, strict execution of
 upstream-pending bodies, and AI Transport have separate reports and pass/fail
 states. A result from one lane is never used to claim another lane passed.
 
+Pull requests also run a moving latest-upstream gate. It resolves and records
+the current `main` commits of `ably-js` and `ably-ai-transport-js`, forces
+realtime cases to WebSocket, runs every discovered Node REST/realtime/unit file
+outside the Live Objects and multi-transport files, and runs the complete AI
+Transport unit and integration suites. Three exact SDK/harness-only assertions
+are filtered: the Comet transport inventory and two default TLS/port assertions
+that local sandbox routing overrides. This gate detects upstream drift but does
+not replace the immutable pinned reports used for release claims.
+
 Current release evidence is not fully green. The fresh Node default lane is
 575 passed with no failures, and the AIT lane is 50/50. The strict lane has four
 pinned-fixture failures before its wire assertion; Chromium, Firefox, and WebKit

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -6,6 +6,15 @@ const withMDX = createMDX();
 const config = {
   reactStrictMode: true,
   allowedDevOrigins: ['127.0.0.1'],
+  async redirects() {
+    return [
+      {
+        source: '/install.sh',
+        destination: 'https://github.com/sockudo/sockudo/releases/latest/download/install.sh',
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default withMDX(config);

--- a/docs/specs/ai-transport-wire-protocol.md
+++ b/docs/specs/ai-transport-wire-protocol.md
@@ -159,6 +159,7 @@ Transport keys:
 | `parent` | Parent `codec-message-id` |
 | `fork-of` | Fork source `codec-message-id` |
 | `msg-regenerate` | Non-empty codec-message-id of the assistant message being regenerated |
+| `supersedes` | Non-empty `run-id` of a suspended reply replaced by a client tool-result fork; the superseded run is hidden from branch selection |
 | `stream` | `true` or `false` |
 | `stream-id` | Non-empty opaque string |
 | `status` | `streaming`, `complete`, `cancelled` |

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,12 @@ EOF
 }
 
 need_value() {
-  [ "$#" -ge 2 ] && [ -n "$2" ] || fail "$1 requires a value"
+  if [ "$#" -lt 2 ]; then
+    fail "$1 requires a value"
+  fi
+  if [ -z "$2" ]; then
+    fail "$1 requires a value"
+  fi
   case "$2" in
     -*) fail "$1 requires a value" ;;
   esac

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+
+set -eu
+
+RELEASES_URL="https://github.com/sockudo/sockudo/releases"
+VERSION=${SOCKUDO_VERSION:-}
+BIN_DIR=${SOCKUDO_INSTALL_DIR:-}
+
+say() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  say "sockudo installer: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Install a released Sockudo binary on Linux.
+
+Usage:
+  install.sh [--version <version>] [--bin-dir <directory>]
+
+Options:
+  --version <version>    Install a specific release (for example, 4.7.0).
+  --bin-dir <directory>  Install into this directory.
+  -h, --help             Show this help.
+
+Environment:
+  SOCKUDO_VERSION        Same as --version.
+  SOCKUDO_INSTALL_DIR    Same as --bin-dir.
+
+The default installation directory is $HOME/.local/bin.
+EOF
+}
+
+need_value() {
+  [ "$#" -ge 2 ] && [ -n "$2" ] || fail "$1 requires a value"
+  case "$2" in
+    -*) fail "$1 requires a value" ;;
+  esac
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      need_value "$@"
+      VERSION=$2
+      shift 2
+      ;;
+    --version=*)
+      VERSION=${1#*=}
+      shift
+      ;;
+    --bin-dir)
+      need_value "$@"
+      BIN_DIR=$2
+      shift 2
+      ;;
+    --bin-dir=*)
+      BIN_DIR=${1#*=}
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+command -v tar >/dev/null 2>&1 || fail "tar is required"
+command -v install >/dev/null 2>&1 || fail "install is required"
+
+[ "$(uname -s)" = "Linux" ] || fail "prebuilt binaries are available only for Linux; use 'cargo install sockudo' on other platforms"
+
+case "$(uname -m)" in
+  x86_64 | amd64)
+    ARCH=x86_64
+    ;;
+  aarch64 | arm64)
+    ARCH=aarch64
+    ;;
+  *)
+    fail "unsupported Linux architecture: $(uname -m)"
+    ;;
+esac
+
+LIBC=gnu
+if [ -f /etc/alpine-release ] || (command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl); then
+  LIBC=musl
+fi
+TARGET="${ARCH}-unknown-linux-${LIBC}"
+
+if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
+  LATEST_URL=$(curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+    --output /dev/null --write-out '%{url_effective}' "${RELEASES_URL}/latest")
+  case "$LATEST_URL" in
+    */tag/v*) VERSION=${LATEST_URL##*/v} ;;
+    *) fail "could not determine the latest release version" ;;
+  esac
+fi
+VERSION=${VERSION#v}
+
+case "$VERSION" in
+  '' | [!0-9]* | *[!0-9A-Za-z.+-]*)
+    fail "invalid release version: $VERSION"
+    ;;
+esac
+
+if [ -z "$BIN_DIR" ]; then
+  [ -n "${HOME:-}" ] || fail "HOME is not set; pass --bin-dir"
+  BIN_DIR="$HOME/.local/bin"
+fi
+
+ARCHIVE="sockudo-v${VERSION}-${TARGET}.tgz"
+DOWNLOAD_URL="${RELEASES_URL}/download/v${VERSION}/${ARCHIVE}"
+
+TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t sockudo-install) || fail "could not create a temporary directory"
+trap 'rm -rf "$TMP_DIR"' EXIT HUP INT TERM
+
+say "Downloading Sockudo ${VERSION} for ${TARGET}..."
+curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+  --output "$TMP_DIR/$ARCHIVE" "$DOWNLOAD_URL"
+curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+  --output "$TMP_DIR/${ARCHIVE}.sha256" "${DOWNLOAD_URL}.sha256"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$TMP_DIR" && sha256sum -c "${ARCHIVE}.sha256")
+elif command -v shasum >/dev/null 2>&1; then
+  (cd "$TMP_DIR" && shasum -a 256 -c "${ARCHIVE}.sha256")
+else
+  fail "sha256sum or shasum is required to verify the download"
+fi
+
+tar -xzf "$TMP_DIR/$ARCHIVE" -C "$TMP_DIR"
+[ -f "$TMP_DIR/sockudo" ] || fail "release archive does not contain the sockudo binary"
+
+mkdir -p "$BIN_DIR" || fail "could not create $BIN_DIR"
+install -m 0755 "$TMP_DIR/sockudo" "$BIN_DIR/sockudo" || fail "could not install to $BIN_DIR; choose a writable --bin-dir"
+
+say "Installed Sockudo ${VERSION} to $BIN_DIR/sockudo"
+case ":${PATH:-}:" in
+  *:"$BIN_DIR":*) ;;
+  *) say "Add $BIN_DIR to PATH to run 'sockudo' from any directory." ;;
+esac

--- a/tests/ably-compat/upstream-sandbox.mjs
+++ b/tests/ably-compat/upstream-sandbox.mjs
@@ -1,0 +1,492 @@
+import { spawn } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import {
+  closeSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createServer } from 'node:http';
+import { createServer as createTcpServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FULL_CAPABILITY = '{"*":["*"]}';
+const MAX_REQUEST_BYTES = 5 * 1024 * 1024;
+const ACTION = Object.freeze({ CONNECTED: 4, ERROR: 9, ATTACH: 10, ATTACHED: 11, PRESENCE: 14 });
+const PRESENCE_ENTER = 2;
+
+function token(bytes) {
+  return randomBytes(bytes).toString('base64url');
+}
+
+function tomlString(value) {
+  return `"${String(value).replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+}
+
+function capabilityString(capability) {
+  if (capability === undefined || capability === null) return FULL_CAPABILITY;
+  return typeof capability === 'string' ? capability : JSON.stringify(capability);
+}
+
+function regexEscape(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function createAppDefinition(request) {
+  const appId = `app-${token(6)}`;
+  const requestedKeys = request.keys?.length ? request.keys : [{}];
+  const configKeys = [];
+  const responseKeys = [];
+
+  requestedKeys.forEach((requested, index) => {
+    const id = `k${index}`;
+    const secret = token(18);
+    const keyName = `${appId}.${id}`;
+    const keyStr = `${keyName}:${secret}`;
+    const capability = capabilityString(requested.capability);
+
+    configKeys.push({
+      id,
+      secret,
+      capability: requested.capability == null ? undefined : capability,
+      revocableTokens: requested.revocableTokens === true,
+    });
+    responseKeys.push({
+      ...requested,
+      id,
+      value: secret,
+      keyName,
+      keySecret: secret,
+      keyStr,
+      capability,
+    });
+  });
+
+  return {
+    accountId: `account-${token(4)}`,
+    appId,
+    channels: request.channels ?? [],
+    configKeys,
+    namespaces: request.namespaces ?? [],
+    primaryKey: responseKeys[0].keyStr,
+    responseKeys,
+  };
+}
+
+function namespaceConfig(namespace) {
+  const id = String(namespace.id);
+  const values = [
+    '[[app_manager.array.apps.policy.channels.channel_namespaces]]',
+    `name = ${tomlString(id)}`,
+    `channel_name_pattern = ${tomlString(`^${regexEscape(id)}:.+$`)}`,
+    'max_channel_name_length = 200',
+  ];
+  if (namespace.mutableMessages === true) values.push('annotations_enabled = true');
+  return values.join('\n');
+}
+
+function appManagerConfig(definition) {
+  const primary = definition.configKeys[0];
+  const namespaces = definition.namespaces.map(namespaceConfig).join('\n\n');
+  return `[[app_manager.array.apps]]
+id = ${tomlString(definition.appId)}
+key = ${tomlString(`${definition.appId}.${primary.id}`)}
+secret = ${tomlString(primary.secret)}
+enabled = true
+
+[app_manager.array.apps.policy.limits]
+max_connections = 100000
+max_client_events_per_second = 1000
+
+[app_manager.array.apps.policy.features]
+enable_client_messages = true
+enable_user_authentication = true
+
+[app_manager.array.apps.policy.channels]
+allowed_origins = ["*"]
+
+${namespaces}
+
+[app_manager.array.apps.policy.idempotency]
+enabled = true
+ttl_seconds = 300
+
+[app_manager.array.apps.policy.connection_recovery]
+enabled = true
+`;
+}
+
+function compatibilityConfig(definition) {
+  const keys = definition.configKeys
+    .map((key) => {
+      const values = [
+        '[[ably_compat.keys]]',
+        `app_id = ${tomlString(definition.appId)}`,
+        `key_name = ${tomlString(`${definition.appId}.${key.id}`)}`,
+        `secret = ${tomlString(key.secret)}`,
+        'enabled = true',
+      ];
+      if (key.capability !== undefined) values.push(`capability = ${tomlString(key.capability)}`);
+      if (key.revocableTokens) values.push('revocable_tokens = true');
+      return values.join('\n');
+    })
+    .join('\n\n');
+
+  return `enabled = true
+stats_fixture_ingest_enabled = true
+
+${keys}
+`;
+}
+
+function replaceSection(source, startMarker, endMarker, body) {
+  const start = new RegExp(`^${regexEscape(startMarker)}$`, 'm').exec(source);
+  const end = new RegExp(`^${regexEscape(endMarker)}$`, 'm').exec(source);
+  if (!start || !end || end.index <= start.index) {
+    throw new Error(`config template is missing ${startMarker} or ${endMarker}`);
+  }
+  return `${source.slice(0, start.index + startMarker.length)}\n${body}\n${source.slice(end.index)}`;
+}
+
+export function renderConfig(template, port, definition) {
+  let config = template.replace(/^port\s*=\s*\d+\s*$/m, `port = ${port}`);
+  config = replaceSection(
+    config,
+    '[app_manager.array]',
+    '[app_manager.cache]',
+    appManagerConfig(definition),
+  );
+  config = replaceSection(config, '[ably_compat]', '[cache]', compatibilityConfig(definition));
+  return config.replace(/^enabled\s*=\s*true\s*\n(driver\s*=\s*"prometheus")/m, 'enabled = false\n$1');
+}
+
+function readBody(request) {
+  return new Promise((resolveBody, reject) => {
+    const chunks = [];
+    let size = 0;
+    request.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > MAX_REQUEST_BYTES) {
+        reject(new Error('request body is too large'));
+        request.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    request.on('end', () => resolveBody(Buffer.concat(chunks).toString('utf8')));
+    request.on('error', reject);
+  });
+}
+
+function sendJson(response, status, value) {
+  const body = JSON.stringify(value);
+  response.writeHead(status, {
+    'content-length': Buffer.byteLength(body),
+    'content-type': 'application/json',
+  });
+  response.end(body);
+}
+
+function sendText(response, status, body) {
+  response.writeHead(status, { 'content-type': 'text/plain; charset=utf-8' });
+  response.end(body);
+}
+
+function lastLogLines(path, count = 20) {
+  try {
+    return readFileSync(path, 'utf8').trim().split('\n').slice(-count).join('\n');
+  } catch {
+    return '';
+  }
+}
+
+function portIsAvailable(port) {
+  return new Promise((resolveAvailable) => {
+    const server = createTcpServer();
+    server.once('error', () => resolveAvailable(false));
+    server.listen(port, '127.0.0.1', () => server.close(() => resolveAvailable(true)));
+  });
+}
+
+function wait(milliseconds) {
+  return new Promise((resolveWait) => setTimeout(resolveWait, milliseconds));
+}
+
+export function createSandbox({ binary, configTemplate, logDirectory, childPortBase = 7100 }) {
+  if (!binary || !configTemplate || !logDirectory) {
+    throw new Error('binary, configTemplate, and logDirectory are required');
+  }
+
+  mkdirSync(logDirectory, { recursive: true });
+  const children = new Map();
+  let portCursor = childPortBase;
+
+  async function allocatePort() {
+    for (let attempt = 0; attempt < 1000; attempt += 1) {
+      const port = portCursor;
+      portCursor += 1;
+      if (await portIsAvailable(port)) return port;
+    }
+    throw new Error('no free child port found');
+  }
+
+  function stopChild(child) {
+    if (child.presenceSocket) child.presenceSocket.close();
+    if (child.process.exitCode === null && child.process.signalCode === null) {
+      child.process.kill('SIGKILL');
+    }
+    rmSync(child.directory, { force: true, recursive: true });
+  }
+
+  async function waitUntilReady(child) {
+    for (let attempt = 0; attempt < 150; attempt += 1) {
+      if (child.process.exitCode !== null || child.process.signalCode !== null) {
+        throw new Error(`Sockudo exited during startup:\n${lastLogLines(child.logPath)}`);
+      }
+      try {
+        if ((await fetch(`http://127.0.0.1:${child.port}/time`)).ok) return;
+      } catch {
+        // The listener is not ready yet.
+      }
+      await wait(200);
+    }
+    throw new Error(`Sockudo did not start within 30 seconds:\n${lastLogLines(child.logPath)}`);
+  }
+
+  async function seedPresence(child, definition) {
+    const channels = definition.channels.filter(
+      (channel) => channel.name && channel.presence?.length,
+    );
+    if (channels.length === 0) return;
+
+    await new Promise((resolveSeed, reject) => {
+      const socket = new WebSocket(
+        `ws://127.0.0.1:${child.port}/?key=${encodeURIComponent(definition.primaryKey)}&format=json&v=3`,
+      );
+      const pending = new Map(channels.map((channel) => [channel.name, channel]));
+      const timeout = setTimeout(
+        () => finish(new Error('presence fixture seeding timed out')),
+        15_000,
+      );
+
+      function finish(error) {
+        clearTimeout(timeout);
+        socket.removeEventListener('message', onMessage);
+        socket.removeEventListener('error', onError);
+        if (error) {
+          socket.close();
+          reject(error);
+        } else {
+          child.presenceSocket = socket;
+          resolveSeed();
+        }
+      }
+
+      function onError() {
+        finish(new Error('presence fixture WebSocket failed'));
+      }
+
+      function onMessage(event) {
+        let message;
+        try {
+          message = JSON.parse(event.data);
+        } catch {
+          return;
+        }
+
+        if (message.action === ACTION.CONNECTED) {
+          for (const channel of channels) {
+            socket.send(JSON.stringify({ action: ACTION.ATTACH, channel: channel.name }));
+          }
+          return;
+        }
+        if (message.action === ACTION.ATTACHED && pending.has(message.channel)) {
+          const channel = pending.get(message.channel);
+          socket.send(
+            JSON.stringify({
+              action: ACTION.PRESENCE,
+              channel: channel.name,
+              presence: channel.presence.map((member) => ({
+                action: PRESENCE_ENTER,
+                clientId: member.clientId,
+                ...(member.data === undefined ? {} : { data: member.data }),
+                ...(member.encoding === undefined ? {} : { encoding: member.encoding }),
+              })),
+            }),
+          );
+          pending.delete(message.channel);
+          if (pending.size === 0) finish();
+          return;
+        }
+        if (message.action === ACTION.ERROR) {
+          finish(
+            new Error(`presence fixture rejected with code ${message.error?.code ?? 'unknown'}`),
+          );
+        }
+      }
+
+      socket.addEventListener('message', onMessage);
+      socket.addEventListener('error', onError);
+    });
+  }
+
+  async function startChild(definition) {
+    const port = await allocatePort();
+    const directory = mkdtempSync(join(tmpdir(), 'sockudo-upstream-'));
+    const configPath = join(directory, 'config.toml');
+    const logPath = join(logDirectory, `${definition.appId}.log`);
+    writeFileSync(configPath, renderConfig(configTemplate, port, definition));
+
+    const logFile = openSync(logPath, 'w');
+    const process = spawn(binary, ['--config', configPath], {
+      stdio: ['ignore', logFile, logFile],
+    });
+    closeSync(logFile);
+    const child = { definition, directory, logPath, port, presenceSocket: undefined, process };
+
+    try {
+      await waitUntilReady(child);
+      await seedPresence(child, definition);
+      return child;
+    } catch (error) {
+      stopChild(child);
+      throw error;
+    }
+  }
+
+  function appIdFromRequest(request) {
+    const authorization = request.headers.authorization;
+    const rawKey = authorization?.startsWith('Basic ')
+      ? Buffer.from(authorization.slice(6), 'base64').toString('utf8')
+      : new URL(request.url, 'http://127.0.0.1').searchParams.get('key') ?? '';
+    return rawKey.split(':', 1)[0].split('.', 1)[0] || undefined;
+  }
+
+  async function createApp(request, response) {
+    const body = JSON.parse(await readBody(request));
+    const definition = createAppDefinition(body);
+    const child = await startChild(definition);
+    children.set(definition.appId, child);
+    sendJson(response, 201, {
+      accountId: definition.accountId,
+      appId: definition.appId,
+      endpoint: '127.0.0.1',
+      keys: definition.responseKeys,
+      namespaces: definition.namespaces,
+      port: child.port,
+      tls: false,
+    });
+  }
+
+  function deleteApp(response, appId) {
+    const child = children.get(appId);
+    if (child) {
+      children.delete(appId);
+      stopChild(child);
+    }
+    response.writeHead(204).end();
+  }
+
+  async function forwardStats(request, response) {
+    const body = await readBody(request);
+    const appId = appIdFromRequest(request);
+    const child = appId ? children.get(appId) : undefined;
+    if (!child) {
+      sendText(response, 404, 'unknown fixture app');
+      return;
+    }
+
+    const upstream = await fetch(`http://127.0.0.1:${child.port}/stats`, {
+      body,
+      headers: {
+        'content-type': request.headers['content-type'] ?? 'application/json',
+        ...(request.headers.authorization ? { authorization: request.headers.authorization } : {}),
+      },
+      method: 'POST',
+    });
+    response.writeHead(upstream.status, {
+      'content-type': upstream.headers.get('content-type') ?? 'application/json',
+    });
+    response.end(await upstream.text());
+  }
+
+  const server = createServer(async (request, response) => {
+    try {
+      const path = new URL(request.url, 'http://127.0.0.1').pathname;
+      if (request.method === 'GET' && path === '/') {
+        sendText(response, 200, 'ready');
+      } else if (request.method === 'POST' && path === '/apps') {
+        await createApp(request, response);
+      } else if (request.method === 'DELETE' && path.startsWith('/apps/')) {
+        deleteApp(response, decodeURIComponent(path.slice('/apps/'.length)));
+      } else if (request.method === 'POST' && path === '/stats') {
+        await forwardStats(request, response);
+      } else {
+        sendText(response, 404, 'not found');
+      }
+    } catch (error) {
+      console.error(
+        '[upstream-sandbox] request failed',
+        error instanceof Error ? error.message : String(error),
+      );
+      if (!response.headersSent) sendText(response, 500, 'fixture provisioning failed');
+      else response.end();
+    }
+  });
+
+  return {
+    close: () =>
+      new Promise((resolveClose) => {
+        for (const child of children.values()) stopChild(child);
+        children.clear();
+        server.close(resolveClose);
+      }),
+    listen: (port, host = '127.0.0.1') =>
+      new Promise((resolveListen, reject) => {
+        server.once('error', reject);
+        server.listen(port, host, () => resolveListen(server.address()));
+      }),
+  };
+}
+
+function argument(name, fallback) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  const binary = argument('--sockudo-bin', process.env.SOCKUDO_BIN);
+  const configPath = argument('--config', process.env.SOCKUDO_CONFIG_TEMPLATE ?? 'config/config.toml');
+  const listen = argument('--listen', process.env.ABLY_LOCAL_SANDBOX_LISTEN ?? '127.0.0.1:9080');
+  const logDirectory = argument(
+    '--log-dir',
+    process.env.SANDBOX_LOG_DIR ?? mkdtempSync(join(tmpdir(), 'sockudo-upstream-logs-')),
+  );
+  if (!binary) throw new Error('--sockudo-bin is required');
+
+  const separator = listen.lastIndexOf(':');
+  const host = listen.slice(0, separator) || '127.0.0.1';
+  const port = Number(listen.slice(separator + 1));
+  const sandbox = createSandbox({
+    binary: resolve(binary),
+    configTemplate: readFileSync(resolve(configPath), 'utf8'),
+    logDirectory: resolve(logDirectory),
+  });
+  const address = await sandbox.listen(port, host);
+  console.log(`[upstream-sandbox] listening on http://${address.address}:${address.port}`);
+
+  let closing = false;
+  async function shutdown() {
+    if (closing) return;
+    closing = true;
+    await sandbox.close();
+  }
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+}

--- a/tests/ably-compat/upstream-sandbox.mjs
+++ b/tests/ably-compat/upstream-sandbox.mjs
@@ -10,6 +10,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { createServer } from 'node:http';
+import { createRequire } from 'node:module';
 import { createServer as createTcpServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -217,7 +218,13 @@ function wait(milliseconds) {
   return new Promise((resolveWait) => setTimeout(resolveWait, milliseconds));
 }
 
-export function createSandbox({ binary, configTemplate, logDirectory, childPortBase = 7100 }) {
+export function createSandbox({
+  binary,
+  configTemplate,
+  logDirectory,
+  childPortBase = 7100,
+  WebSocketImplementation = globalThis.WebSocket,
+}) {
   if (!binary || !configTemplate || !logDirectory) {
     throw new Error('binary, configTemplate, and logDirectory are required');
   }
@@ -263,9 +270,12 @@ export function createSandbox({ binary, configTemplate, logDirectory, childPortB
       (channel) => channel.name && channel.presence?.length,
     );
     if (channels.length === 0) return;
+    if (!WebSocketImplementation) {
+      throw new Error('presence fixtures require a WebSocket implementation');
+    }
 
     await new Promise((resolveSeed, reject) => {
-      const socket = new WebSocket(
+      const socket = new WebSocketImplementation(
         `ws://127.0.0.1:${child.port}/?key=${encodeURIComponent(definition.primaryKey)}&format=json&v=3`,
       );
       const pending = new Map(channels.map((channel) => [channel.name, channel]));
@@ -468,7 +478,14 @@ if (invokedPath === fileURLToPath(import.meta.url)) {
     '--log-dir',
     process.env.SANDBOX_LOG_DIR ?? mkdtempSync(join(tmpdir(), 'sockudo-upstream-logs-')),
   );
+  const wsPackageRoot = argument('--ws-package-root', process.env.SANDBOX_WS_PACKAGE_ROOT);
   if (!binary) throw new Error('--sockudo-bin is required');
+
+  let WebSocketImplementation = globalThis.WebSocket;
+  if (!WebSocketImplementation && wsPackageRoot) {
+    const requireFromPackage = createRequire(join(resolve(wsPackageRoot), 'package.json'));
+    WebSocketImplementation = requireFromPackage('ws');
+  }
 
   const separator = listen.lastIndexOf(':');
   const host = listen.slice(0, separator) || '127.0.0.1';
@@ -477,6 +494,7 @@ if (invokedPath === fileURLToPath(import.meta.url)) {
     binary: resolve(binary),
     configTemplate: readFileSync(resolve(configPath), 'utf8'),
     logDirectory: resolve(logDirectory),
+    WebSocketImplementation,
   });
   const address = await sandbox.listen(port, host);
   console.log(`[upstream-sandbox] listening on http://${address.address}:${address.port}`);

--- a/tests/ably-compat/upstream-sandbox.test.mjs
+++ b/tests/ably-compat/upstream-sandbox.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { createAppDefinition, renderConfig } from './upstream-sandbox.mjs';
+
+const template = readFileSync(new URL('../../config/config.toml', import.meta.url), 'utf8');
+
+test('renders all fixture keys onto one isolated app', () => {
+  const definition = createAppDefinition({
+    keys: [
+      {},
+      { capability: { 'chat:*': ['publish'] }, revocableTokens: true },
+    ],
+    namespaces: [{ id: 'chat', mutableMessages: true }],
+  });
+  const rendered = renderConfig(template, 7123, definition);
+
+  assert.match(rendered, /^port = 7123$/m);
+  assert.match(rendered, new RegExp(`id = "${definition.appId}"`));
+  assert.match(rendered, /name = "chat"/);
+  assert.match(rendered, /annotations_enabled = true/);
+  assert.equal((rendered.match(/^\[ably_compat\]$/gm) ?? []).length, 1);
+  assert.equal((rendered.match(/\[\[ably_compat\.keys\]\]/g) ?? []).length, 2);
+  assert.match(rendered, /capability = "\{\\"chat:\*\\":\[\\"publish\\"\]\}"/);
+  assert.match(rendered, /revocable_tokens = true/);
+  assert.match(rendered, /stats_fixture_ingest_enabled = true/);
+});
+
+test('uses a full-capability response when a fixture omits capability', () => {
+  const definition = createAppDefinition({ keys: [{}] });
+
+  assert.equal(definition.responseKeys[0].capability, '{"*":["*"]}');
+  assert.equal(definition.configKeys[0].capability, undefined);
+});

--- a/tools/chaos/distributed-correctness.mjs
+++ b/tools/chaos/distributed-correctness.mjs
@@ -550,11 +550,11 @@ class OneShotClient {
   async connect(timeoutMs = 12_000) {
     const socket = new WebSocket(`ws://127.0.0.1:${this.port}/app/${APP_KEY}?protocol=7&client=distributed-chaos&version=1.0`);
     this.socket = socket;
-    socket.addEventListener("message", (event) => this.onMessage(event.data));
+    socket.addEventListener("message", (event) => this.onMessage(event.data, socket));
     await waitFor(() => this.isSubscribed(), timeoutMs, `${this.name} subscription`);
   }
 
-  onMessage(raw) {
+  onMessage(raw, socket = this.socket) {
     const frame = parseJson(String(raw));
     if (!frame) {
       return;
@@ -568,18 +568,22 @@ class OneShotClient {
     )) {
       record("diagnostic_client_frame", { client: this.name, event, channel: frame.channel, data: frame.data });
     }
-    if (event === "connection_established") {
+    if (event === "ping") {
+      if (socket?.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ event: "pusher:pong" }));
+      }
+    } else if (event === "connection_established") {
       const socketId = frame.data?.socket_id;
       if (!socketId) {
         return;
       }
-      this.socket.send(JSON.stringify({
+      socket.send(JSON.stringify({
         event: "pusher:subscribe",
         data: this.userId
           ? presenceSubscription(socketId, this.channel, this.userId)
           : { channel: this.channel },
       }));
-    } else if (event === "subscription_succeeded" && frame.channel === this.channel) {
+    } else if (event === "subscription_succeeded" && frame.channel === this.channel && socket === this.socket) {
       this.snapshot = frame.data?.presence ?? null;
       this.currentSubscribed = true;
     } else if (frame.channel === this.channel && frame.event === EVENT_NAME) {
@@ -635,11 +639,39 @@ class ResilientClient extends OneShotClient {
         this.socket = socket;
         this.connections += 1;
         await new Promise((resolveSocket) => {
-          socket.addEventListener("message", (event) => this.onMessage(event.data));
-          socket.addEventListener("close", resolveSocket, { once: true });
-          socket.addEventListener("error", () => {}, { once: true });
+          let settled = false;
+          const finish = (reason) => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            record("client_connection_ended", {
+              client: this.name,
+              connection: this.connections,
+              reason,
+            });
+            resolveSocket();
+          };
+
+          socket.addEventListener("message", (event) => this.onMessage(event.data, socket));
+          socket.addEventListener("close", () => finish("close"), { once: true });
+          socket.addEventListener("error", () => {
+            record("client_connection_error", {
+              client: this.name,
+              connection: this.connections,
+            });
+            try {
+              socket.close();
+            } catch {
+              // The failed handshake may already have closed the socket.
+            }
+            finish("error");
+          }, { once: true });
         });
-        this.currentSubscribed = false;
+        if (this.socket === socket) {
+          this.currentSubscribed = false;
+          this.socket = null;
+        }
       } catch (error) {
         record("client_connection_error", { client: this.name, message: error.message });
       }


### PR DESCRIPTION
## Summary

- publish prebuilt binaries only for Linux x86_64 and ARM64, with GNU and musl variants
- add a checksum-verifying `install.sh` and expose it through `https://sockudo.io/install.sh`
- keep Cargo installation as the source-build path for macOS, Windows, and other platforms
- replace the brittle custom dependency updater with grouped Dependabot updates for Cargo, GitHub Actions, and Docker
- repair recurring distributed-chaos reconnect failures, ARM64 Docker linker exhaustion, fuzz artifact loss, and Swift mirror credential diagnostics
- run the latest `ably-js/main` Node unit, REST, and realtime suites on every pull request, excluding Live Objects and non-WebSocket transport coverage
- run the complete latest `ably-ai-transport-js/main` unit and integration suites on every pull request
- add a public, credential-free local app provisioner so fork pull requests do not depend on the internal `ably-labs/sockudo-compatibility` repository
- accept and validate the current AI Transport `supersedes` header used by upstream client tool-result forks

## Why

The release workflow was spending substantial effort on unused platform binaries while several scheduled jobs were permanently red:

- dependency maintenance compiled all features without the required native curl headers
- the chaos observer did not answer Pusher heartbeats and could stall forever after a failed reconnect
- full-feature ARM64 Docker linking exhausted runner memory under fat LTO
- fuzz reproducers disappeared when the workflow failed
- Swift mirror failures only surfaced after the expensive repository split

The Ably team also asked for each Sockudo pull request to be checked against the current upstream JavaScript SDK suites. The compatibility gate resolves `main` at job start, records the exact commits in the step summary and artifacts, forces realtime cases onto WebSocket, and provisions isolated Sockudo apps locally without Ably credentials or private-repository access. This detects upstream drift while keeping the immutable pinned compatibility reports as the release-evidence source.

The first current-upstream AI Transport run exposed a newly emitted `extras.ai.transport.supersedes` field. Sockudo now recognizes it as a bounded, non-empty transport value and retains the same fail-closed behavior for unknown fields.

## Validation

- `sh -n install.sh`
- `shellcheck install.sh`
- all changed workflows pass `actionlint`
- YAML and JavaScript parsing checks
- local provisioner unit tests: 2 passed
- current `ably/ably-js@7fa7dc5993af3b67ab05fea2b6a242f729d9088f`: 595 passed, 27 upstream-pending
- current `ably/ably-ai-transport-js@c49c4e8d65e477b1bda729c3a1d6f259348f98be`: 1,729 unit passed / 3 skipped; 73 integration passed
- `cargo fmt --all -- --check`
- `cargo test --workspace` with an ephemeral Redis test service
- `cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_PROFILE_RELEASE_LTO=thin CARGO_PROFILE_RELEASE_CODEGEN_UNITS=8 CARGO_BUILD_JOBS=2 cargo check -p sockudo --features full`
- `cd docs && npm run types:check && npm run build`
- exercised the maintenance parser against a real `cargo audit --json` report
- verified the rotated Swift mirror token with a successful two-repository run: https://github.com/sockudo/sockudo/actions/runs/31402187221

## Remaining remote verification

The full multi-architecture Docker build and distributed-chaos scenario require GitHub-hosted Linux services and will be confirmed by this PR's checks. The new Ably compatibility jobs will independently fetch whatever commits are at both upstream `main` heads when they run.

The stable installer URL should be advertised after the next release publishes `install.sh` and the new checksum assets.
