### PR TITLE
feat(charts): support config from a Secret, strategy, and raw HPA metrics

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fixture: [default, ingress, dashboard, ha]
+        fixture: [default, ingress, dashboard, ha, external-config]
         kubernetes-version: ["1.29.0", "1.33.0"]
 
     steps:

--- a/charts/sockudo/README.md
+++ b/charts/sockudo/README.md
@@ -37,6 +37,101 @@ there is no separate chart version to cross-reference.
 One consequence worth knowing: consecutive chart versions may be identical charts. `4.7.1`
 following `4.7.0` means a new application release, not necessarily a chart change.
 
+## Configuration file
+
+By default the chart generates a ConfigMap from the `config.*` values and mounts it at
+`/app/config/config.json`. That is fine as long as the configuration holds no secrets.
+
+It cannot hold secrets, though, for any deployment that needs per-app webhooks: those are
+expressible only in the config file, not through environment variables, so the app secret
+has to sit next to them - and a ConfigMap means plaintext in the values file, and in
+practice in the repository holding it.
+
+Point `config.existingSecret` at a Secret to supply the whole file instead:
+
+```yaml
+config:
+  existingSecret: sockudo-config
+  existingSecretKey: config.json
+```
+
+The ConfigMap is then not rendered at all, and the `config` volume is backed by the Secret.
+`config.existingSecret` and `configJson` are mutually exclusive; setting both fails the
+render.
+
+Two things to know:
+
+- The mount path is `/app/config/config.json` and Sockudo picks its parser from the file
+  extension, so the Secret's content must be JSON even though the annotated reference
+  configuration is TOML.
+- Because Helm never sees the Secret's content, the `checksum/config` pod annotation is not
+  emitted in this mode. Rotating the Secret does not restart the pods; use a reloader
+  controller or restart the Deployment yourself.
+
+The Secret is usually managed outside the chart. With External Secrets Operator:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sockudo-config
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: my-secret-store
+  target:
+    name: sockudo-config
+    template:
+      engineVersion: v2
+      data:
+        config.json: "{{ .sockudoConfig }}"
+  data:
+    - secretKey: sockudoConfig
+      remoteRef:
+        key: SOCKUDO_CONFIG_FILE
+```
+
+## Rollouts and autoscaling
+
+`strategy` is passed straight through to the Deployment. Left unset, Kubernetes applies its
+default of `maxUnavailable: 25%` / `maxSurge: 25%`, which drops a quarter of the connection
+capacity mid-rollout - precisely while the clients from those pods are all reconnecting:
+
+```yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 25%
+```
+
+`autoscaling.metrics` is passed straight through to the HorizontalPodAutoscaler and accepts
+any `autoscaling/v2` metric type. CPU utilisation tracks message throughput rather than
+connection headroom - a pod can sit near its connection ceiling at low CPU - so the metric
+that reflects capacity is `sockudo_connected`:
+
+```yaml
+autoscaling:
+  enabled: true
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: sockudo_connected
+        target:
+          type: AverageValue
+          averageValue: "4000"
+```
+
+Setting `autoscaling.metrics` **replaces** the CPU and memory metrics generated from
+`targetCPUUtilizationPercentage` and `targetMemoryUtilizationPercentage` rather than adding
+to them: an HPA scales on the highest recommendation from any metric, so leaving CPU in
+place would keep overriding a connection-count metric.
+
+`dashboard.api.strategy`, `dashboard.web.strategy`,
+`dashboard.autoscaling.api.metrics` and `dashboard.autoscaling.web.metrics` behave the same
+way for the dashboard deployments.
+
 ## Dashboard
 
 The dashboard is disabled by default:

--- a/charts/sockudo/ci/dashboard-values.yaml
+++ b/charts/sockudo/ci/dashboard-values.yaml
@@ -6,6 +6,18 @@ config:
   appManagerDriver: mysql
 dashboard:
   enabled: true
+  api:
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
+  web:
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 1
+        maxSurge: 1
   sessionSecret:
     value: ci-render-only-not-a-real-secret
   persistence:
@@ -22,6 +34,15 @@ dashboard:
   autoscaling:
     api:
       enabled: true
+      # Set on api only, so web keeps covering the generated CPU/memory Resource path.
+      metrics:
+        - type: Pods
+          pods:
+            metric:
+              name: dashboard_active_sessions
+            target:
+              type: AverageValue
+              averageValue: "50"
     web:
       enabled: true
   pdb:

--- a/charts/sockudo/ci/external-config-values.yaml
+++ b/charts/sockudo/ci/external-config-values.yaml
@@ -1,0 +1,25 @@
+# Exercises the three configurable surfaces no other fixture sets: the config file coming
+# from a Secret (so configmap.yaml is not rendered, the config volume is Secret-backed, and
+# the pod annotations block disappears entirely), an explicit rollout strategy, and a raw HPA
+# metric of a type the generated Resource blocks cannot express. ha-values.yaml still covers
+# the generated CPU/memory path.
+config:
+  existingSecret: sockudo-config
+  existingSecretKey: config.json
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 25%
+
+autoscaling:
+  enabled: true
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: sockudo_connected
+        target:
+          type: AverageValue
+          averageValue: "4000"

--- a/charts/sockudo/templates/configmap.yaml
+++ b/charts/sockudo/templates/configmap.yaml
@@ -1,3 +1,7 @@
+{{- if and .Values.config.existingSecret .Values.configJson }}
+{{- fail "config.existingSecret and configJson are mutually exclusive: the config file is supplied by the Secret, so remove configJson" -}}
+{{- end }}
+{{- if not .Values.config.existingSecret -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -70,3 +74,4 @@ data:
       }
     }
   {{- end }}
+{{- end }}

--- a/charts/sockudo/templates/dashboard-api-deployment.yaml
+++ b/charts/sockudo/templates/dashboard-api-deployment.yaml
@@ -12,6 +12,10 @@ spec:
   {{- if not .Values.dashboard.autoscaling.api.enabled }}
   replicas: {{ .Values.dashboard.api.replicaCount }}
   {{- end }}
+  {{- with .Values.dashboard.api.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "sockudo.dashboardSelectorLabels" (dict "root" . "component" "dashboard-api") | nindent 6 }}

--- a/charts/sockudo/templates/dashboard-hpa.yaml
+++ b/charts/sockudo/templates/dashboard-hpa.yaml
@@ -13,6 +13,9 @@ spec:
   minReplicas: {{ .Values.dashboard.autoscaling.api.minReplicas }}
   maxReplicas: {{ .Values.dashboard.autoscaling.api.maxReplicas }}
   metrics:
+    {{- if .Values.dashboard.autoscaling.api.metrics }}
+    {{- toYaml .Values.dashboard.autoscaling.api.metrics | nindent 4 }}
+    {{- else }}
     {{- if .Values.dashboard.autoscaling.api.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
@@ -28,6 +31,7 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.dashboard.autoscaling.api.targetMemoryUtilizationPercentage }}
+    {{- end }}
     {{- end }}
   {{- with .Values.dashboard.autoscaling.api.behavior }}
   behavior:
@@ -50,6 +54,9 @@ spec:
   minReplicas: {{ .Values.dashboard.autoscaling.web.minReplicas }}
   maxReplicas: {{ .Values.dashboard.autoscaling.web.maxReplicas }}
   metrics:
+    {{- if .Values.dashboard.autoscaling.web.metrics }}
+    {{- toYaml .Values.dashboard.autoscaling.web.metrics | nindent 4 }}
+    {{- else }}
     {{- if .Values.dashboard.autoscaling.web.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
@@ -65,6 +72,7 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.dashboard.autoscaling.web.targetMemoryUtilizationPercentage }}
+    {{- end }}
     {{- end }}
   {{- with .Values.dashboard.autoscaling.web.behavior }}
   behavior:

--- a/charts/sockudo/templates/dashboard-web-deployment.yaml
+++ b/charts/sockudo/templates/dashboard-web-deployment.yaml
@@ -9,6 +9,10 @@ spec:
   {{- if not .Values.dashboard.autoscaling.web.enabled }}
   replicas: {{ .Values.dashboard.web.replicaCount }}
   {{- end }}
+  {{- with .Values.dashboard.web.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "sockudo.dashboardSelectorLabels" (dict "root" . "component" "dashboard-web") | nindent 6 }}

--- a/charts/sockudo/templates/deployment.yaml
+++ b/charts/sockudo/templates/deployment.yaml
@@ -8,16 +8,24 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "sockudo.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- if or (not .Values.config.existingSecret) .Values.podAnnotations }}
       annotations:
+        {{- if not .Values.config.existingSecret }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
       labels:
         {{- include "sockudo.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
@@ -347,8 +355,16 @@ spec:
         {{- end }}
       volumes:
         - name: config
+          {{- if .Values.config.existingSecret }}
+          secret:
+            secretName: {{ .Values.config.existingSecret }}
+            items:
+              - key: {{ .Values.config.existingSecretKey }}
+                path: config.json
+          {{- else }}
           configMap:
             name: {{ include "sockudo.configMapName" . }}
+          {{- end }}
         - name: tmp
           emptyDir: {}
         - name: logs

--- a/charts/sockudo/templates/hpa.yaml
+++ b/charts/sockudo/templates/hpa.yaml
@@ -13,6 +13,9 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
+    {{- if .Values.autoscaling.metrics }}
+    {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+    {{- else }}
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
@@ -28,6 +31,7 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
     {{- end }}
   {{- with .Values.autoscaling.behavior }}
   behavior:

--- a/charts/sockudo/values.yaml
+++ b/charts/sockudo/values.yaml
@@ -1,5 +1,16 @@
 replicaCount: 1
 
+# -- Deployment update strategy. Left unset, Kubernetes applies its default of
+# maxUnavailable: 25% / maxSurge: 25%. For a WebSocket server, maxUnavailable: 0
+# keeps connection capacity from dipping during a rollout, so the clients being
+# disconnected always have somewhere to reconnect to.
+# strategy:
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 0
+#     maxSurge: 25%
+strategy: {}
+
 image:
   repository: sockudo/sockudo
   pullPolicy: IfNotPresent
@@ -36,6 +47,19 @@ securityContext:
 
 # -- Sockudo server configuration
 config:
+  # -- Supply the whole config file from an existing Secret instead of the chart's
+  # generated ConfigMap. Required for any config containing secrets, since per-app
+  # webhooks cannot be expressed through environment variables and therefore need a
+  # config file. When set, the ConfigMap is not rendered and every other config.*
+  # value below that is only written to the ConfigMap is ignored - the config.* keys
+  # the chart also emits as environment variables still apply and still override the
+  # file. Mutually exclusive with configJson.
+  existingSecret: ""
+  # -- Key inside config.existingSecret holding the complete config file. Mounted at
+  # /app/config/config.json, so the content must be JSON: Sockudo selects its parser
+  # by file extension.
+  existingSecretKey: config.json
+
   # -- Server mode: "production" or "development"
   mode: production
   # -- Enable debug logging
@@ -263,6 +287,8 @@ dashboard:
 
   api:
     replicaCount: 1
+    # -- Deployment update strategy. See the top-level strategy value.
+    strategy: {}
     image:
       repository: sockudo/dashboard-api
       pullPolicy: IfNotPresent
@@ -334,6 +360,8 @@ dashboard:
 
   web:
     replicaCount: 1
+    # -- Deployment update strategy. See the top-level strategy value.
+    strategy: {}
     image:
       repository: sockudo/dashboard-web
       pullPolicy: IfNotPresent
@@ -406,6 +434,9 @@ dashboard:
       maxReplicas: 5
       targetCPUUtilizationPercentage: 70
       targetMemoryUtilizationPercentage: 80
+      # -- Raw HPA metrics, replacing the generated Resource metrics. See the
+      # top-level autoscaling.metrics value.
+      metrics: []
       behavior: {}
     web:
       enabled: false
@@ -413,6 +444,9 @@ dashboard:
       maxReplicas: 5
       targetCPUUtilizationPercentage: 70
       targetMemoryUtilizationPercentage: 80
+      # -- Raw HPA metrics, replacing the generated Resource metrics. See the
+      # top-level autoscaling.metrics value.
+      metrics: []
       behavior: {}
 
   pdb:
@@ -472,6 +506,23 @@ autoscaling:
   maxReplicas: 10
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 80
+  # -- Raw HorizontalPodAutoscaler metrics. When set, this REPLACES the CPU and memory
+  # Resource metrics generated from the two target*UtilizationPercentage values above,
+  # rather than adding to them: an HPA scales on the highest recommendation from any
+  # metric, so leaving CPU in place would override a connection-count metric. Accepts
+  # any autoscaling/v2 metric type - Pods, Object, External - which the generated
+  # Resource blocks cannot express. For a WebSocket server, CPU tracks message
+  # throughput rather than connection headroom, and sockudo_connected is the signal
+  # that actually reflects capacity.
+  # metrics:
+  #   - type: External
+  #     external:
+  #       metric:
+  #         name: sockudo_connected
+  #       target:
+  #         type: AverageValue
+  #         averageValue: "4000"
+  metrics: []
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 300

--- a/docs/content/docs/deployment/kubernetes.mdx
+++ b/docs/content/docs/deployment/kubernetes.mdx
@@ -54,6 +54,64 @@ spec:
 Note `repoURL` carries no `oci://` prefix: for a Helm chart source, ArgoCD takes the bare
 registry path and infers the OCI protocol from `chart` being set.
 
+## Configuration from a Secret
+
+By default the chart renders the `config.*` values into a ConfigMap and mounts it at
+`/app/config/config.json`. Under GitOps that ConfigMap is generated from values held in a
+repository, so it can only carry configuration that is safe to commit.
+
+Per-app webhooks are the case where it is not. Webhooks are expressible only in the config file,
+never through environment variables, so an app that has them must carry its secret in the same
+file. `defaultApp.existingSecret` does not help: it configures the environment-defined default
+app, which has no webhook support.
+
+Point `config.existingSecret` at a Secret to supply the whole file instead:
+
+```yaml
+config:
+  existingSecret: sockudo-config
+  existingSecretKey: config.json
+```
+
+The ConfigMap is then not rendered, and the `config` volume is backed by the Secret. Combining
+`config.existingSecret` with `configJson` fails the render rather than silently ignoring one of
+them.
+
+The content must be JSON: it is mounted as `config.json` and Sockudo selects its parser from the
+file extension, even though the annotated reference configuration is TOML.
+
+Helm never sees the Secret's content, so the `checksum/config` pod annotation is not emitted in
+this mode. Rotating the Secret updates the mounted file but does not restart the pods, and Sockudo
+reads its configuration only at startup - use a reloader controller or restart the Deployment.
+
+This is the shape that pairs with a secret operator. With External Secrets Operator, an
+`ExternalSecret` pulls the config file out of the backing store and the chart mounts the Secret it
+produces:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sockudo-config
+  namespace: sockudo
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: my-secret-store
+  target:
+    name: sockudo-config
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        config.json: "{{ .sockudoConfig }}"
+  data:
+    - secretKey: sockudoConfig
+      remoteRef:
+        key: SOCKUDO_CONFIG_FILE
+```
+
 ## Production values example
 
 The following is a regional three-pod baseline with one immutable app sourced from a Kubernetes
@@ -251,6 +309,30 @@ CPU and memory are fallback signals, not a complete realtime scaling policy. A s
 uses active connections per pod, connection admission rejections, event-loop or fanout latency,
 adapter backlog, and reconnect rate through an external/custom metrics adapter.
 
+`autoscaling.metrics` is passed through to the HPA verbatim and accepts any `autoscaling/v2` metric
+type, so those signals can be expressed directly. `sockudo_connected` is the connection gauge:
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 12
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: sockudo_connected
+        target:
+          type: AverageValue
+          averageValue: "40000"
+```
+
+Setting it **replaces** the CPU and memory metrics generated from
+`targetCPUUtilizationPercentage` and `targetMemoryUtilizationPercentage` rather than adding to
+them. That is deliberate: an HPA acts on the highest recommendation from any metric, so leaving
+CPU in place would keep overriding a connection-based policy. Put CPU back in the list explicitly
+if you want both.
+
 Scale up early. Scale down slowly and one pod at a time. Every removed pod makes its clients
 reconnect, so an aggressive HPA can oscillate and manufacture load.
 
@@ -263,6 +345,22 @@ Set:
 - a termination grace period longer than `SHUTDOWN_GRACE_PERIOD`
 - a rollout `maxUnavailable` compatible with the PDB and remaining socket capacity
 - load-balancer deregistration or endpoint propagation time inside the drain budget
+
+`strategy` is passed through to the Deployment. Left unset, Kubernetes applies its default of
+`maxUnavailable: 25%` / `maxSurge: 25%`, which takes a quarter of the connection capacity offline
+during a rollout - exactly while the clients from the replaced pods are reconnecting. Surging
+instead keeps capacity flat:
+
+```yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 25%
+```
+
+Note that a PodDisruptionBudget does not cover this. A PDB governs the eviction API - node drains
+and upgrades - not Deployment rollouts.
 
 During a rollout, watch connection count by pod. Kubernetes considers replica count, not how many
 sockets each replica owns. One terminating pod may hold a disproportionate share after a long


### PR DESCRIPTION
Three values the chart does not currently expose. All additive; every default is unchanged.

- `config.existingSecret` / `config.existingSecretKey` - supply the whole config file from a Secret
- `strategy` - passed through to the Deployment
- `autoscaling.metrics` - passed through to the HorizontalPodAutoscaler

### The config file cannot come from a Secret

`templates/configmap.yaml` always renders, `deployment.yaml` mounts that ConfigMap at
`/app/config` unconditionally, and the container args hardcode `--config
/app/config/config.json`. So the config file can only ever be the chart's own ConfigMap.

That is fine until the configuration has to contain a secret, which happens as soon as an app
needs webhooks. Webhooks are expressible only in the config file - `options/env/apps.rs` sets
`webhooks: None` for the environment-defined app - so an app with webhooks must carry its
secret in that same file, and `defaultApp.existingSecret` cannot help. Under GitOps the
ConfigMap is generated from committed values, so the app secret ends up in plaintext in the
repository.

`values.yaml` currently points users straight at this: `configJson` is documented as "the
preferred chart entrypoint for advanced app-manager or inline app policy configuration" -
which is exactly the configuration that needs secrets.

Nesting a `subPath` Secret mount inside the chart's ConfigMap-backed volume is not available
as a workaround; the container fails to start. Two directory mounts at `/app/config` are
rejected by API validation. `extraVolumes` can put the Secret anywhere else, but nothing can
change where the binary looks.

With this change:

```yaml
config:
  existingSecret: sockudo-config
  existingSecretKey: config.json
```

The ConfigMap is not rendered and the `config` volume is Secret-backed. Setting
`config.existingSecret` together with `configJson` fails the render rather than silently
ignoring one of them.

Because Helm never sees the Secret's content, `checksum/config` would hash an empty string in
this mode, so the annotation is omitted rather than left in place as a constant. The docs say
so, and note that rotation therefore needs a reloader controller or a manual restart.

### `strategy` is not templated

`spec.strategy` appears nowhere in the chart, so every deployment gets the Kubernetes default
`maxUnavailable: 25%` / `maxSurge: 25%` with no way to override it. For a WebSocket server
that means a quarter of connection capacity goes offline during a rollout, exactly while the
clients from the replaced pods are reconnecting. `maxUnavailable: 0` / `maxSurge: 25%` keeps
capacity flat.

`docs/content/docs/deployment/kubernetes.mdx` already advises setting "a rollout
`maxUnavailable` compatible with the PDB and remaining socket capacity", which the chart
cannot currently do.

### The HPA can only express `Resource` metrics

`templates/hpa.yaml` emits two hardcoded `type: Resource` blocks. `autoscaling/v2` also
supports `Pods`, `Object` and `External`, and none of them can be reached from values.

The same docs page already says a stronger setup "uses active connections per pod, connection
admission rejections, event-loop or fanout latency, adapter backlog, and reconnect rate
through an external/custom metrics adapter". `sockudo_connected` is the natural signal - CPU
tracks message throughput, not connection headroom, and a pod can sit near its connection
ceiling at low CPU.

When `autoscaling.metrics` is set it **replaces** the generated CPU/memory blocks rather than
appending to them. An HPA acts on the highest recommendation from any metric, so leaving CPU
in place would keep overriding a connection-based policy; appending would make the feature
unusable for its main purpose. CPU can be listed explicitly if both are wanted.

### Notes on the approach

- `config.existingSecret` follows the naming already used throughout the chart -
  `redis.existingSecret`, `database.existingSecret`, `nats.existingSecret`,
  `defaultApp.existingSecret`. The mutual-exclusion `fail` follows the pattern in
  `dashboard-secret.yaml`.
- `strategy` and the metrics passthrough are applied to the dashboard templates too
  (`dashboard.api.strategy`, `dashboard.web.strategy`,
  `dashboard.autoscaling.{api,web}.metrics`) rather than only the main workload, so the
  chart stays consistent. Happy to drop the dashboard half if you would rather keep it out.
- No `Chart.yaml` change: `release.yml` stamps version and appVersion from the release tag.

### Verification

- `helm lint` and `helm template` pass for all five CI fixtures.
- Renders for `default`, `ingress` and `ha` are **byte-identical** to master, including the
  `checksum/config` hash - so existing installs get no rollout from this upgrade. The new
  `{{- if ... -}}` trim in `configmap.yaml` exists specifically to keep that hash stable.
- New fixture `ci/external-config-values.yaml` covers `config.existingSecret`, `strategy` and
  an `External` HPA metric, and is added to the `chart-ci.yml` matrix. `ha-values.yaml` still
  covers the generated CPU/memory path. `dashboard-values.yaml` gains both dashboard
  strategies plus a `Pods` metric on the API HPA only, so the web HPA keeps covering the
  generated path.
- Not run: `kubeconform`, and the Helm 4.2.4 that CI pins - neither was available locally, so
  those come from CI.
