### PR TITLE
fix: stop Ably push worker warning spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- Started the Ably realtime push worker only when compatibility and its local provider capability
+  are active, preventing repeated unsupported-stage warnings, and compiled the standard Docker
+  image with the in-process `monolith` push workers.
+
 ## [5.0.0] - 2026-08-17
 
 ### Breaking Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,9 @@ RUN for dir in protocol filter core app cache queue rate-limiter metrics webhook
 # Generate lockfile if missing
 RUN test -f Cargo.lock || cargo generate-lockfile
 
-ARG SOCKUDO_FEATURES=full
+# The release image runs the in-process push pipeline workers. Custom worker/API
+# images can still override this build argument with a narrower feature set.
+ARG SOCKUDO_FEATURES=full,monolith
 # The full feature graph exceeds the standard ARM64 runner's memory with fat LTO.
 # Thin LTO keeps cross-architecture images optimized while bounding link memory.
 ARG CARGO_PROFILE_RELEASE_LTO=thin

--- a/crates/sockudo-ably-compat/src/channel_name.rs
+++ b/crates/sockudo-ably-compat/src/channel_name.rs
@@ -199,7 +199,9 @@ mod tests {
             .collect::<String>();
         let decoded = encoded
             .as_bytes()
-            .chunks_exact(3)
+            .as_chunks::<3>()
+            .0
+            .iter()
             .map(|chunk| {
                 u8::from_str_radix(std::str::from_utf8(&chunk[1..]).expect("ASCII hex"), 16)
                     .expect("valid hex")

--- a/crates/sockudo-ably-compat/src/runtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime.rs
@@ -1275,6 +1275,14 @@ pub trait AblyPushAdmissionGuard: Send + Sync {
         required_providers: &BTreeSet<PushProviderKind>,
         expected_recipients: u64,
     ) -> Option<String>;
+
+    /// Return whether this node has an active worker for the provider.
+    ///
+    /// The default keeps existing admission guards fail-closed when worker
+    /// capability reporting is unavailable.
+    fn provider_worker_active(&self, _provider: PushProviderKind) -> bool {
+        false
+    }
 }
 
 /// Dependencies used to construct an isolated compatibility runtime.
@@ -1415,7 +1423,8 @@ impl AblyCompatRuntime {
     pub fn bind_handler(&self, handler: &Arc<ConnectionHandler>) {
         if self.hub.handler.set(Arc::downgrade(handler)).is_ok() {
             #[cfg(feature = "push")]
-            if let Some(queue) = self.hub.push_queue.clone()
+            if self.realtime_push_worker_enabled()
+                && let Some(queue) = self.hub.push_queue.clone()
                 && let Ok(runtime) = tokio::runtime::Handle::try_current()
             {
                 let dispatcher = Arc::new(AblyRealtimePushDispatcher::new(Arc::downgrade(handler)));
@@ -1434,6 +1443,14 @@ impl AblyCompatRuntime {
                 });
             }
         }
+    }
+
+    #[cfg(feature = "push")]
+    fn realtime_push_worker_enabled(&self) -> bool {
+        self.hub.config.enabled
+            && self.hub.push_admission.as_deref().is_some_and(|admission| {
+                admission.provider_worker_active(PushProviderKind::Realtime)
+            })
     }
 
     /// Build the compatibility router with this runtime installed as an

--- a/crates/sockudo-ably-compat/src/runtime/tests.rs
+++ b/crates/sockudo-ably-compat/src/runtime/tests.rs
@@ -4848,6 +4848,67 @@ fn constructed_runtimes_do_not_share_compatibility_state() {
     assert!(!Arc::ptr_eq(&first_state, &second_state));
 }
 
+#[cfg(feature = "push")]
+struct TestPushAdmission {
+    realtime_worker_active: bool,
+}
+
+#[cfg(feature = "push")]
+impl AblyPushAdmissionGuard for TestPushAdmission {
+    fn rejection_for(
+        &self,
+        _targets: &[PublishTarget],
+        _required_providers: &BTreeSet<PushProviderKind>,
+        _expected_recipients: u64,
+    ) -> Option<String> {
+        None
+    }
+
+    fn provider_worker_active(&self, provider: PushProviderKind) -> bool {
+        self.realtime_worker_active && provider == PushProviderKind::Realtime
+    }
+}
+
+#[cfg(feature = "push")]
+#[test]
+fn realtime_push_worker_requires_enabled_compat_and_active_capability() {
+    let queue: DynPushQueue = Arc::new(sockudo_push::MemoryPushQueue::new());
+    let active_admission: Arc<dyn AblyPushAdmissionGuard> = Arc::new(TestPushAdmission {
+        realtime_worker_active: true,
+    });
+
+    let disabled = AblyCompatRuntime::new(AblyCompatDependencies {
+        push_queue: Some(queue.clone()),
+        push_admission: Some(active_admission.clone()),
+        ..Default::default()
+    });
+    assert!(!disabled.realtime_push_worker_enabled());
+
+    let enabled = AblyCompatRuntime::new(AblyCompatDependencies {
+        config: AblyCompatConfig {
+            enabled: true,
+            ..Default::default()
+        },
+        push_queue: Some(queue.clone()),
+        push_admission: Some(active_admission),
+        ..Default::default()
+    });
+    assert!(enabled.realtime_push_worker_enabled());
+
+    let inactive = AblyCompatRuntime::new(AblyCompatDependencies {
+        config: AblyCompatConfig {
+            enabled: true,
+            ..Default::default()
+        },
+        push_queue: Some(queue),
+        push_admission: Some(Arc::new(TestPushAdmission {
+            realtime_worker_active: false,
+        })),
+        ..Default::default()
+    });
+    assert!(!inactive.realtime_push_worker_enabled());
+}
+
 #[tokio::test]
 async fn expiry_sweep_removes_expired_sessions_and_tokens() {
     let hub = AblyCompatHub::default();

--- a/crates/sockudo-server/src/bootstrap/push/capability.rs
+++ b/crates/sockudo-server/src/bootstrap/push/capability.rs
@@ -155,6 +155,12 @@ impl PushAdmissionSnapshot {
             .collect()
     }
 
+    fn has_active_provider_worker(&self, provider: PushProviderKind) -> bool {
+        self.providers
+            .get(&provider)
+            .is_some_and(|capability| matches!(capability.status, PushProviderStatus::Active))
+    }
+
     pub(crate) fn backpressure_lag_threshold_secs(&self) -> u64 {
         self.backpressure_lag_threshold_secs
     }
@@ -293,6 +299,10 @@ impl sockudo_ably_compat::AblyPushAdmissionGuard for PushAdmissionSnapshot {
                     .find_map(|provider| self.provider_rejection(*provider))
             })
             .map(|rejection| rejection.message())
+    }
+
+    fn provider_worker_active(&self, provider: PushProviderKind) -> bool {
+        self.has_active_provider_worker(provider)
     }
 }
 
@@ -809,6 +819,35 @@ mod tests {
                 .rejection_for(&targets, &BTreeSet::from([PushProviderKind::Realtime]), 1,)
                 .is_none()
         );
+    }
+
+    #[cfg(feature = "ably-compat")]
+    #[tokio::test]
+    async fn realtime_worker_capability_requires_compat_and_monolith() {
+        use sockudo_ably_compat::AblyPushAdmissionGuard;
+
+        let mut config = ServerOptions::default();
+        let store: DynPushStore = Arc::new(MemoryPushStore::new());
+
+        let disabled = PushAdmissionSnapshot::from_config(&config, &store).await;
+        assert!(!AblyPushAdmissionGuard::provider_worker_active(
+            &disabled,
+            PushProviderKind::Realtime,
+        ));
+
+        config.ably_compat.enabled = true;
+        let enabled = PushAdmissionSnapshot::from_config(&config, &store).await;
+        assert_eq!(
+            AblyPushAdmissionGuard::provider_worker_active(&enabled, PushProviderKind::Realtime,),
+            cfg!(feature = "monolith")
+        );
+
+        config.push.dispatch_worker_count = 0;
+        let worker_disabled = PushAdmissionSnapshot::from_config(&config, &store).await;
+        assert!(!AblyPushAdmissionGuard::provider_worker_active(
+            &worker_disabled,
+            PushProviderKind::Realtime,
+        ));
     }
 
     #[test]

--- a/crates/sockudo-server/src/history/mysql/store_impl.rs
+++ b/crates/sockudo-server/src/history/mysql/store_impl.rs
@@ -1,4 +1,3 @@
-use super::state::*;
 use super::*;
 
 #[async_trait::async_trait]

--- a/crates/sockudo-server/src/history/scylla/store_impl.rs
+++ b/crates/sockudo-server/src/history/scylla/store_impl.rs
@@ -1,4 +1,3 @@
-use super::state::*;
 use super::*;
 
 #[async_trait::async_trait]

--- a/crates/sockudo-server/src/history/scylla/version_store/mod.rs
+++ b/crates/sockudo-server/src/history/scylla/version_store/mod.rs
@@ -1,6 +1,5 @@
 mod store_impl;
 
-use super::state::*;
 use super::*;
 
 // ── ScyllaDB VersionStore ─────────────────────────────────────────────────────

--- a/crates/sockudo-server/src/history/surreal/store_impl.rs
+++ b/crates/sockudo-server/src/history/surreal/store_impl.rs
@@ -1,4 +1,3 @@
-use super::state::*;
 use super::*;
 
 #[async_trait::async_trait]

--- a/crates/sockudo-server/src/history/surreal/version_store/mod.rs
+++ b/crates/sockudo-server/src/history/surreal/version_store/mod.rs
@@ -1,6 +1,5 @@
 mod store_impl;
 
-use super::state::*;
 use super::*;
 
 // =================== SurrealVersionStore ===================

--- a/docs/content/docs/server/ably-ai-transport-compatibility.mdx
+++ b/docs/content/docs/server/ably-ai-transport-compatibility.mdx
@@ -469,6 +469,10 @@ provider worker. External FCM, APNs, Web Push, HMS, and WNS outcomes are never
 synthesized: delivery requires the corresponding native provider feature,
 worker, and real credentials.
 
+The standard Sockudo Docker image includes `monolith`. Custom images that
+override the `SOCKUDO_FEATURES` build argument must include it when Ably push
+compatibility uses a broker-backed `push.queue_driver`.
+
 ## Additional compatibility surfaces
 
 | Surface | Status | Scope |


### PR DESCRIPTION
## Summary

- start the Ably realtime push worker only when compatibility is enabled and the local realtime provider capability is active
- keep non-`monolith` and zero-dispatch-worker nodes from consuming unsupported push queue stages
- compile the standard Docker image with `full,monolith`
- add regression coverage and document the Docker feature requirement
- clear Rust 1.98 Clippy diagnostics exposed by the all-feature CI jobs

## Verification

- `cargo test -p sockudo-ably-compat --features push`: 175 local tests passed; two existing Redis-backed tests were skipped because the expected Redis service was unavailable
- `cargo test -p sockudo --features ably-compat,monolith`: 148 tests passed
- `cargo test -p sockudo-ably-compat channel_name::tests`: 7 tests passed
- feature-boundary tests passed with and without `monolith`
- `cargo check -p sockudo --features full,monolith`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy -p sockudo --all-targets --no-default-features --features full -- -D warnings`
- docs type-check and production build

Closes #400