### PR TITLE
fix: harden release capacity and outbound ordering

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -266,7 +266,7 @@
   },
   "websocket": {
     "max_messages": 1000,
-    "max_bytes": 1048576,
+    "max_bytes": 4194304,
     "disconnect_on_buffer_full": false,
     "max_message_size": 67108864,
     "max_frame_size": 16777216,

--- a/config/config.toml
+++ b/config/config.toml
@@ -567,7 +567,7 @@ max_events_per_channel = 1000
 
 [websocket]
 max_messages = 1000
-max_bytes = 1048576
+max_bytes = 4194304
 disconnect_on_buffer_full = false
 max_message_size = 67108864
 max_frame_size = 16777216

--- a/crates/sockudo-ably-compat/src/outbound.rs
+++ b/crates/sockudo-ably-compat/src/outbound.rs
@@ -8,6 +8,7 @@
 use bytes::Bytes;
 use crossfire::mpsc;
 use serde::Serialize;
+use sockudo_core::options::WebSocketConfig;
 use std::sync::{
     Arc, Weak,
     atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -40,6 +41,16 @@ impl Default for OutboundLimits {
             data_messages: DEFAULT_DATA_MESSAGES,
             control_bytes: DEFAULT_CONTROL_BYTES,
             data_bytes: DEFAULT_DATA_BYTES,
+        }
+    }
+}
+
+impl OutboundLimits {
+    pub(crate) fn from_websocket(config: &WebSocketConfig) -> Self {
+        Self {
+            data_messages: config.max_messages.unwrap_or(DEFAULT_DATA_MESSAGES),
+            data_bytes: config.max_bytes.unwrap_or(DEFAULT_DATA_BYTES),
+            ..Self::default()
         }
     }
 }
@@ -432,6 +443,22 @@ mod tests {
         let snapshot = metrics.snapshot();
         assert_eq!(snapshot.encoded, 1);
         assert_eq!(snapshot.data_encoded, 0);
+    }
+
+    #[test]
+    fn data_queue_uses_configured_websocket_bounds() {
+        let config = WebSocketConfig {
+            max_messages: Some(123),
+            max_bytes: Some(456_789),
+            ..WebSocketConfig::default()
+        };
+
+        let limits = OutboundLimits::from_websocket(&config);
+
+        assert_eq!(limits.data_messages, 123);
+        assert_eq!(limits.data_bytes, 456_789);
+        assert_eq!(limits.control_messages, DEFAULT_CONTROL_MESSAGES);
+        assert_eq!(limits.control_bytes, DEFAULT_CONTROL_BYTES);
     }
 
     #[tokio::test]

--- a/crates/sockudo-ably-compat/src/runtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime.rs
@@ -1247,6 +1247,7 @@ pub struct AblyCompatHub {
     tokens: DashMap<String, AblyTokenRecord>,
     revocations: Mutex<AblyRevocationStore>,
     live_sessions: DashMap<String, AblyLiveSession>,
+    node_session_owners: DashMap<AblyPresenceConnectionKey, String>,
     session_echo: DashMap<String, bool>,
     presence_removals: Arc<AblyPresenceRemovalQueue>,
     presence_registry: Arc<PresenceRegistry>,
@@ -1280,7 +1281,11 @@ pub trait AblyPushAdmissionGuard: Send + Sync {
 #[derive(Clone, Default)]
 pub struct AblyCompatDependencies {
     pub config: AblyCompatConfig,
+    /// Shared cache used as the cross-node compatibility coordination authority.
+    /// Leave unset for a process-local deployment.
     pub cache: Option<Arc<dyn CacheManager>>,
+    /// Optional persistence for time-bucketed compatibility statistics.
+    pub stats_cache: Option<Arc<dyn CacheManager>>,
     pub presence_registry: Arc<PresenceRegistry>,
     #[cfg(feature = "push")]
     pub push_store: Option<sockudo_push::DynPushStore>,
@@ -1298,8 +1303,12 @@ pub struct AblyCompatRuntime {
 impl AblyCompatRuntime {
     #[must_use]
     pub fn new(dependencies: AblyCompatDependencies) -> Self {
+        let stats_cache = dependencies
+            .stats_cache
+            .clone()
+            .or_else(|| dependencies.cache.clone());
         let stats = StatsAggregator::new(
-            dependencies.cache.clone(),
+            stats_cache,
             StatsRuntimeConfig {
                 queue_capacity: dependencies.config.stats_queue_capacity,
                 flush_interval: Duration::from_millis(dependencies.config.stats_flush_interval_ms),
@@ -2273,7 +2282,10 @@ impl AblyCompatHub {
         session_id: &str,
     ) -> bool {
         let Some(cache) = &self.cache else {
-            return true;
+            return self
+                .node_session_owners
+                .remove_if(key, |_, owner| owner == session_id)
+                .is_some();
         };
         match cache
             .compare_and_remove(
@@ -2463,6 +2475,10 @@ impl AblyCompatHub {
             self.metrics.expiry.fetch_add(1, Ordering::Relaxed);
         }
         for (connection_id, app_id) in expired_connections {
+            self.node_session_owners.remove(&AblyPresenceConnectionKey {
+                app_id: app_id.clone(),
+                connection_id: connection_id.clone(),
+            });
             self.remove_presence_connection(
                 &app_id,
                 &connection_id,
@@ -3078,55 +3094,54 @@ impl AblyCompatHub {
         (true, state.recovery_gates.remove(&key).unwrap_or_default())
     }
 
-    fn mark_session_subscribers_recoverable(&self, app_id: &str, session_id: &str) {
-        for entry in &self.channels {
-            if entry.key().app_id != app_id {
+    fn mark_session_subscribers_recoverable<'a>(
+        &self,
+        app_id: &str,
+        session_id: &str,
+        channels: impl IntoIterator<Item = &'a AblyChannelName>,
+    ) {
+        for channel in channels {
+            let Some(state) = self.channels.get(&channel_key(app_id, channel.base())) else {
+                continue;
+            };
+            let mut state = lock_channel_state(state.value());
+            let key = subscriber_key(session_id, channel.requested());
+            let recovery = {
+                let Some(subscriber) = state.subscribers.get_mut(&key) else {
+                    continue;
+                };
+                let direct_recovery = std::mem::take(&mut subscriber.direct_recovery_gate);
+                let direct_recovery = (!direct_recovery.messages.is_empty()
+                    || direct_recovery.overflowed)
+                    .then_some(direct_recovery);
+                subscriber.recoverable = true;
+                (
+                    subscriber.recovery_tail_start,
+                    Arc::clone(&subscriber.connection_id),
+                    subscriber.echo,
+                    subscriber.mode_flags,
+                    subscriber_uses_shared_recovery(&key, subscriber, channel.base()),
+                    direct_recovery,
+                )
+            };
+            if state.recovery_gates.contains_key(&key) {
                 continue;
             }
-            let base_channel = entry.key().channel.clone();
-            let mut state = lock_channel_state(entry.value());
-            let recovery_subscribers = state
-                .subscribers
-                .iter_mut()
-                .filter_map(|(key, subscriber)| {
-                    (key.session_id.as_ref() == session_id).then(|| {
-                        let direct_recovery = std::mem::take(&mut subscriber.direct_recovery_gate);
-                        let direct_recovery = (!direct_recovery.messages.is_empty()
-                            || direct_recovery.overflowed)
-                            .then_some(direct_recovery);
-                        subscriber.recoverable = true;
-                        (
-                            key.clone(),
-                            subscriber.recovery_tail_start,
-                            Arc::clone(&subscriber.connection_id),
-                            subscriber.echo,
-                            subscriber.mode_flags,
-                            subscriber_uses_shared_recovery(key, subscriber, &base_channel),
-                            direct_recovery,
-                        )
-                    })
-                })
-                .collect::<Vec<_>>();
-            for (key, start, connection_id, echo, mode_flags, shared_recovery, direct_recovery) in
-                recovery_subscribers
-            {
-                if state.recovery_gates.contains_key(&key) {
-                    continue;
-                }
-                let gate = if let Some(gate) = direct_recovery {
-                    gate
-                } else if shared_recovery {
-                    state.recovery_tail.gate_for_subscriber(
-                        start,
-                        connection_id.as_ref(),
-                        echo,
-                        mode_flags,
-                    )
-                } else {
-                    AblyAttachGate::default()
-                };
-                state.recovery_gates.insert(key, gate);
-            }
+            let (start, connection_id, echo, mode_flags, shared_recovery, direct_recovery) =
+                recovery;
+            let gate = if let Some(gate) = direct_recovery {
+                gate
+            } else if shared_recovery {
+                state.recovery_tail.gate_for_subscriber(
+                    start,
+                    connection_id.as_ref(),
+                    echo,
+                    mode_flags,
+                )
+            } else {
+                AblyAttachGate::default()
+            };
+            state.recovery_gates.insert(key, gate);
         }
     }
 
@@ -3886,6 +3901,13 @@ impl AblyCompatHub {
         session_id: &str,
     ) -> Result<(), AblyAuthError> {
         let Some(cache) = &self.cache else {
+            self.node_session_owners.insert(
+                AblyPresenceConnectionKey {
+                    app_id: app_id.to_string(),
+                    connection_id: connection_id.to_string(),
+                },
+                session_id.to_string(),
+            );
             return Ok(());
         };
         cache
@@ -3906,9 +3928,12 @@ impl AblyCompatHub {
     ) -> bool {
         let Some(cache) = &self.cache else {
             return self
-                .live_sessions
-                .get(connection_id)
-                .is_some_and(|session| session.session_id == session_id);
+                .node_session_owners
+                .get(&AblyPresenceConnectionKey {
+                    app_id: app_id.to_string(),
+                    connection_id: connection_id.to_string(),
+                })
+                .is_some_and(|owner| owner.as_str() == session_id);
         };
         match cache
             .compare_and_swap(
@@ -3936,9 +3961,12 @@ impl AblyCompatHub {
     ) -> bool {
         let Some(cache) = &self.cache else {
             return self
-                .live_sessions
-                .get(connection_id)
-                .is_some_and(|session| session.session_id == session_id);
+                .node_session_owners
+                .get(&AblyPresenceConnectionKey {
+                    app_id: app_id.to_string(),
+                    connection_id: connection_id.to_string(),
+                })
+                .is_some_and(|owner| owner.as_str() == session_id);
         };
         match cache
             .get(&session_owner_cache_key(app_id, connection_id))
@@ -3956,6 +3984,13 @@ impl AblyCompatHub {
 
     async fn release_session_owner(&self, app_id: &str, connection_id: &str, session_id: &str) {
         let Some(cache) = &self.cache else {
+            self.node_session_owners.remove_if(
+                &AblyPresenceConnectionKey {
+                    app_id: app_id.to_string(),
+                    connection_id: connection_id.to_string(),
+                },
+                |_, owner| owner == session_id,
+            );
             return;
         };
         if let Err(error) = cache

--- a/crates/sockudo-ably-compat/src/runtime/realtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime/realtime.rs
@@ -368,8 +368,9 @@ pub(super) async fn run_ably_realtime_socket(
         hub.forget_connection(requested_recovery_key).await;
     }
     let (mut reader, mut writer) = socket.split();
+    let outbound_limits = OutboundLimits::from_websocket(&handler.server_options().websocket);
     let (sender, mut outbound) =
-        AblyOutbound::channel(format, OutboundLimits::default(), Arc::clone(&hub.metrics));
+        AblyOutbound::channel(format, outbound_limits, Arc::clone(&hub.metrics));
     let (peer_close_tx, mut peer_close_rx) = crossfire::oneshot::oneshot();
     let mut peer_close_tx = Some(peer_close_tx);
     let (writer_shutdown_tx, mut writer_shutdown_rx) = crossfire::oneshot::oneshot();
@@ -800,7 +801,13 @@ pub(super) async fn run_ably_realtime_socket(
         .await;
     let attached_channel_count = attached_channels.len();
     if !graceful_close {
-        hub.mark_session_subscribers_recoverable(&app.id, &session_id);
+        hub.mark_session_subscribers_recoverable(
+            &app.id,
+            &session_id,
+            attached_channels
+                .values()
+                .map(|attachment| &attachment.channel),
+        );
     } else {
         for (requested, _) in attached_channels {
             if let Ok(channel) = AblyChannelName::parse(requested)

--- a/crates/sockudo-ably-compat/src/runtime/tests.rs
+++ b/crates/sockudo-ably-compat/src/runtime/tests.rs
@@ -1254,6 +1254,9 @@ async fn abrupt_disconnect_presence_removal_runs_after_its_deadline() {
         )
         .expect("presence entry succeeds");
 
+    hub.claim_session_owner("app", "connection-a", "disconnected-session")
+        .await
+        .unwrap();
     hub.schedule_pending_presence_removal("app", "connection-a", "disconnected-session", 1)
         .await
         .expect("presence removal is scheduled");
@@ -1355,9 +1358,15 @@ async fn second_disconnect_uses_a_new_presence_removal_deadline() {
             },
         )
         .expect("presence entry succeeds");
+    hub.claim_session_owner("app", "connection-a", "first-session")
+        .await
+        .unwrap();
     hub.schedule_pending_presence_removal("app", "connection-a", "first-session", 20)
         .await
         .expect("first removal is scheduled");
+    hub.claim_session_owner("app", "connection-a", "second-session")
+        .await
+        .unwrap();
     let (command_tx, _command_rx) = crossfire::mpsc::bounded_async(1);
     hub.register_live_session(
         "connection-a".to_string(),
@@ -1651,6 +1660,44 @@ async fn auth_key_rotation_invalidates_previous_key_on_every_runtime() {
             .await,
         AblyConnectionStart::Resumed { .. }
     ));
+}
+
+#[tokio::test]
+async fn node_local_session_owner_survives_socket_registry_cleanup() {
+    let hub = AblyCompatHub::default();
+
+    hub.claim_session_owner("app", "connection-a", "session-a")
+        .await
+        .unwrap();
+    assert!(
+        hub.session_is_current("app", "connection-a", "session-a")
+            .await
+    );
+
+    hub.claim_session_owner("app", "connection-a", "session-b")
+        .await
+        .unwrap();
+    assert!(
+        !hub.session_is_current("app", "connection-a", "session-a")
+            .await
+    );
+    assert!(
+        hub.session_is_current("app", "connection-a", "session-b")
+            .await
+    );
+
+    hub.release_session_owner("app", "connection-a", "session-a")
+        .await;
+    assert!(
+        hub.session_is_current("app", "connection-a", "session-b")
+            .await
+    );
+    hub.release_session_owner("app", "connection-a", "session-b")
+        .await;
+    assert!(
+        !hub.session_is_current("app", "connection-a", "session-b")
+            .await
+    );
 }
 
 #[tokio::test]
@@ -2016,7 +2063,7 @@ async fn resumed_subscriber_replays_the_bounded_delivery_window_in_order() {
             None,
         );
     }
-    hub.mark_session_subscribers_recoverable("app", "old-session");
+    hub.mark_session_subscribers_recoverable("app", "old-session", std::iter::once(&channel));
 
     let (replacement, _replacement_receiver) = AblyOutbound::channel(
         AblyFormat::Json,
@@ -2106,7 +2153,7 @@ async fn resumed_subscriber_replays_the_shared_channel_tail_in_order() {
             None,
         );
     }
-    hub.mark_session_subscribers_recoverable("app", "old-session");
+    hub.mark_session_subscribers_recoverable("app", "old-session", std::iter::once(&channel));
 
     let (replacement, _replacement_receiver) = AblyOutbound::channel(
         AblyFormat::Json,
@@ -2127,6 +2174,54 @@ async fn resumed_subscriber_replays_the_shared_channel_tail_in_order() {
             Some(json!(format!("message-{index}")))
         );
     }
+}
+
+#[test]
+fn recoverable_marking_does_not_lock_unrelated_channels() {
+    let hub = Arc::new(AblyCompatHub::default());
+    let (sender, _receiver) = AblyOutbound::channel(
+        AblyFormat::Json,
+        OutboundLimits::default(),
+        Arc::clone(&hub.metrics),
+    );
+    let channel = AblyChannelName::parse("owned-channel".to_string()).unwrap();
+    hub.attach_clean(
+        "app",
+        &channel,
+        AblyAttachment {
+            connection_id: "connection",
+            session_id: "session",
+            sender,
+            filter: None,
+            params: HashMap::new(),
+            mode_flags: ABLY_DEFAULT_MODE_FLAGS,
+            echo: true,
+            presence: Vec::new(),
+        },
+        None,
+        Vec::new(),
+        false,
+    );
+
+    let unrelated = hub.channel_state("app", "unrelated-channel");
+    let unrelated_guard = lock_channel_state(&unrelated);
+    let worker_hub = Arc::clone(&hub);
+    let worker_channel = channel.clone();
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        worker_hub.mark_session_subscribers_recoverable(
+            "app",
+            "session",
+            std::iter::once(&worker_channel),
+        );
+        done_tx.send(()).unwrap();
+    });
+
+    done_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("session cleanup waited on an unrelated channel lock");
+    drop(unrelated_guard);
+    worker.join().unwrap();
 }
 
 #[tokio::test]

--- a/crates/sockudo-adapter/tests/adapter/handler/clustered_runtime_rewind_recovery_redis_test.rs
+++ b/crates/sockudo-adapter/tests/adapter/handler/clustered_runtime_rewind_recovery_redis_test.rs
@@ -1849,7 +1849,8 @@ async fn rewind_live_handoff_across_nodes_has_no_gap_and_no_duplicates_via_redis
     assert!(
         ordered_events
             .windows(2)
-            .any(|events| { events[0] == "history-1" && events[1] == "history-2" })
+            .any(|events| { events[0] == "history-1" && events[1] == "history-2" }),
+        "rewind history was not contiguous: {ordered_events:?}"
     );
     assert!(
         ordered_events

--- a/crates/sockudo-adapter/tests/adapter/redis_cluster_adapter_health_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/redis_cluster_adapter_health_tests.rs
@@ -12,13 +12,29 @@ use tokio::sync::Mutex;
 use tokio::time::sleep;
 use uuid::Uuid;
 
-/// Helper to check if Redis Cluster is available
-async fn is_redis_cluster_available() -> bool {
+fn redis_cluster_nodes() -> Vec<String> {
     let nodes = env::var("REDIS_CLUSTER_NODES").unwrap_or_else(|_| {
         "redis://127.0.0.1:7001,redis://127.0.0.1:7002,redis://127.0.0.1:7003".to_string()
     });
 
-    let node_list: Vec<String> = nodes.split(',').map(|s| s.to_string()).collect();
+    nodes
+        .split(',')
+        .filter_map(|node| {
+            let node = node.trim();
+            if node.is_empty() {
+                None
+            } else if node.contains("://") {
+                Some(node.to_string())
+            } else {
+                Some(format!("redis://{node}"))
+            }
+        })
+        .collect()
+}
+
+/// Helper to check if Redis Cluster is available
+async fn is_redis_cluster_available() -> bool {
+    let node_list = redis_cluster_nodes();
 
     if node_list.is_empty() {
         return false;
@@ -41,18 +57,11 @@ async fn is_redis_cluster_available() -> bool {
 /// Helper to create a RedisCluster adapter with cluster health enabled
 async fn create_redis_cluster_adapter(
     test_prefix: &str,
-    node_id: &str,
     cluster_config: &ClusterHealthConfig,
 ) -> RedisClusterAdapter {
-    let nodes = env::var("REDIS_CLUSTER_NODES").unwrap_or_else(|_| {
-        "redis://127.0.0.1:7001,redis://127.0.0.1:7002,redis://127.0.0.1:7003".to_string()
-    });
-
-    let node_list: Vec<String> = nodes.split(',').map(|s| s.to_string()).collect();
-
     let config = RedisClusterAdapterConfig {
-        nodes: node_list,
-        prefix: format!("{test_prefix}_{node_id}"),
+        nodes: redis_cluster_nodes(),
+        prefix: test_prefix.to_string(),
         request_timeout_ms: 5000,
         use_connection_manager: true,
         use_sharded_pubsub: false,
@@ -105,10 +114,8 @@ async fn test_redis_cluster_adapter_heartbeat() {
     let test_prefix = unique_test_prefix("cluster_heartbeat");
 
     // Create two adapters simulating two Sockudo nodes
-    let adapter1 =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node1", &cluster_config).await;
-    let adapter2 =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node2", &cluster_config).await;
+    let adapter1 = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
+    let adapter2 = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
 
     adapter1.init().await;
     adapter2.init().await;
@@ -144,16 +151,32 @@ async fn test_redis_cluster_presence_synchronization() {
     let cluster_config = fast_cluster_health_config();
     let test_prefix = unique_test_prefix("cluster_presence_sync");
 
-    let adapter1 =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node1", &cluster_config).await;
-    let adapter2 =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node2", &cluster_config).await;
-    let adapter3 =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node3", &cluster_config).await;
+    let adapter1 = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
+    let adapter2 = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
+    let adapter3 = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
 
     adapter1.init().await;
     adapter2.init().await;
     adapter3.init().await;
+
+    assert!(
+        wait_until(
+            Duration::from_millis(1_500),
+            Duration::from_millis(20),
+            || {
+                let adapter1 = &adapter1;
+                let adapter2 = &adapter2;
+                let adapter3 = &adapter3;
+                async move {
+                    adapter1.horizontal.get_effective_node_count().await >= 3
+                        && adapter2.horizontal.get_effective_node_count().await >= 3
+                        && adapter3.horizontal.get_effective_node_count().await >= 3
+                }
+            }
+        )
+        .await,
+        "Cluster nodes did not discover one another before presence synchronization"
+    );
 
     let app_id = "test-app";
     let channel = "presence-cluster-test";
@@ -279,13 +302,28 @@ async fn test_redis_cluster_dead_node_cleanup() {
     };
     let test_prefix = unique_test_prefix("cluster_dead_node_cleanup");
 
-    let adapter1 =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node1", &cluster_config).await;
-    let adapter2 =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node2", &cluster_config).await;
+    let adapter1 = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
+    let adapter2 = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
 
     adapter1.init().await;
     adapter2.init().await;
+
+    assert!(
+        wait_until(
+            Duration::from_millis(1_500),
+            Duration::from_millis(20),
+            || {
+                let adapter1 = &adapter1;
+                let adapter2 = &adapter2;
+                async move {
+                    adapter1.horizontal.get_effective_node_count().await >= 2
+                        && adapter2.horizontal.get_effective_node_count().await >= 2
+                }
+            }
+        )
+        .await,
+        "Cluster nodes did not discover one another before dead-node setup"
+    );
 
     let app_id = "test-app";
     let channel = "presence-cleanup-test";
@@ -359,8 +397,7 @@ async fn test_redis_cluster_sharding_consistency() {
 
     let cluster_config = fast_cluster_health_config();
     let test_prefix = unique_test_prefix("cluster_sharding");
-    let adapter =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node1", &cluster_config).await;
+    let adapter = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
     adapter.init().await;
 
     // Test presence across different shards (different channel names will hash to different slots)
@@ -398,8 +435,7 @@ async fn test_redis_cluster_failover_handling() {
 
     let cluster_config = fast_cluster_health_config();
     let test_prefix = unique_test_prefix("cluster_failover");
-    let adapter =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node1", &cluster_config).await;
+    let adapter = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
     adapter.init().await;
 
     // Add presence data
@@ -441,13 +477,8 @@ async fn test_redis_cluster_concurrent_multi_node_operations() {
     // Create multiple adapters
     let adapters = Arc::new(Mutex::new(Vec::new()));
 
-    for i in 0..3 {
-        let adapter = create_redis_cluster_adapter(
-            &test_prefix,
-            &format!("cluster_node_{}", i),
-            &cluster_config,
-        )
-        .await;
+    for _ in 0..3 {
+        let adapter = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
         adapter.init().await;
         adapters.lock().await.push(adapter);
     }
@@ -507,8 +538,7 @@ async fn test_redis_cluster_large_presence_data() {
     };
 
     let test_prefix = unique_test_prefix("cluster_large_presence");
-    let adapter =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node1", &cluster_config).await;
+    let adapter = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
     adapter.init().await;
 
     // Create large user info object (near 2KB limit)
@@ -549,8 +579,7 @@ async fn test_redis_cluster_disabled_health_monitoring() {
     };
 
     let test_prefix = unique_test_prefix("cluster_health_disabled");
-    let adapter =
-        create_redis_cluster_adapter(&test_prefix, "cluster_node1", &cluster_config).await;
+    let adapter = create_redis_cluster_adapter(&test_prefix, &cluster_config).await;
     adapter.init().await;
 
     // Should still handle presence operations without health monitoring

--- a/crates/sockudo-core/src/websocket/buffer.rs
+++ b/crates/sockudo-core/src/websocket/buffer.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use crossfire::mpsc;
+use crossfire::{TrySendError, mpsc};
 use sockudo_protocol::messages::PusherMessage;
 use sockudo_ws::Message;
 use std::sync::Arc;
@@ -165,6 +165,7 @@ impl ByteCounter {
 }
 
 /// Message wrapper that includes size for byte tracking
+#[derive(Debug)]
 pub struct SizedMessage {
     pub bytes: Bytes,
     pub size: usize,
@@ -341,11 +342,106 @@ impl RewindGate {
     }
 }
 
-pub(super) type MessageChannelFlavor = mpsc::Array<Message>;
-pub(super) type MessageSenderHandle = crossfire::MAsyncTx<MessageChannelFlavor>;
-pub(super) type SizedMessageChannelFlavor = mpsc::Array<SizedMessage>;
-pub type SizedMessageSenderHandle = crossfire::MAsyncTx<SizedMessageChannelFlavor>;
-pub(super) type SizedMessageReceiverHandle = crossfire::AsyncRx<SizedMessageChannelFlavor>;
+#[derive(Debug)]
+pub(super) enum OutboundFrame {
+    Direct(Message),
+    Broadcast(SizedMessage),
+}
+
+pub(super) type OutboundChannelFlavor = mpsc::Array<OutboundFrame>;
+type OutboundSenderHandle = crossfire::MAsyncTx<OutboundChannelFlavor>;
+
+#[derive(Debug, Clone)]
+pub(super) struct MessageSenderHandle {
+    pub(super) sender: OutboundSenderHandle,
+    pub(super) pending: Arc<AtomicUsize>,
+    pub(super) limit: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct SizedMessageSenderHandle {
+    pub(super) sender: OutboundSenderHandle,
+    pub(super) pending: Arc<AtomicUsize>,
+    pub(super) limit: usize,
+}
+
+fn try_reserve_message(pending: &AtomicUsize, limit: usize) -> bool {
+    pending
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+            current.checked_add(1).filter(|next| *next <= limit)
+        })
+        .is_ok()
+}
+
+impl MessageSenderHandle {
+    pub(super) fn new(
+        sender: OutboundSenderHandle,
+        pending: Arc<AtomicUsize>,
+        limit: usize,
+    ) -> Self {
+        Self {
+            sender,
+            pending,
+            limit,
+        }
+    }
+
+    pub(super) fn try_send(
+        &self,
+        message: Message,
+    ) -> std::result::Result<(), TrySendError<Message>> {
+        if !try_reserve_message(&self.pending, self.limit) {
+            return Err(TrySendError::Full(message));
+        }
+        match self.sender.try_send(OutboundFrame::Direct(message)) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(OutboundFrame::Direct(message))) => {
+                self.pending.fetch_sub(1, Ordering::Release);
+                Err(TrySendError::Full(message))
+            }
+            Err(TrySendError::Disconnected(OutboundFrame::Direct(message))) => {
+                self.pending.fetch_sub(1, Ordering::Release);
+                Err(TrySendError::Disconnected(message))
+            }
+            Err(_) => unreachable!("direct frame changed variant while enqueueing"),
+        }
+    }
+}
+
+impl SizedMessageSenderHandle {
+    pub(super) fn new(
+        sender: OutboundSenderHandle,
+        pending: Arc<AtomicUsize>,
+        limit: usize,
+    ) -> Self {
+        Self {
+            sender,
+            pending,
+            limit,
+        }
+    }
+
+    pub fn try_send(
+        &self,
+        message: SizedMessage,
+    ) -> std::result::Result<(), TrySendError<SizedMessage>> {
+        if !try_reserve_message(&self.pending, self.limit) {
+            return Err(TrySendError::Full(message));
+        }
+        match self.sender.try_send(OutboundFrame::Broadcast(message)) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(OutboundFrame::Broadcast(message))) => {
+                self.pending.fetch_sub(1, Ordering::Release);
+                Err(TrySendError::Full(message))
+            }
+            Err(TrySendError::Disconnected(OutboundFrame::Broadcast(message))) => {
+                self.pending.fetch_sub(1, Ordering::Release);
+                Err(TrySendError::Disconnected(message))
+            }
+            Err(_) => unreachable!("broadcast frame changed variant while enqueueing"),
+        }
+    }
+}
 
 impl SizedMessage {
     #[inline]

--- a/crates/sockudo-core/src/websocket/connection.rs
+++ b/crates/sockudo-core/src/websocket/connection.rs
@@ -1,4 +1,4 @@
-use super::buffer::{ByteCounter, SizedMessage, SizedMessageSenderHandle, WebSocketBufferConfig};
+use super::buffer::{ByteCounter, SizedMessageSenderHandle, WebSocketBufferConfig};
 use super::capabilities::UserInfo;
 use super::sender::MessageSender;
 use super::socket_id::SocketId;
@@ -8,7 +8,6 @@ use crate::channel::PresenceMemberInfo;
 use crate::error::{Error, Result};
 use ahash::AHashMap as HashMap;
 use bytes::Bytes;
-use crossfire::mpsc;
 use sockudo_filter::FilterNode;
 use sockudo_protocol::messages::PusherMessage;
 use sockudo_ws::Message;
@@ -44,16 +43,15 @@ impl WebSocket {
         };
 
         let channel_capacity = buffer_config.channel_capacity();
-        let (broadcast_tx, broadcast_rx) = mpsc::bounded_async::<SizedMessage>(channel_capacity);
         let shutdown_token = CancellationToken::new();
 
         let message_sender = MessageSender::new_with_broadcast(
             socket,
-            broadcast_rx,
             channel_capacity,
             byte_counter.clone(),
             shutdown_token.clone(),
         );
+        let broadcast_tx = message_sender.broadcast_sender_handle();
 
         WebSocket {
             state: ConnectionState::with_socket_id(socket_id),

--- a/crates/sockudo-core/src/websocket/reference.rs
+++ b/crates/sockudo-core/src/websocket/reference.rs
@@ -25,7 +25,7 @@ use tracing::warn;
 #[derive(Clone)]
 pub struct WebSocketRef {
     pub broadcast_tx: SizedMessageSenderHandle,
-    pub message_sender: MessageSenderHandle,
+    pub(super) message_sender: MessageSenderHandle,
     pub channel_state: Arc<DashMap<Arc<str>, PerChannelState>>,
     continuity_gates: Arc<DashMap<Arc<str>, Arc<Mutex<RewindGate>>>>,
     pub socket_id: SocketId,

--- a/crates/sockudo-core/src/websocket/sender.rs
+++ b/crates/sockudo-core/src/websocket/sender.rs
@@ -1,9 +1,10 @@
-use super::buffer::{ByteCounter, MessageSenderHandle, SizedMessageReceiverHandle};
+use super::buffer::{ByteCounter, MessageSenderHandle, OutboundFrame, SizedMessageSenderHandle};
 use crate::error::{Error, Result};
 use crossfire::{TrySendError, mpsc};
 use sockudo_ws::Message;
 use sockudo_ws::axum_integration::WebSocketWriter;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -13,6 +14,7 @@ use tracing::{debug, error, warn};
 #[derive(Debug)]
 pub struct MessageSender {
     sender: MessageSenderHandle,
+    broadcast_sender: SizedMessageSenderHandle,
     close_flushed: Arc<Notify>,
     shutdown_token: Option<CancellationToken>,
     receiver_handle: Option<JoinHandle<()>>,
@@ -50,12 +52,24 @@ impl SocketOperation {
 impl MessageSender {
     pub fn new_with_broadcast(
         mut socket: WebSocketWriter,
-        broadcast_rx: SizedMessageReceiverHandle,
         buffer_capacity: usize,
         byte_counter: Option<Arc<ByteCounter>>,
         shutdown_token: CancellationToken,
     ) -> Self {
-        let (sender, receiver) = mpsc::bounded_async::<Message>(buffer_capacity);
+        let combined_capacity = buffer_capacity.saturating_mul(2);
+        let (outbound_sender, receiver) = mpsc::bounded_async::<OutboundFrame>(combined_capacity);
+        let direct_pending = Arc::new(AtomicUsize::new(0));
+        let broadcast_pending = Arc::new(AtomicUsize::new(0));
+        let sender = MessageSenderHandle::new(
+            outbound_sender.clone(),
+            Arc::clone(&direct_pending),
+            buffer_capacity,
+        );
+        let broadcast_sender = SizedMessageSenderHandle::new(
+            outbound_sender,
+            Arc::clone(&broadcast_pending),
+            buffer_capacity,
+        );
         let close_flushed = Arc::new(Notify::new());
         let writer_close_flushed = Arc::clone(&close_flushed);
         let close_shutdown_token = shutdown_token.clone();
@@ -63,8 +77,6 @@ impl MessageSender {
         let receiver_handle = tokio::spawn(async move {
             let mut msg_count = 0;
             let mut is_shutting_down = false;
-            let mut broadcast_closed = false;
-            let mut receiver_closed = false;
 
             loop {
                 tokio::select! {
@@ -74,35 +86,10 @@ impl MessageSender {
                         debug!("Receiver task shutting down via cancellation token");
                         break;
                     }
-                    recv_result = broadcast_rx.recv(), if !broadcast_closed => {
+                    recv_result = receiver.recv() => {
                         match recv_result {
-                            Ok(sized_msg) => {
-                                msg_count += 1;
-                                let msg_size = sized_msg.size;
-                                let msg = Message::Text(sized_msg.bytes);
-
-                                if let Err(e) = socket.send(msg).await {
-                                    Self::log_connection_error(
-                                        &e,
-                                        SocketOperation::WriteFrame,
-                                        msg_count,
-                                        is_shutting_down,
-                                    );
-                                    break;
-                                }
-
-                                if let Some(ref counter) = byte_counter {
-                                    counter.sub(msg_size);
-                                }
-                            }
-                            Err(_) => {
-                                broadcast_closed = true;
-                            }
-                        }
-                    }
-                    recv_result = receiver.recv(), if !receiver_closed => {
-                        match recv_result {
-                            Ok(message) => {
+                            Ok(OutboundFrame::Direct(message)) => {
+                                direct_pending.fetch_sub(1, Ordering::Release);
                                 msg_count += 1;
 
                                 let is_close = matches!(message, Message::Close(_));
@@ -127,12 +114,29 @@ impl MessageSender {
                                     break;
                                 }
                             }
-                            Err(_) => {
-                                receiver_closed = true;
+                            Ok(OutboundFrame::Broadcast(sized_msg)) => {
+                                broadcast_pending.fetch_sub(1, Ordering::Release);
+                                msg_count += 1;
+                                let msg_size = sized_msg.size;
+                                let msg = Message::Text(sized_msg.bytes);
+
+                                if let Err(e) = socket.send(msg).await {
+                                    Self::log_connection_error(
+                                        &e,
+                                        SocketOperation::WriteFrame,
+                                        msg_count,
+                                        is_shutting_down,
+                                    );
+                                    break;
+                                }
+
+                                if let Some(ref counter) = byte_counter {
+                                    counter.sub(msg_size);
+                                }
                             }
+                            Err(_) => break,
                         }
                     }
-                    else => break,
                 }
             }
 
@@ -143,6 +147,7 @@ impl MessageSender {
 
         Self {
             sender,
+            broadcast_sender,
             close_flushed,
             shutdown_token: Some(close_shutdown_token),
             receiver_handle: Some(receiver_handle),
@@ -197,7 +202,20 @@ impl MessageSender {
     }
 
     pub fn new(mut socket: WebSocketWriter, buffer_capacity: usize) -> Self {
-        let (sender, receiver) = mpsc::bounded_async::<Message>(buffer_capacity);
+        let combined_capacity = buffer_capacity.saturating_mul(2);
+        let (outbound_sender, receiver) = mpsc::bounded_async::<OutboundFrame>(combined_capacity);
+        let direct_pending = Arc::new(AtomicUsize::new(0));
+        let broadcast_pending = Arc::new(AtomicUsize::new(0));
+        let sender = MessageSenderHandle::new(
+            outbound_sender.clone(),
+            Arc::clone(&direct_pending),
+            buffer_capacity,
+        );
+        let broadcast_sender = SizedMessageSenderHandle::new(
+            outbound_sender,
+            Arc::clone(&broadcast_pending),
+            buffer_capacity,
+        );
         let close_flushed = Arc::new(Notify::new());
         let writer_close_flushed = Arc::clone(&close_flushed);
 
@@ -205,29 +223,47 @@ impl MessageSender {
             let mut msg_count = 0;
             let mut is_shutting_down = false;
 
-            while let Ok(message) = receiver.recv().await {
-                msg_count += 1;
+            while let Ok(frame) = receiver.recv().await {
+                match frame {
+                    OutboundFrame::Direct(message) => {
+                        direct_pending.fetch_sub(1, Ordering::Release);
+                        msg_count += 1;
 
-                let is_close = matches!(message, Message::Close(_));
-                if is_close {
-                    is_shutting_down = true;
-                }
+                        let is_close = matches!(message, Message::Close(_));
+                        if is_close {
+                            is_shutting_down = true;
+                        }
 
-                let send_result = socket.send(message).await;
-                if is_close {
-                    writer_close_flushed.notify_one();
-                }
-                if let Err(e) = send_result {
-                    Self::log_connection_error(
-                        &e,
-                        SocketOperation::WriteFrame,
-                        msg_count,
-                        is_shutting_down,
-                    );
-                    break;
-                }
-                if is_close {
-                    break;
+                        let send_result = socket.send(message).await;
+                        if is_close {
+                            writer_close_flushed.notify_one();
+                        }
+                        if let Err(e) = send_result {
+                            Self::log_connection_error(
+                                &e,
+                                SocketOperation::WriteFrame,
+                                msg_count,
+                                is_shutting_down,
+                            );
+                            break;
+                        }
+                        if is_close {
+                            break;
+                        }
+                    }
+                    OutboundFrame::Broadcast(sized_msg) => {
+                        broadcast_pending.fetch_sub(1, Ordering::Release);
+                        msg_count += 1;
+                        if let Err(e) = socket.send(Message::Text(sized_msg.bytes)).await {
+                            Self::log_connection_error(
+                                &e,
+                                SocketOperation::WriteFrame,
+                                msg_count,
+                                is_shutting_down,
+                            );
+                            break;
+                        }
+                    }
                 }
             }
 
@@ -238,6 +274,7 @@ impl MessageSender {
 
         Self {
             sender,
+            broadcast_sender,
             close_flushed,
             shutdown_token: None,
             receiver_handle: Some(receiver_handle),
@@ -248,8 +285,12 @@ impl MessageSender {
         self.sender.try_send(message)
     }
 
-    pub(crate) fn sender_handle(&self) -> MessageSenderHandle {
+    pub(super) fn sender_handle(&self) -> MessageSenderHandle {
         self.sender.clone()
+    }
+
+    pub(crate) fn broadcast_sender_handle(&self) -> SizedMessageSenderHandle {
+        self.broadcast_sender.clone()
     }
 
     pub fn send(&self, message: Message) -> Result<()> {

--- a/crates/sockudo-core/src/websocket/tests/mod.rs
+++ b/crates/sockudo-core/src/websocket/tests/mod.rs
@@ -859,6 +859,79 @@ async fn test_send_broadcast_delivers_without_lock() {
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn outbound_frames_preserve_enqueue_order_across_sources() {
+    use sockudo_ws::Message;
+
+    let socket_id = SocketId::new();
+    let (writer, mut client) = create_server_writer_with_client().await;
+    let ws_ref = WebSocketRef::new(WebSocket::new(socket_id, writer));
+
+    let mut protocol_message = PusherMessage::pong();
+    protocol_message.event = Some("protocol-before-broadcast".to_string());
+    ws_ref
+        .send_message(&protocol_message)
+        .expect("protocol frame should enqueue");
+    ws_ref
+        .send_broadcast(Bytes::from_static(
+            b"{\"event\":\"broadcast-after-protocol\"}",
+        ))
+        .expect("broadcast should enqueue");
+
+    let first = tokio::time::timeout(std::time::Duration::from_secs(1), client.next())
+        .await
+        .expect("timed out waiting for protocol frame")
+        .expect("client stream ended unexpectedly")
+        .expect("protocol frame read failed");
+    let second = tokio::time::timeout(std::time::Duration::from_secs(1), client.next())
+        .await
+        .expect("timed out waiting for broadcast frame")
+        .expect("client stream ended unexpectedly")
+        .expect("broadcast frame read failed");
+
+    let Message::Text(first_payload) = first else {
+        panic!("protocol frame must be text")
+    };
+    let Message::Text(second_payload) = second else {
+        panic!("broadcast frame must be text")
+    };
+    assert!(
+        std::str::from_utf8(&first_payload)
+            .expect("protocol frame must be UTF-8")
+            .contains("protocol-before-broadcast")
+    );
+    assert!(
+        std::str::from_utf8(&second_payload)
+            .expect("broadcast frame must be UTF-8")
+            .contains("broadcast-after-protocol")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unified_outbound_queue_keeps_independent_source_bounds() {
+    let socket_id = SocketId::new();
+    let (writer, _client) = create_server_writer_with_client().await;
+    let ws_ref = WebSocketRef::new(WebSocket::with_buffer_config(
+        socket_id,
+        writer,
+        WebSocketBufferConfig::with_message_limit(2, true),
+    ));
+
+    assert!(ws_ref.send_message(&PusherMessage::pong()).is_ok());
+    assert!(ws_ref.send_message(&PusherMessage::pong()).is_ok());
+    assert!(matches!(
+        ws_ref.send_message(&PusherMessage::pong()),
+        Err(crate::error::Error::BufferFull(_))
+    ));
+
+    assert!(ws_ref.send_broadcast(Bytes::from_static(b"first")).is_ok());
+    assert!(ws_ref.send_broadcast(Bytes::from_static(b"second")).is_ok());
+    assert!(matches!(
+        ws_ref.send_broadcast(Bytes::from_static(b"third")),
+        Err(crate::error::Error::BufferFull(_))
+    ));
+}
+
 #[tokio::test]
 async fn test_send_after_close_returns_error() {
     use crate::error::Error;

--- a/crates/sockudo-server/src/bootstrap/server.rs
+++ b/crates/sockudo-server/src/bootstrap/server.rs
@@ -16,7 +16,9 @@ use sockudo_app::AppManagerFactory;
 use sockudo_cache::CacheManagerFactory;
 use sockudo_core::auth::AuthValidator;
 use sockudo_core::error::{Error, Result};
-use sockudo_core::options::{AdapterDriver, DeltaCoordinationBackend, QueueDriver, ServerOptions};
+use sockudo_core::options::{
+    AdapterDriver, CacheDriver, DeltaCoordinationBackend, QueueDriver, ServerOptions,
+};
 use sockudo_queue::QueueManagerFactory;
 use sockudo_rate_limiter::factory::RateLimiterFactory;
 use sockudo_webhook::integration::QueueManager;
@@ -820,7 +822,17 @@ impl SockudoServer {
         let ably_compat = Arc::new(sockudo_ably_compat::AblyCompatRuntime::new(
             sockudo_ably_compat::AblyCompatDependencies {
                 config: config.ably_compat.clone(),
-                cache: Some(state.cache_manager.clone()),
+                // Process-local compatibility state must not share the bounded,
+                // evictable application memory cache. Redis-backed deployments
+                // use the cache as their cross-node coordination authority.
+                cache: matches!(
+                    config.cache.driver,
+                    CacheDriver::Redis | CacheDriver::RedisCluster
+                )
+                .then(|| state.cache_manager.clone() as Arc<dyn sockudo_core::cache::CacheManager>),
+                stats_cache: Some(
+                    state.cache_manager.clone() as Arc<dyn sockudo_core::cache::CacheManager>
+                ),
                 presence_registry: Arc::clone(&ably_presence_registry),
                 push_store: Some(state.push_store.clone()),
                 push_queue: Some(state.push_queue.clone()),

--- a/crates/sockudo-server/src/bootstrap/server.rs
+++ b/crates/sockudo-server/src/bootstrap/server.rs
@@ -16,9 +16,9 @@ use sockudo_app::AppManagerFactory;
 use sockudo_cache::CacheManagerFactory;
 use sockudo_core::auth::AuthValidator;
 use sockudo_core::error::{Error, Result};
-use sockudo_core::options::{
-    AdapterDriver, CacheDriver, DeltaCoordinationBackend, QueueDriver, ServerOptions,
-};
+#[cfg(feature = "ably-compat")]
+use sockudo_core::options::CacheDriver;
+use sockudo_core::options::{AdapterDriver, DeltaCoordinationBackend, QueueDriver, ServerOptions};
 use sockudo_queue::QueueManagerFactory;
 use sockudo_rate_limiter::factory::RateLimiterFactory;
 use sockudo_webhook::integration::QueueManager;

--- a/crates/sockudo-server/tests/clustered_durable_history_redis_test.rs
+++ b/crates/sockudo-server/tests/clustered_durable_history_redis_test.rs
@@ -598,9 +598,14 @@ async fn run_cross_node_cold_recovery_test(history_store: Arc<dyn HistoryStore +
         .filter(|msg| matches!(msg.event.as_deref(), Some("cold-2" | "cold-3")))
         .filter_map(|msg| msg.message_id.clone())
         .collect();
+    let received = messages
+        .iter()
+        .map(|msg| (msg.event.clone(), msg.message_id.clone(), msg.serial))
+        .collect::<Vec<_>>();
     assert_eq!(
         replayed_ids,
-        vec!["cold-msg-2".to_string(), "cold-msg-3".to_string()]
+        vec!["cold-msg-2".to_string(), "cold-msg-3".to_string()],
+        "unexpected recovery sequence: {received:?}"
     );
 
     let aggregate = messages.last().unwrap();

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -109,6 +109,12 @@ transport. The default is `accept`.
 `attach_timeout_ms` bounds the complete native presence/recovery/history attach
 path. On expiry Sockudo removes the partial subscription and returns
 `DETACHED`/`50003`; the default is 10 seconds.
+Ably realtime data queues use `[websocket].max_messages` and
+`[websocket].max_bytes`. When a slow session exceeds either configured bound,
+Sockudo marks its continuity lost and requires recovery instead of allowing the
+session to buffer beyond the operator-configured limit. The shipped
+configuration uses a 4 MiB byte bound so a healthy short burst of maximum-size
+application events is not mistaken for a stalled reader.
 Ably `delta=vcdiff` is negotiated per realtime channel and uses a fixed bounded
 compatibility cache; native `[delta_compression]` settings continue to configure
 only Sockudo's Pusher/V2 delta contract and do not select the Ably VCDIFF mode.

--- a/docs/content/docs/server/ably-ai-transport-compatibility.mdx
+++ b/docs/content/docs/server/ably-ai-transport-compatibility.mdx
@@ -367,26 +367,35 @@ raw annotation event nor the V2/Ably summary projection.
 Compatibility delivery is injected at the native local delivery boundary. It
 is interest-gated, synchronous, and non-blocking when no Ably session is
 attached to a channel. Active sessions use separate bounded control and data
-queues, each limited by both frame count and bytes. ACK, ERROR, heartbeat, and
+queues, each limited by both frame count and bytes. The data queue honors the
+server's `[websocket].max_messages` and `[websocket].max_bytes` bounds; unset
+limits retain bounded compatibility defaults. ACK, ERROR, heartbeat, and
 close-control frames are prioritized over data frames. A data overflow marks
-continuity lost, sends a recoverable `90003` error when possible, and removes
-the stalled subscriber; the next attach/recovery reads canonical Sockudo hot
-replay or durable history.
+continuity lost, stops further data for that session, and sends a recoverable
+`90003` error when possible; the next attach/recovery reads canonical Sockudo
+hot replay or durable history.
 
 Messages are encoded once for each active JSON/MessagePack group and shared as
 immutable bytes across that group's subscribers. Session, token, channel, and
-queue state has hard bounds and periodic expiry. No compatibility lock is held
+queue state have hard bounds and periodic expiry. No compatibility lock is held
 while encoding or fanning out, and the compatibility projection does not alter
 Protocol V1 delivery. `/operator/stats/ably-runtime` exposes `data_encoded` for
 these shared projections separately from `encoded`, which also includes
 connection, channel, ACK, and heartbeat control frames.
 
-Connection recovery keys are stored for the advertised connection-state TTL in
-the configured shared cache as well as the local runtime. A reconnect routed to
-another node can therefore validate the key and recover each reattached channel
-from canonical hot replay or durable history; a missing or expired `recover` key
-returns `80018`. The active key lease is refreshed at half the advertised TTL,
-then receives a full TTL from an ungraceful disconnect; an explicit `CLOSE`
+For process-local deployments, compatibility coordination state is kept in the
+runtime rather than the general bounded memory cache. Redis and Redis Cluster
+remain the shared coordination authority for multi-node deployments; the
+configured cache still persists compatibility statistics in both deployment
+modes.
+
+In Redis-backed deployments, connection recovery keys are stored for the
+advertised connection-state TTL in the shared cache as well as the local
+runtime. A reconnect routed to another node can therefore validate the key and
+recover each reattached channel from canonical hot replay or durable history; a
+missing or expired `recover` key returns `80018`. The active key lease is
+refreshed at half the advertised TTL, then receives a full TTL from an
+ungraceful disconnect; an explicit `CLOSE`
 invalidates the active key after sending `CLOSED`. Cached state never includes
 app secrets or provider credentials.
 

--- a/tests/load/ably-compat/capacity-runner.mjs
+++ b/tests/load/ably-compat/capacity-runner.mjs
@@ -113,7 +113,9 @@ async function runTopology(topology) {
       const started = performance.now();
       let outcome;
       try {
-        outcome = await runScenario(scenario, nodes);
+        outcome = await runScenario(scenario, nodes, (phase) => {
+          sampler.phase = phase;
+        });
       } catch (error) {
         outcome = { status: "failed", error: error.message };
       }
@@ -237,9 +239,9 @@ async function startNode(topology, index, port, metricsPort, topologyDir) {
   return node;
 }
 
-async function runScenario(scenario, nodes) {
+async function runScenario(scenario, nodes, setPhase) {
   if (["steady_publish", "burst", "payload_64k", "encrypted_binary", "fanout_1000", "slow_consumers"].includes(scenario.name)) {
-    return broadcastScenario(scenario, nodes);
+    return broadcastScenario(scenario, nodes, setPhase);
   }
   if (scenario.name === "recovery_storm") return recoveryScenario(scenario, nodes);
   if (scenario.name === "presence_churn") return presenceScenario(scenario, nodes);
@@ -249,7 +251,7 @@ async function runScenario(scenario, nodes) {
   throw new Error(`unsupported scenario ${scenario.name}`);
 }
 
-async function broadcastScenario(scenario, nodes) {
+async function broadcastScenario(scenario, nodes, setPhase) {
   const channel = `capacity:${runId}:${scenario.name}`;
   const slowCount = Math.floor(scenario.subscribers * (scenario.slowPercent ?? 0) / 100);
   const normalCount = scenario.subscribers - slowCount;
@@ -298,7 +300,10 @@ async function broadcastScenario(scenario, nodes) {
   const deliveryDelta = snapshotDelta(deliveryBefore, deliveryAfter);
   const encodeCount = deliveryDelta.reduce((sum, entry) => sum + (entry.delivery?.data_encoded ?? 0), 0);
   const expectedEncodeCount = normalCount > 0 || slowCount > 0 ? messages.length : 0;
-  if (slowCount > 0) await sleep(scenario.stallHoldMs ?? 30000);
+  if (slowCount > 0) {
+    setPhase(`${scenario.name}_stalled`);
+    await sleep(scenario.stallHoldMs ?? 30000);
+  }
   await Promise.all(clients.map((client) => client.close()));
   for (const peer of slow) peer.destroy();
   const duration = secondsSince(started);
@@ -333,7 +338,7 @@ async function recoveryScenario(scenario, nodes) {
     connectionId: client.connectionId,
     channelSerial: client.deliveryAudit.lastChannelSerial,
   }));
-  await Promise.all(original.map((client) => client.close()));
+  await Promise.all(original.map((client) => client.disconnect()));
   await sleep(50);
   for (let sequence = 1; sequence <= scenario.messages; sequence += 1) {
     await ablyRequest(nodes[0], "POST", `/channels/${encodeURIComponent(channel)}/messages`, {
@@ -491,7 +496,7 @@ class Subscriber {
       await client.waitFor((frame) => frame.action === 11 && frame.channel === channel, 15000);
       return client;
     } catch (error) {
-      await client.close();
+      await client.disconnect();
       throw new Error(`${stage}: ${error.message}`);
     }
   }
@@ -536,6 +541,14 @@ class Subscriber {
   }
   send(value) { this.ws.send(JSON.stringify(value)); }
   async close() {
+    if (this.ws.readyState === 1) {
+      const closed = this.waitFor((frame) => frame.action === 8, 5000).catch(() => undefined);
+      try { this.send({ action: 7 }); } catch {}
+      await closed;
+    }
+    await this.disconnect();
+  }
+  async disconnect() {
     this.ws.removeEventListener("message", this.messageListener);
     this.frames.length = 0;
     for (const waiter of this.waiters) {
@@ -684,7 +697,7 @@ function rssPlateau(samples, nodeCount) {
   const stalledPeersExercised = selected.some((scenario) => scenario.name === "slow_consumers" && (scenario.slowPercent ?? 0) > 0);
   const byNode = Array.from({ length: nodeCount }, (_, index) => samples.filter((sample) => sample.node === index + 1));
   const nodes = byNode.map((nodeSamples) => {
-    const stalled = nodeSamples.filter((sample) => sample.phase === "slow_consumers");
+    const stalled = nodeSamples.filter((sample) => sample.phase === "slow_consumers_stalled");
     const postDisconnect = nodeSamples.filter((sample) => sample.phase === "post_disconnect");
     const stalledSlope = linearSlope(stalled.map((sample) => [sample.atMs / 1000, sample.rssBytes]));
     const postDisconnectSlope = linearSlope(postDisconnect.map((sample) => [sample.atMs / 1000, sample.rssBytes]));

--- a/tests/load/ably-compat/profiles/release.json
+++ b/tests/load/ably-compat/profiles/release.json
@@ -7,7 +7,7 @@
     { "name": "payload_64k", "messages": 1000, "subscribers": 100, "concurrency": 20, "payloadBytes": 65536 },
     { "name": "encrypted_binary", "messages": 5000, "subscribers": 100, "concurrency": 100, "payloadBytes": 4096 },
     { "name": "fanout_1000", "messages": 1000, "subscribers": 1000, "concurrency": 20, "payloadBytes": 256 },
-    { "name": "slow_consumers", "messages": 2000, "subscribers": 1000, "slowPercent": 10, "concurrency": 20, "payloadBytes": 65536, "stallHoldMs": 60000 },
+    { "name": "slow_consumers", "messages": 2000, "subscribers": 1000, "slowPercent": 10, "concurrency": 1, "payloadBytes": 65536, "stallHoldMs": 60000 },
     { "name": "recovery_storm", "connections": 1000, "messages": 100 },
     { "name": "presence_churn", "transitions": 10000 },
     { "name": "append_storm", "streams": 2000, "appendsPerStream": 100, "concurrency": 200 },


### PR DESCRIPTION
## Summary

- keep process-local Ably session ownership in a dedicated bounded runtime map instead of the evictable application memory cache; Redis and Redis Cluster remain the cross-node authority, while stats can still use the configured cache
- apply the configured WebSocket message/byte bounds to Ably data queues, raise the shipped byte bound to 4 MiB, and scope disconnect recovery cleanup to channels actually attached by that session
- preserve FIFO enqueue order between native direct/control frames and broadcast frames through one writer queue, while retaining independent per-source admission limits
- make the Redis Cluster health tests use valid seed URLs, one shared namespace, and explicit node discovery so the CI environment exercises the tests instead of silently skipping or isolating its simulated nodes
- make the capacity harness use protocol CLOSE for normal teardown, reserve transport disconnects for recovery, measure the actual 60-second stalled phase, and isolate the slow-consumer scenario from the separate burst/fanout concurrency targets

## Why this blocks 5.0.0

On the merged `3edd15929` candidate (`95131f831a7c9067ad191b64d7368ba1ba8c37d76055a46631849e3e3c168758`), the exact release profile exposed two failures:

- after the 10,000-message one-node burst, later connections timed out waiting for ATTACHED because bounded memory-cache churn evicted live compatibility ownership state
- with 900 healthy and 100 stalled subscribers across two nodes, the hard-coded 64 MiB per-session data bound accumulated 6,437,405,350 queued bytes, peaked at 4,074,209,280 RSS bytes, lost/gapped 387,621 healthy deliveries, and reordered all 900 audited healthy streams

While repeating recovery tests, the formerly separate native writer queues also exposed a real ordering race: a live broadcast could overtake rewind history, while simply prioritizing direct frames made `resume_success` overtake cold-recovery replay. The unified bounded FIFO fixes both cases without widening either source's admission budget.

## Release evidence

Locked optimized binary:

- features: `full`
- SHA-256: `176a50b6a1aff70e6b2495d3a53ec810637f0a8a2de64fd35f79628c74061d43`

One-node regression on that exact binary:

- 10,000-message burst to 100 subscribers: 1,000,000/1,000,000 deliveries, zero loss, duplicates, reordering, unexpected messages, or gaps
- 1,000 × 64 KiB messages to 100 subscribers: 100,000/100,000 deliveries, the same zero-error audit

Two-node slow-consumer run on that exact binary:

- 900 healthy + 100 stalled subscribers; 2,000 × 64 KiB messages
- 1,800,000/1,800,000 healthy deliveries with zero loss, duplicates, reordering, unexpected messages, or gaps
- all 100 stalled sessions overflowed explicitly, lost continuity, and were marked reset-required
- p99 publish latency 34.599 ms; p99 delivery latency 29 ms
- peak RSS 589,709,312 and 131,858,432 bytes; stalled and post-disconnect slopes were negative on both nodes
- no sensitive payload sentinel in logs and both nodes shut down cleanly

## Verification

- `cargo test --workspace --all-features` with Redis, Redis Cluster, NATS, MySQL, PostgreSQL, ScyllaDB, DynamoDB Local, and SurrealDB available: passed
- adapter integration suite with the exact CI Redis Cluster seed format: 398 passed, 2 ignored
- Redis Cluster health suite: 8 passed and no silent skips
- rewind/live handoff regression repeated 20 times: passed 20/20
- DynamoDB and SurrealDB cross-node cold recovery: passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed
- load-runner syntax check: passed
- docs type check and production build: passed

## Release note

This PR does not tag or publish 5.0.0. After it merges and CI is green, the final release gate should rebuild from the exact merge commit and run the independent full release-capacity evidence set before tagging.
