### PR TITLE
feat(server): add server_role option for stateless API HTTP-only pods

### DIFF
--- a/crates/sockudo-ably-compat/src/runtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime.rs
@@ -1510,6 +1510,73 @@ impl AblyCompatRuntime {
             .layer(Extension(Arc::clone(self)))
     }
 
+    /// REST routes safe for api-role pods. If new routes here bind `socket_id`, re-evaluate.
+    pub fn rest_router_api(self: &Arc<Self>) -> axum::Router<Arc<ConnectionHandler>> {
+        use axum::{
+            Extension, Router,
+            routing::{get, post},
+        };
+
+        let router = Router::new()
+            .route("/time", get(ably_time))
+            .route("/stats", post(ably_ingest_stats))
+            .route(
+                "/keys/{keyName}/requestToken",
+                get(ably_not_found).post(ably_request_token),
+            )
+            .route("/keys/{keyName}/revokeTokens", post(ably_revoke_tokens))
+            .route("/messages", post(ably_batch_publish))
+            .route(
+                "/channels/{channelName}/messages",
+                get(ably_channel_history).post(ably_channel_publish),
+            )
+            .route(
+                "/channels/{channelName}/presence/history",
+                get(ably_channel_presence_history),
+            )
+            .route(
+                "/channels/{channelName}/messages/{messageSerial}",
+                get(ably_channel_message).patch(ably_channel_message_mutation),
+            )
+            .route(
+                "/channels/{channelName}/messages/{messageSerial}/versions",
+                get(ably_channel_message_versions),
+            )
+            .route(
+                "/channels/{channelName}/messages/{messageSerial}/annotations",
+                get(ably_channel_annotations).post(ably_publish_annotations),
+            );
+        #[cfg(feature = "push")]
+        let router = router
+            .route("/push/publish", post(ably_push_publish))
+            .route(
+                "/push/deviceRegistrations",
+                post(ably_push_save_device)
+                    .patch(ably_push_save_device)
+                    .get(ably_push_list_devices)
+                    .delete(ably_push_delete_devices),
+            )
+            .route(
+                "/push/deviceRegistrations/{deviceId}",
+                get(ably_push_get_device)
+                    .put(ably_push_put_device)
+                    .delete(ably_push_delete_device),
+            )
+            .route(
+                "/push/channelSubscriptions",
+                post(ably_push_save_subscription)
+                    .get(ably_push_list_subscriptions)
+                    .delete(ably_push_delete_subscriptions),
+            )
+            .route("/push/channels", get(ably_push_list_channels));
+        router
+            .layer(axum::middleware::from_fn_with_state(
+                Arc::clone(self),
+                ably_stats_api_middleware,
+            ))
+            .layer(Extension(Arc::clone(self)))
+    }
+
     pub fn router(self: &Arc<Self>) -> axum::Router<Arc<ConnectionHandler>> {
         self.realtime_router().merge(self.rest_router())
     }

--- a/crates/sockudo-adapter/src/factory.rs
+++ b/crates/sockudo-adapter/src/factory.rs
@@ -191,16 +191,22 @@ impl TypedAdapter {
 pub struct AdapterFactory;
 
 impl AdapterFactory {
-    /// Create a connection manager without the Mutex wrapper
-    /// Use this for lock-free runtime access (all trait methods are &self)
-    #[allow(unused_variables)]
-    pub async fn create(
+    #[allow(dead_code)]
+    async fn configure_horizontal_adapter<T>(
+        adapter: &mut crate::horizontal_adapter_base::HorizontalAdapterBase<T>,
         config: &AdapterConfig,
-        db_config: &DatabaseConfig,
-    ) -> Result<Arc<dyn ConnectionManager + Send + Sync>> {
-        Self::create_with_typed(config, db_config)
-            .await
-            .map(|(adapter, _)| adapter)
+        api_only: bool,
+    ) -> Result<()>
+    where
+        T: crate::horizontal_transport::HorizontalTransport + 'static,
+        T::Config: crate::horizontal_transport::TransportConfig,
+    {
+        adapter.set_cluster_health(&config.cluster_health).await?;
+        adapter.set_socket_counting(config.enable_socket_counting);
+        adapter.set_aggregate_counts(config.aggregate_counts);
+        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
+        adapter.set_api_only(api_only);
+        Ok(())
     }
 
     /// Create a connection manager with typed adapter for configuration
@@ -211,8 +217,12 @@ impl AdapterFactory {
     pub async fn create_with_typed(
         config: &AdapterConfig,
         db_config: &DatabaseConfig,
+        api_only: bool,
     ) -> Result<(Arc<dyn ConnectionManager + Send + Sync>, TypedAdapter)> {
         info!(adapter = ?config.driver, "connection manager initializing");
+        if api_only {
+            info!(server_role = "api", "adapter configured for api-only mode");
+        }
         match config.driver {
             // Match on the enum
             #[cfg(feature = "redis")]
@@ -249,10 +259,7 @@ impl AdapterFactory {
                 };
                 match RedisAdapter::new(adapter_options).await {
                     Ok(mut adapter) => {
-                        adapter.set_cluster_health(&config.cluster_health).await?;
-                        adapter.set_socket_counting(config.enable_socket_counting);
-                        adapter.set_aggregate_counts(config.aggregate_counts);
-                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
+                        Self::configure_horizontal_adapter(&mut adapter, config, api_only).await?;
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Redis(adapter.clone());
                         Ok((adapter, typed))
@@ -309,10 +316,7 @@ impl AdapterFactory {
                 };
                 match RedisClusterAdapter::new(cluster_adapter_config).await {
                     Ok(mut adapter) => {
-                        adapter.set_cluster_health(&config.cluster_health).await?;
-                        adapter.set_socket_counting(config.enable_socket_counting);
-                        adapter.set_aggregate_counts(config.aggregate_counts);
-                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
+                        Self::configure_horizontal_adapter(&mut adapter, config, api_only).await?;
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::RedisCluster(adapter.clone());
                         Ok((adapter, typed))
@@ -353,10 +357,7 @@ impl AdapterFactory {
                 };
                 match NatsAdapter::new(nats_cfg).await {
                     Ok(mut adapter) => {
-                        adapter.set_cluster_health(&config.cluster_health).await?;
-                        adapter.set_socket_counting(config.enable_socket_counting);
-                        adapter.set_aggregate_counts(config.aggregate_counts);
-                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
+                        Self::configure_horizontal_adapter(&mut adapter, config, api_only).await?;
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Nats(adapter.clone());
                         Ok((adapter, typed))
@@ -386,10 +387,7 @@ impl AdapterFactory {
                 };
                 match PulsarAdapter::new(pulsar_cfg).await {
                     Ok(mut adapter) => {
-                        adapter.set_cluster_health(&config.cluster_health).await?;
-                        adapter.set_socket_counting(config.enable_socket_counting);
-                        adapter.set_aggregate_counts(config.aggregate_counts);
-                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
+                        Self::configure_horizontal_adapter(&mut adapter, config, api_only).await?;
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Pulsar(adapter.clone());
                         Ok((adapter, typed))
@@ -419,10 +417,7 @@ impl AdapterFactory {
                 };
                 match RabbitMqAdapter::new(rabbitmq_cfg).await {
                     Ok(mut adapter) => {
-                        adapter.set_cluster_health(&config.cluster_health).await?;
-                        adapter.set_socket_counting(config.enable_socket_counting);
-                        adapter.set_aggregate_counts(config.aggregate_counts);
-                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
+                        Self::configure_horizontal_adapter(&mut adapter, config, api_only).await?;
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::RabbitMq(adapter.clone());
                         Ok((adapter, typed))
@@ -452,10 +447,7 @@ impl AdapterFactory {
                 };
                 match GooglePubSubAdapter::new(google_pubsub_cfg).await {
                     Ok(mut adapter) => {
-                        adapter.set_cluster_health(&config.cluster_health).await?;
-                        adapter.set_socket_counting(config.enable_socket_counting);
-                        adapter.set_aggregate_counts(config.aggregate_counts);
-                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
+                        Self::configure_horizontal_adapter(&mut adapter, config, api_only).await?;
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::GooglePubSub(adapter.clone());
                         Ok((adapter, typed))
@@ -488,10 +480,7 @@ impl AdapterFactory {
                 };
                 match KafkaAdapter::new(kafka_cfg).await {
                     Ok(mut adapter) => {
-                        adapter.set_cluster_health(&config.cluster_health).await?;
-                        adapter.set_socket_counting(config.enable_socket_counting);
-                        adapter.set_aggregate_counts(config.aggregate_counts);
-                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
+                        Self::configure_horizontal_adapter(&mut adapter, config, api_only).await?;
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Kafka(adapter.clone());
                         Ok((adapter, typed))
@@ -532,10 +521,7 @@ impl AdapterFactory {
                 };
                 match IggyAdapter::new(iggy_cfg).await {
                     Ok(mut adapter) => {
-                        adapter.set_cluster_health(&config.cluster_health).await?;
-                        adapter.set_socket_counting(config.enable_socket_counting);
-                        adapter.set_aggregate_counts(config.aggregate_counts);
-                        adapter.set_fast_presence_transitions(config.fast_presence_transitions);
+                        Self::configure_horizontal_adapter(&mut adapter, config, api_only).await?;
                         let adapter = Arc::new(adapter);
                         let typed = TypedAdapter::Iggy(adapter.clone());
                         Ok((adapter, typed))

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
@@ -8,6 +8,11 @@ where
     async fn init(&self) {
         self.local_adapter.init().await;
 
+        if self.api_only {
+            info!("horizontal adapter initialized in api-only mode");
+            return;
+        }
+
         if let Err(e) = self.start_listeners().await {
             error!(error = %e, "failed to start transport listeners");
         }

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
@@ -33,6 +33,7 @@ where
             enable_socket_counting: true,     // Default to enabled
             aggregate_counts: false,          // Tier 1A: opt-in via config
             fast_presence_transitions: false, // Opt-in eventual presence transitions
+            api_only: false,                  // Publish-only, no listeners or request/reply
             #[cfg(feature = "delta")]
             delta_compression: None,
             #[cfg(feature = "delta")]
@@ -147,13 +148,18 @@ where
         self.fast_presence_transitions = enable;
     }
 
+    pub fn set_api_only(&mut self, enable: bool) {
+        self.api_only = enable;
+    }
+
     /// Publish a pre-built RequestBody and collect responses from other nodes
     pub async fn send_request_with_body(&self, request: RequestBody) -> Result<ResponseBody> {
         let app_id = request.app_id.clone();
         let request_type = request.request_type.clone();
         let request_id = request.request_id.clone();
 
-        let should_skip_horizontal = self.should_skip_horizontal_communication().await;
+        let should_skip_horizontal =
+            self.api_only || self.should_skip_horizontal_communication().await;
         let discovered_node_count = self.horizontal.get_effective_node_count().await;
         let node_count = if should_skip_horizontal {
             1

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/mod.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/mod.rs
@@ -59,6 +59,8 @@ pub struct HorizontalAdapterBase<T: HorizontalTransport> {
     /// When true, first-join/last-leave presence transition checks use the
     /// replicated presence registry instead of request/reply.
     pub fast_presence_transitions: bool,
+    /// API-only mode: publish-only, no listeners or request/reply.
+    api_only: bool,
     #[cfg(feature = "delta")]
     // Delta compression manager for bandwidth optimization
     delta_compression: Option<Arc<sockudo_delta::DeltaCompressionManager>>,
@@ -94,6 +96,9 @@ impl<T: HorizontalTransport> HorizontalAdapterBase<T> {
     /// This is determined by checking if cluster health is enabled and
     /// if the effective node count is 1 or less.
     pub async fn should_skip_horizontal_communication(&self) -> bool {
+        if self.api_only {
+            return false;
+        }
         should_skip_horizontal_communication_impl(self.cluster_health_enabled, &self.horizontal)
             .await
     }

--- a/crates/sockudo-adapter/tests/adapter/mod.rs
+++ b/crates/sockudo-adapter/tests/adapter/mod.rs
@@ -96,3 +96,6 @@ mod async_disconnect_cleanup_tests;
 
 #[cfg(test)]
 mod user_socket_index_regression_tests;
+
+#[cfg(test)]
+mod server_role_tests;

--- a/crates/sockudo-adapter/tests/adapter/server_role_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/server_role_tests.rs
@@ -1,0 +1,156 @@
+use sockudo_adapter::connection_manager::ConnectionManager;
+use sockudo_adapter::horizontal_adapter::RequestType;
+use sockudo_adapter::horizontal_adapter_base::HorizontalAdapterBase;
+use sockudo_core::error::Result;
+use sockudo_protocol::messages::{MessageData, PusherMessage};
+use std::time::{Duration, Instant};
+
+use super::horizontal_adapter_helpers::{MockConfig, MockNodeState, MockTransport};
+
+#[tokio::test]
+async fn test_api_only_always_publishes_horizontally() -> Result<()> {
+    let config = MockConfig {
+        node_states: vec![MockNodeState::new("single-node")],
+        ..Default::default()
+    };
+
+    let mut adapter = HorizontalAdapterBase::<MockTransport>::new(config.clone()).await?;
+    adapter.cluster_health_enabled = true;
+    adapter.set_api_only(true);
+    adapter.init().await;
+
+    let message = PusherMessage {
+        channel: Some("test-channel".to_string()),
+        event: Some("test-event".to_string()),
+        data: Some(MessageData::String("test message".to_string())),
+        name: None,
+        user_id: None,
+        tags: None,
+        sequence: None,
+        conflation_key: None,
+        message_id: None,
+        stream_id: None,
+        serial: None,
+        idempotency_key: None,
+        extras: None,
+        delta_sequence: None,
+        delta_conflation_key: None,
+    };
+
+    adapter
+        .send("test-channel", message, None, "test-app", None)
+        .await?;
+
+    let published_broadcasts = adapter.transport.get_published_broadcasts().await;
+    assert_eq!(
+        published_broadcasts.len(),
+        1,
+        "API-only mode must publish broadcasts even when it is the only node"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_api_only_should_skip_horizontal_communication_is_false() -> Result<()> {
+    let config = MockConfig {
+        node_states: vec![MockNodeState::new("single-node")],
+        ..Default::default()
+    };
+
+    let mut adapter = HorizontalAdapterBase::<MockTransport>::new(config.clone()).await?;
+    adapter.cluster_health_enabled = true;
+    adapter.set_api_only(true);
+
+    assert!(
+        !adapter.should_skip_horizontal_communication().await,
+        "API-only mode must never skip horizontal publishing"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_default_should_skip_horizontal_communication_is_true() -> Result<()> {
+    let config = MockConfig {
+        node_states: vec![MockNodeState::new("single-node")],
+        ..Default::default()
+    };
+
+    let mut adapter = HorizontalAdapterBase::<MockTransport>::new(config.clone()).await?;
+    adapter.cluster_health_enabled = true;
+
+    assert!(
+        adapter.should_skip_horizontal_communication().await,
+        "default single-node mode must keep the horizontal short-circuit"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_api_only_request_reply_short_circuits() -> Result<()> {
+    let config = MockConfig {
+        node_states: vec![MockNodeState::new("single-node")],
+        ..Default::default()
+    };
+
+    let mut adapter = HorizontalAdapterBase::<MockTransport>::new(config.clone()).await?;
+    adapter.cluster_health_enabled = true;
+    adapter.set_api_only(true);
+    adapter.init().await;
+
+    let start = Instant::now();
+    let response = adapter
+        .send_request("test-app", RequestType::SocketsCount, None, None, None)
+        .await?;
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < Duration::from_millis(100),
+        "api-only request/reply must return immediately, took {:?}",
+        elapsed
+    );
+    assert!(response.complete, "api-only response must be complete");
+    assert_eq!(response.sockets_count, 0);
+    assert_eq!(response.responses_received, 0);
+
+    let published_requests = adapter.transport.get_published_requests().await;
+    let app_requests: Vec<_> = published_requests
+        .into_iter()
+        .filter(|r| r.request_type != RequestType::Heartbeat)
+        .collect();
+    assert_eq!(
+        app_requests.len(),
+        0,
+        "api-only adapter must not publish requests to the transport"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_api_only_get_sockets_count_returns_local() -> Result<()> {
+    let config = MockConfig {
+        node_states: vec![MockNodeState::new("single-node")],
+        ..Default::default()
+    };
+
+    let mut adapter = HorizontalAdapterBase::<MockTransport>::new(config.clone()).await?;
+    adapter.cluster_health_enabled = true;
+    adapter.set_api_only(true);
+    adapter.init().await;
+
+    let start = Instant::now();
+    let count = adapter.get_sockets_count("test-app").await?;
+    let elapsed = start.elapsed();
+
+    assert_eq!(count, 0, "api-only pod has no local connections");
+    assert!(
+        elapsed < Duration::from_millis(100),
+        "get_sockets_count must not hang on api-only adapter, took {:?}",
+        elapsed
+    );
+
+    Ok(())
+}

--- a/crates/sockudo-core/src/options/env/core.rs
+++ b/crates/sockudo-core/src/options/env/core.rs
@@ -29,6 +29,9 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
     if let Ok(id) = std::env::var("INSTANCE_PROCESS_ID") {
         options.instance.process_id = id;
     }
+    if let Ok(server_role) = std::env::var("SOCKUDO_SERVER_ROLE") {
+        options.server_role = server_role.parse().map_err(|e: String| e)?;
+    }
 
     Ok(())
 }

--- a/crates/sockudo-core/src/options/server.rs
+++ b/crates/sockudo-core/src/options/server.rs
@@ -2,6 +2,45 @@ use super::*;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
+/// Deployment topology role for this process.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ServerRole {
+    /// WebSocket + HTTP + cluster participation.
+    #[default]
+    Default,
+    /// HTTP publish only — no WebSocket listeners or cluster participation.
+    Api,
+}
+
+impl ServerRole {
+    pub fn is_api(&self) -> bool {
+        matches!(self, ServerRole::Api)
+    }
+}
+
+impl std::fmt::Display for ServerRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ServerRole::Default => write!(f, "default"),
+            ServerRole::Api => write!(f, "api"),
+        }
+    }
+}
+
+impl std::str::FromStr for ServerRole {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "default" => Ok(ServerRole::Default),
+            "api" => Ok(ServerRole::Api),
+            _ => Err(format!(
+                "Unknown server role: {s} (expected \"default\" or \"api\")"
+            )),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ServerOptions {
@@ -22,6 +61,7 @@ pub struct ServerOptions {
     pub max_connections: u32,
     pub metrics: MetricsConfig,
     pub mode: String,
+    pub server_role: ServerRole,
     pub port: u16,
     pub path_prefix: String,
     pub presence: PresenceConfig,
@@ -77,6 +117,7 @@ impl Default for ServerOptions {
             max_connections: 0,
             metrics: MetricsConfig::default(),
             mode: "production".to_string(),
+            server_role: ServerRole::default(),
             port: 6001,
             path_prefix: "/".to_string(),
             presence: PresenceConfig::default(),
@@ -139,6 +180,17 @@ impl ServerOptions {
             self.cache.driver,
             CacheDriver::Redis | CacheDriver::RedisCluster
         );
+        if self.server_role.is_api() {
+            if self.adapter.driver == AdapterDriver::Local {
+                return Err(
+                    "server_role=api requires a horizontal adapter; adapter.driver=local is not supported"
+                        .to_string(),
+                );
+            }
+            if self.adapter.fallback_to_local {
+                return Err("server_role=api cannot use adapter.fallback_to_local".to_string());
+            }
+        }
         if clustered && (self.ably_compat.enabled || self.idempotency.enabled) && !shared_cache {
             return Err(
                 "clustered Ably compatibility and idempotency require cache.driver=redis or redis-cluster; node-local cache cannot authorize or deduplicate across nodes"
@@ -479,5 +531,75 @@ mod tests {
             options.validate().unwrap_err(),
             "connection_recovery.max_buffer_size must be greater than 0"
         );
+    }
+
+    #[test]
+    fn server_role_defaults_to_default() {
+        assert_eq!(ServerOptions::default().server_role, ServerRole::Default);
+        assert!(!ServerOptions::default().server_role.is_api());
+    }
+
+    #[test]
+    fn server_role_parses_case_insensitive() {
+        for raw in ["api", "Api", "API"] {
+            assert_eq!(raw.parse::<ServerRole>().unwrap(), ServerRole::Api);
+        }
+        assert_eq!(
+            "default".parse::<ServerRole>().unwrap(),
+            ServerRole::Default
+        );
+    }
+
+    #[test]
+    fn server_role_rejects_unknown() {
+        assert!("ws".parse::<ServerRole>().is_err());
+        assert!("".parse::<ServerRole>().is_err());
+    }
+
+    #[test]
+    fn server_role_displays_lowercase() {
+        assert_eq!(ServerRole::Api.to_string(), "api");
+        assert_eq!(ServerRole::Default.to_string(), "default");
+    }
+
+    #[test]
+    fn api_role_rejects_local_adapter() {
+        let mut options = ServerOptions {
+            server_role: ServerRole::Api,
+            ..Default::default()
+        };
+        options.adapter.driver = AdapterDriver::Local;
+        let error = options.validate().unwrap_err();
+        assert!(error.contains("horizontal adapter"), "got: {error}");
+    }
+
+    #[test]
+    fn api_role_rejects_fallback_to_local() {
+        let mut options = ServerOptions {
+            server_role: ServerRole::Api,
+            ..Default::default()
+        };
+        options.adapter.driver = AdapterDriver::Redis;
+        options.adapter.fallback_to_local = true;
+        let error = options.validate().unwrap_err();
+        assert!(error.contains("fallback_to_local"), "got: {error}");
+    }
+
+    #[test]
+    fn api_role_accepts_redis_adapter() {
+        let mut options = ServerOptions {
+            server_role: ServerRole::Api,
+            ..Default::default()
+        };
+        options.adapter.driver = AdapterDriver::Redis;
+        options.adapter.fallback_to_local = false;
+        options.cache.driver = CacheDriver::Redis;
+        options.validate().unwrap();
+    }
+
+    #[test]
+    fn default_role_accepts_local_adapter() {
+        let options = ServerOptions::default();
+        options.validate().unwrap();
     }
 }

--- a/crates/sockudo-protocol/src/messages.rs
+++ b/crates/sockudo-protocol/src/messages.rs
@@ -1653,10 +1653,19 @@ pub trait InfoQueryParser {
     fn wants_cache(&self) -> bool;
 }
 
-impl InfoQueryParser for Option<&String> {
+fn parse_info_tokens(raw: Option<&str>) -> Vec<&str> {
+    raw.map(|s| {
+        s.split(',')
+            .map(str::trim)
+            .filter(|token| !token.is_empty())
+            .collect::<Vec<_>>()
+    })
+    .unwrap_or_default()
+}
+
+impl<T: AsRef<str>> InfoQueryParser for Option<T> {
     fn parse_info(&self) -> Vec<&str> {
-        self.map(|s| s.split(',').collect::<Vec<_>>())
-            .unwrap_or_default()
+        parse_info_tokens(self.as_ref().map(AsRef::as_ref))
     }
 
     fn wants_user_count(&self) -> bool {
@@ -1788,5 +1797,29 @@ mod tests {
             value["annotations"]["summary"]["reactions:distinct.v1"]["thumbsup"]["total"].as_u64(),
             Some(5)
         );
+    }
+
+    #[test]
+    fn info_query_parser_trims_and_matches_exactly() {
+        use super::InfoQueryParser;
+
+        let s = "user_count".to_string();
+        assert!(Some(&s).wants_user_count());
+        assert!(!Some(&s).wants_subscription_count());
+
+        assert!(Some("user_count").wants_user_count());
+        assert!(Some("subscription_count").wants_subscription_count());
+
+        assert!(Some(" user_count ").wants_user_count());
+        assert!(Some("cache, user_count").wants_user_count());
+
+        assert!(!Some("subscription_counts").wants_subscription_count());
+        assert!(!Some("user_count_extra").wants_user_count());
+
+        assert!(!None::<&str>.wants_user_count());
+        assert!(!None::<&str>.wants_subscription_count());
+        assert!(!None::<&str>.wants_cache());
+
+        assert!(Some("cache").wants_cache());
     }
 }

--- a/crates/sockudo-server/src/bootstrap/router.rs
+++ b/crates/sockudo-server/src/bootstrap/router.rs
@@ -211,15 +211,6 @@ impl SockudoServer {
             "configuring http body limit"
         );
 
-        let mut websocket_router = Router::new().route("/app/{appKey}", get(handle_ws_upgrade));
-        #[cfg(feature = "ably-compat")]
-        {
-            websocket_router = websocket_router.merge(self.ably_compat.realtime_router());
-        }
-        if let Some(middleware) = websocket_rate_limiter_middleware_layer {
-            websocket_router = websocket_router.layer(middleware);
-        }
-
         let mut api_router = Router::new()
             .route(
                 "/apps/{appId}/events",
@@ -238,20 +229,6 @@ impl SockudoServer {
             .route(
                 "/apps/{appId}/revocations",
                 post(revoke_capability_tokens).route_layer(axum_middleware::from_fn_with_state(
-                    self.handler.clone(),
-                    pusher_api_auth_middleware,
-                )),
-            )
-            .route(
-                "/apps/{appId}/channels",
-                get(channels).route_layer(axum_middleware::from_fn_with_state(
-                    self.handler.clone(),
-                    pusher_api_auth_middleware,
-                )),
-            )
-            .route(
-                "/apps/{appId}/channels/{channelName}",
-                get(channel).route_layer(axum_middleware::from_fn_with_state(
                     self.handler.clone(),
                     pusher_api_auth_middleware,
                 )),
@@ -368,32 +345,57 @@ impl SockudoServer {
                     self.handler.clone(),
                     pusher_api_auth_middleware,
                 )),
-            )
-            .route(
-                "/apps/{appId}/channels/{channelName}/users",
-                get(channel_users).route_layer(axum_middleware::from_fn_with_state(
-                    self.handler.clone(),
-                    pusher_api_auth_middleware,
-                )),
-            )
-            .route(
-                "/apps/{appId}/users/{userId}/terminate_connections",
-                post(terminate_user_connections).route_layer(axum_middleware::from_fn_with_state(
-                    self.handler.clone(),
-                    pusher_api_auth_middleware,
-                )),
-            )
-            .route(
-                "/apps/{appId}/users/{userId}/force_reconnect",
-                post(force_reconnect_user).route_layer(axum_middleware::from_fn_with_state(
-                    self.handler.clone(),
-                    pusher_api_auth_middleware,
-                )),
             );
+
+        // Routes that require local socket state (channels, users, terminate, force-reconnect).
+        if !self.config.server_role.is_api() {
+            api_router = api_router
+                .route(
+                    "/apps/{appId}/channels",
+                    get(channels).route_layer(axum_middleware::from_fn_with_state(
+                        self.handler.clone(),
+                        pusher_api_auth_middleware,
+                    )),
+                )
+                .route(
+                    "/apps/{appId}/channels/{channelName}",
+                    get(channel).route_layer(axum_middleware::from_fn_with_state(
+                        self.handler.clone(),
+                        pusher_api_auth_middleware,
+                    )),
+                )
+                .route(
+                    "/apps/{appId}/channels/{channelName}/users",
+                    get(channel_users).route_layer(axum_middleware::from_fn_with_state(
+                        self.handler.clone(),
+                        pusher_api_auth_middleware,
+                    )),
+                )
+                .route(
+                    "/apps/{appId}/users/{userId}/terminate_connections",
+                    post(terminate_user_connections).route_layer(
+                        axum_middleware::from_fn_with_state(
+                            self.handler.clone(),
+                            pusher_api_auth_middleware,
+                        ),
+                    ),
+                )
+                .route(
+                    "/apps/{appId}/users/{userId}/force_reconnect",
+                    post(force_reconnect_user).route_layer(axum_middleware::from_fn_with_state(
+                        self.handler.clone(),
+                        pusher_api_auth_middleware,
+                    )),
+                );
+        }
 
         #[cfg(feature = "ably-compat")]
         {
-            api_router = api_router.merge(self.ably_compat.rest_router());
+            if self.config.server_role.is_api() {
+                api_router = api_router.merge(self.ably_compat.rest_router_api());
+            } else {
+                api_router = api_router.merge(self.ably_compat.rest_router());
+            }
         }
 
         #[cfg(feature = "push")]
@@ -569,8 +571,21 @@ impl SockudoServer {
             api_router = api_router.layer(middleware);
         }
 
-        let mut router = Router::new()
-            .merge(websocket_router)
+        let mut router = Router::new();
+
+        if !self.config.server_role.is_api() {
+            let mut websocket_router = Router::new().route("/app/{appKey}", get(handle_ws_upgrade));
+            #[cfg(feature = "ably-compat")]
+            {
+                websocket_router = websocket_router.merge(self.ably_compat.realtime_router());
+            }
+            if let Some(middleware) = websocket_rate_limiter_middleware_layer {
+                websocket_router = websocket_router.layer(middleware);
+            }
+            router = router.merge(websocket_router);
+        }
+
+        let mut router = router
             .merge(api_router)
             .route("/up", get(up))
             .route("/up/{appId}", get(up))

--- a/crates/sockudo-server/src/bootstrap/runtime.rs
+++ b/crates/sockudo-server/src/bootstrap/runtime.rs
@@ -472,12 +472,13 @@ impl SockudoServer {
         self.state.running.store(false, Ordering::SeqCst);
         self.handler.shutdown_ai_workers().await;
 
-        // Tell cluster peers this node is leaving and no responses are expected
-        if let Err(e) = self
-            .state
-            .connection_manager
-            .announce_node_departure()
-            .await
+        // Tell cluster peers this node is leaving and no responses are expected.
+        if !self.config.server_role.is_api()
+            && let Err(e) = self
+                .state
+                .connection_manager
+                .announce_node_departure()
+                .await
         {
             warn!(error = %e, "failed to announce node departure");
         }

--- a/crates/sockudo-server/src/bootstrap/server.rs
+++ b/crates/sockudo-server/src/bootstrap/server.rs
@@ -61,8 +61,12 @@ impl SockudoServer {
             "app manager initialized"
         );
 
-        let (connection_manager, typed_adapter) =
-            AdapterFactory::create_with_typed(&config.adapter, &config.database).await?;
+        let (connection_manager, typed_adapter) = AdapterFactory::create_with_typed(
+            &config.adapter,
+            &config.database,
+            config.server_role.is_api(),
+        )
+        .await?;
         let local_adapter = Some(typed_adapter.local_adapter());
 
         info!(adapter = ?config.adapter.driver, "adapter initialized");
@@ -593,37 +597,38 @@ impl SockudoServer {
             )));
         }
 
-        let (cleanup_queue, cleanup_worker_handles) = if cleanup_config.async_enabled {
-            let presence_cleanup = PresenceCleanupContext {
-                history_store: Arc::clone(&presence_history_store),
-                history_config: config.presence_history.clone(),
-                manager: Arc::clone(&presence_manager),
-            };
-            let multi_worker_system = MultiWorkerCleanupSystem::new(
-                connection_manager.clone(),
-                app_manager.clone(),
-                Some(webhook_integration.clone()),
-                presence_cleanup,
-                cleanup_config.clone(),
-                metrics.clone(),
-            );
-
-            let cleanup_sender =
-                if let Some(direct_sender) = multi_worker_system.get_direct_sender() {
-                    info!(cleanup_mode = "direct", "cleanup sender initialized");
-                    CleanupSender::Direct(direct_sender)
-                } else {
-                    info!(cleanup_mode = "multi_worker", "cleanup sender initialized");
-                    CleanupSender::Multi(multi_worker_system.get_sender())
+        let (cleanup_queue, cleanup_worker_handles) =
+            if !config.server_role.is_api() && cleanup_config.async_enabled {
+                let presence_cleanup = PresenceCleanupContext {
+                    history_store: Arc::clone(&presence_history_store),
+                    history_config: config.presence_history.clone(),
+                    manager: Arc::clone(&presence_manager),
                 };
+                let multi_worker_system = MultiWorkerCleanupSystem::new(
+                    connection_manager.clone(),
+                    app_manager.clone(),
+                    Some(webhook_integration.clone()),
+                    presence_cleanup,
+                    cleanup_config.clone(),
+                    metrics.clone(),
+                );
 
-            let worker_handles = multi_worker_system.get_worker_handles();
+                let cleanup_sender =
+                    if let Some(direct_sender) = multi_worker_system.get_direct_sender() {
+                        info!(cleanup_mode = "direct", "cleanup sender initialized");
+                        CleanupSender::Direct(direct_sender)
+                    } else {
+                        info!(cleanup_mode = "multi_worker", "cleanup sender initialized");
+                        CleanupSender::Multi(multi_worker_system.get_sender())
+                    };
 
-            info!("multi-worker cleanup system initialized");
-            (Some(cleanup_sender), Some(worker_handles))
-        } else {
-            (None, None)
-        };
+                let worker_handles = multi_worker_system.get_worker_handles();
+
+                info!("multi-worker cleanup system initialized");
+                (Some(cleanup_sender), Some(worker_handles))
+            } else {
+                (None, None)
+            };
 
         // Initialize delta compression manager
         #[cfg(feature = "delta")]
@@ -987,8 +992,10 @@ impl SockudoServer {
         #[cfg(feature = "ably-compat")]
         ably_compat.bind_handler(&handler);
 
-        // Start dead node cleanup event processing loop (only runs if cluster health is enabled)
-        if let Some(event_receiver) = dead_node_event_receiver {
+        // Start dead node cleanup event processing loop (only runs if cluster health is enabled).
+        if !config.server_role.is_api()
+            && let Some(event_receiver) = dead_node_event_receiver
+        {
             let handler_clone = handler.clone();
             tokio::spawn(async move {
                 info!("dead node cleanup event loop started");
@@ -1001,9 +1008,10 @@ impl SockudoServer {
             });
         }
 
-        // Start replay buffer eviction task (only when connection recovery is enabled)
+        // Start replay buffer eviction task (only when connection recovery is enabled).
         #[cfg(feature = "recovery")]
-        if config.connection_recovery.enabled
+        if !config.server_role.is_api()
+            && config.connection_recovery.enabled
             && let Some(replay_buf) = handler.replay_buffer().cloned()
         {
             let eviction_interval =

--- a/crates/sockudo-server/src/http_handler/annotations/mod.rs
+++ b/crates/sockudo-server/src/http_handler/annotations/mod.rs
@@ -143,6 +143,18 @@ fn annotation_wire_event(annotation: &Annotation) -> AnnotationEventData {
     }
 }
 
+fn reject_socket_actor_in_api_role(
+    handler: &ConnectionHandler,
+    requested_socket_id: Option<&str>,
+) -> Result<(), AppError> {
+    if requested_socket_id.is_some() && handler.server_options().server_role.is_api() {
+        return Err(AppError::InvalidInput(
+            "socket_id cannot be verified in the api server role (no local WebSocket connections); omit socket_id or send the request to a WebSocket pod".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 async fn resolve_annotation_publish_actor(
     handler: &Arc<ConnectionHandler>,
     app_id: &str,
@@ -150,6 +162,7 @@ async fn resolve_annotation_publish_actor(
     requested_client_id: Option<&str>,
     requested_socket_id: Option<&str>,
 ) -> Result<Option<String>, AppError> {
+    reject_socket_actor_in_api_role(handler, requested_socket_id)?;
     if let Some(raw_socket_id) = requested_socket_id {
         let socket_id = SocketId::from_string(raw_socket_id)
             .map_err(|e| AppError::InvalidInput(format!("Invalid socket_id: {e}")))?;
@@ -205,6 +218,7 @@ async fn authorize_annotation_delete(
     target_client_id: Option<&str>,
     requested_socket_id: Option<&str>,
 ) -> Result<Option<String>, AppError> {
+    reject_socket_actor_in_api_role(handler, requested_socket_id)?;
     let Some(raw_socket_id) = requested_socket_id else {
         return Ok(None);
     };
@@ -259,6 +273,7 @@ async fn authorize_annotation_subscribe(
     channel: &str,
     requested_socket_id: Option<&str>,
 ) -> Result<(), AppError> {
+    reject_socket_actor_in_api_role(handler, requested_socket_id)?;
     let Some(raw_socket_id) = requested_socket_id else {
         return Ok(());
     };
@@ -454,6 +469,7 @@ pub async fn delete_annotation(
     validate_channel_name(&app, &path.channel_name).await?;
     require_versioned_messages_enabled(&handler, &path.channel_name)?;
     require_annotations_enabled(&handler, &app, &path.channel_name)?;
+    reject_socket_actor_in_api_role(&handler, query.get("socket_id").map(String::as_str))?;
     let message_serial = parse_message_serial(&path.message_serial)?;
     let target_serial = parse_annotation_serial(&path.annotation_serial)?;
     let target = handler

--- a/crates/sockudo-server/src/http_handler/annotations/tests.rs
+++ b/crates/sockudo-server/src/http_handler/annotations/tests.rs
@@ -520,3 +520,143 @@ async fn annotation_delete_any_allows_moderator() {
 
     assert_eq!(response.status(), StatusCode::OK);
 }
+
+#[tokio::test]
+async fn annotation_publish_rejects_socket_id_in_api_role() {
+    let store = Arc::new(MemoryVersionStore::new());
+    let handler = test_api_role_handler_with_store(100, store.clone());
+    let app = test_annotation_app();
+
+    store
+        .append_version(test_versioned_record(
+            "msg:1",
+            "00000000000000000001:test:00000000000000000001",
+            10,
+            1,
+            "hello",
+        ))
+        .await
+        .unwrap();
+
+    let response = match publish_annotation(
+        Path(VersionMutationPath {
+            app_id: "app-1".to_string(),
+            channel_name: "versioned-room".to_string(),
+            message_serial: "msg:1".to_string(),
+        }),
+        Extension(app),
+        State(handler),
+        Json(PublishAnnotationRequest {
+            annotation_type: "reactions:total.v1".to_string(),
+            name: None,
+            client_id: None,
+            socket_id: Some("socket-123".to_string()),
+            count: None,
+            data: None,
+            encoding: None,
+        }),
+    )
+    .await
+    {
+        Err(err) => err.into_response(),
+        Ok(_) => panic!("expected socket_id rejection in api role"),
+    };
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(text.contains("omit socket_id"));
+}
+
+#[tokio::test]
+async fn annotation_delete_rejects_socket_id_in_api_role() {
+    let store = Arc::new(MemoryVersionStore::new());
+    let handler = test_api_role_handler_with_store(100, store.clone());
+    let app = test_annotation_app();
+
+    store
+        .append_version(test_versioned_record(
+            "msg:1",
+            "00000000000000000001:test:00000000000000000001",
+            10,
+            1,
+            "hello",
+        ))
+        .await
+        .unwrap();
+
+    let response = match delete_annotation(
+        Path(AnnotationMutationPath {
+            app_id: "app-1".to_string(),
+            channel_name: "versioned-room".to_string(),
+            message_serial: "msg:1".to_string(),
+            annotation_serial: "ann:1".to_string(),
+        }),
+        Query(HashMap::from([(
+            "socket_id".to_string(),
+            "socket-123".to_string(),
+        )])),
+        Extension(app),
+        State(handler),
+    )
+    .await
+    {
+        Err(err) => err.into_response(),
+        Ok(_) => panic!("expected socket_id rejection in api role"),
+    };
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(text.contains("omit socket_id"));
+}
+
+#[tokio::test]
+async fn annotation_subscribe_rejects_socket_id_in_api_role() {
+    let store = Arc::new(MemoryVersionStore::new());
+    let handler = test_api_role_handler_with_store(100, store.clone());
+    let app = test_annotation_app();
+
+    store
+        .append_version(test_versioned_record(
+            "msg:1",
+            "00000000000000000001:test:00000000000000000001",
+            10,
+            1,
+            "hello",
+        ))
+        .await
+        .unwrap();
+
+    let response = match channel_message_annotations(
+        Path(VersionMutationPath {
+            app_id: "app-1".to_string(),
+            channel_name: "versioned-room".to_string(),
+            message_serial: "msg:1".to_string(),
+        }),
+        Query(AnnotationEventsQuery {
+            annotation_type: None,
+            limit: None,
+            from_serial: None,
+            socket_id: Some("socket-123".to_string()),
+        }),
+        Extension(app),
+        State(handler),
+    )
+    .await
+    {
+        Err(err) => err.into_response(),
+        Ok(_) => panic!("expected socket_id rejection in api role"),
+    };
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(text.contains("omit socket_id"));
+}

--- a/crates/sockudo-server/src/http_handler/events/mod.rs
+++ b/crates/sockudo-server/src/http_handler/events/mod.rs
@@ -10,7 +10,9 @@ use axum::{
 use sockudo_adapter::ConnectionHandler;
 use sockudo_core::app::App;
 use sockudo_core::auth::EventQuery;
-use sockudo_protocol::messages::{BatchPusherApiMessage, PusherApiMessage, is_ai_event};
+use sockudo_protocol::messages::{
+    BatchPusherApiMessage, InfoQueryParser, PusherApiMessage, is_ai_event,
+};
 use sonic_rs::{Value, json};
 use std::{collections::HashMap, sync::Arc};
 use tracing::{debug, field, instrument, warn};
@@ -91,6 +93,10 @@ pub(super) fn idempotency_ttl(app: &App, handler: &ConnectionHandler) -> u64 {
         .ttl_seconds
 }
 
+fn requires_realtime_counts(info: Option<&str>) -> bool {
+    info.wants_user_count() || info.wants_subscription_count()
+}
+
 /// Merge per-app idempotency overrides with the global config.
 /// Only fields explicitly set at the app level take precedence.
 /// POST /apps/{app_id}/events
@@ -117,8 +123,16 @@ pub async fn events(
         .as_nanos() as f64
         / 1_000_000.0;
 
-    let incoming_request_size_bytes = sonic_rs::to_vec(&event_payload)?.len();
+    // Checked before the idempotency claim so a rejected request never poisons the key slot.
+    if handler.server_options().server_role.is_api()
+        && requires_realtime_counts(event_payload.info.as_deref())
+    {
+        return Err(AppError::InvalidInput(
+            "user_count and subscription_count are unavailable in api server role".to_string(),
+        ));
+    }
 
+    let incoming_request_size_bytes = sonic_rs::to_vec(&event_payload)?.len();
     let idempotency_config = app.resolved_idempotency(&handler.server_options().idempotency);
     let idempotency_key = resolve_idempotency_key(
         &event_payload.idempotency_key,
@@ -385,8 +399,21 @@ pub async fn batch_events(
         .as_nanos() as f64
         / 1_000_000.0;
 
-    let body_bytes = sonic_rs::to_vec(&batch_message_payload)?;
+    // Checked before the idempotency claim so a rejected request never poisons the key slot.
+    if handler.server_options().server_role.is_api()
+        && batch_message_payload
+            .batch
+            .iter()
+            .any(|single_event_message| {
+                requires_realtime_counts(single_event_message.info.as_deref())
+            })
+    {
+        return Err(AppError::InvalidInput(
+            "user_count and subscription_count are unavailable in api server role".to_string(),
+        ));
+    }
 
+    let body_bytes = sonic_rs::to_vec(&batch_message_payload)?;
     let idempotency_config = app_config.resolved_idempotency(&handler.server_options().idempotency);
     let batch_len = batch_message_payload.batch.len();
     tracing::Span::current().record("batch_len", batch_len);

--- a/crates/sockudo-server/src/http_handler/events/processor.rs
+++ b/crates/sockudo-server/src/http_handler/events/processor.rs
@@ -7,7 +7,9 @@ use sockudo_core::app::App;
 use sockudo_core::utils::{self, validate_channel_name};
 use sockudo_core::websocket::SocketId;
 use sockudo_protocol::constants::EVENT_NAME_MAX_LENGTH as DEFAULT_EVENT_NAME_MAX_LENGTH;
-use sockudo_protocol::messages::{ApiMessageData, MessageData, PusherApiMessage, PusherMessage};
+use sockudo_protocol::messages::{
+    ApiMessageData, InfoQueryParser, MessageData, PusherApiMessage, PusherMessage,
+};
 use sonic_rs::{Value, json};
 use std::{collections::HashMap, sync::Arc};
 use tracing::{debug, error, field, instrument, warn};
@@ -214,7 +216,7 @@ pub(super) async fn process_single_event_parallel(
                     current_channel_info_map.insert("version_serial", json!(version_serial));
                 }
 
-                if is_presence && info_for_task.as_deref().is_some_and(|s| s.contains("user_count")) {
+                if is_presence && info_for_task.as_deref().wants_user_count() {
                     match handler_clone
                         .connection_manager()
                         .get_local_channel_members(&app.id, &target_channel_str)
@@ -230,10 +232,7 @@ pub(super) async fn process_single_event_parallel(
                     }
                 }
 
-                if info_for_task
-                    .as_deref()
-                    .is_some_and(|s| s.contains("subscription_count"))
-                {
+                if info_for_task.as_deref().wants_subscription_count() {
                     let count = handler_clone
                         .connection_manager()
                         .get_channel_socket_count(&app.id, &target_channel_str)

--- a/crates/sockudo-server/src/http_handler/events/tests.rs
+++ b/crates/sockudo-server/src/http_handler/events/tests.rs
@@ -1,6 +1,29 @@
 use super::*;
 use crate::http_handler::test_support::*;
 use sockudo_protocol::messages::{ApiMessageData, PusherApiMessage};
+
+#[test]
+fn requires_realtime_counts_detects_count_requests() {
+    assert!(requires_realtime_counts(Some("user_count")));
+    assert!(requires_realtime_counts(Some("subscription_count")));
+    assert!(requires_realtime_counts(Some(
+        "user_count,subscription_count"
+    )));
+    assert!(requires_realtime_counts(Some(" cache, user_count ")));
+}
+
+#[test]
+fn requires_realtime_counts_ignores_non_count_requests() {
+    assert!(!requires_realtime_counts(Some("cache")));
+    assert!(!requires_realtime_counts(Some("")));
+    assert!(!requires_realtime_counts(None));
+}
+
+#[test]
+fn requires_realtime_counts_rejects_superstring_matches() {
+    assert!(!requires_realtime_counts(Some("subscription_counts")));
+    assert!(!requires_realtime_counts(Some("user_count_extra")));
+}
 use sockudo_push::{
     ChannelSubscription, MemoryPushQueue, MemoryPushStore, PushDeviceStore, PushProviderKind,
     PushPublishLogStore, PushSubscriptionStore,

--- a/crates/sockudo-server/src/http_handler/system.rs
+++ b/crates/sockudo-server/src/http_handler/system.rs
@@ -70,6 +70,9 @@ struct StatsResponse {
     presence_history: PresenceHistoryStatusResponse,
     totals: GlobalStats,
     apps: Vec<AppStats>,
+    /// Present only for api-role pods.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server_role: Option<sockudo_core::options::ServerRole>,
 }
 
 /// Records API metrics (helper async function)
@@ -224,9 +227,12 @@ pub async fn stats(
 
     app_stats.sort_by(|a, b| a.app_id.cmp(&b.app_id));
 
+    let server_role = handler.server_options().server_role;
+
     Ok((
         StatusCode::OK,
         Json(StatsResponse {
+            server_role: server_role.is_api().then_some(server_role),
             memory,
             history: HistoryStatusResponse {
                 enabled: history_status.enabled,

--- a/crates/sockudo-server/src/http_handler/test_support.rs
+++ b/crates/sockudo-server/src/http_handler/test_support.rs
@@ -268,6 +268,35 @@ pub(crate) fn test_versioned_handler_with_store(
     handler
 }
 
+pub(crate) fn test_api_role_handler_with_store(
+    max_page_size: usize,
+    version_store: Arc<dyn VersionStore + Send + Sync>,
+) -> Arc<ConnectionHandler> {
+    let app_manager = Arc::new(MemoryAppManager::new()) as Arc<dyn AppManager + Send + Sync>;
+    let adapter =
+        Arc::new(LocalAdapter::new()) as Arc<dyn sockudo_adapter::ConnectionManager + Send + Sync>;
+    let cache = Arc::new(MemoryCacheManager::new(
+        "test".to_string(),
+        MemoryCacheOptions::default(),
+    ));
+
+    let mut options = sockudo_core::options::ServerOptions::default();
+    options.versioned_messages.enabled = true;
+    options.versioned_messages.max_page_size = max_page_size;
+    options.history.enabled = true;
+    options.annotations.enabled = true;
+    options.server_role = sockudo_core::options::ServerRole::Api;
+
+    Arc::new(
+        ConnectionHandlerBuilder::new(app_manager, adapter, cache, options)
+            .history_store(Arc::new(MemoryHistoryStore::new(
+                MemoryHistoryStoreConfig::default(),
+            )))
+            .version_store(version_store)
+            .build(),
+    )
+}
+
 pub(crate) fn test_ai_versioned_handler_with_store(
     max_page_size: usize,
     version_store: Arc<dyn VersionStore + Send + Sync>,

--- a/crates/sockudo-server/src/http_handler/versioned_messages/mod.rs
+++ b/crates/sockudo-server/src/http_handler/versioned_messages/mod.rs
@@ -157,6 +157,11 @@ async fn resolve_mutation_actor(
     requested_socket_id: Option<&str>,
 ) -> Result<MutableMessageActor, AppError> {
     let action_metric = format!("message.{}", kind.as_verb());
+    if requested_socket_id.is_some() && handler.server_options().server_role.is_api() {
+        return Err(AppError::InvalidInput(
+            "socket_id cannot be verified in the api server role (no local WebSocket connections); omit socket_id or send the request to a WebSocket pod".to_string(),
+        ));
+    }
     if let Some(raw_socket_id) = requested_socket_id {
         let socket_id = SocketId::from_string(raw_socket_id)
             .map_err(|e| AppError::InvalidInput(format!("Invalid socket_id: {e}")))?;

--- a/docs/content/docs/deployment/capacity-planning.mdx
+++ b/docs/content/docs/deployment/capacity-planning.mdx
@@ -348,3 +348,23 @@ After the stable knee is known:
    shared backend
 
 Capacity belongs to the complete deployment, not the Sockudo process in isolation.
+
+## API pod topology
+
+When HTTP publish traffic is large relative to WebSocket connection count, running
+separate API pods (`server_role = "api"`) isolates publish latency and cuts memory
+on the API tier. See [server role configuration](/docs/reference/configuration#server-role)
+for setup and requirements.
+
+Expected operational behavior:
+
+| Metric | API pod | WS pod |
+| --- | --- | --- |
+| `sockudo_horizontal_broadcast_published_total` | > 0 | varies |
+| `sockudo_horizontal_broadcast_received_total` | 0 | > 0 |
+| `sockudo_horizontal_request_received_total` | 0 | > 0 |
+| WebSocket connections | 0 | > 0 |
+| Memory (100K+ connections) | ~50 MiB baseline | ~2–4 GiB |
+
+API pods report `"server_role": "api"` in `/stats` so dashboards can distinguish
+them from WS pods reporting zero connections.

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -19,6 +19,32 @@ runtime variable parsed by the server and push subsystem.
 | `port` | Bind port for WebSocket and HTTP API. |
 | `max_connections` | Per-node WebSocket connection limit. When exceeded the server returns close code 4100 so clients reconnect with backoff. `0` disables the limit. |
 | `debug` | Enables verbose diagnostics for local development. |
+| `server_role` | Deployment topology role. `"default"` runs the full server. `"api"` runs HTTP publish, history, mutable messages, and push — without WebSocket listeners, cluster heartbeats, or presence sync. Default: `"default"`. |
+
+## Server role
+
+`server_role` controls which subsystems the process starts.
+
+```toml
+server_role = "api"
+
+[adapter]
+driver = "redis-cluster"
+fallback_to_local = false
+```
+
+API pods publish to the horizontal broadcast stream and serve HTTP endpoints
+(publish, history, mutable messages, annotations, push). They skip WebSocket
+listeners, adapter subscriptions, heartbeats, presence sync, and request/reply —
+so they never appear in peer accounting and WS pods never await replies from them.
+
+The server rejects startup when `server_role = "api"` is combined with
+`adapter.driver = "local"` or `adapter.fallback_to_local = true`.
+
+For endpoint availability details see
+[HTTP endpoints — availability by server role](/docs/reference/http-endpoints#availability-by-server-role).
+For capacity and operational metrics see
+[Capacity planning — API pod topology](/docs/deployment/capacity-planning#api-pod-topology).
 
 ## App manager
 

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -102,6 +102,7 @@ url = "${REDIS_URL:-redis://localhost:6379}"
 | `USER_AUTHENTICATION_TIMEOUT` | Timeout used by user authentication flows. |
 | `SOCKUDO_MAX_CONNECTIONS` | Per-node WebSocket connection limit. `0` disables. |
 | `WEBSOCKET_MAX_PAYLOAD_KB` | Legacy maximum WebSocket payload size in KiB. |
+| `SOCKUDO_SERVER_ROLE` | Deployment topology role. `"default"` or `"api"`. Overrides `server_role` in the config file. |
 | `INSTANCE_PROCESS_ID` | Stable node/process identity used by clustering and Iggy consumers. |
 | `HOSTNAME` | Fallback node identity for Iggy when `INSTANCE_PROCESS_ID` is not set. |
 | `HEALTH_CHECK_TIMEOUT_MS` | Per-dependency timeout for `/up` health checks in milliseconds. Defaults to `2000`. |

--- a/docs/content/docs/reference/http-endpoints.mdx
+++ b/docs/content/docs/reference/http-endpoints.mdx
@@ -12,6 +12,20 @@ Sockudo exposes three endpoint groups:
 
 Every route under `/apps/{appId}` requires Pusher-compatible signed query authentication. Push routes also evaluate the push capability headers described below.
 
+## Availability by server role
+
+With `server_role = "api"` (see [Configuration](/docs/reference/configuration#server-role)),
+endpoints that depend on live socket state return 404: channels, channel users,
+terminate/force-reconnect, and the WebSocket upgrade. All publish, history, mutable-message,
+annotation, revocation, and push endpoints remain available.
+
+Additional restrictions in API mode:
+
+- `info` values `user_count` and `subscription_count` are rejected with HTTP 400.
+- `socket_id` on mutation and annotation requests is rejected with HTTP 400.
+- When built with `ably-compat`, Ably live-state routes (presence, channel detail)
+  return 404; the REST publish surface is available.
+
 ## WebSocket
 
 | Method | Path | Auth | Purpose |

--- a/docs/content/docs/server/mutable-messages.mdx
+++ b/docs/content/docs/server/mutable-messages.mdx
@@ -94,6 +94,8 @@ The path and body serial must identify the same logical message.
 
 Mutation bodies may include `socket_id` and `client_id` to bind the operation to a connected V2
 actor. Without `socket_id`, signed app-key HTTP requests are privileged server operations.
+In `server_role = "api"` mode, `socket_id` cannot be verified (no local WebSocket connections)
+and the request is rejected with HTTP 400. See [Server role](/docs/reference/configuration#server-role).
 
 ## Authorization
 


### PR DESCRIPTION
Introduce a `server_role` configuration option: `default` or `api`
It lets Sockudo run as an API-only pod where: API pods serve HTTP publish, history, mutable messages, annotations, and push endpoints without starting WebSocket listeners, cluster heartbeats, presence sync, request/reply, cleanup workers, or replay buffer eviction.

API mode requires a horizontal adapter (local is rejected at startup).
Broadcasts are always published horizontally so WS peers deliver them.
Socket-dependent routes (channels, users, terminate, force_reconnect, WebSocket upgrade) return 404.
Event publish rejects `user_count` and `subscription_count` info queries.
Actor binding via `socket_id` is rejected in mutation and annotation endpoints.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
