### PR TITLE
feat(charts): publish the Helm chart as an OCI package on release

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -1,0 +1,60 @@
+name: Chart CI - Lint and Validate
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main, master, develop, beta]
+    paths:
+      - "charts/**"
+      - ".github/workflows/chart-ci.yml"
+  pull_request:
+    branches: [main, master, develop, beta]
+    paths:
+      - "charts/**"
+      - ".github/workflows/chart-ci.yml"
+
+permissions:
+  contents: read
+
+env:
+  HELM_VERSION: v3.21.4
+  KUBECONFORM_VERSION: v0.8.0
+
+jobs:
+  lint-and-validate:
+    name: Lint and validate (${{ matrix.fixture }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        fixture: [default, ingress, dashboard, ha]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Install kubeconform
+        run: |
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -sSfL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C "${RUNNER_TEMP}/bin" kubeconform
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Lint chart
+        run: helm lint charts/sockudo -f "charts/sockudo/ci/${{ matrix.fixture }}-values.yaml"
+
+      - name: Validate rendered manifests
+        run: |
+          for kube_version in 1.29.0 1.33.0; do
+            echo "::group::kubeconform ${kube_version}"
+            helm template ci charts/sockudo \
+              -f "charts/sockudo/ci/${{ matrix.fixture }}-values.yaml" \
+              | kubeconform -strict -summary -ignore-missing-schemas \
+                  -kubernetes-version "${kube_version}"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -17,17 +17,20 @@ permissions:
   contents: read
 
 env:
+  # Helm 4 is released, so setup-helm's `latest` default would install it. ArgoCD ships
+  # Helm 3, so the chart is linted here on the same 3.x line that release.yml packages with.
   HELM_VERSION: v3.21.4
   KUBECONFORM_VERSION: v0.8.0
 
 jobs:
   lint-and-validate:
-    name: Lint and validate (${{ matrix.fixture }})
+    name: Lint and validate (${{ matrix.fixture }}, k8s ${{ matrix.kubernetes-version }})
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         fixture: [default, ingress, dashboard, ha]
+        kubernetes-version: ["1.29.0", "1.33.0"]
 
     steps:
       - name: Checkout repository
@@ -40,9 +43,13 @@ jobs:
 
       - name: Install kubeconform
         run: |
-          mkdir -p "${RUNNER_TEMP}/bin"
-          curl -sSfL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
-            | tar -xz -C "${RUNNER_TEMP}/bin" kubeconform
+          cd "${RUNNER_TEMP}"
+          base="https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}"
+          curl -sSfL -O "${base}/kubeconform-linux-amd64.tar.gz"
+          curl -sSfL -O "${base}/CHECKSUMS"
+          sha256sum --check --ignore-missing CHECKSUMS
+          mkdir -p bin
+          tar -xzf kubeconform-linux-amd64.tar.gz -C bin kubeconform
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
 
       - name: Lint chart
@@ -50,11 +57,7 @@ jobs:
 
       - name: Validate rendered manifests
         run: |
-          for kube_version in 1.29.0 1.33.0; do
-            echo "::group::kubeconform ${kube_version}"
-            helm template ci charts/sockudo \
-              -f "charts/sockudo/ci/${{ matrix.fixture }}-values.yaml" \
-              | kubeconform -strict -summary -ignore-missing-schemas \
-                  -kubernetes-version "${kube_version}"
-            echo "::endgroup::"
-          done
+          helm template ci charts/sockudo \
+            -f "charts/sockudo/ci/${{ matrix.fixture }}-values.yaml" \
+            | kubeconform -strict -summary -ignore-missing-schemas \
+                -kubernetes-version "${{ matrix.kubernetes-version }}"

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -17,9 +17,9 @@ permissions:
   contents: read
 
 env:
-  # Helm 4 is released, so setup-helm's `latest` default would install it. ArgoCD ships
-  # Helm 3, so the chart is linted here on the same 3.x line that release.yml packages with.
-  HELM_VERSION: v3.21.4
+  # Pinned rather than the action's `latest` default, so a Helm release cannot silently change
+  # how the chart is linted or packaged. Tracks the Helm 4 line that ArgoCD bundles.
+  HELM_VERSION: v4.2.4
   KUBECONFORM_VERSION: v0.8.0
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -441,6 +441,7 @@ jobs:
         build-linux-arm64-musl,
         docker-manifest,
         publish-crates,
+        publish-chart,
       ]
     if: |
       always() && !cancelled() &&
@@ -449,7 +450,8 @@ jobs:
       needs.build-linux-arm64-gnu.result == 'success' &&
       needs.build-linux-arm64-musl.result == 'success' &&
       needs.docker-manifest.result == 'success' &&
-      (needs.publish-crates.result == 'success' || needs.publish-crates.result == 'skipped')
+      (needs.publish-crates.result == 'success' || needs.publish-crates.result == 'skipped') &&
+      needs.publish-chart.result == 'success'
 
     steps:
       - name: Checkout repository
@@ -489,6 +491,13 @@ jobs:
             ```bash
             docker pull ghcr.io/${{ needs.prepare.outputs.lowercase_image_name }}:${{ needs.prepare.outputs.version }}
             docker pull sockudo/sockudo:${{ needs.prepare.outputs.version }}
+            ```
+
+            ### Using Helm
+            ```bash
+            helm install sockudo \
+              oci://ghcr.io/${{ needs.prepare.outputs.lowercase_owner }}/charts/sockudo \
+              --version ${{ needs.prepare.outputs.version }}
             ```
 
             ### Direct Download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
       prerelease: ${{ steps.version.outputs.prerelease }}
       lowercase_image_name: ${{ steps.lowercase_repo.outputs.name }} # New output for lowercased repo name
+      lowercase_owner: ${{ steps.lowercase_repo.outputs.owner }}
       docker_tag_suffix: ${{ steps.docker_suffix.outputs.suffix }}
 
     steps:
@@ -96,7 +97,9 @@ jobs:
 
       - name: Get repository name in lowercase
         id: lowercase_repo # Step to convert repo name to lowercase
-        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+        run: |
+          echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Get Docker tag suffix
         id: docker_suffix
@@ -284,6 +287,51 @@ jobs:
           else
             echo "Failed to authenticate for cleanup, temp tags will remain"
           fi
+
+  # =============================================================================
+  # Publish Helm Chart
+  # =============================================================================
+  publish-chart:
+    name: Publish Helm Chart
+    runs-on: ubuntu-24.04
+    needs: [prepare, docker-manifest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.21.4
+
+      - name: Package chart
+        run: |
+          helm package charts/sockudo \
+            --version "${{ needs.prepare.outputs.version }}" \
+            --app-version "${{ needs.prepare.outputs.version }}" \
+            --destination dist
+
+      - name: Push chart
+        run: |
+          helm push "dist/sockudo-${{ needs.prepare.outputs.version }}.tgz" \
+            "oci://${{ env.REGISTRY }}/${{ needs.prepare.outputs.lowercase_owner }}/charts"
+
+      - name: Upload chart artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sockudo-chart
+          path: dist/sockudo-${{ needs.prepare.outputs.version }}.tgz
+          retention-days: 1
 
   # =============================================================================
   # Publish to Crates.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  # Helm 4 is released, so setup-helm's `latest` default would install it. ArgoCD ships
-  # Helm 3, so the chart is packaged here on the same 3.x line that chart-ci.yml lints with.
-  HELM_VERSION: v3.21.4
+  # Pinned rather than the action's `latest` default, so a Helm release cannot silently change
+  # how the chart is packaged. Tracks the Helm 4 line that ArgoCD bundles.
+  HELM_VERSION: v4.2.4
 
 jobs:
   # =============================================================================

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
+  # Helm 4 is released, so setup-helm's `latest` default would install it. ArgoCD ships
+  # Helm 3, so the chart is packaged here on the same 3.x line that chart-ci.yml lints with.
+  HELM_VERSION: v3.21.4
 
 jobs:
   # =============================================================================
@@ -95,7 +98,7 @@ jobs:
             echo "Skipping version verification for tag: ${TAG} (not in vX.X.X format)"
           fi
 
-      - name: Get repository name in lowercase
+      - name: Get repository and owner names in lowercase
         id: lowercase_repo # Step to convert repo name to lowercase
         run: |
           echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
@@ -312,7 +315,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
         with:
-          version: v3.21.4
+          version: ${{ env.HELM_VERSION }}
 
       - name: Package chart
         run: |

--- a/README.md
+++ b/README.md
@@ -140,13 +140,19 @@ cargo build -p sockudo --release --features full
 ### Kubernetes
 
 ```bash
+helm install sockudo oci://ghcr.io/sockudo/charts/sockudo --version 4.7.0
+```
+
+Or from a checkout, when developing the chart itself:
+
+```bash
 helm install sockudo ./charts/sockudo
 ```
 
 Example production shape with Redis, ingress, autoscaling, and monitoring:
 
 ```bash
-helm install sockudo ./charts/sockudo \
+helm install sockudo oci://ghcr.io/sockudo/charts/sockudo --version 4.7.0 \
   --set config.adapterDriver=redis \
   --set redis.host=redis-master \
   --set redis.existingSecret=my-redis-secret \

--- a/charts/sockudo/.helmignore
+++ b/charts/sockudo/.helmignore
@@ -5,3 +5,4 @@
 *.swp
 *.bak
 *.tmp
+ci/

--- a/charts/sockudo/Chart.yaml
+++ b/charts/sockudo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sockudo
 description: A simple, fast, and secure WebSocket server implementing the Pusher protocol
 type: application
-version: 0.1.0
-appVersion: "3.2.1"
+version: 4.7.0
+appVersion: "4.7.0"
 keywords:
   - websocket
   - pusher

--- a/charts/sockudo/README.md
+++ b/charts/sockudo/README.md
@@ -3,6 +3,40 @@
 This chart deploys the Sockudo server and can optionally deploy the Sockudo
 operator dashboard.
 
+## Install
+
+```bash
+helm install sockudo oci://ghcr.io/sockudo/charts/sockudo --version 4.7.0
+```
+
+Always pass `--version`. Without it Helm resolves the newest release at install time,
+which makes redeploys non-reproducible.
+
+GitHub Packages renders a Helm chart as though it were a container image, so the package
+page lists it under "Containers" and never displays the `oci://` address. The command above
+is the address; it cannot be derived from that page.
+
+To see every available option:
+
+```bash
+helm show values oci://ghcr.io/sockudo/charts/sockudo --version 4.7.0
+```
+
+For chart development, install from a checkout instead:
+
+```bash
+helm install sockudo ./charts/sockudo
+```
+
+## Versioning
+
+The chart version always equals the Sockudo application version, and the chart is
+republished with every application release. Chart `4.7.0` deploys application `4.7.0`;
+there is no separate chart version to cross-reference.
+
+One consequence worth knowing: consecutive chart versions may be identical charts. `4.7.1`
+following `4.7.0` means a new application release, not necessarily a chart change.
+
 ## Dashboard
 
 The dashboard is disabled by default:

--- a/charts/sockudo/ci/dashboard-values.yaml
+++ b/charts/sockudo/ci/dashboard-values.yaml
@@ -1,0 +1,29 @@
+config:
+  appManagerDriver: mysql
+dashboard:
+  enabled: true
+  sessionSecret:
+    value: ci-render-only-not-a-real-secret
+  persistence:
+    enabled: true
+    size: 1Gi
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: sockudo-admin.ci.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+  autoscaling:
+    api:
+      enabled: true
+    web:
+      enabled: true
+  pdb:
+    api:
+      enabled: true
+    web:
+      enabled: true
+  networkPolicy:
+    enabled: true

--- a/charts/sockudo/ci/dashboard-values.yaml
+++ b/charts/sockudo/ci/dashboard-values.yaml
@@ -1,3 +1,7 @@
+# persistence is enabled alongside a mysql app manager on purpose. It reads oddly against
+# values.yaml ("Needed when dashboard.databaseDriver=sqlite"), but sqlite refuses to render
+# with dashboard.autoscaling.api enabled, and this is the only combination that exercises
+# both dashboard-pvc.yaml and dashboard-hpa.yaml.
 config:
   appManagerDriver: mysql
 dashboard:

--- a/charts/sockudo/ci/default-values.yaml
+++ b/charts/sockudo/ci/default-values.yaml
@@ -1,0 +1,2 @@
+# Chart defaults. Kept as an explicit fixture so the default render is covered
+# by the same matrix as every other configuration.

--- a/charts/sockudo/ci/ha-values.yaml
+++ b/charts/sockudo/ci/ha-values.yaml
@@ -1,0 +1,14 @@
+replicaCount: 3
+config:
+  adapterDriver: redis
+redis:
+  host: redis-master
+  password: ci-render-only-not-a-real-password
+autoscaling:
+  enabled: true
+pdb:
+  enabled: true
+serviceMonitor:
+  enabled: true
+networkPolicy:
+  enabled: true

--- a/charts/sockudo/ci/ingress-values.yaml
+++ b/charts/sockudo/ci/ingress-values.yaml
@@ -1,0 +1,20 @@
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: sockudo.ci.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: sockudo-tls
+      hosts:
+        - sockudo.ci.example.com
+wsIngress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: ws.sockudo.ci.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/sockudo/templates/ingress.yaml
+++ b/charts/sockudo/templates/ingress.yaml
@@ -40,7 +40,7 @@ spec:
     {{- end }}
 {{- end }}
 ---
-{{- if .Values.wsIngress.enabled -}}
+{{- if .Values.wsIngress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/docs/content/docs/deployment/kubernetes.mdx
+++ b/docs/content/docs/deployment/kubernetes.mdx
@@ -23,7 +23,7 @@ Pin the chart and image version in GitOps or release automation. Do not deploy `
 To work on the chart itself, install from a checkout instead: `helm upgrade --install sockudo
 ./charts/sockudo`.
 
-### ArgoCD
+## ArgoCD
 
 The chart is published as an OCI artifact, so ArgoCD consumes it directly without cloning this
 repository:
@@ -51,8 +51,8 @@ spec:
       - CreateNamespace=true
 ```
 
-Note `repoURL` carries no `oci://` prefix: ArgoCD infers the OCI protocol for Helm chart
-sources, and including the scheme makes the repository fail to resolve.
+Note `repoURL` carries no `oci://` prefix: for a Helm chart source, ArgoCD takes the bare
+registry path and infers the OCI protocol from `chart` being set.
 
 ## Production values example
 

--- a/docs/content/docs/deployment/kubernetes.mdx
+++ b/docs/content/docs/deployment/kubernetes.mdx
@@ -11,13 +11,48 @@ pods still need shared adapters and stores, and scale-down still disconnects the
 ## Install the chart
 
 ```bash
-helm upgrade --install sockudo ./charts/sockudo \
+helm upgrade --install sockudo oci://ghcr.io/sockudo/charts/sockudo \
+  --version 4.7.0 \
   --namespace sockudo \
   --create-namespace \
   --values values-production.yaml
 ```
 
 Pin the chart and image version in GitOps or release automation. Do not deploy `latest`.
+
+To work on the chart itself, install from a checkout instead: `helm upgrade --install sockudo
+./charts/sockudo`.
+
+### ArgoCD
+
+The chart is published as an OCI artifact, so ArgoCD consumes it directly without cloning this
+repository:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sockudo
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: ghcr.io/sockudo/charts
+    chart: sockudo
+    targetRevision: 4.7.0
+    helm:
+      valuesObject:
+        replicaCount: 3
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: sockudo
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+```
+
+Note `repoURL` carries no `oci://` prefix: ArgoCD infers the OCI protocol for Helm chart
+sources, and including the scheme makes the repository fail to resolve.
 
 ## Production values example
 

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -208,7 +208,7 @@ For exact loading precedence, equivalent JSON, secret injection, and clustered e
 ## Kubernetes with Helm
 
 ```bash
-helm install sockudo ./charts/sockudo \
+helm install sockudo oci://ghcr.io/sockudo/charts/sockudo --version 4.7.0 \
   --set config.adapterDriver=redis \
   --set redis.host=redis-master \
   --set autoscaling.enabled=true \


### PR DESCRIPTION
Closes #331.

Publishes `charts/sockudo` to GHCR as an OCI artifact on every release, so the chart can be
consumed by GitOps tooling and pinned to a version instead of cloned.

```bash
helm install sockudo oci://ghcr.io/sockudo/charts/sockudo --version 4.7.0
```

### No manual step is needed

The package inherits this repository's visibility, so it is public on creation and `helm install`
works immediately after the first release. Verified by rehearsing the job in a public fork: an
unauthenticated `helm pull` succeeds and GHCR issues an anonymous pull token. The package also
auto-links back here, because Helm maps `Chart.yaml` `sources` into
`org.opencontainers.image.source`.

### Notes on the approach

- Chart version and appVersion are stamped from the release tag via
  `helm package --version/--app-version`, so chart `4.7.0` always deploys app `4.7.0`. This also
  fixes existing drift: `Chart.yaml` declared `appVersion: "3.2.1"` while the app was at `4.7.0`,
  and since `image.tag` defaults to appVersion, installs from a clone were deploying 3.2.1.
- Published to `oci://ghcr.io/sockudo/charts` rather than `oci://ghcr.io/sockudo`, so the chart
  does not share a GHCR package with the `ghcr.io/sockudo/sockudo` container image. The chart keeps
  the name `sockudo`: renaming it would change `app.kubernetes.io/name`, an immutable Deployment
  selector, breaking `helm upgrade` for anyone already installing from a clone.
- `publish-chart` runs after `docker-manifest`, so the chart is never published pointing at an
  image that does not exist yet.
- Helm is pinned to `v4.2.4` in both workflows rather than the action's `latest`, so a Helm release
  cannot silently change how the chart is packaged mid-release. Verified the chart lints, templates
  and packages identically on Helm 3 and Helm 4, and that each renders the other's packaged tarball
  byte-identically, so Helm 3 users are unaffected.
- Prereleases publish too, so an RC can be tested on a cluster. **One consequence worth your call:**
  `create-release` now gates on the chart publish for prereleases as well, where previously a
  prerelease depended on no registry at all (`publish-crates` self-skips on prereleases). I chose
  blocking because the release notes advertise the Helm command unconditionally, so a failed push
  would otherwise ship notes containing a command that 404s. Say the word and I will make it
  `|| skipped` for prereleases.
- `templates/ingress.yaml` had a template-whitespace bug that collapsed a `---` separator into the
  next document, failing `helm lint` whenever `wsIngress.enabled=true`. Fixed here because the new
  lint job needs it. Rendered output is byte-identical before and after, so installs were unaffected.
- The new `chart-ci.yml` lints and validates four value fixtures covering all 24 templates, across
  Kubernetes 1.29 and 1.33. `kubeconform` runs with `-ignore-missing-schemas`, which means the
  ServiceMonitor CRD is skipped rather than validated: one resource in the `ha` fixture.

### Verified

Rehearsed end to end in a public fork before opening this, using the same job:

- `helm push` authenticates from `docker/login-action` alone; no `helm registry login` needed.
- A second push to the now-existing package still authenticates, which is what a second release hits.
- `helm pull oci://ghcr.io/<owner>/charts/sockudo --version <v>` returns the chart.

Locally: `helm lint` and `kubeconform -strict` pass for all four fixtures on both Kubernetes
versions, `actionlint` is clean on both workflows, and the docs site builds (`bun run types:check`
and `bun run build` both pass).

Happy to adjust the Kubernetes versions in the validation matrix if you have a support floor in
mind, or to split any of this out if you would rather review it separately.