### PR TITLE
chore(release): prepare Sockudo 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
+## [5.0.1] - 2026-08-21
+
 ### Fixed
 
 - Started the Ably realtime push worker only when compatibility and its local provider capability
   are active, preventing repeated unsupported-stage warnings, and compiled the standard Docker
-  image with the in-process `monolith` push workers.
+  image with the in-process `monolith` push workers. Fixes #400.
 
 ## [5.0.0] - 2026-08-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7896,7 +7896,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -7958,7 +7958,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-ably-compat"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -7996,7 +7996,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-adapter"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "async-nats",
@@ -8047,7 +8047,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-ai-benches"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "async-trait",
  "criterion",
@@ -8060,7 +8060,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-ai-transport"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -8074,7 +8074,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-app"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -8101,7 +8101,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-cache"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -8114,7 +8114,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-core"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -8155,7 +8155,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-delta"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "async-nats",
@@ -8175,7 +8175,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-filter"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "criterion",
@@ -8191,7 +8191,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-metrics"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8208,7 +8208,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-protocol"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "criterion",
@@ -8223,7 +8223,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-push"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -8257,7 +8257,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-queue"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "async-nats",
@@ -8289,7 +8289,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-rate-limiter"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -8311,7 +8311,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-simulator"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "bytes",
  "clap",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "sockudo-webhook"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 resolver = "3"
 
 [workspace.package]
-version = "5.0.0"
+version = "5.0.1"
 edition = "2024"
 rust-version = "1.94"
 repository = "https://github.com/sockudo/sockudo"
@@ -33,20 +33,20 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal crates
-sockudo-protocol = { version = "5.0.0", path = "crates/sockudo-protocol" }
-sockudo-filter = { version = "5.0.0", path = "crates/sockudo-filter" }
-sockudo-core = { version = "5.0.0", path = "crates/sockudo-core" }
-sockudo-app = { version = "5.0.0", path = "crates/sockudo-app" }
-sockudo-cache = { version = "5.0.0", path = "crates/sockudo-cache" }
-sockudo-queue = { version = "5.0.0", path = "crates/sockudo-queue" }
-sockudo-rate-limiter = { version = "5.0.0", path = "crates/sockudo-rate-limiter" }
-sockudo-metrics = { version = "5.0.0", path = "crates/sockudo-metrics" }
-sockudo-webhook = { version = "5.0.0", path = "crates/sockudo-webhook" }
-sockudo-delta = { version = "5.0.0", path = "crates/sockudo-delta" }
-sockudo-push = { version = "5.0.0", path = "crates/sockudo-push" }
-sockudo-ai-transport = { version = "5.0.0", path = "crates/sockudo-ai-transport" }
-sockudo-ably-compat = { version = "5.0.0", path = "crates/sockudo-ably-compat", default-features = false }
-sockudo-adapter = { version = "5.0.0", path = "crates/sockudo-adapter", default-features = false }
+sockudo-protocol = { version = "5.0.1", path = "crates/sockudo-protocol" }
+sockudo-filter = { version = "5.0.1", path = "crates/sockudo-filter" }
+sockudo-core = { version = "5.0.1", path = "crates/sockudo-core" }
+sockudo-app = { version = "5.0.1", path = "crates/sockudo-app" }
+sockudo-cache = { version = "5.0.1", path = "crates/sockudo-cache" }
+sockudo-queue = { version = "5.0.1", path = "crates/sockudo-queue" }
+sockudo-rate-limiter = { version = "5.0.1", path = "crates/sockudo-rate-limiter" }
+sockudo-metrics = { version = "5.0.1", path = "crates/sockudo-metrics" }
+sockudo-webhook = { version = "5.0.1", path = "crates/sockudo-webhook" }
+sockudo-delta = { version = "5.0.1", path = "crates/sockudo-delta" }
+sockudo-push = { version = "5.0.1", path = "crates/sockudo-push" }
+sockudo-ai-transport = { version = "5.0.1", path = "crates/sockudo-ai-transport" }
+sockudo-ably-compat = { version = "5.0.1", path = "crates/sockudo-ably-compat", default-features = false }
+sockudo-adapter = { version = "5.0.1", path = "crates/sockudo-adapter", default-features = false }
 
 # External dependencies (shared versions)
 async-trait = "0.1.89"

--- a/docs/content/docs/deployment/docker.mdx
+++ b/docs/content/docs/deployment/docker.mdx
@@ -23,7 +23,7 @@ docker run -d \
   --env-file "$PWD/sockudo.env" \
   -p 6001:6001 \
   -p 127.0.0.1:9601:9601 \
-  ghcr.io/sockudo/sockudo:5.0.0 \
+  ghcr.io/sockudo/sockudo:5.0.1 \
   sockudo --config /app/config/production.toml
 ```
 
@@ -44,7 +44,7 @@ name: sockudo
 
 services:
   sockudo:
-    image: ghcr.io/sockudo/sockudo:5.0.0
+    image: ghcr.io/sockudo/sockudo:5.0.1
     command: ["sockudo", "--config", "/app/config/production.toml"]
     restart: unless-stopped
     init: true

--- a/docs/content/docs/deployment/kubernetes.mdx
+++ b/docs/content/docs/deployment/kubernetes.mdx
@@ -64,7 +64,7 @@ replicaCount: 3
 
 image:
   repository: ghcr.io/sockudo/sockudo
-  tag: "5.0.0"
+  tag: "5.0.1"
   pullPolicy: IfNotPresent
 
 config:

--- a/docs/content/docs/deployment/static-configuration.mdx
+++ b/docs/content/docs/deployment/static-configuration.mdx
@@ -261,7 +261,7 @@ Mount a read-only file into the published container and replace the default comm
 ```bash
 docker run --rm \
   --mount type=bind,src="$PWD/config.toml",dst=/app/config/production.toml,readonly \
-  ghcr.io/sockudo/sockudo:5.0.0 \
+  ghcr.io/sockudo/sockudo:5.0.1 \
   sockudo --config /app/config/production.toml
 ```
 

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -43,7 +43,7 @@ Pin the binary version in deployments:
 ```bash
 curl --proto '=https' --tlsv1.2 -sSfL \
   https://sockudo.io/install.sh \
-  | sh -s -- --version 5.0.0
+  | sh -s -- --version 5.0.1
 ```
 
 Choose another writable installation directory with `--bin-dir`:
@@ -75,7 +75,7 @@ cargo install sockudo --locked
 Pin a release or enable the same production-oriented features you would use from source:
 
 ```bash
-cargo install sockudo --version 5.0.0 --locked
+cargo install sockudo --version 5.0.1 --locked
 cargo install sockudo --locked --features "redis,postgres,push"
 ```
 
@@ -95,8 +95,8 @@ docker pull sockudo/sockudo:latest
 Use versioned tags for production rollouts:
 
 ```bash
-docker pull ghcr.io/sockudo/sockudo:5.0.0
-docker pull sockudo/sockudo:5.0.0
+docker pull ghcr.io/sockudo/sockudo:5.0.1
+docker pull sockudo/sockudo:5.0.1
 ```
 
 Start a local container with an in-memory app and Prometheus metrics exposed:

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ Usage:
   install.sh [--version <version>] [--bin-dir <directory>]
 
 Options:
-  --version <version>    Install a specific release (for example, 5.0.0).
+  --version <version>    Install a specific release (for example, 5.0.1).
   --bin-dir <directory>  Install into this directory.
   -h, --help             Show this help.
 


### PR DESCRIPTION
## Summary

- bump the server workspace and internal crate requirements to 5.0.1
- publish the urgent Docker fix from #401 for issue #400
- update current installation and deployment examples to 5.0.1

## Verification

- cargo fmt --all -- --check
- focused Ably push-worker regression test with push enabled
- package file-list preflight for all publishable workspace crates
- docs type check
- merged fix CI: full Rust test/clippy/feature matrix and AI Docker feature builds passed

After merge, the annotated v5.0.1 tag will run the official release workflow for crates.io, Linux binaries, GHCR, Docker Hub, Helm, and the GitHub release.