### PR TITLE
fix(push): allow memory push drivers in production when no provider is enabled

### DIFF
--- a/crates/sockudo-server/src/bootstrap/push/mod.rs
+++ b/crates/sockudo-server/src/bootstrap/push/mod.rs
@@ -19,8 +19,20 @@ use std::sync::Arc;
 use tracing::warn;
 
 #[cfg(feature = "push")]
+fn any_push_provider_enabled(config: &ServerOptions) -> bool {
+    config.push.fcm_enabled
+        || config.push.apns_enabled
+        || config.push.webpush_enabled
+        || config.push.hms_enabled
+        || config.push.wns_enabled
+}
+
+#[cfg(feature = "push")]
 fn production_memory_drivers_allowed(config: &ServerOptions) -> bool {
-    !config.mode.eq_ignore_ascii_case("production") || config.push.allow_memory_drivers
+    // Node-local memory push drivers are only unsafe when push is actually in use
+    !config.mode.eq_ignore_ascii_case("production")
+        || config.push.allow_memory_drivers
+        || !any_push_provider_enabled(config)
 }
 
 #[cfg(feature = "push")]
@@ -106,6 +118,8 @@ mod tests {
         };
         config.push.storage_driver = PushStorageDriver::Memory;
         config.push.allow_memory_drivers = false;
+        // A provider must be enabled for the memory-driver check to apply.
+        config.push.fcm_enabled = true;
 
         let error = match create_push_store(&config).await {
             Ok(_) => panic!("memory push store should be rejected in production"),
@@ -116,6 +130,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn production_memory_push_store_allowed_when_no_provider_enabled() {
+        let mut config = ServerOptions {
+            mode: "production".to_owned(),
+            ..Default::default()
+        };
+        config.push.storage_driver = PushStorageDriver::Memory;
+        config.push.allow_memory_drivers = false;
+        // No push provider enabled: push is effectively unused, so memory drivers are fine.
+
+        create_push_store(&config)
+            .await
+            .expect("memory push store should be allowed when no provider is enabled");
+    }
+
+    #[tokio::test]
     async fn production_memory_push_queue_requires_explicit_allow() {
         let mut config = ServerOptions {
             mode: "production".to_owned(),
@@ -123,6 +152,8 @@ mod tests {
         };
         config.push.queue_driver = PushQueueDriver::Memory;
         config.push.allow_memory_drivers = false;
+        // A provider must be enabled for the memory-driver check to apply.
+        config.push.fcm_enabled = true;
 
         let store: sockudo_push::DynPushStore = Arc::new(sockudo_push::MemoryPushStore::new());
         let admission = PushAdmissionSnapshot::from_config(&config, &store).await;

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -406,7 +406,9 @@ include_remaining_fields = true
 external key refs default to unset and are omitted from the checked block.
 
 `storage_driver = "memory"` and `queue_driver = "memory"` are node-local development drivers. In
-`mode = "production"`, Sockudo rejects them unless `allow_memory_drivers = true` is set explicitly.
+`mode = "production"`, when a push provider is enabled, Sockudo rejects them unless
+`allow_memory_drivers = true` is set explicitly. When no push provider is enabled, push is unused
+and memory drivers are accepted without the flag.
 Push publish admission also requires a healthy queue, a safe store, local pipeline workers, and
 local provider-worker capability. Raw provider-specific recipients require the matching provider
 worker before the request is accepted; shard-path publishes also require a local shard worker.

--- a/docs/content/docs/server/push-notifications.mdx
+++ b/docs/content/docs/server/push-notifications.mdx
@@ -58,9 +58,11 @@ provider worker without scanning large channel subscription sets during admissio
 publishes also require a local shard worker. The planner still resolves exact devices
 asynchronously.
 
-In `mode = "production"`, `storage_driver = "memory"` and `queue_driver = "memory"` are rejected
-unless `allow_memory_drivers = true` or `PUSH_ALLOW_MEMORY_DRIVERS=true` is set explicitly. Memory
-drivers are node-local and lose state on restart or dead-node loss.
+In `mode = "production"` with a push provider enabled, `storage_driver = "memory"` and
+`queue_driver = "memory"` are rejected unless `allow_memory_drivers = true` or
+`PUSH_ALLOW_MEMORY_DRIVERS=true` is set explicitly. When no push provider is enabled, push is unused
+and memory drivers are accepted without the flag. Memory drivers are node-local and lose state on
+restart or dead-node loss.
 
 Readiness failures return `503`. Queue pressure returns `429` with `Retry-After`. Quota rejection
 persists a terminal `quota_exceeded` publish status and idempotency record without appending publish


### PR DESCRIPTION
Production startup v5 validation rejects node-local memory push storage/queue drivers
unless `push.allow_memory_drivers=true`, even when **no push provider is enabled**.
Clustered/production deployments that don't use push are forced to stand up a
Redis/durable driver (or set the flag) just to boot.

This gates the durable-driver requirement on a push provider actually being enabled
(FCM/APNs/WebPush/HMS/WNS). When none is enabled, the push pipeline never persists,
queues, or delivers anything, so node-local memory drivers are harmless and startup
validation passes. Behavior is unchanged when a provider is enabled or when
`allow_memory_drivers` is already set. Docs updated to match.

### Repro (before this PR)
`mode=production` + memory push storage/queue + no provider enabled fails startup with:
`push storage driver memory is unsafe in production; set push.allow_memory_drivers=true ...`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Unit tests pass — `cargo test -p sockudo --features push production_memory_push` (3 passed)
- [ ] Integration tests pass — n/a (logic covered by unit tests)
- [ ] Manual testing completed — n/a

`cargo fmt --all -- --check` clean; `cargo clippy -p sockudo --features push --tests` produces no
new warnings. Added `production_memory_push_store_allowed_when_no_provider_enabled`; the existing
rejection tests now enable a provider so the check still applies.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published — n/a

## Protocol Change Checklist
- [x] N/A - no protocol-visible changes