### PR TITLE
fix(release): restore installs, Docker startup, and Ably annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      - name: Check published metrics build without Tokio unstable APIs
+        run: cargo check -p sockudo-metrics --config 'build.rustflags=[]'
+
       - name: Check Linux installer
         run: |
           sh -n install.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -280,7 +280,6 @@ jobs:
             -e DATABASE_REDIS_HOST=localhost \
             -e DATABASE_REDIS_PORT=6379 \
             -e SOCKUDO_DEFAULT_APP_ENABLED=true \
-            -e PUSH_ALLOW_MEMORY_DRIVERS=true \
             sockudo:test
           
           # Wait for startup

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,7 @@
   "debug": false,
   "host": "0.0.0.0",
   "port": 6001,
-  "mode": "production",
+  "mode": "development",
   "path_prefix": "/",
   "shutdown_grace_period": 2,
   "websocket_max_payload_kb": 64,

--- a/crates/sockudo-ably-compat/src/codec.rs
+++ b/crates/sockudo-ably-compat/src/codec.rs
@@ -184,7 +184,7 @@ pub(crate) fn encode_protocol_bytes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{ACTION_MESSAGE, AblyMessage, empty_protocol_message};
+    use crate::protocol::{ACTION_ANNOTATION, ACTION_MESSAGE, AblyMessage, empty_protocol_message};
     use proptest::prelude::*;
     use sonic_rs::JsonValueTrait;
 
@@ -295,6 +295,76 @@ mod tests {
             message.encoding.as_deref(),
             Some("cipher+aes-256-cbc/base64")
         );
+    }
+
+    #[test]
+    fn msgpack_annotation_binary_data_is_normalized_with_base64_encoding() {
+        #[derive(Serialize)]
+        struct Frame<'a> {
+            action: u8,
+            annotations: Vec<Annotation<'a>>,
+        }
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Annotation<'a> {
+            action: u8,
+            message_serial: &'a str,
+            #[serde(rename = "type")]
+            annotation_type: &'a str,
+            data: &'a [u8],
+            encoding: &'a str,
+        }
+        let frame = Frame {
+            action: ACTION_ANNOTATION,
+            annotations: vec![Annotation {
+                action: 0,
+                message_serial: "msg:1",
+                annotation_type: "reaction:unique.v1",
+                data: &[0xde, 0xad, 0xbe, 0xef],
+                encoding: "cipher+aes-256-cbc",
+            }],
+        };
+        let mut bytes = Vec::new();
+        let mut serializer = rmp_serde::Serializer::new(&mut bytes)
+            .with_struct_map()
+            .with_bytes(rmp_serde::config::BytesMode::ForceAll);
+        frame.serialize(&mut serializer).unwrap();
+
+        let decoded = decode_protocol_bytes(&bytes, AblyFormat::MsgPack).unwrap();
+        let annotation = &decoded.annotations.unwrap()[0];
+        assert_eq!(
+            annotation.data.as_ref().and_then(sonic_rs::Value::as_str),
+            Some("3q2+7w==")
+        );
+        assert_eq!(
+            annotation.encoding.as_deref(),
+            Some("cipher+aes-256-cbc/base64")
+        );
+    }
+
+    #[test]
+    fn json_annotation_structured_data_preserves_value_and_encoding() {
+        let frame = br#"{
+            "action": 21,
+            "annotations": [{
+                "action": 0,
+                "messageSerial": "msg:1",
+                "type": "metadata:distinct.v1",
+                "data": {"encrypted": false, "source": "json"},
+                "encoding": "json"
+            }]
+        }"#;
+
+        let decoded = decode_protocol_bytes(frame, AblyFormat::Json).unwrap();
+        let annotation = &decoded.annotations.unwrap()[0];
+        assert_eq!(
+            annotation.data,
+            Some(sonic_rs::json!({
+                "encrypted": false,
+                "source": "json"
+            }))
+        );
+        assert_eq!(annotation.encoding.as_deref(), Some("json"));
     }
 
     #[test]

--- a/crates/sockudo-ably-compat/src/protocol.rs
+++ b/crates/sockudo-ably-compat/src/protocol.rs
@@ -225,7 +225,7 @@ pub(crate) struct AblyProtocolMessage {
     pub(crate) res: Option<Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[derive(Debug, Serialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AblyAnnotation {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -250,6 +250,46 @@ pub(crate) struct AblyAnnotation {
     pub(crate) encoding: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) timestamp: Option<i64>,
+}
+
+impl<'de> Deserialize<'de> for AblyAnnotation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize, Default)]
+        #[serde(rename_all = "camelCase")]
+        struct Raw {
+            action: Option<u8>,
+            id: Option<String>,
+            serial: Option<String>,
+            message_serial: Option<String>,
+            #[serde(rename = "type")]
+            annotation_type: Option<String>,
+            name: Option<String>,
+            client_id: Option<String>,
+            count: Option<u64>,
+            data: Option<WireValue>,
+            encoding: Option<String>,
+            timestamp: Option<i64>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let (data, encoding) = normalize_wire_data::<D::Error>(raw.data, raw.encoding)?;
+        Ok(Self {
+            action: raw.action,
+            id: raw.id,
+            serial: raw.serial,
+            message_serial: raw.message_serial,
+            annotation_type: raw.annotation_type,
+            name: raw.name,
+            client_id: raw.client_id,
+            count: raw.count,
+            data,
+            encoding,
+            timestamp: raw.timestamp,
+        })
+    }
 }
 
 #[derive(Debug, Serialize, Clone, Default)]
@@ -336,24 +376,7 @@ impl<'de> Deserialize<'de> for AblyMessage {
         D: Deserializer<'de>,
     {
         let raw = RawAblyMessage::deserialize(deserializer)?;
-        let (data, binary) = match raw.data {
-            Some(WireValue::Binary(bytes)) => (
-                Some(sonic_rs::json!(
-                    base64::engine::general_purpose::STANDARD.encode(bytes)
-                )),
-                true,
-            ),
-            Some(value) => (
-                Some(sonic_rs::to_value(&value).map_err(serde::de::Error::custom)?),
-                false,
-            ),
-            None => (None, false),
-        };
-        let encoding = if binary {
-            Some(append_encoding(raw.encoding.as_deref(), "base64"))
-        } else {
-            raw.encoding
-        };
+        let (data, encoding) = normalize_wire_data::<D::Error>(raw.data, raw.encoding)?;
         let mut version = raw.version;
         if let Some(version) = version.as_mut()
             && version.serial.is_empty()
@@ -399,6 +422,28 @@ fn append_encoding(existing: Option<&str>, component: &str) -> String {
         }
         Some(existing) => format!("{existing}/{component}"),
         None => component.to_string(),
+    }
+}
+
+fn normalize_wire_data<E>(
+    data: Option<WireValue>,
+    encoding: Option<String>,
+) -> Result<(Option<Value>, Option<String>), E>
+where
+    E: serde::de::Error,
+{
+    match data {
+        Some(WireValue::Binary(bytes)) => Ok((
+            Some(sonic_rs::json!(
+                base64::engine::general_purpose::STANDARD.encode(bytes)
+            )),
+            Some(append_encoding(encoding.as_deref(), "base64")),
+        )),
+        Some(value) => Ok((
+            Some(sonic_rs::to_value(&value).map_err(E::custom)?),
+            encoding,
+        )),
+        None => Ok((None, encoding)),
     }
 }
 
@@ -463,19 +508,7 @@ impl<'de> Deserialize<'de> for AblyPresenceMessage {
             extras: Option<WireValue>,
         }
         let raw = Raw::deserialize(deserializer)?;
-        let (data, encoding) = match raw.data {
-            Some(WireValue::Binary(bytes)) => (
-                Some(sonic_rs::json!(
-                    base64::engine::general_purpose::STANDARD.encode(bytes)
-                )),
-                Some(append_encoding(raw.encoding.as_deref(), "base64")),
-            ),
-            Some(value) => (
-                Some(sonic_rs::to_value(&value).map_err(serde::de::Error::custom)?),
-                raw.encoding,
-            ),
-            None => (None, raw.encoding),
-        };
+        let (data, encoding) = normalize_wire_data::<D::Error>(raw.data, raw.encoding)?;
         Ok(Self {
             id: raw.id,
             action: raw.action,

--- a/crates/sockudo-metrics/Cargo.toml
+++ b/crates/sockudo-metrics/Cargo.toml
@@ -22,3 +22,6 @@ tracing = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 libc = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/crates/sockudo-metrics/src/prometheus/driver.rs
+++ b/crates/sockudo-metrics/src/prometheus/driver.rs
@@ -1275,23 +1275,33 @@ impl PrometheusMetricsDriver {
 
         let num_workers = metrics.num_workers();
 
-        self.tokio_budget_forced_yield_count
-            .set(metrics.budget_forced_yield_count() as f64);
-        let mut total_polls: u64 = 0;
-        let mut total_poll_duration_ns: u64 = 0;
+        // These metrics require Tokio's unstable metrics API. Published crates must also compile
+        // without the repository-local `--cfg tokio_unstable` rustflag used by release builds.
+        #[cfg(tokio_unstable)]
+        {
+            self.tokio_budget_forced_yield_count
+                .set(metrics.budget_forced_yield_count() as f64);
+            let mut total_polls: u64 = 0;
+            let mut total_poll_duration_ns: u64 = 0;
 
-        for worker in 0..num_workers {
-            let worker_label = worker.to_string();
+            for worker in 0..num_workers {
+                let worker_label = worker.to_string();
+                let queue_depth = metrics.worker_local_queue_depth(worker);
 
-            let queue_depth = metrics.worker_local_queue_depth(worker);
+                self.tokio_worker_local_queue_depth
+                    .with_label_values(&[&worker_label])
+                    .set(queue_depth as f64);
 
-            self.tokio_worker_local_queue_depth
-                .with_label_values(&[&worker_label])
-                .set(queue_depth as f64);
+                let polls = metrics.worker_poll_count(worker);
+                total_polls += polls;
+                total_poll_duration_ns +=
+                    metrics.worker_total_busy_duration(worker).as_nanos() as u64;
+            }
 
-            let polls = metrics.worker_poll_count(worker);
-            total_polls += polls;
-            total_poll_duration_ns += metrics.worker_total_busy_duration(worker).as_nanos() as u64;
+            if total_polls > 0 {
+                let mean_poll_us = total_poll_duration_ns as f64 / total_polls as f64 / 1000.0;
+                self.tokio_worker_mean_poll_duration_us.set(mean_poll_us);
+            }
         }
 
         // Approximate busy ratio: busy_duration / process_uptime
@@ -1309,11 +1319,6 @@ impl PrometheusMetricsDriver {
                         .set(ratio.min(1.0));
                 }
             }
-        }
-
-        if total_polls > 0 {
-            let mean_poll_us = total_poll_duration_ns as f64 / total_polls as f64 / 1000.0;
-            self.tokio_worker_mean_poll_duration_us.set(mean_poll_us);
         }
     }
 

--- a/docs/content/docs/deployment/docker.mdx
+++ b/docs/content/docs/deployment/docker.mdx
@@ -5,8 +5,10 @@ icon: Container
 ---
 
 The published Sockudo image runs as a non-root user and starts the binary with
-`--config /app/config/config.json`. For production, pin a release tag, mount or generate the exact
-configuration, inject secrets separately, and set limits on the container itself.
+`--config /app/config/config.json`. The bundled file is a development example so a bare
+`docker run` can start safely with node-local drivers. For production, pin a release tag, mount or
+generate the exact configuration, inject secrets separately, and set limits on the container
+itself.
 
 ## Production-like docker run
 


### PR DESCRIPTION
## Summary

- gate Tokio unstable runtime metrics behind `cfg(tokio_unstable)` so crates.io installs compile without the repository-local Rust flag
- register the custom cfg with rustc and add a CI build that explicitly removes repository rustflags
- make the bundled JSON configuration an explicit development example so the default Docker image can start with node-local drivers
- remove the Docker smoke test `PUSH_ALLOW_MEMORY_DRIVERS` bypass so it exercises the shipped defaults
- decode binary Ably annotation payloads through the same base64 normalization used by messages and presence payloads
- add MessagePack binary and JSON structured annotation regression tests
- document the development-only bundled container configuration

## Root causes

`cargo install sockudo --version 5.0.1` builds published crates outside this repository, so `.cargo/config.toml` does not provide `--cfg tokio_unstable`. Three metrics calls therefore failed to compile.

The image launches `/app/config/config.json`, which declared production mode while retaining node-local push defaults. Startup correctly failed closed. This change fixes the bundled example instead of weakening the production durability guard: push registration, subscription, credential, template, and status APIs can persist state even when provider flags are disabled.

Encrypted Ably annotations arrive in MessagePack as binary data. `AblyAnnotation` previously deserialized its data directly as a JSON value, causing the Ably JS main WebSocket suite to reject the frame. Binary annotation data is now base64-normalized and receives a `/base64` encoding component, matching existing message and presence handling.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p sockudo-metrics --config "build.rustflags=[]"`
- `cargo check -p sockudo-metrics`
- `cargo test -p sockudo-metrics --config "build.rustflags=[]"`
- `cargo clippy -p sockudo-metrics --all-targets --config "build.rustflags=[]" -- -D warnings`
- `cargo clippy -p sockudo-metrics --all-targets -- -D warnings`
- `cargo package -p sockudo-metrics --allow-dirty --config "build.rustflags=[]"`
- `cargo test -p sockudo --features push production_memory_push`
- `cargo test -p sockudo-ably-compat --all-features` (192 passed)
- `cargo clippy -p sockudo-ably-compat --all-targets --all-features -- -D warnings`
- `cargo build --locked -p sockudo --features v2,ai-transport,ably-compat,redis,postgres,push,monolith`
- released `sockudo/sockudo:5.0.1` image with the corrected JSON reached `/up/app-id` without `PUSH_ALLOW_MEMORY_DRIVERS=true`
- `cd docs && npm run types:check && npm run build`
- `git diff --check`

The already-published 5.0.1 crates and images remain immutable; the release fixes need a subsequent patch release.