### PR TITLE
Rebenchmark both revisions on compatibility failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,10 +530,19 @@ jobs:
 
       - name: Confirm reported compatibility regressions
         if: steps.initial-compatibility-budget.outcome == 'failure'
+        env:
+          BASE_SHA: ${{ steps.benchmark-revisions.outputs.base-sha }}
+          HEAD_SHA: ${{ steps.benchmark-revisions.outputs.head-sha }}
         run: |
           set -euo pipefail
           cp -R target/criterion target/criterion-initial
-          cargo bench -p sockudo-ably-compat --features bench --bench compatibility_hot_paths -- --noplot --baseline pr-base
+          # Re-measure both revisions so runner load or CPU frequency drift
+          # cannot make a repeated head-only sample look reproducible.
+          git checkout --detach "$BASE_SHA"
+          rm -rf target/criterion
+          cargo bench -p sockudo-ably-compat --features bench --bench compatibility_hot_paths -- --noplot --save-baseline confirmation-base
+          git checkout --detach "$HEAD_SHA"
+          cargo bench -p sockudo-ably-compat --features bench --bench compatibility_hot_paths -- --noplot --baseline confirmation-base
 
       - name: Enforce compatibility regression budgets
         if: steps.initial-compatibility-budget.outcome == 'success'


### PR DESCRIPTION
## Summary

- preserve the initial Criterion comparison as diagnostic evidence
- when the compatibility guard reports a regression, create a fresh confirmation baseline from the base revision
- rerun the head revision against that fresh baseline before treating the regression as reproduced

## Root cause

The post-merge run for PR #375 reported `ably_compat_adapter_boundary/disabled` as 94% slower and then 59% slower. The merge commit and the tested PR head have identical source trees, and the same comparison passed on the PR at approximately 14.2 ns for both revisions. On the post-merge runner, the original base remained at 14.2 ns while successive head samples shifted to 27.7 ns and 22.7 ns.

The existing confirmation step repeated only the head benchmark against the original base measurement. It therefore could not distinguish a code regression from runner load or CPU-frequency drift.

## Validation

- `git diff --check`
- `actionlint -ignore 'SC2046' .github/workflows/ci.yml`
- ShellCheck on the changed confirmation script

The ignored SC2046 findings are pre-existing warnings in unrelated workflow blocks; the changed block passes ShellCheck without suppressions.
