### PR TITLE
feat(metrics): expose NATS client events as Prometheus counter

### DIFF
--- a/crates/sockudo-adapter/src/transports/nats_transport.rs
+++ b/crates/sockudo-adapter/src/transports/nats_transport.rs
@@ -202,47 +202,71 @@ impl HorizontalTransport for NatsTransport {
         let request_subject = Subject::from(format!("{}.requests", config.prefix));
         let response_subject = Subject::from(format!("{}.responses", config.prefix));
 
+        // The metrics driver is wired later via `set_metrics`; capture a clone so the
+        // NATS event callback can record client events (disconnects, slow consumers,
+        // server/client errors) once metrics are available.
+        let metrics_driver: Arc<OnceLock<Arc<dyn MetricsInterface + Send + Sync>>> =
+            Arc::new(OnceLock::new());
+        let event_metrics = metrics_driver.clone();
+
         // Build NATS Options
         let mut nats_options = NatsOptions::new()
             .retry_on_initial_connect()
-            .event_callback(|event| async move {
-                match event {
-                    async_nats::Event::Connected => {
-                        info!(adapter = "nats", "connection established");
-                    }
-                    async_nats::Event::Disconnected => {
-                        warn!(adapter = "nats", retryable = true, "connection lost");
-                    }
-                    async_nats::Event::SlowConsumer(sid) => {
-                        error!(
-                            adapter = "nats",
-                            subscription_id = sid,
-                            "slow consumer detected"
-                        );
-                    }
-                    async_nats::Event::ServerError(err) => {
-                        error!(adapter = "nats", error = %err, "server error");
-                    }
-                    async_nats::Event::ClientError(ref err) => match err {
-                        async_nats::ClientError::MaxReconnects => {
-                            error!(adapter = "nats", "max reconnects exhausted");
+            .event_callback(move |event| {
+                let event_metrics = event_metrics.clone();
+                async move {
+                    let record = |event_name: &str| {
+                        if let Some(metrics) = event_metrics.get() {
+                            metrics.mark_nats_event(event_name);
                         }
-                        async_nats::ClientError::Other(msg) => {
-                            error!(adapter = "nats", error = %msg, "client error");
+                    };
+                    match event {
+                        async_nats::Event::Connected => {
+                            record("connected");
+                            info!(adapter = "nats", "connection established");
                         }
-                    },
-                    async_nats::Event::LameDuckMode => {
-                        warn!(
-                            adapter = "nats",
-                            retryable = true,
-                            "server entering lame duck mode"
-                        );
-                    }
-                    async_nats::Event::Draining => {
-                        info!(adapter = "nats", "client draining");
-                    }
-                    async_nats::Event::Closed => {
-                        warn!(adapter = "nats", retryable = true, "connection closed");
+                        async_nats::Event::Disconnected => {
+                            record("disconnected");
+                            warn!(adapter = "nats", retryable = true, "connection lost");
+                        }
+                        async_nats::Event::SlowConsumer(sid) => {
+                            record("slow_consumer");
+                            error!(
+                                adapter = "nats",
+                                subscription_id = sid,
+                                "slow consumer detected"
+                            );
+                        }
+                        async_nats::Event::ServerError(err) => {
+                            record("server_error");
+                            error!(adapter = "nats", error = %err, "server error");
+                        }
+                        async_nats::Event::ClientError(ref err) => match err {
+                            async_nats::ClientError::MaxReconnects => {
+                                record("max_reconnects");
+                                error!(adapter = "nats", "max reconnects exhausted");
+                            }
+                            async_nats::ClientError::Other(msg) => {
+                                record("client_error");
+                                error!(adapter = "nats", error = %msg, "client error");
+                            }
+                        },
+                        async_nats::Event::LameDuckMode => {
+                            record("lame_duck");
+                            warn!(
+                                adapter = "nats",
+                                retryable = true,
+                                "server entering lame duck mode"
+                            );
+                        }
+                        async_nats::Event::Draining => {
+                            record("draining");
+                            info!(adapter = "nats", "client draining");
+                        }
+                        async_nats::Event::Closed => {
+                            record("closed");
+                            warn!(adapter = "nats", retryable = true, "connection closed");
+                        }
                     }
                 }
             });
@@ -295,7 +319,7 @@ impl HorizontalTransport for NatsTransport {
             inbox_prefix,
             config,
             metrics: Arc::new(TransportMetrics::new()),
-            metrics_driver: Arc::new(OnceLock::new()),
+            metrics_driver,
             shutdown: Arc::new(Notify::new()),
             is_running: Arc::new(AtomicBool::new(true)),
             owner_count: Arc::new(AtomicUsize::new(1)),

--- a/crates/sockudo-core/src/metrics.rs
+++ b/crates/sockudo-core/src/metrics.rs
@@ -271,6 +271,10 @@ pub trait MetricsInterface: Send + Sync {
     /// Track horizontal transport reconnects.
     fn mark_horizontal_transport_reconnection(&self, _driver: &str) {}
 
+    /// Track a NATS client event by type (e.g. `disconnected`, `slow_consumer`,
+    /// `server_error`, `max_reconnects`). Low, fixed label cardinality.
+    fn mark_nats_event(&self, _event: &str) {}
+
     /// Track a successful presence-history write.
     fn mark_presence_history_write(&self, _app_id: &str) {}
 

--- a/crates/sockudo-metrics/src/prometheus/driver.rs
+++ b/crates/sockudo-metrics/src/prometheus/driver.rs
@@ -203,6 +203,7 @@ pub struct PrometheusMetricsDriver {
     pub(super) horizontal_transport_queue_depth: GaugeVec,
     pub(super) horizontal_transport_messages_dropped_total: CounterVec,
     pub(super) horizontal_transport_reconnections_total: CounterVec,
+    pub(super) nats_events_total: CounterVec,
 }
 
 impl PrometheusMetricsDriver {
@@ -1122,6 +1123,15 @@ impl PrometheusMetricsDriver {
         )
         .unwrap();
 
+        let nats_events_total = register_counter_vec!(
+            Opts::new(
+                format!("{prefix}nats_events_total"),
+                "Total number of NATS client events, by event type (e.g. disconnected, slow_consumer, server_error, max_reconnects)"
+            ),
+            &["event"]
+        )
+        .unwrap();
+
         // Reset gauge metrics to 0 on startup - they represent current state, not historical
         connected_sockets.reset();
         active_channels.reset();
@@ -1248,6 +1258,7 @@ impl PrometheusMetricsDriver {
             horizontal_transport_queue_depth,
             horizontal_transport_messages_dropped_total,
             horizontal_transport_reconnections_total,
+            nats_events_total,
         }
     }
 

--- a/crates/sockudo-metrics/src/prometheus/interface.rs
+++ b/crates/sockudo-metrics/src/prometheus/interface.rs
@@ -586,6 +586,10 @@ impl MetricsInterface for PrometheusMetricsDriver {
             .inc();
     }
 
+    fn mark_nats_event(&self, event: &str) {
+        self.nats_events_total.with_label_values(&[event]).inc();
+    }
+
     fn mark_presence_history_write(&self, app_id: &str) {
         let tags = self.get_tags(app_id);
         self.presence_history_writes_total


### PR DESCRIPTION
The NATS adapter only *logged* connection-lifecycle events (disconnects, slow consumers, server/client errors, max-reconnects), so they weren't alertable via Prometheus. The only NATS signal exposed as a metric was message drops (`horizontal_transport_messages_dropped_total{driver="nats"}`), which counts Sockudo-side parse/handle failures — not slow-consumer drops or connection loss.

This adds a `sockudo_nats_events_total{event}` counter and records every `async-nats` client event from the transport's event callback: `connected`, `disconnected`, `slow_consumer`, `server_error`, `client_error`, `max_reconnects`, `lame_duck`, `draining`, `closed`. Fixed, low label cardinality (9 values). The existing log lines are unchanged.

The `MetricsInterface::mark_nats_event` method has a default no-op body, so non-Prometheus drivers are unaffected; the metric is only recorded once a metrics driver is configured.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

Verified locally: `cargo check -p sockudo-core -p sockudo-metrics` and `cargo check -p sockudo-adapter --features nats` (clean), `cargo fmt --all -- --check` (clean). No unit test added — the metric is emitted from the async-nats event callback, which isn't unit-testable without a live NATS server; behavior is exercised by the existing NATS integration path.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A — no metrics catalog doc enumerates transport metrics; metric is self-documenting via its HELP text)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (N/A)

## Protocol Change Checklist
- [x] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [x] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
Enables Prometheus alerting on NATS slow consumers and connection health (disconnects / reconnect exhaustion) — signals that previously existed only in logs and can't be derived from existing metrics. Consumed by alert rules in our k8s-manifests repo.