### PR TITLE
fix(rate-limiter): document trust_hops offset semantics and log unusable X-Forwarded-For

### DIFF
--- a/crates/sockudo-rate-limiter/src/middleware.rs
+++ b/crates/sockudo-rate-limiter/src/middleware.rs
@@ -12,6 +12,7 @@ use std::{
     fmt,
     net::SocketAddr,
     sync::Arc,
+    sync::atomic::{AtomicBool, Ordering},
     task::{Context, Poll},
 };
 use tower_layer::Layer;
@@ -264,11 +265,15 @@ pub trait KeyExtractor: Send + Sync {
 #[derive(Clone, Debug)]
 pub struct IpKeyExtractor {
     trust_hops: usize,
+    warned_unusable_forwarded_for: Arc<AtomicBool>,
 }
 
 impl IpKeyExtractor {
     pub fn new(trust_hops: usize) -> Self {
-        Self { trust_hops }
+        Self {
+            trust_hops,
+            warned_unusable_forwarded_for: Arc::new(AtomicBool::new(false)),
+        }
     }
 
     fn get_ip<B>(&self, req: &HyperRequest<B>) -> Option<String> {
@@ -277,16 +282,15 @@ impl IpKeyExtractor {
             && let Ok(forwarded_str) = value.to_str()
         {
             let ips: Vec<&str> = forwarded_str.split(',').map(str::trim).collect();
+            // trust_hops is an offset from the right-hand end of the chain, where 1 selects the
+            // last entry. A single proxy that appends the client address therefore needs 2.
             let client_ip_index = ips.len().saturating_sub(self.trust_hops);
-            if let Some(ip_str) = ips.get(client_ip_index) {
-                if ip_str.parse::<std::net::IpAddr>().is_ok() {
-                    return Some(ip_str.to_string());
-                }
-            } else if let Some(ip_str) = ips.first()
+            if let Some(ip_str) = ips.get(client_ip_index)
                 && ip_str.parse::<std::net::IpAddr>().is_ok()
             {
                 return Some(ip_str.to_string());
             }
+            self.warn_unusable_forwarded_for(forwarded_str, client_ip_index);
         }
 
         if let Some(value) = req.headers().get("x-real-ip")
@@ -301,6 +305,29 @@ impl IpKeyExtractor {
         req.extensions()
             .get::<ConnectInfo<SocketAddr>>()
             .map(|ConnectInfo(addr)| addr.ip().to_string())
+    }
+
+    /// Reports a configured `trust_hops` that does not match the actual proxy chain.
+    ///
+    /// Falling through to `x-real-ip` or the socket peer puts every client behind the same proxy
+    /// into one rate-limit bucket, which is otherwise silent. Logged once per extractor: clients
+    /// can set `X-Forwarded-For` themselves, so a per-request log would be a flooding primitive.
+    fn warn_unusable_forwarded_for(&self, forwarded_for: &str, selected_index: usize) {
+        if self
+            .warned_unusable_forwarded_for
+            .swap(true, Ordering::Relaxed)
+        {
+            return;
+        }
+
+        warn!(
+            trust_hops = self.trust_hops,
+            selected_index,
+            forwarded_for,
+            "no usable address at the configured trust_hops offset in X-Forwarded-For; falling \
+             back to x-real-ip or the socket peer, which shares one rate-limit bucket across every \
+             client behind the proxy"
+        );
     }
 }
 
@@ -386,6 +413,83 @@ fn add_rate_limit_headers(
         warn!(
             value = result.reset_after,
             "Failed to convert rate limit reset_after value for header X-RateLimit-Reset/Retry-After"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(headers: &[(&str, &str)]) -> HyperRequest<()> {
+        let mut builder = HyperRequest::builder();
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        builder.body(()).unwrap()
+    }
+
+    #[test]
+    fn trust_hops_counts_from_the_right_so_one_proxy_needs_two() {
+        let chain = [("x-forwarded-for", "203.0.113.7, 198.51.100.1")];
+
+        assert_eq!(
+            IpKeyExtractor::new(2).get_ip(&request(&chain)),
+            Some("203.0.113.7".to_string()),
+            "2 selects the client for a single proxy that appends its own address"
+        );
+        assert_eq!(
+            IpKeyExtractor::new(1).get_ip(&request(&chain)),
+            Some("198.51.100.1".to_string()),
+            "1 selects the last entry, which is the proxy rather than the client"
+        );
+    }
+
+    #[test]
+    fn client_supplied_entries_cannot_reach_the_selected_offset() {
+        let ip = IpKeyExtractor::new(2).get_ip(&request(&[(
+            "x-forwarded-for",
+            "192.0.2.9, 203.0.113.7, 198.51.100.1",
+        )]));
+
+        assert_eq!(
+            ip,
+            Some("203.0.113.7".to_string()),
+            "a prepended entry shifts the offset away from the client, it cannot be selected"
+        );
+    }
+
+    #[test]
+    fn zero_trust_hops_ignores_forwarded_for() {
+        let ip = IpKeyExtractor::new(0).get_ip(&request(&[
+            ("x-forwarded-for", "203.0.113.7, 198.51.100.1"),
+            ("x-real-ip", "192.0.2.44"),
+        ]));
+
+        assert_eq!(ip, Some("192.0.2.44".to_string()));
+    }
+
+    #[test]
+    fn unusable_entry_at_the_offset_falls_back_instead_of_picking_another() {
+        let ip = IpKeyExtractor::new(2).get_ip(&request(&[
+            ("x-forwarded-for", "not-an-ip, 198.51.100.1"),
+            ("x-real-ip", "192.0.2.44"),
+        ]));
+
+        assert_eq!(ip, Some("192.0.2.44".to_string()));
+    }
+
+    #[test]
+    fn a_shorter_chain_than_the_offset_selects_the_first_entry() {
+        let ip = IpKeyExtractor::new(5).get_ip(&request(&[(
+            "x-forwarded-for",
+            "203.0.113.7, 198.51.100.1",
+        )]));
+
+        assert_eq!(
+            ip,
+            Some("203.0.113.7".to_string()),
+            "saturating_sub clamps the offset to the start of the chain"
         );
     }
 }

--- a/docs/content/docs/deployment/kubernetes.mdx
+++ b/docs/content/docs/deployment/kubernetes.mdx
@@ -82,10 +82,10 @@ config:
     enabled: true
     apiMaxRequests: 1000
     apiWindowSeconds: 60
-    apiTrustHops: 1
+    apiTrustHops: 2
     wsMaxRequests: 100
     wsWindowSeconds: 60
-    wsTrustHops: 1
+    wsTrustHops: 2
   metrics:
     enabled: true
 
@@ -180,6 +180,22 @@ ingress:
 Adapt the topology label selector when the release name or chart labels differ. If application
 records must change dynamically, select a durable app manager instead of `memory` and configure its
 database credentials from a Secret.
+
+`apiTrustHops` and `wsTrustHops` are an **offset from the right-hand end** of `X-Forwarded-For`,
+not a count of proxies. `1` selects the last entry in the chain, which is the proxy itself. A
+single load balancer that appends the client address - producing
+`X-Forwarded-For: <client>, <lb>` - therefore needs `2`, which is why the example above uses it.
+
+Getting this wrong is quiet rather than loud. When the offset selects an entry that is not a valid
+address, extraction falls through to `x-real-ip` and then to the socket peer, and behind a load
+balancer the socket peer is the load balancer - so every client on the internet shares one
+rate-limit bucket. With the default `wsMaxRequests` that is a single allowance of WebSocket
+upgrades per window for all clients combined, and any reconnect storm will exhaust it. Sockudo logs
+a warning the first time the configured offset yields nothing usable.
+
+The default is `0`, which skips `X-Forwarded-For` entirely and goes straight to the socket peer.
+Behind any L7 load balancer that is the shared-bucket case above, so set these explicitly whenever
+the rate limiter is enabled.
 
 Create the one-app Secret without placing values in the shell history or a checked-in manifest.
 The required keys are:

--- a/docs/content/docs/deployment/linux.mdx
+++ b/docs/content/docs/deployment/linux.mdx
@@ -221,8 +221,13 @@ above the longest expected interval between application or heartbeat traffic, wi
 network path.
 
 If the proxy adds entries to `X-Forwarded-For`, configure `RATE_LIMITER_API_TRUST_HOPS` and
-`RATE_LIMITER_WS_TRUST_HOPS` to the exact trusted proxy count. Never trust a client-supplied chain
-from the public internet.
+`RATE_LIMITER_WS_TRUST_HOPS`. These are an offset from the right-hand end of the chain, not a count
+of proxies: `1` selects the last entry, which is the proxy itself, so one proxy that appends the
+client address needs `2`. Counting from the right is what makes a client-supplied chain harmless -
+prepended entries shift the offset away from the client, they cannot reach it - but the count must
+match the real path. If it does not, extraction falls back to the socket peer, which behind a proxy
+is the proxy, putting every client into one rate-limit bucket. Sockudo warns once when the
+configured offset yields no usable address.
 
 ## One host versus several
 

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -299,10 +299,10 @@ See [Logging](/docs/reference/logging) for level policy, stable lifecycle fields
 | `RATE_LIMITER_ENABLED` | Enables HTTP and WebSocket rate limiting. |
 | `RATE_LIMITER_API_MAX_REQUESTS` | API requests allowed per rate limit window. |
 | `RATE_LIMITER_API_WINDOW_SECONDS` | API rate limit window length. |
-| `RATE_LIMITER_API_TRUST_HOPS` | Trusted proxy hops for API client IP extraction. |
+| `RATE_LIMITER_API_TRUST_HOPS` | Offset from the right of `X-Forwarded-For` for API client IP extraction. `1` selects the last entry, so one proxy that appends the client address needs `2`. `0` ignores the header. |
 | `RATE_LIMITER_WS_MAX_REQUESTS` | WebSocket upgrade attempts allowed per window. |
 | `RATE_LIMITER_WS_WINDOW_SECONDS` | WebSocket rate limit window length. |
-| `RATE_LIMITER_WS_TRUST_HOPS` | Trusted proxy hops for WebSocket client IP extraction. |
+| `RATE_LIMITER_WS_TRUST_HOPS` | Offset from the right of `X-Forwarded-For` for WebSocket client IP extraction. `1` selects the last entry, so one proxy that appends the client address needs `2`. `0` ignores the header. |
 | `RATE_LIMITER_REDIS_PREFIX` | Redis key prefix for rate limiter state. |
 
 ## Queue backends


### PR DESCRIPTION
> **Full disclosure: this change was written end-to-end by an AI agent**, driven by our
> production migration from soketi to Sockudo. The problem statement is ours and we are
> confident in it; the implementation is the agent's and we cannot personally vouch for the
> Rust. Adopt it, reshape it, or take only the problem and build your own - we have no
> attachment to this diff.

`trust_hops` is an offset from the right-hand end of `X-Forwarded-For`, but it is named and
documented as a count of proxies. The two differ by one, misconfiguring it is silent, and the
consequence is that every client shares a single rate-limit bucket.

No behaviour change to the extraction itself - this makes the existing behaviour correct in the
docs and visible in the logs.

### The off-by-one

`IpKeyExtractor::get_ip` selects `ips[len - trust_hops]`. For a single load balancer that appends
the client address:

```
X-Forwarded-For: 203.0.113.7, 198.51.100.1
                 ^client      ^load balancer

trust_hops = 2  ->  index 0  ->  203.0.113.7   the client
trust_hops = 1  ->  index 1  ->  198.51.100.1  the load balancer
```

So one proxy needs `2`. Every doc that mentions it says otherwise:

- `reference/environment-variables.mdx`: "Trusted proxy hops for API client IP extraction"
- `deployment/linux.mdx`: "configure ... to the exact trusted proxy count"
- `deployment/kubernetes.mdx`: the production values example ships `apiTrustHops: 1` and
  `wsTrustHops: 1` behind a load balancer

Counting from the right is a good design and I have not touched it - prepended client-supplied
entries shift the offset away from the client rather than toward it, so the chain cannot be
spoofed at a fixed hop count. The problem is only that the name implies the other convention.

I deliberately did **not** change the arithmetic. Anyone who worked out the real semantics and
set `2` would silently start rate-limiting on the wrong address if the indexing moved.

### Why it is silent

When the selected entry is not a valid address, extraction falls through to `x-real-ip` and then
to the socket peer. Behind an L7 load balancer the socket peer is the load balancer, so every
client collapses into one bucket - and nothing is logged. With the chart's default
`wsMaxRequests: 20 / 60s` that is 20 WebSocket upgrades per minute for all clients combined, so
any reconnect storm 429s essentially everyone.

This adds a `warn!` the first time the configured offset yields nothing usable. Once per
extractor, not per request: clients can set `X-Forwarded-For` themselves, so a per-request log
would hand them a log-flooding primitive.

### Dead code

The `else if let Some(ip_str) = ips.first()` fallback is unreachable. `client_ip_index` is
`ips.len().saturating_sub(trust_hops)` and the branch requires `trust_hops > 0`, so the index is
always `<= len - 1` and `ips.get(...)` always returns `Some`. Removed, and the surviving arm
folded into the existing let-chain.

### Two things left open

Neither is implemented here - both are your call and we did not want to design them uninvited:

1. **The default.** `RateLimiterConfig::default()` is `enabled: true` with `trust_hops: Some(0)`
   on both limits, and `0` skips `X-Forwarded-For` entirely. So the out-of-the-box configuration,
   in any container behind a load balancer, is default-on rate limiting with every client in one
   bucket. Should `trust_hops` default differently, or should an enabled rate limiter with
   `trust_hops: 0` warn at startup?
2. **A trusted-proxy CIDR list**, as an alternative to hop counting. Counting is fragile when the
   number of hops varies by path; an allowlist of proxy addresses to skip from the right would
   not be. Happy to implement if you want it, in whatever shape you prefer.

### Verification

- `cargo test -p sockudo-rate-limiter`
- `cargo clippy -p sockudo-rate-limiter --all-targets -- -D warnings`
- `cargo fmt --all`
- Five new tests in `middleware.rs` pinning the offset semantics, including that `1` selects the
  proxy and `2` the client for a one-proxy chain, that a prepended entry cannot reach the selected
  offset, and that an unusable entry falls back rather than picking a different entry. The crate
  had no test module for this file before.
