### PR TITLE
fix(server): flush buffered webhooks and drain before disconnecting backends

### DIFF
--- a/crates/sockudo-server/src/bootstrap/runtime.rs
+++ b/crates/sockudo-server/src/bootstrap/runtime.rs
@@ -549,6 +549,20 @@ impl SockudoServer {
         #[cfg(feature = "delta")]
         self.state.delta_compression.stop_cleanup_task().await;
 
+        // Closing every connection above produced the last presence events. They sit in the
+        // webhook batching buffer until an interval tick, so flush them before the queue
+        // manager is disconnected, then spend the grace period letting the workers deliver
+        // them. Disconnecting the backends first would discard the buffer.
+        if let Some(webhook_integration) = self.handler.webhook_integration() {
+            webhook_integration.flush_batched_webhooks().await;
+        }
+
+        info!(
+            grace_period_s = self.config.shutdown_grace_period,
+            "waiting for shutdown grace period"
+        );
+        tokio::time::sleep(Duration::from_secs(self.config.shutdown_grace_period)).await;
+
         // Disconnect from backend services
         if let Err(e) = self.state.cache_manager.disconnect().await {
             warn!(error = %e, "error disconnecting cache manager");
@@ -576,11 +590,6 @@ impl SockudoServer {
             }
         }
 
-        info!(
-            grace_period_s = self.config.shutdown_grace_period,
-            "waiting for shutdown grace period"
-        );
-        tokio::time::sleep(Duration::from_secs(self.config.shutdown_grace_period)).await;
         info!("Server stopped");
         Ok(())
     }

--- a/crates/sockudo-webhook/src/integration.rs
+++ b/crates/sockudo-webhook/src/integration.rs
@@ -11,7 +11,7 @@ use sonic_rs::{Value, json};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::interval;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 const WEBHOOK_QUEUE_NAME: &str = "webhooks";
 
@@ -184,30 +184,70 @@ impl WebhookIntegration {
             let mut interval = interval(Duration::from_millis(batch_duration));
             loop {
                 interval.tick().await;
-                let jobs_to_process = {
-                    let mut batched = batched_webhooks_clone.lock();
-                    std::mem::take(&mut *batched)
-                };
-
-                if jobs_to_process.is_empty() {
-                    continue;
-                }
-                debug!(
-                    job_count = jobs_to_process.len(),
-                    "processing batched webhook jobs"
-                );
-
-                if let Some(qm) = &queue_manager_clone {
-                    let batches = Self::merge_jobs_for_queue(jobs_to_process, batch_size);
-                    if let Err(e) = qm.add_batch_to_queue(WEBHOOK_QUEUE_NAME, batches).await {
-                        error!(
-                            error = %e,
-                            "failed to enqueue batched webhook jobs"
-                        );
-                    }
-                }
+                Self::drain_batched_webhooks(
+                    &batched_webhooks_clone,
+                    &queue_manager_clone,
+                    batch_size,
+                )
+                .await;
             }
         });
+    }
+
+    /// Moves everything currently buffered into the queue, returning how many jobs were
+    /// enqueued.
+    async fn drain_batched_webhooks(
+        batched_webhooks: &Arc<Mutex<Vec<JobData>>>,
+        queue_manager: &Option<Arc<QueueManager>>,
+        batch_size: usize,
+    ) -> usize {
+        let jobs_to_process = {
+            let mut batched = batched_webhooks.lock();
+            std::mem::take(&mut *batched)
+        };
+
+        if jobs_to_process.is_empty() {
+            return 0;
+        }
+        let job_count = jobs_to_process.len();
+        debug!(job_count, "processing batched webhook jobs");
+
+        if let Some(qm) = queue_manager {
+            let batches = Self::merge_jobs_for_queue(jobs_to_process, batch_size);
+            if let Err(e) = qm.add_batch_to_queue(WEBHOOK_QUEUE_NAME, batches).await {
+                error!(
+                    error = %e,
+                    "failed to enqueue batched webhook jobs"
+                );
+                return 0;
+            }
+        }
+
+        job_count
+    }
+
+    /// Drains the batching buffer immediately instead of waiting for the next interval tick.
+    ///
+    /// The buffer is process-local, so anything still in it when the queue manager is
+    /// disconnected is lost. Shutdown closes every connection first, which produces a burst of
+    /// `member_removed` events, and those land in this buffer with no guarantee that a tick
+    /// follows before the queue goes away.
+    ///
+    /// Returns the number of jobs handed to the queue, which is zero if the buffer was empty or
+    /// the enqueue failed.
+    pub async fn flush_batched_webhooks(&self) -> usize {
+        let flushed = Self::drain_batched_webhooks(
+            &self.batched_webhooks,
+            &self.queue_manager,
+            self.config.batching.size.max(1),
+        )
+        .await;
+
+        if flushed > 0 {
+            info!(job_count = flushed, "flushed buffered webhook jobs");
+        }
+
+        flushed
     }
 
     pub fn is_enabled(&self) -> bool {
@@ -918,6 +958,64 @@ mod tests {
             .await
             .unwrap();
         assert!(integration.batched_webhooks.lock().is_empty());
+    }
+
+    #[tokio::test]
+    async fn flush_drains_buffered_webhooks_into_the_queue() {
+        let mut app = test_app();
+        app.policy.webhooks = Some(vec![Webhook {
+            event_types: vec!["member_removed".to_string()],
+            ..Webhook::default()
+        }]);
+        let app_manager = Arc::new(MemoryAppManager::new());
+        let queue_manager = create_test_queue_manager();
+        let integration = WebhookIntegration::new(
+            WebhookConfig {
+                batching: BatchingConfig {
+                    enabled: true,
+                    // Long enough that no interval tick can fire while the test runs, so the
+                    // explicit flush is the only thing that can move the job.
+                    duration: 60_000,
+                    size: 100,
+                },
+                ..WebhookConfig::default()
+            },
+            app_manager,
+            Some(queue_manager),
+        )
+        .await
+        .unwrap();
+
+        integration
+            .send_member_removed(&app, "presence-room", "user-1")
+            .await
+            .unwrap();
+        assert_eq!(integration.batched_webhooks.lock().len(), 1);
+
+        assert_eq!(integration.flush_batched_webhooks().await, 1);
+        assert!(integration.batched_webhooks.lock().is_empty());
+    }
+
+    #[tokio::test]
+    async fn flush_is_a_noop_when_nothing_is_buffered() {
+        let app_manager = Arc::new(MemoryAppManager::new());
+        let queue_manager = create_test_queue_manager();
+        let integration = WebhookIntegration::new(
+            WebhookConfig {
+                batching: BatchingConfig {
+                    enabled: true,
+                    duration: 60_000,
+                    size: 100,
+                },
+                ..WebhookConfig::default()
+            },
+            app_manager,
+            Some(queue_manager),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(integration.flush_batched_webhooks().await, 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
> **Full disclosure: this change was written end-to-end by an AI agent**, driven by our
> production migration from soketi to Sockudo. The problem statement is ours and we are
> confident in it; the implementation is the agent's and we cannot personally vouch for the
> Rust. Adopt it, reshape it, or take only the problem and build your own - we have no
> attachment to this diff.

`stop()` disconnects the queue manager before it waits out the shutdown grace period, so
presence webhooks produced by the shutdown itself are very likely never enqueued.

### What happens today

The order in `bootstrap/runtime.rs` is:

1. `running = false` - `/up` reports draining, WebSocket upgrades are rejected
2. `announce_node_departure()`
3. close every socket with 4200, `join_all()`
4. abort push workers, stop the delta cleanup task
5. `cache_manager.disconnect()`, `queue_manager.disconnect()`
6. `sleep(shutdown_grace_period)`

Step 3 produces a burst of `member_removed` events. With `webhooks.batching.enabled`, those do
not go to the queue directly - `add_webhook` pushes them onto a process-local `Vec` that is
drained only by an interval tick in `start_batching_task`. The queue manager is then
disconnected in step 5, before any tick is guaranteed to have run, and the grace period in
step 6 is spent with the queue already gone.

For a deployment running presence webhooks at-most-once, that means every rollout and
scale-down can permanently strand those users as "online". Peers do not compensate:
`RequestType::NodeDead` handling only cleans the local presence registry and channel counts, it
does not emit the webhooks.

soketi does the reverse (`src/server.ts`): close sockets, wait out the grace period, and only
then disconnect queue, rate limiter, cache and adapter.

### What this changes

Two things, in `stop()`:

- flush the webhook batching buffer explicitly, right after the sockets are closed
- move `sleep(shutdown_grace_period)` to before the `cache_manager` / `queue_manager`
  disconnects, so the grace period is spent with the queue still up and the workers able to
  deliver

The flush is the half that makes it a guarantee rather than a probability. Moving the sleep
alone would leave delivery dependent on an interval tick landing inside the window, which for a
2000 ms batch duration and a short grace period is not a safe assumption. `flush_batched_webhooks`
returns the number of jobs handed to the queue, which is what the new tests assert on.

Internally the drain body is lifted out of the interval task into
`drain_batched_webhooks`, so the tick path and the flush path cannot diverge.

### Two side notes

Moving the sleep also delays the unix-socket file cleanup by the grace period.
`start_unix_socket_server` unlinks an existing socket file before binding, so a file left behind
by a hard kill is cleaned up on the next start.

The batching task is still a fire-and-forget spawn with no cancellation. This fix closes the
window that mattered - the grace period now runs with the queue connected - but if you want a
proper task lifecycle we are happy to do that separately.

### Verification

- `cargo test -p sockudo-webhook` - 35 passed, 0 failed
- `cargo test -p sockudo` - 93 + 2 passed, 0 failed
- `cargo clippy -p sockudo-webhook -p sockudo --all-targets -- -D warnings` - clean
- `cargo fmt --all` - touches only the two changed files
- Two new tests in `integration.rs`: one asserts a buffered `member_removed` is enqueued by an
  explicit flush, with the batch interval set long enough that no tick can fire during the test;
  the other asserts the flush is a no-op on an empty buffer.

Run on `rust:1.98-bookworm`, matching the Dockerfile. The full `--workspace` sweep is not
included here.
