### PR TITLE
Fix Queue v2 Redis blocking timeouts

### DIFF
--- a/crates/sockudo-core/src/redis_client.rs
+++ b/crates/sockudo-core/src/redis_client.rs
@@ -79,12 +79,20 @@ impl RedisClient {
         }
     }
 
-    async fn build_manager(&self) -> Result<ConnectionManager> {
+    async fn build_manager_with_config(
+        &self,
+        manager_config: ConnectionManagerConfig,
+    ) -> Result<ConnectionManager> {
         self.master_client()
             .await?
-            .get_connection_manager_with_config(self.inner.manager_config.clone())
+            .get_connection_manager_with_config(manager_config)
             .await
             .map_err(|error| Error::Redis(format!("failed to connect to Redis: {error}")))
+    }
+
+    async fn build_manager(&self) -> Result<ConnectionManager> {
+        self.build_manager_with_config(self.inner.manager_config.clone())
+            .await
     }
 
     async fn get_or_build(
@@ -111,6 +119,21 @@ impl RedisClient {
     /// that may issue a blocking command.
     pub async fn fresh_connection_manager(&self) -> Result<ConnectionManager> {
         self.build_manager().await
+    }
+
+    /// Returns an independent connection manager with a caller-specific
+    /// response timeout. Blocking-command users can extend the deadline beyond
+    /// the server-side wait without changing cached command connections.
+    pub async fn fresh_connection_manager_with_response_timeout(
+        &self,
+        response_timeout: Option<Duration>,
+    ) -> Result<ConnectionManager> {
+        let manager_config = self
+            .inner
+            .manager_config
+            .clone()
+            .set_response_timeout(response_timeout);
+        self.build_manager_with_config(manager_config).await
     }
 
     /// Invalidates cached data-plane connections after a Sentinel failover.

--- a/crates/sockudo-queue/examples/queue_bench.rs
+++ b/crates/sockudo-queue/examples/queue_bench.rs
@@ -25,6 +25,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|value| value.parse::<u64>())
         .transpose()?
         .unwrap_or(5_000);
+    let worker_poll_interval_ms = std::env::var("QUEUE_BENCH_WORKER_POLL_INTERVAL_MS")
+        .ok()
+        .map(|value| value.parse::<u64>())
+        .transpose()?
+        .unwrap_or(100);
+    let idle_before_enqueue_ms = std::env::var("QUEUE_BENCH_IDLE_BEFORE_ENQUEUE_MS")
+        .ok()
+        .map(|value| value.parse::<u64>())
+        .transpose()?
+        .unwrap_or_default();
     let explicit_job_ids = std::env::var("QUEUE_BENCH_EXPLICIT_JOB_IDS")
         .ok()
         .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"));
@@ -40,7 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         retry_jitter: 0.0,
         lease_duration_ms: 30_000,
         lease_renew_interval_ms: 10_000,
-        worker_poll_interval_ms: 100,
+        worker_poll_interval_ms,
         shutdown_timeout_ms: 30_000,
         completed_retention: 0,
         failed_retention: 1_000,
@@ -151,6 +161,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
+    if idle_before_enqueue_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(idle_before_enqueue_ms)).await;
+    }
+
     let end_to_end_started = Instant::now();
     let enqueue_started = Instant::now();
     let mut requests = Vec::with_capacity(jobs);
@@ -217,7 +231,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let end_to_end_rate = jobs as f64 / end_to_end_elapsed.as_secs_f64();
     let deliveries = completed.load(Ordering::Acquire);
     println!(
-        "{{\"topology\":\"{}\",\"jobs\":{},\"deliveries\":{},\"duplicates\":{},\"concurrency\":{},\"batch_size\":{},\"explicit_job_ids\":{},\"callback_delay_us\":{},\"response_timeout_ms\":{},\"request_build_seconds\":{:.6},\"enqueue_seconds\":{:.6},\"enqueue_jobs_per_second\":{:.2},\"end_to_end_seconds\":{:.6},\"end_to_end_jobs_per_second\":{:.2},\"latency_ms_p50\":{},\"latency_ms_p95\":{},\"latency_ms_p99\":{},\"ready\":{},\"active\":{},\"delayed\":{},\"dead_letter\":{}}}",
+        "{{\"topology\":\"{}\",\"jobs\":{},\"deliveries\":{},\"duplicates\":{},\"concurrency\":{},\"batch_size\":{},\"explicit_job_ids\":{},\"callback_delay_us\":{},\"response_timeout_ms\":{},\"worker_poll_interval_ms\":{},\"idle_before_enqueue_ms\":{},\"request_build_seconds\":{:.6},\"enqueue_seconds\":{:.6},\"enqueue_jobs_per_second\":{:.2},\"end_to_end_seconds\":{:.6},\"end_to_end_jobs_per_second\":{:.2},\"latency_ms_p50\":{},\"latency_ms_p95\":{},\"latency_ms_p99\":{},\"ready\":{},\"active\":{},\"delayed\":{},\"dead_letter\":{}}}",
         topology,
         jobs,
         deliveries,
@@ -227,6 +241,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         explicit_job_ids,
         callback_delay_us,
         response_timeout_ms,
+        worker_poll_interval_ms,
+        idle_before_enqueue_ms,
         request_build_elapsed.as_secs_f64(),
         enqueue_elapsed.as_secs_f64(),
         enqueue_rate,

--- a/crates/sockudo-queue/src/redis_cluster_queue_manager.rs
+++ b/crates/sockudo-queue/src/redis_cluster_queue_manager.rs
@@ -40,7 +40,12 @@ impl RedisClusterQueueManager {
         request_timeout_ms: u64,
         reliability: QueueReliabilityConfig,
     ) -> Result<Self> {
-        let provider = ClusterRedisProvider::connect(cluster_nodes, request_timeout_ms).await?;
+        let provider = ClusterRedisProvider::connect(
+            cluster_nodes,
+            request_timeout_ms,
+            reliability.worker_poll_interval_ms,
+        )
+        .await?;
         Ok(Self {
             backend: ReliableRedisQueue::new(
                 provider,

--- a/crates/sockudo-queue/src/redis_connection.rs
+++ b/crates/sockudo-queue/src/redis_connection.rs
@@ -14,8 +14,22 @@ use sockudo_core::queue::QueueBackendKind;
 use sockudo_core::redis_client::RedisClient;
 #[cfg(feature = "redis-cluster")]
 use std::sync::Arc;
-#[cfg(feature = "redis-cluster")]
 use std::time::Duration;
+
+const MINIMUM_BLOCKING_WAIT_MS: u64 = 10;
+
+/// Gives a blocking Redis command its finite server-side wait plus the normal
+/// response budget. Matching those deadlines makes a successful nil response
+/// race the client's timeout when the queue is idle.
+pub(crate) fn blocking_response_timeout(
+    response_timeout_ms: u64,
+    worker_poll_interval_ms: u64,
+) -> Option<Duration> {
+    (response_timeout_ms > 0).then(|| {
+        Duration::from_millis(worker_poll_interval_ms.max(MINIMUM_BLOCKING_WAIT_MS))
+            .saturating_add(Duration::from_millis(response_timeout_ms))
+    })
+}
 
 #[async_trait]
 pub(crate) trait QueueRedisProvider: Clone + Send + Sync + 'static {
@@ -30,12 +44,18 @@ pub(crate) trait QueueRedisProvider: Clone + Send + Sync + 'static {
 #[derive(Clone)]
 pub(crate) struct StandaloneRedisProvider {
     client: RedisClient,
+    worker_response_timeout: Option<Duration>,
 }
 
 impl StandaloneRedisProvider {
-    pub(crate) async fn connect(url: &str, sentinel: Option<SentinelSpec>) -> Result<Self> {
+    pub(crate) async fn connect(
+        url: &str,
+        sentinel: Option<SentinelSpec>,
+        worker_response_timeout: Option<Duration>,
+    ) -> Result<Self> {
         Ok(Self {
             client: RedisClient::connect(url, sentinel).await?,
+            worker_response_timeout,
         })
     }
 }
@@ -49,7 +69,9 @@ impl QueueRedisProvider for StandaloneRedisProvider {
     }
 
     async fn worker_connection(&self) -> Result<Self::Connection> {
-        self.client.fresh_connection_manager().await
+        self.client
+            .fresh_connection_manager_with_response_timeout(self.worker_response_timeout)
+            .await
     }
 
     fn invalidate(&self) {
@@ -67,7 +89,8 @@ impl QueueRedisProvider for StandaloneRedisProvider {
 
 #[cfg(feature = "redis-cluster")]
 struct ClusterInner {
-    client: ClusterClient,
+    command_client: ClusterClient,
+    worker_client: ClusterClient,
     command: Mutex<Option<ClusterConnection>>,
 }
 
@@ -79,43 +102,42 @@ pub(crate) struct ClusterRedisProvider {
 
 #[cfg(feature = "redis-cluster")]
 impl ClusterRedisProvider {
-    pub(crate) async fn connect(nodes: Vec<String>, request_timeout_ms: u64) -> Result<Self> {
+    pub(crate) async fn connect(
+        nodes: Vec<String>,
+        request_timeout_ms: u64,
+        worker_poll_interval_ms: u64,
+    ) -> Result<Self> {
         if nodes.is_empty() {
             return Err(Error::Config(
                 "Redis Cluster queue requires at least one seed node".to_string(),
             ));
         }
-        let builder = ClusterClientBuilder::new(nodes);
-        let builder = if request_timeout_ms == 0 {
-            builder.overall_response_timeout(None)
-        } else {
-            let timeout = Duration::from_millis(request_timeout_ms);
-            builder
-                .response_timeout(timeout)
-                .overall_response_timeout(Some(timeout))
-        };
-        let client = builder.build().map_err(|error| {
-            Error::Config(format!("failed to create Redis Cluster client: {error}"))
-        })?;
-        let connection = client.get_async_connection().await.map_err(|error| {
-            Error::Connection(format!("failed to connect to Redis Cluster: {error}"))
-        })?;
+        let response_timeout =
+            (request_timeout_ms > 0).then(|| Duration::from_millis(request_timeout_ms));
+        let command_client = build_cluster_client(nodes.clone(), response_timeout)?;
+        let worker_client = build_cluster_client(
+            nodes,
+            blocking_response_timeout(request_timeout_ms, worker_poll_interval_ms),
+        )?;
+        let connection = command_client
+            .get_async_connection()
+            .await
+            .map_err(|error| {
+                Error::Connection(format!("failed to connect to Redis Cluster: {error}"))
+            })?;
         Ok(Self {
             inner: Arc::new(ClusterInner {
-                client,
+                command_client,
+                worker_client,
                 command: Mutex::new(Some(connection)),
             }),
         })
     }
 
-    async fn build_connection(&self) -> Result<ClusterConnection> {
-        self.inner
-            .client
-            .get_async_connection()
-            .await
-            .map_err(|error| {
-                Error::Connection(format!("failed to connect to Redis Cluster: {error}"))
-            })
+    async fn build_connection(client: &ClusterClient) -> Result<ClusterConnection> {
+        client.get_async_connection().await.map_err(|error| {
+            Error::Connection(format!("failed to connect to Redis Cluster: {error}"))
+        })
     }
 }
 
@@ -128,13 +150,13 @@ impl QueueRedisProvider for ClusterRedisProvider {
         if let Some(connection) = self.inner.command.lock().as_ref() {
             return Ok(connection.clone());
         }
-        let connection = self.build_connection().await?;
+        let connection = Self::build_connection(&self.inner.command_client).await?;
         *self.inner.command.lock() = Some(connection.clone());
         Ok(connection)
     }
 
     async fn worker_connection(&self) -> Result<Self::Connection> {
-        self.build_connection().await
+        Self::build_connection(&self.inner.worker_client).await
     }
 
     fn invalidate(&self) {
@@ -143,5 +165,109 @@ impl QueueRedisProvider for ClusterRedisProvider {
 
     fn backend(&self) -> QueueBackendKind {
         QueueBackendKind::RedisCluster
+    }
+}
+
+#[cfg(feature = "redis-cluster")]
+fn build_cluster_client(
+    nodes: Vec<String>,
+    response_timeout: Option<Duration>,
+) -> Result<ClusterClient> {
+    let builder = ClusterClientBuilder::new(nodes).overall_response_timeout(response_timeout);
+    let builder = match response_timeout {
+        Some(timeout) => builder.response_timeout(timeout),
+        None => builder,
+    };
+    builder
+        .build()
+        .map_err(|error| Error::Config(format!("failed to create Redis Cluster client: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocking_timeout_includes_server_wait_and_response_budget() {
+        assert_eq!(
+            blocking_response_timeout(500, 500),
+            Some(Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn blocking_timeout_uses_same_minimum_as_notification_wait() {
+        assert_eq!(
+            blocking_response_timeout(500, 1),
+            Some(Duration::from_millis(510))
+        );
+    }
+
+    #[test]
+    fn blocking_timeout_can_be_disabled() {
+        assert_eq!(blocking_response_timeout(0, 500), None);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires SOCKUDO_REDIS_QUEUE_TEST_URL"]
+    async fn blocking_worker_connection_outlives_empty_redis_wait() {
+        let url = std::env::var("SOCKUDO_REDIS_QUEUE_TEST_URL")
+            .expect("SOCKUDO_REDIS_QUEUE_TEST_URL is required");
+        let provider =
+            StandaloneRedisProvider::connect(&url, None, blocking_response_timeout(500, 500))
+                .await
+                .expect("Redis queue provider should connect");
+        let mut connection = provider
+            .worker_connection()
+            .await
+            .expect("worker connection should connect");
+        let key = format!(
+            "sockudo_queue_timeout_test:{}",
+            uuid::Uuid::new_v4().simple()
+        );
+
+        let result = redis::cmd("BLPOP")
+            .arg(key)
+            .arg(0.5)
+            .query_async::<Option<(String, String)>>(&mut connection)
+            .await;
+
+        assert_eq!(
+            result.expect("empty blocking wait should not time out"),
+            None
+        );
+    }
+
+    #[cfg(feature = "redis-cluster")]
+    #[tokio::test]
+    #[ignore = "requires SOCKUDO_REDIS_CLUSTER_QUEUE_TEST_NODES"]
+    async fn blocking_cluster_worker_connection_outlives_empty_redis_wait() {
+        let nodes = std::env::var("SOCKUDO_REDIS_CLUSTER_QUEUE_TEST_NODES")
+            .expect("SOCKUDO_REDIS_CLUSTER_QUEUE_TEST_NODES is required")
+            .split(',')
+            .map(str::to_string)
+            .collect();
+        let provider = ClusterRedisProvider::connect(nodes, 500, 500)
+            .await
+            .expect("Redis Cluster queue provider should connect");
+        let mut connection = provider
+            .worker_connection()
+            .await
+            .expect("cluster worker connection should connect");
+        let key = format!(
+            "sockudo_queue_timeout_test:{{{}}}",
+            uuid::Uuid::new_v4().simple()
+        );
+
+        let result = redis::cmd("BLPOP")
+            .arg(key)
+            .arg(0.5)
+            .query_async::<Option<(String, String)>>(&mut connection)
+            .await;
+
+        assert_eq!(
+            result.expect("empty cluster blocking wait should not time out"),
+            None
+        );
     }
 }

--- a/crates/sockudo-queue/src/redis_queue_manager.rs
+++ b/crates/sockudo-queue/src/redis_queue_manager.rs
@@ -1,5 +1,5 @@
 use crate::redis_backend::ReliableRedisQueue;
-use crate::redis_connection::StandaloneRedisProvider;
+use crate::redis_connection::{StandaloneRedisProvider, blocking_response_timeout};
 use async_trait::async_trait;
 use sockudo_core::error::Result;
 use sockudo_core::options::{QueueReliabilityConfig, SentinelSpec};
@@ -41,7 +41,10 @@ impl RedisQueueManager {
         response_timeout_ms: u64,
         reliability: QueueReliabilityConfig,
     ) -> Result<Self> {
-        let provider = StandaloneRedisProvider::connect(redis_url, sentinel).await?;
+        let worker_response_timeout =
+            blocking_response_timeout(response_timeout_ms, reliability.worker_poll_interval_ms);
+        let provider =
+            StandaloneRedisProvider::connect(redis_url, sentinel, worker_response_timeout).await?;
         Ok(Self {
             backend: ReliableRedisQueue::new(
                 provider,

--- a/crates/sockudo-webhook/src/integration.rs
+++ b/crates/sockudo-webhook/src/integration.rs
@@ -822,13 +822,12 @@ mod tests {
     use sockudo_app::memory_app_manager::MemoryAppManager;
     use sockudo_core::app::{AppFeaturesPolicy, AppLimitsPolicy, AppPolicy};
     use sockudo_core::webhook_types::{JobData, JobPayload, Webhook, WebhookFilter};
-    use sockudo_queue::manager::QueueManagerFactory;
+    use sockudo_queue::MemoryQueueManager;
 
-    async fn create_test_queue_manager() -> Arc<QueueManager> {
-        let driver = QueueManagerFactory::create("memory", None, None, None, None)
-            .await
-            .expect("Failed to create test queue manager");
-        Arc::new(QueueManager::new(driver))
+    fn create_test_queue_manager() -> Arc<QueueManager> {
+        let driver = MemoryQueueManager::new();
+        driver.start_processing();
+        Arc::new(QueueManager::new(Box::new(driver)))
     }
 
     fn test_app() -> App {
@@ -859,7 +858,7 @@ mod tests {
         let config = WebhookConfig {
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager.clone(), Some(queue_manager))
             .await
             .unwrap();
@@ -879,7 +878,7 @@ mod tests {
         let config = WebhookConfig {
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager, Some(queue_manager))
             .await
             .unwrap();
@@ -898,7 +897,7 @@ mod tests {
             ..Webhook::default()
         }]);
         let app_manager = Arc::new(MemoryAppManager::new());
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(
             WebhookConfig {
                 batching: BatchingConfig {
@@ -939,7 +938,7 @@ mod tests {
             ..Webhook::default()
         }]);
         let app_manager = Arc::new(MemoryAppManager::new());
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration =
             WebhookIntegration::new(WebhookConfig::default(), app_manager, Some(queue_manager))
                 .await
@@ -1015,7 +1014,7 @@ mod tests {
         let config = WebhookConfig {
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager.clone(), Some(queue_manager))
             .await
             .unwrap();
@@ -1029,7 +1028,7 @@ mod tests {
             enabled: true,
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager, Some(queue_manager))
             .await
             .unwrap();
@@ -1071,7 +1070,7 @@ mod tests {
             ..Default::default()
         };
 
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager, Some(queue_manager)).await;
         assert!(integration.is_ok());
     }
@@ -1083,7 +1082,7 @@ mod tests {
         let config = WebhookConfig {
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager.clone(), Some(queue_manager))
             .await
             .unwrap();
@@ -1108,7 +1107,7 @@ mod tests {
         let config = WebhookConfig {
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager.clone(), Some(queue_manager))
             .await
             .unwrap();
@@ -1133,7 +1132,7 @@ mod tests {
         let config = WebhookConfig {
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager.clone(), Some(queue_manager))
             .await
             .unwrap();
@@ -1151,7 +1150,7 @@ mod tests {
         let config = WebhookConfig {
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager.clone(), Some(queue_manager))
             .await
             .unwrap();
@@ -1169,7 +1168,7 @@ mod tests {
         let config = WebhookConfig {
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager.clone(), Some(queue_manager))
             .await
             .unwrap();
@@ -1187,7 +1186,7 @@ mod tests {
         let config = WebhookConfig {
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager.clone(), Some(queue_manager))
             .await
             .unwrap();
@@ -1203,7 +1202,7 @@ mod tests {
         let config = WebhookConfig {
             ..Default::default()
         };
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         let integration = WebhookIntegration::new(config, app_manager.clone(), Some(queue_manager))
             .await
             .unwrap();
@@ -1265,7 +1264,7 @@ mod tests {
 
     async fn make_integration(enabled: bool) -> WebhookIntegration {
         let app_manager = Arc::new(MemoryAppManager::new());
-        let queue_manager = create_test_queue_manager().await;
+        let queue_manager = create_test_queue_manager();
         WebhookIntegration::new(
             WebhookConfig {
                 enabled,


### PR DESCRIPTION
## Summary

- give Queue v2 blocking Redis worker connections a response deadline equal to the finite server-side wait plus the configured response budget
- keep ordinary command connections on the existing configured timeout
- use separate command and blocking-worker clients for Redis Cluster
- add standalone and cluster regressions for an empty `BLPOP` wait
- make the queue benchmark's worker poll interval and idle warm-up configurable

## Root cause

Queue v2 used `BLPOP` with a 500 ms empty-queue wait while the standalone Redis 1.4.1 client connection inherited its 500 ms default response timeout. The client deadline therefore raced Redis's valid empty response, causing false timeout warnings, discarded connections, and a roughly 500 ms reconnection loop.

Cluster deployments were safe under the normal 5-second configured response timeout, but could reproduce the same collision when their configured client deadline matched the worker poll interval.

## Impact

Idle Queue v2 workers stop generating false timeouts and unnecessary Redis reconnects. Message delivery semantics are unchanged.

## Benchmarks

Release builds compared against the previous implementation on local Redis 8.10.0:

| Scenario | Previous | Fixed |
| --- | ---: | ---: |
| Standalone idle, 5 s response / 500 ms poll | 14 accepted connections | 5 (-64%) |
| Cluster idle, 5 s response / 500 ms poll | 12 | 12 |
| Cluster idle, 500 ms response / 500 ms poll | 42 | 12 (-71%) |
| Standalone loaded median | 91,514 jobs/s | 92,180 jobs/s |
| Three-node cluster loaded median | 90,697 jobs/s | 88,363 jobs/s |

Loaded tests used 25,000 jobs per run and 16 workers. The cluster paired-run median difference was -0.18%, with overlapping ranges. Across 750,000 loaded deliveries there were no duplicates, failures, or residual jobs.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sockudo-queue --features redis-cluster`
- live standalone and three-node Redis Cluster timeout regressions
- `cargo test --workspace` with the repository's disposable Redis test service on port 16379
- `cargo clippy --workspace --all-targets -- -D warnings`
