### PR TITLE
perf(sockudo-js): optimize message hot paths

### DIFF
--- a/client-sdks/sockudo-js/src/core/connection/protocol/protocol.ts
+++ b/client-sdks/sockudo-js/src/core/connection/protocol/protocol.ts
@@ -101,6 +101,9 @@ function toUint8Array(payload: unknown): Uint8Array {
 const JSON_SERIAL_FIELD_PATTERN = /("[-_A-Za-z0-9]*serial[-_A-Za-z0-9]*"\s*:\s*)(-?\d+)/g;
 
 function preserveUnsafeJsonSerials(raw: string): string {
+  if (raw.indexOf("serial") === -1) {
+    return raw;
+  }
   return raw.replace(JSON_SERIAL_FIELD_PATTERN, (match, prefix: string, literal: string) => {
     const serial = normalizeWireSerial(literal);
     return typeof serial === "string" ? `${prefix}${JSON.stringify(serial)}` : match;

--- a/client-sdks/sockudo-js/src/core/delta/decoders.ts
+++ b/client-sdks/sockudo-js/src/core/delta/decoders.ts
@@ -9,6 +9,9 @@ import { decode as vcdiffDecode } from "@ably/vcdiff-decoder";
 const fossilDeltaGlobal = typeof window !== "undefined" ? (window as any).fossilDelta : undefined;
 const vcdiffGlobal = typeof window !== "undefined" ? (window as any).vcdiff : undefined;
 
+const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
+
 /**
  * Base64 decode a string to Uint8Array
  */
@@ -29,14 +32,14 @@ function bytesToString(bytes: Uint8Array | number[]): string {
   if (Array.isArray(bytes) || !(bytes instanceof Uint8Array)) {
     bytes = new Uint8Array(bytes);
   }
-  return new TextDecoder().decode(bytes);
+  return textDecoder.decode(bytes);
 }
 
 /**
  * Convert string to Uint8Array
  */
 function stringToBytes(str: string): Uint8Array {
-  return new TextEncoder().encode(str);
+  return textEncoder.encode(str);
 }
 
 /**

--- a/client-sdks/sockudo-js/src/core/logger.ts
+++ b/client-sdks/sockudo-js/src/core/logger.ts
@@ -50,6 +50,9 @@ class Logger {
   }
 
   private log(defaultLoggingFunction: (message: string) => void, ..._args: any[]) {
+    if (!config.log && !config.logToConsole) {
+      return;
+    }
     const message = stringify.apply(this, arguments);
     if (config.log) {
       config.log(message);

--- a/client-sdks/sockudo-js/test/delta-decoders.test.ts
+++ b/client-sdks/sockudo-js/test/delta-decoders.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { bytesToString, stringToBytes } from "../src/core/delta/decoders";
+
+describe("delta text conversion", () => {
+  it("round trips multibyte UTF-8 across repeated calls", () => {
+    const values = ["hello", "caf\u00e9", "\u6f22\u5b57", "\ud83d\ude80", ""];
+
+    for (const value of values) {
+      expect(bytesToString(stringToBytes(value))).toBe(value);
+    }
+  });
+
+  it("does not carry malformed input state into the next decode", () => {
+    expect(bytesToString(new Uint8Array([0xe2, 0x82]))).toBe("\ufffd");
+    expect(bytesToString(stringToBytes("next message"))).toBe("next message");
+  });
+
+  it("decodes number arrays without mutating the input", () => {
+    const bytes = [83, 111, 99, 107, 117, 100, 111];
+
+    expect(bytesToString(bytes)).toBe("Sockudo");
+    expect(bytes).toEqual([83, 111, 99, 107, 117, 100, 111]);
+  });
+});

--- a/client-sdks/sockudo-js/test/logger.test.ts
+++ b/client-sdks/sockudo-js/test/logger.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Logger, { setLoggerConfig } from "../src/core/logger";
+
+beforeEach(() => {
+  setLoggerConfig({ log: undefined, logToConsole: false });
+});
+
+afterEach(() => {
+  setLoggerConfig({ log: undefined, logToConsole: false });
+  vi.restoreAllMocks();
+});
+
+describe("logger", () => {
+  it("does not serialize arguments when logging is disabled", () => {
+    const toJSON = vi.fn(() => ({ event: "message" }));
+
+    Logger.debug("event received", { toJSON });
+
+    expect(toJSON).not.toHaveBeenCalled();
+  });
+
+  it("preserves formatted output when a logger is configured", () => {
+    const log = vi.fn();
+    setLoggerConfig({ log });
+
+    Logger.debug("event received", { event: "message", count: 2 });
+
+    expect(log).toHaveBeenCalledOnce();
+    expect(log.mock.calls[0][0]).toContain("event received");
+    expect(log.mock.calls[0][0]).toContain('"event":"message"');
+    expect(log.mock.calls[0][0]).toContain('"count":2');
+  });
+
+  it("continues logging to the console when explicitly enabled", () => {
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    setLoggerConfig({ logToConsole: true });
+
+    Logger.debug("event received", { event: "message" });
+
+    expect(consoleLog).toHaveBeenCalledOnce();
+    expect(consoleLog.mock.calls[0][0]).toContain("event received");
+  });
+});

--- a/client-sdks/sockudo-js/test/protocol-wire-format.test.ts
+++ b/client-sdks/sockudo-js/test/protocol-wire-format.test.ts
@@ -57,6 +57,24 @@ describe("protocol wire formats", () => {
     expect(url).toContain("echo_messages=false");
   });
 
+  it("decodes JSON frames without serial metadata", () => {
+    setWireFormat("json");
+    const rawMessage = JSON.stringify({
+      event: "app:test",
+      channel: "public-room",
+      data: JSON.stringify({ message: "hello" }),
+    });
+
+    const decoded = Protocol.decodeMessage({ data: rawMessage } as MessageEvent);
+
+    expect(decoded).toMatchObject({
+      event: "app:test",
+      channel: "public-room",
+      data: { message: "hello" },
+      rawMessage,
+    });
+  });
+
   it("round trips messagepack", () => {
     setWireFormat("messagepack");
     const payload = Protocol.encodeMessage({


### PR DESCRIPTION
JSON frames without serial fields were still paying for a full regex scan. Disabled logging also formatted and serialized every message before throwing the result away. Skip that work and reuse the UTF-8 encoder and decoder used by delta reconstruction.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
