### PR TITLE
feat: shed new connections under memory pressure

### DIFF
--- a/charts/sockudo/templates/configmap.yaml
+++ b/charts/sockudo/templates/configmap.yaml
@@ -33,7 +33,13 @@ data:
         "driver": {{ .Values.config.queueDriver | quote }}
       },
       "http_api": {
-        "usage_enabled": {{ .Values.config.httpApi.usageEnabled }}
+        "usage_enabled": {{ .Values.config.httpApi.usageEnabled }},
+        "accept_traffic": {
+          "enabled": {{ .Values.config.httpApi.acceptTraffic.enabled }},
+          "memory_threshold": {{ .Values.config.httpApi.acceptTraffic.memoryThreshold }},
+          "memory_limit_bytes": {{ .Values.config.httpApi.acceptTraffic.memoryLimitBytes | default "null" }},
+          "sample_interval_ms": {{ .Values.config.httpApi.acceptTraffic.sampleIntervalMs | int64 }}
+        }
       },
       "rate_limiter": {
         "enabled": {{ .Values.config.rateLimiter.enabled }},

--- a/charts/sockudo/templates/deployment.yaml
+++ b/charts/sockudo/templates/deployment.yaml
@@ -106,6 +106,16 @@ spec:
             # HTTP API
             - name: HTTP_API_USAGE_ENABLED
               value: {{ .Values.config.httpApi.usageEnabled | quote }}
+            - name: HTTP_API_ACCEPT_TRAFFIC_ENABLED
+              value: {{ .Values.config.httpApi.acceptTraffic.enabled | quote }}
+            - name: HTTP_API_ACCEPT_TRAFFIC_MEMORY_THRESHOLD
+              value: {{ .Values.config.httpApi.acceptTraffic.memoryThreshold | quote }}
+            {{- with .Values.config.httpApi.acceptTraffic.memoryLimitBytes }}
+            - name: HTTP_API_ACCEPT_TRAFFIC_MEMORY_LIMIT_BYTES
+              value: {{ . | quote }}
+            {{- end }}
+            - name: HTTP_API_ACCEPT_TRAFFIC_SAMPLE_INTERVAL_MS
+              value: {{ .Values.config.httpApi.acceptTraffic.sampleIntervalMs | quote }}
             # Rate limiter
             - name: RATE_LIMITER_ENABLED
               value: {{ .Values.config.rateLimiter.enabled | quote }}

--- a/charts/sockudo/values.yaml
+++ b/charts/sockudo/values.yaml
@@ -94,6 +94,15 @@ config:
   # -- HTTP API settings
   httpApi:
     usageEnabled: true
+    acceptTraffic:
+      # -- Reject only new WebSocket connections when process RSS reaches the threshold
+      enabled: false
+      # -- Fraction of the cgroup or explicit memory limit that closes admission
+      memoryThreshold: 0.9
+      # -- Explicit byte limit; null discovers the Linux cgroup limit
+      memoryLimitBytes: null
+      # -- Memory sampling cadence, independent of Prometheus scraping
+      sampleIntervalMs: 500
 
   # -- Rate limiter settings
   rateLimiter:

--- a/config/config.toml
+++ b/config/config.toml
@@ -443,6 +443,15 @@ v2_ungraceful_timeout_seconds = 15
 [http_api]
 request_limit_in_mb = 10
 
+# Optional Linux memory-pressure admission control. This rejects only new
+# WebSocket connections; established connections and /up remain unaffected.
+[http_api.accept_traffic]
+enabled = false
+memory_threshold = 0.90
+# Omit memory_limit_bytes to discover the cgroup v2/v1 limit automatically.
+# memory_limit_bytes = 2147483648
+sample_interval_ms = 500
+
 [webhooks]
 request_timeout_ms = 10000
 

--- a/config/node1.json
+++ b/config/node1.json
@@ -229,7 +229,9 @@
   "http_api": {
     "request_limit_in_mb": 10,
     "accept_traffic": {
-      "memory_threshold": 0.9
+      "enabled": false,
+      "memory_threshold": 0.9,
+      "sample_interval_ms": 500
     }
   },
 

--- a/config/node2.json
+++ b/config/node2.json
@@ -216,7 +216,9 @@
   "http_api": {
     "request_limit_in_mb": 10,
     "accept_traffic": {
-      "memory_threshold": 0.9
+      "enabled": false,
+      "memory_threshold": 0.9,
+      "sample_interval_ms": 500
     }
   },
   "webhooks": {

--- a/crates/sockudo-ably-compat/src/runtime/realtime.rs
+++ b/crates/sockudo-ably-compat/src/runtime/realtime.rs
@@ -84,6 +84,15 @@ pub async fn handle_ably_realtime_upgrade(
     if !handler.is_accepting() {
         return StatusCode::SERVICE_UNAVAILABLE.into_response();
     }
+    if handler.is_memory_pressure_shedding() {
+        handler.mark_memory_pressure_rejection();
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            [(axum::http::header::RETRY_AFTER, "1")],
+            "MEMORY_PRESSURE",
+        )
+            .into_response();
+    }
     let format = match parse_ably_format(params.format.as_deref()) {
         Ok(format) => format,
         Err(message) => return ably_error_response(StatusCode::BAD_REQUEST, 40000, message),

--- a/crates/sockudo-adapter/src/handler/mod.rs
+++ b/crates/sockudo-adapter/src/handler/mod.rs
@@ -36,6 +36,9 @@ use sockudo_core::app::AppManager;
 use sockudo_core::cache::CacheManager;
 use sockudo_core::error::{Error, Result};
 use sockudo_core::history::{HistoryStore, NoopHistoryStore};
+use sockudo_core::memory_pressure::{
+    MemoryPressureMonitor, MemoryPressureObserver, MemoryPressureSnapshot,
+};
 use sockudo_core::message_envelope::MessageEnvelope;
 use sockudo_core::metrics::MetricsInterface;
 use sockudo_core::options::ServerOptions;
@@ -187,6 +190,8 @@ pub struct ConnectionHandler {
     /// Shared with the server runtime. Flipped to false on shutdown so the handler
     /// stops accepting new connections and `/up` reports draining.
     running: Arc<AtomicBool>,
+    /// Independent sampler used only for new-connection admission.
+    memory_pressure_monitor: Arc<MemoryPressureMonitor>,
 }
 
 /// Builder for constructing a `ConnectionHandler` without feature-gated function parameters.
@@ -363,6 +368,16 @@ impl ConnectionHandlerBuilder {
                 .set_realtime_egress_tap(Arc::clone(tap));
         }
 
+        let memory_pressure_observer = self.metrics.as_ref().map(|metrics| {
+            let metrics = Arc::clone(metrics);
+            Arc::new(move |shedding| metrics.update_memory_pressure_shedding(shedding))
+                as MemoryPressureObserver
+        });
+        let memory_pressure_monitor = MemoryPressureMonitor::new(
+            &self.server_options.http_api.accept_traffic,
+            memory_pressure_observer,
+        );
+
         let handler = ConnectionHandler {
             app_manager: self.app_manager,
             connection_manager: self.connection_manager,
@@ -416,7 +431,10 @@ impl ConnectionHandlerBuilder {
             running: self
                 .running
                 .unwrap_or_else(|| Arc::new(AtomicBool::new(true))),
+            memory_pressure_monitor,
         };
+
+        handler.memory_pressure_monitor.start();
 
         #[cfg(feature = "ai-transport")]
         if handler.server_options.ai_transport.enabled {
@@ -547,6 +565,23 @@ impl ConnectionHandler {
     /// shutdown has flipped the shared running flag, signalling drain.
     pub fn is_accepting(&self) -> bool {
         self.running.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Whether memory pressure is currently closing only new-connection admission.
+    pub fn is_memory_pressure_shedding(&self) -> bool {
+        self.memory_pressure_monitor.is_shedding()
+    }
+
+    /// Latest memory-pressure state for operational endpoints.
+    pub fn memory_pressure_snapshot(&self) -> MemoryPressureSnapshot {
+        self.memory_pressure_monitor.snapshot()
+    }
+
+    /// Record one connection rejected by the memory-pressure admission gate.
+    pub fn mark_memory_pressure_rejection(&self) {
+        if let Some(metrics) = self.metrics.as_ref() {
+            metrics.mark_memory_pressure_rejection();
+        }
     }
 
     /// Get a reference to the presence manager
@@ -802,6 +837,13 @@ impl ConnectionHandler {
         app_config: &App,
         wire_options: SocketWireOptions,
     ) -> Result<()> {
+        // Memory pressure closes admission only; established sockets remain untouched.
+        if self.is_memory_pressure_shedding() {
+            self.mark_memory_pressure_rejection();
+            Self::send_error_frame(&mut socket_tx, &Error::OverCapacity).await;
+            return Err(Error::OverCapacity);
+        }
+
         // Per-pod capacity check (across all apps on this node)
         if self.server_options.max_connections > 0 {
             let node_count = if let Some(ref la) = self.local_adapter {

--- a/crates/sockudo-adapter/tests/adapter/server_capacity_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/server_capacity_tests.rs
@@ -24,6 +24,7 @@ use tokio::net::{TcpListener, TcpStream};
 struct CountingMetrics {
     new_connections: AtomicUsize,
     disconnections: AtomicUsize,
+    memory_pressure_rejections: AtomicUsize,
 }
 
 impl CountingMetrics {
@@ -31,11 +32,16 @@ impl CountingMetrics {
         Self {
             new_connections: AtomicUsize::new(0),
             disconnections: AtomicUsize::new(0),
+            memory_pressure_rejections: AtomicUsize::new(0),
         }
     }
 
     fn new_connections(&self) -> usize {
         self.new_connections.load(Ordering::SeqCst)
+    }
+
+    fn memory_pressure_rejections(&self) -> usize {
+        self.memory_pressure_rejections.load(Ordering::SeqCst)
     }
 }
 
@@ -54,6 +60,10 @@ impl MetricsInterface for CountingMetrics {
     }
 
     fn mark_connection_error(&self, _: &str, _: &str) {}
+    fn mark_memory_pressure_rejection(&self) {
+        self.memory_pressure_rejections
+            .fetch_add(1, Ordering::SeqCst);
+    }
     fn mark_rate_limit_check(&self, _: &str, _: &str) {}
     fn mark_rate_limit_check_with_context(&self, _: &str, _: &str, _: &str) {}
     fn mark_rate_limit_triggered(&self, _: &str, _: &str) {}
@@ -275,6 +285,71 @@ async fn server_max_connections_rejects_over_capacity() {
         metrics.new_connections(),
         0,
         "mark_new_connection must NOT be called on capacity rejection"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn memory_pressure_rejects_new_connection_without_marking_it_connected() {
+    let app_manager = Arc::new(MemoryAppManager::new());
+    app_manager.create_app(make_app(0)).await.unwrap();
+
+    let adapter = Arc::new(LocalAdapter::new());
+    adapter.init().await;
+    let metrics = Arc::new(CountingMetrics::new());
+    let mut options = ServerOptions::default();
+    options.http_api.accept_traffic.enabled = true;
+    options.http_api.accept_traffic.memory_limit_bytes = Some(1);
+
+    let handler = ConnectionHandler::builder(
+        app_manager.clone() as Arc<dyn AppManager + Send + Sync>,
+        adapter.clone() as Arc<dyn ConnectionManager + Send + Sync>,
+        Arc::new(NullCacheManager),
+        options,
+    )
+    .local_adapter(adapter.clone())
+    .metrics(metrics.clone())
+    .build();
+
+    assert!(handler.is_memory_pressure_shedding());
+    let established_socket_id = SocketId::new();
+    let (established_writer, _established_client) = make_ws_pair().await;
+    adapter
+        .add_socket(
+            established_socket_id,
+            established_writer,
+            APP_ID,
+            app_manager as Arc<dyn AppManager + Send + Sync>,
+            WebSocketBufferConfig::default(),
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+            sockudo_protocol::AppendMode::Delta,
+        )
+        .await
+        .unwrap();
+
+    let (server_ws, _client) = make_full_ws_pair().await;
+    let result = handler
+        .handle_socket(
+            server_ws,
+            APP_KEY.to_string(),
+            None,
+            ProtocolVersion::V1,
+            WireFormat::Json,
+            true,
+            sockudo_protocol::AppendMode::Delta,
+            None,
+        )
+        .await;
+
+    assert!(matches!(result, Err(Error::OverCapacity)));
+    assert_eq!(metrics.memory_pressure_rejections(), 1);
+    assert_eq!(metrics.new_connections(), 0);
+    assert_eq!(
+        adapter.get_total_sockets_count(),
+        1,
+        "memory-pressure admission must leave established connections open"
     );
 }
 

--- a/crates/sockudo-core/src/lib.rs
+++ b/crates/sockudo-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod history;
 #[doc(hidden)]
 pub mod history_conformance;
 pub mod idempotency;
+pub mod memory_pressure;
 pub mod message_envelope;
 pub mod metrics;
 pub mod namespace;

--- a/crates/sockudo-core/src/memory_pressure.rs
+++ b/crates/sockudo-core/src/memory_pressure.rs
@@ -1,0 +1,387 @@
+//! Process memory sampling used to shed new connections before a cgroup OOM.
+
+use crate::options::AcceptTraffic;
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::time::Duration;
+use tracing::{info, warn};
+
+const LIMIT_SOURCE_UNAVAILABLE: u8 = 0;
+const LIMIT_SOURCE_CONFIGURED: u8 = 1;
+const LIMIT_SOURCE_CGROUP_V2: u8 = 2;
+const LIMIT_SOURCE_CGROUP_V1: u8 = 3;
+const CGROUP_V1_UNLIMITED_FLOOR: u64 = 1 << 60;
+
+/// Callback notified whenever the current shedding state is sampled.
+pub type MemoryPressureObserver = Arc<dyn Fn(bool) + Send + Sync>;
+
+/// Current memory-pressure admission state.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MemoryPressureSnapshot {
+    pub enabled: bool,
+    pub sample_available: bool,
+    pub shedding: bool,
+    pub resident_memory_bytes: u64,
+    pub memory_limit_bytes: u64,
+    pub memory_threshold: f64,
+    pub limit_source: &'static str,
+}
+
+/// Periodically samples process RSS without depending on metrics collection.
+pub struct MemoryPressureMonitor {
+    enabled: bool,
+    memory_threshold: f64,
+    configured_limit_bytes: Option<u64>,
+    sample_interval: Duration,
+    sample_available: AtomicBool,
+    shedding: AtomicBool,
+    resident_memory_bytes: AtomicU64,
+    memory_limit_bytes: AtomicU64,
+    limit_source: AtomicU8,
+    unavailable_reported: AtomicBool,
+    observer: Option<MemoryPressureObserver>,
+}
+
+/// Read the current process resident set size in bytes.
+///
+/// Linux exposes the current (not peak) RSS through `/proc/self/status`.
+pub fn process_resident_memory_bytes() -> io::Result<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        let status = std::fs::read_to_string("/proc/self/status")?;
+        parse_linux_resident_memory_bytes(&status).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "VmRSS was missing or invalid in /proc/self/status",
+            )
+        })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "current process RSS sampling is supported only on Linux",
+        ))
+    }
+}
+
+impl MemoryPressureMonitor {
+    /// Construct a monitor from validated server configuration.
+    #[must_use]
+    pub fn new(config: &AcceptTraffic, observer: Option<MemoryPressureObserver>) -> Arc<Self> {
+        Arc::new(Self {
+            enabled: config.enabled,
+            memory_threshold: config.memory_threshold,
+            configured_limit_bytes: config.memory_limit_bytes.filter(|limit| *limit > 0),
+            sample_interval: Duration::from_millis(config.sample_interval_ms.max(1)),
+            sample_available: AtomicBool::new(false),
+            shedding: AtomicBool::new(false),
+            resident_memory_bytes: AtomicU64::new(0),
+            memory_limit_bytes: AtomicU64::new(0),
+            limit_source: AtomicU8::new(LIMIT_SOURCE_UNAVAILABLE),
+            unavailable_reported: AtomicBool::new(false),
+            observer,
+        })
+    }
+
+    /// Take an initial sample and start the independent periodic sampler.
+    pub fn start(self: &Arc<Self>) {
+        if !self.enabled {
+            self.notify_observer(false);
+            return;
+        }
+
+        self.sample_once();
+
+        let sample_interval = self.sample_interval;
+        let monitor = Arc::downgrade(self);
+        if let Err(error) = std::thread::Builder::new()
+            .name("sockudo-memory-pressure".to_string())
+            .spawn(move || {
+                loop {
+                    std::thread::sleep(sample_interval);
+                    let Some(monitor) = monitor.upgrade() else {
+                        return;
+                    };
+                    monitor.sample_once();
+                }
+            })
+        {
+            warn!(error = %error, "memory pressure admission sampler could not start");
+        }
+    }
+
+    /// Whether new connections should currently be rejected for memory pressure.
+    #[must_use]
+    pub fn is_shedding(&self) -> bool {
+        self.enabled && self.shedding.load(Ordering::Acquire)
+    }
+
+    /// Return the latest sampled admission state.
+    #[must_use]
+    pub fn snapshot(&self) -> MemoryPressureSnapshot {
+        MemoryPressureSnapshot {
+            enabled: self.enabled,
+            sample_available: self.sample_available.load(Ordering::Acquire),
+            shedding: self.is_shedding(),
+            resident_memory_bytes: self.resident_memory_bytes.load(Ordering::Acquire),
+            memory_limit_bytes: self.memory_limit_bytes.load(Ordering::Acquire),
+            memory_threshold: self.memory_threshold,
+            limit_source: limit_source_name(self.limit_source.load(Ordering::Acquire)),
+        }
+    }
+
+    fn sample_once(&self) {
+        match read_memory_sample(self.configured_limit_bytes) {
+            Ok(sample) => self.apply_sample(sample),
+            Err(error) => self.fail_open(error),
+        }
+    }
+
+    fn apply_sample(&self, sample: MemorySample) {
+        self.resident_memory_bytes
+            .store(sample.resident_memory_bytes, Ordering::Release);
+        self.memory_limit_bytes
+            .store(sample.memory_limit_bytes, Ordering::Release);
+        self.limit_source
+            .store(sample.limit_source, Ordering::Release);
+        self.sample_available.store(true, Ordering::Release);
+        self.unavailable_reported.store(false, Ordering::Release);
+
+        let shedding = sample.resident_memory_bytes as f64
+            >= sample.memory_limit_bytes as f64 * self.memory_threshold;
+        let previous = self.shedding.swap(shedding, Ordering::AcqRel);
+        self.notify_observer(shedding);
+
+        if shedding && !previous {
+            warn!(
+                resident_memory_bytes = sample.resident_memory_bytes,
+                memory_limit_bytes = sample.memory_limit_bytes,
+                memory_threshold = self.memory_threshold,
+                limit_source = limit_source_name(sample.limit_source),
+                "memory pressure admission shedding started"
+            );
+        } else if !shedding && previous {
+            info!(
+                resident_memory_bytes = sample.resident_memory_bytes,
+                memory_limit_bytes = sample.memory_limit_bytes,
+                memory_threshold = self.memory_threshold,
+                limit_source = limit_source_name(sample.limit_source),
+                "memory pressure admission shedding stopped"
+            );
+        }
+    }
+
+    fn fail_open(&self, error: io::Error) {
+        self.sample_available.store(false, Ordering::Release);
+        self.shedding.store(false, Ordering::Release);
+        self.limit_source
+            .store(LIMIT_SOURCE_UNAVAILABLE, Ordering::Release);
+        self.notify_observer(false);
+
+        if !self.unavailable_reported.swap(true, Ordering::AcqRel) {
+            warn!(error = %error, "memory pressure admission sampling unavailable; failing open");
+        }
+    }
+
+    fn notify_observer(&self, shedding: bool) {
+        if let Some(observer) = self.observer.as_ref() {
+            observer(shedding);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MemorySample {
+    resident_memory_bytes: u64,
+    memory_limit_bytes: u64,
+    limit_source: u8,
+}
+
+#[cfg(target_os = "linux")]
+fn read_memory_sample(configured_limit_bytes: Option<u64>) -> io::Result<MemorySample> {
+    let resident_memory_bytes = process_resident_memory_bytes()?;
+    let (memory_limit_bytes, limit_source) = match configured_limit_bytes {
+        Some(limit) => (limit, LIMIT_SOURCE_CONFIGURED),
+        None => read_linux_cgroup_limit()?,
+    };
+
+    Ok(MemorySample {
+        resident_memory_bytes,
+        memory_limit_bytes,
+        limit_source,
+    })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_memory_sample(_configured_limit_bytes: Option<u64>) -> io::Result<MemorySample> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "memory pressure admission is supported only on Linux",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn read_linux_cgroup_limit() -> io::Result<(u64, u8)> {
+    let v2 = std::fs::read_to_string("/sys/fs/cgroup/memory.max");
+    if let Ok(value) = v2.as_deref()
+        && let Some(limit) = parse_cgroup_limit(value, false)
+    {
+        return Ok((limit, LIMIT_SOURCE_CGROUP_V2));
+    }
+
+    let v1 = std::fs::read_to_string("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+    if let Ok(value) = v1.as_deref()
+        && let Some(limit) = parse_cgroup_limit(value, true)
+    {
+        return Ok((limit, LIMIT_SOURCE_CGROUP_V1));
+    }
+
+    let error = match (v2.err(), v1.err()) {
+        (Some(v2_error), Some(v1_error)) => io::Error::new(
+            v2_error.kind(),
+            format!("no readable cgroup memory limit (v2: {v2_error}; v1: {v1_error})"),
+        ),
+        _ => io::Error::new(
+            io::ErrorKind::NotFound,
+            "no finite cgroup memory limit is configured",
+        ),
+    };
+    Err(error)
+}
+
+fn parse_linux_resident_memory_bytes(status: &str) -> Option<u64> {
+    let line = status.lines().find(|line| line.starts_with("VmRSS:"))?;
+    let mut fields = line["VmRSS:".len()..].split_whitespace();
+    let value = fields.next()?.parse::<u64>().ok()?;
+    match fields.next() {
+        Some("kB") => value.checked_mul(1024),
+        None => Some(value),
+        _ => None,
+    }
+}
+
+fn parse_cgroup_limit(value: &str, is_v1: bool) -> Option<u64> {
+    let value = value.trim();
+    if value.eq_ignore_ascii_case("max") {
+        return None;
+    }
+    let value = value.parse::<u64>().ok()?;
+    if value == 0 || (is_v1 && value >= CGROUP_V1_UNLIMITED_FLOOR) {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn limit_source_name(source: u8) -> &'static str {
+    match source {
+        LIMIT_SOURCE_CONFIGURED => "configured",
+        LIMIT_SOURCE_CGROUP_V2 => "cgroup_v2",
+        LIMIT_SOURCE_CGROUP_V1 => "cgroup_v1",
+        _ => "unavailable",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn monitor(threshold: f64) -> Arc<MemoryPressureMonitor> {
+        MemoryPressureMonitor::new(
+            &AcceptTraffic {
+                enabled: true,
+                memory_threshold: threshold,
+                memory_limit_bytes: Some(1_000),
+                sample_interval_ms: 500,
+            },
+            None,
+        )
+    }
+
+    #[test]
+    fn parses_linux_rss_in_kibibytes() {
+        assert_eq!(
+            parse_linux_resident_memory_bytes("Name:\tsockudo\nVmRSS:\t  123 kB\n"),
+            Some(123 * 1024)
+        );
+        assert_eq!(parse_linux_resident_memory_bytes("Name:\tsockudo\n"), None);
+    }
+
+    #[test]
+    fn parses_finite_cgroup_limits_and_rejects_unlimited_values() {
+        assert_eq!(parse_cgroup_limit("1048576\n", false), Some(1_048_576));
+        assert_eq!(parse_cgroup_limit("max\n", false), None);
+        assert_eq!(parse_cgroup_limit("0", false), None);
+        assert_eq!(parse_cgroup_limit("9223372036854771712", true), None);
+    }
+
+    #[test]
+    fn threshold_crossing_changes_only_new_connection_admission() {
+        let monitor = monitor(0.9);
+        monitor.apply_sample(MemorySample {
+            resident_memory_bytes: 899,
+            memory_limit_bytes: 1_000,
+            limit_source: LIMIT_SOURCE_CONFIGURED,
+        });
+        assert!(!monitor.is_shedding());
+
+        monitor.apply_sample(MemorySample {
+            resident_memory_bytes: 900,
+            memory_limit_bytes: 1_000,
+            limit_source: LIMIT_SOURCE_CONFIGURED,
+        });
+        assert!(monitor.is_shedding());
+        assert!(monitor.snapshot().sample_available);
+    }
+
+    #[test]
+    fn unavailable_sample_fails_open() {
+        let monitor = monitor(0.9);
+        monitor.apply_sample(MemorySample {
+            resident_memory_bytes: 950,
+            memory_limit_bytes: 1_000,
+            limit_source: LIMIT_SOURCE_CONFIGURED,
+        });
+        assert!(monitor.is_shedding());
+
+        monitor.fail_open(io::Error::new(
+            io::ErrorKind::NotFound,
+            "test source missing",
+        ));
+        assert!(!monitor.is_shedding());
+        assert!(!monitor.snapshot().sample_available);
+    }
+
+    #[test]
+    fn observer_tracks_shedding_and_fail_open_state() {
+        let observed = Arc::new(AtomicBool::new(false));
+        let observer_state = Arc::clone(&observed);
+        let monitor = MemoryPressureMonitor::new(
+            &AcceptTraffic {
+                enabled: true,
+                memory_threshold: 0.9,
+                memory_limit_bytes: Some(1_000),
+                sample_interval_ms: 500,
+            },
+            Some(Arc::new(move |shedding| {
+                observer_state.store(shedding, Ordering::Release);
+            })),
+        );
+
+        monitor.apply_sample(MemorySample {
+            resident_memory_bytes: 950,
+            memory_limit_bytes: 1_000,
+            limit_source: LIMIT_SOURCE_CONFIGURED,
+        });
+        assert!(observed.load(Ordering::Acquire));
+
+        monitor.fail_open(io::Error::new(
+            io::ErrorKind::NotFound,
+            "test source missing",
+        ));
+        assert!(!observed.load(Ordering::Acquire));
+    }
+}

--- a/crates/sockudo-core/src/metrics.rs
+++ b/crates/sockudo-core/src/metrics.rs
@@ -17,6 +17,12 @@ pub trait MetricsInterface: Send + Sync {
     /// Handle a connection error
     fn mark_connection_error(&self, app_id: &str, error_type: &str);
 
+    /// Track a new connection rejected by memory-pressure admission control.
+    fn mark_memory_pressure_rejection(&self) {}
+
+    /// Update whether the node is currently shedding new connections.
+    fn update_memory_pressure_shedding(&self, _shedding: bool) {}
+
     /// Track a rate limit check
     fn mark_rate_limit_check(&self, app_id: &str, limiter_type: &str);
 

--- a/crates/sockudo-core/src/options/env/runtime.rs
+++ b/crates/sockudo-core/src/options/env/runtime.rs
@@ -79,6 +79,23 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
     // --- HTTP API ---
     options.http_api.usage_enabled =
         parse_bool_env("HTTP_API_USAGE_ENABLED", options.http_api.usage_enabled);
+    options.http_api.accept_traffic.enabled = parse_bool_env(
+        "HTTP_API_ACCEPT_TRAFFIC_ENABLED",
+        options.http_api.accept_traffic.enabled,
+    );
+    options.http_api.accept_traffic.memory_threshold = parse_env::<f64>(
+        "HTTP_API_ACCEPT_TRAFFIC_MEMORY_THRESHOLD",
+        options.http_api.accept_traffic.memory_threshold,
+    );
+    if let Some(limit_bytes) =
+        parse_env_optional::<u64>("HTTP_API_ACCEPT_TRAFFIC_MEMORY_LIMIT_BYTES")
+    {
+        options.http_api.accept_traffic.memory_limit_bytes = Some(limit_bytes);
+    }
+    options.http_api.accept_traffic.sample_interval_ms = parse_env::<u64>(
+        "HTTP_API_ACCEPT_TRAFFIC_SAMPLE_INTERVAL_MS",
+        options.http_api.accept_traffic.sample_interval_ms,
+    );
 
     // --- Rate Limiter ---
     options.rate_limiter.enabled =

--- a/crates/sockudo-core/src/options/runtime.rs
+++ b/crates/sockudo-core/src/options/runtime.rs
@@ -48,7 +48,14 @@ pub struct HttpApiConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AcceptTraffic {
+    /// Enable memory-pressure admission control for new WebSocket connections.
+    pub enabled: bool,
+    /// Fraction of the effective memory limit at which admission is closed.
     pub memory_threshold: f64,
+    /// Optional explicit memory limit. When unset, Linux cgroup limits are discovered.
+    pub memory_limit_bytes: Option<u64>,
+    /// Interval used by the admission sampler, independent of metrics scraping.
+    pub sample_interval_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -433,8 +440,29 @@ impl Default for HttpApiConfig {
 impl Default for AcceptTraffic {
     fn default() -> Self {
         Self {
+            enabled: false,
             memory_threshold: 0.90,
+            memory_limit_bytes: None,
+            sample_interval_ms: 500,
         }
+    }
+}
+
+impl AcceptTraffic {
+    pub fn validate(&self) -> Result<(), String> {
+        if !self.memory_threshold.is_finite()
+            || self.memory_threshold <= 0.0
+            || self.memory_threshold > 1.0
+        {
+            return Err("memory_threshold must be greater than 0 and at most 1".to_string());
+        }
+        if self.memory_limit_bytes == Some(0) {
+            return Err("memory_limit_bytes must be greater than 0 when set".to_string());
+        }
+        if self.sample_interval_ms == 0 {
+            return Err("sample_interval_ms must be greater than 0".to_string());
+        }
+        Ok(())
     }
 }
 

--- a/crates/sockudo-core/src/options/server.rs
+++ b/crates/sockudo-core/src/options/server.rs
@@ -167,6 +167,10 @@ impl ServerOptions {
 
     pub fn validate(&self) -> Result<(), String> {
         self.ably_compat.validate()?;
+        self.http_api
+            .accept_traffic
+            .validate()
+            .map_err(|error| format!("http_api.accept_traffic: {error}"))?;
         if self.ai_transport.enabled {
             self.ai_transport.validate_deployment_matrix(
                 &self.adapter,
@@ -450,6 +454,36 @@ mod tests {
     #[test]
     fn default_health_check_timeout_leaves_probe_headroom() {
         assert_eq!(ServerOptions::default().health_check_timeout_ms, 2000);
+    }
+
+    #[test]
+    fn memory_pressure_admission_configuration_is_validated() {
+        let mut options = ServerOptions::default();
+        options.http_api.accept_traffic.memory_threshold = 1.01;
+        assert!(
+            options
+                .validate()
+                .unwrap_err()
+                .contains("http_api.accept_traffic")
+        );
+
+        options.http_api.accept_traffic.memory_threshold = 0.9;
+        options.http_api.accept_traffic.sample_interval_ms = 0;
+        assert!(
+            options
+                .validate()
+                .unwrap_err()
+                .contains("sample_interval_ms")
+        );
+
+        options.http_api.accept_traffic.sample_interval_ms = 500;
+        options.http_api.accept_traffic.memory_limit_bytes = Some(0);
+        assert!(
+            options
+                .validate()
+                .unwrap_err()
+                .contains("memory_limit_bytes")
+        );
     }
 
     #[test]

--- a/crates/sockudo-metrics/src/prometheus/driver.rs
+++ b/crates/sockudo-metrics/src/prometheus/driver.rs
@@ -113,6 +113,8 @@ pub struct PrometheusMetricsDriver {
     pub(super) new_connections_total: CounterVec,
     pub(super) new_disconnections_total: CounterVec,
     pub(super) connection_errors_total: CounterVec,
+    pub(super) memory_pressure_rejections_total: CounterVec,
+    pub(super) memory_pressure_shedding: Gauge,
     pub(super) socket_bytes_received: CounterVec,
     pub(super) socket_bytes_transmitted: CounterVec,
     pub(super) ws_messages_received: CounterVec,
@@ -352,6 +354,21 @@ impl PrometheusMetricsDriver {
             ),
             &["app_id", "port", "error_type"]
         )
+        .unwrap();
+
+        let memory_pressure_rejections_total = register_counter_vec!(
+            Opts::new(
+                format!("{prefix}memory_pressure_rejections_total"),
+                "Total number of new connections rejected due to memory pressure"
+            ),
+            &["port"]
+        )
+        .unwrap();
+
+        let memory_pressure_shedding = register_gauge!(Opts::new(
+            format!("{prefix}memory_pressure_shedding"),
+            "Whether the node is currently shedding new connections due to memory pressure"
+        ))
         .unwrap();
 
         let socket_bytes_received = register_counter_vec!(
@@ -1134,6 +1151,7 @@ impl PrometheusMetricsDriver {
 
         // Reset gauge metrics to 0 on startup - they represent current state, not historical
         connected_sockets.reset();
+        memory_pressure_shedding.set(0.0);
         active_channels.reset();
         history_retained_messages.reset();
         history_retained_bytes.reset();
@@ -1174,6 +1192,8 @@ impl PrometheusMetricsDriver {
             new_connections_total,
             new_disconnections_total,
             connection_errors_total,
+            memory_pressure_rejections_total,
+            memory_pressure_shedding,
             socket_bytes_received,
             socket_bytes_transmitted,
             ws_messages_received,
@@ -1330,18 +1350,22 @@ impl PrometheusMetricsDriver {
             // Read /proc/self/statm for memory info (in pages)
             if let Ok(statm) = std::fs::read_to_string("/proc/self/statm") {
                 let parts: Vec<&str> = statm.split_whitespace().collect();
-                if parts.len() >= 2 {
+                if !parts.is_empty() {
                     let page_size = 4096_u64; // Standard page size on Linux
                     // First value is total program size (virtual memory) in pages
                     if let Ok(vsize_pages) = parts[0].parse::<u64>() {
                         self.process_virtual_memory_bytes
                             .set((vsize_pages * page_size) as f64);
                     }
-                    // Second value is resident set size in pages
-                    if let Ok(rss_pages) = parts[1].parse::<u64>() {
-                        self.process_resident_memory_bytes
-                            .set((rss_pages * page_size) as f64);
-                    }
+                }
+            }
+
+            match sockudo_core::memory_pressure::process_resident_memory_bytes() {
+                Ok(resident_memory_bytes) => self
+                    .process_resident_memory_bytes
+                    .set(resident_memory_bytes as f64),
+                Err(error) => {
+                    tracing::debug!(error = %error, "process resident memory sampling failed");
                 }
             }
 

--- a/crates/sockudo-metrics/src/prometheus/interface.rs
+++ b/crates/sockudo-metrics/src/prometheus/interface.rs
@@ -42,6 +42,17 @@ impl MetricsInterface for PrometheusMetricsDriver {
         debug!(app_id, error_type, "metrics: connection error");
     }
 
+    fn mark_memory_pressure_rejection(&self) {
+        self.memory_pressure_rejections_total
+            .with_label_values(&[&self.port.to_string()])
+            .inc();
+    }
+
+    fn update_memory_pressure_shedding(&self, shedding: bool) {
+        self.memory_pressure_shedding
+            .set(if shedding { 1.0 } else { 0.0 });
+    }
+
     fn mark_rate_limit_check(&self, app_id: &str, limiter_type: &str) {
         self.mark_rate_limit_check_with_context(app_id, limiter_type, "unknown");
     }

--- a/crates/sockudo-server/src/bootstrap/router.rs
+++ b/crates/sockudo-server/src/bootstrap/router.rs
@@ -1,6 +1,6 @@
 use super::SockudoServer;
 use crate::http_handler::{
-    append_message, batch_events, channel, channel_history, channel_history_purge,
+    accept_traffic, append_message, batch_events, channel, channel_history, channel_history_purge,
     channel_history_reset, channel_history_state, channel_message, channel_message_annotations,
     channel_message_versions, channel_presence_history, channel_presence_history_reset,
     channel_presence_history_snapshot, channel_presence_history_state, channel_users, channels,
@@ -587,6 +587,7 @@ impl SockudoServer {
 
         let mut router = router
             .merge(api_router)
+            .route("/accept-traffic", get(accept_traffic))
             .route("/up", get(up))
             .route("/up/{appId}", get(up))
             .route("/live", get(live));

--- a/crates/sockudo-server/src/http_handler/mod.rs
+++ b/crates/sockudo-server/src/http_handler/mod.rs
@@ -28,7 +28,7 @@ pub use presence_history::{
     channel_presence_history_state,
 };
 pub use sockudo_core::auth::EventQuery;
-pub use system::{fallback_404, live, metrics, stats, up, usage};
+pub use system::{accept_traffic, fallback_404, live, metrics, stats, up, usage};
 pub use versioned_messages::{
     append_message, channel_message, channel_message_versions, delete_message, update_message,
 };

--- a/crates/sockudo-server/src/http_handler/system.rs
+++ b/crates/sockudo-server/src/http_handler/system.rs
@@ -340,6 +340,40 @@ pub async fn live() -> StatusCode {
     StatusCode::OK
 }
 
+/// GET /accept-traffic
+///
+/// This admission probe is intentionally separate from `/up`: memory pressure
+/// stops new connections without declaring the process or its dependencies dead.
+pub async fn accept_traffic(
+    State(handler): State<Arc<ConnectionHandler>>,
+) -> Result<impl IntoResponse, AppError> {
+    let snapshot = handler.memory_pressure_snapshot();
+    let monitor_state = if !snapshot.enabled {
+        "DISABLED"
+    } else if !snapshot.sample_available {
+        "UNAVAILABLE"
+    } else if snapshot.shedding {
+        "SHEDDING"
+    } else {
+        "AVAILABLE"
+    };
+
+    let (status, admission_state) = if !handler.is_accepting() {
+        (StatusCode::SERVICE_UNAVAILABLE, "DRAINING")
+    } else if snapshot.shedding {
+        (StatusCode::SERVICE_UNAVAILABLE, "MEMORY_PRESSURE")
+    } else {
+        (StatusCode::OK, "ACCEPTING")
+    };
+
+    Ok(axum::http::Response::builder()
+        .status(status)
+        .header("X-Accept-Traffic", admission_state)
+        .header("X-Memory-Pressure-Monitor", monitor_state)
+        .header("X-Memory-Limit-Source", snapshot.limit_source)
+        .body(admission_state.to_string())?)
+}
+
 /// GET /up or /up/{app_id}
 #[instrument(skip(handler), fields(app_id = field::Empty))]
 pub async fn up(
@@ -493,6 +527,62 @@ mod tests {
         MemoryPresenceHistoryStore, PresenceHistoryDurableState, PresenceHistoryStreamRuntimeState,
     };
     use sonic_rs::{JsonValueTrait, Value};
+
+    #[tokio::test]
+    async fn accept_traffic_fails_open_when_memory_admission_is_disabled() {
+        let handler = Arc::new(
+            ConnectionHandlerBuilder::new(
+                Arc::new(MemoryAppManager::new()),
+                Arc::new(LocalAdapter::new()),
+                Arc::new(MemoryCacheManager::new(
+                    "test".to_string(),
+                    MemoryCacheOptions::default(),
+                )),
+                sockudo_core::options::ServerOptions::default(),
+            )
+            .build(),
+        );
+
+        let response = accept_traffic(State(handler))
+            .await
+            .unwrap()
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()["X-Memory-Pressure-Monitor"], "DISABLED");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn accept_traffic_reports_memory_pressure_without_changing_readiness() {
+        let mut options = sockudo_core::options::ServerOptions::default();
+        options.http_api.accept_traffic.enabled = true;
+        options.http_api.accept_traffic.memory_limit_bytes = Some(1);
+
+        let handler = Arc::new(
+            ConnectionHandlerBuilder::new(
+                Arc::new(MemoryAppManager::new()),
+                Arc::new(LocalAdapter::new()),
+                Arc::new(MemoryCacheManager::new(
+                    "test".to_string(),
+                    MemoryCacheOptions::default(),
+                )),
+                options,
+            )
+            .build(),
+        );
+
+        assert!(
+            handler.is_accepting(),
+            "memory pressure must not change /up"
+        );
+        assert!(handler.is_memory_pressure_shedding());
+        let response = accept_traffic(State(handler))
+            .await
+            .unwrap()
+            .into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers()["X-Accept-Traffic"], "MEMORY_PRESSURE");
+    }
 
     #[tokio::test]
     async fn stats_endpoint_returns_empty_totals_for_empty_server() {

--- a/crates/sockudo-server/src/ws_handler.rs
+++ b/crates/sockudo-server/src/ws_handler.rs
@@ -55,6 +55,15 @@ pub async fn handle_ws_upgrade(
     if !handler.is_accepting() {
         return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
     }
+    if handler.is_memory_pressure_shedding() {
+        handler.mark_memory_pressure_rejection();
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            [(axum::http::header::RETRY_AFTER, "1")],
+            "MEMORY_PRESSURE",
+        )
+            .into_response();
+    }
 
     // Extract Origin header if present
     let origin = headers

--- a/docs/content/docs/deployment/kubernetes.mdx
+++ b/docs/content/docs/deployment/kubernetes.mdx
@@ -260,6 +260,7 @@ Use different endpoints for different decisions:
 | Startup | `/live` | The process has started. |
 | Liveness | `/live` | The process runtime is alive. |
 | Readiness | `/up` or `/up/<app-id>` | Required apps and shared dependencies are available. |
+| New-connection admission | `/accept-traffic` | The pod is not draining or shedding new connections under memory pressure. |
 
 Do not use dependency-aware `/up` as liveness. Restarting every pod because Redis is slow creates a
 reconnect storm and does not repair Redis.
@@ -278,6 +279,27 @@ Persistent connections do not map cleanly onto CPU-only autoscaling:
 Set `SOCKUDO_MAX_CONNECTIONS` on every pod so a single replica cannot absorb more connections than
 its measured memory and file-descriptor budget. Keep minimum replicas high enough for the peak
 quiet-socket count even when CPU is low.
+
+For a second guard based on actual memory use, enable the chart's memory-pressure admission control:
+
+```yaml
+config:
+  httpApi:
+    acceptTraffic:
+      enabled: true
+      memoryThreshold: 0.9
+      sampleIntervalMs: 500
+```
+
+With `memoryLimitBytes: null` (the default), Sockudo discovers the pod's finite cgroup memory limit.
+When process RSS reaches the configured fraction, the pod rejects only new native and Ably
+WebSocket connections with `503`/retry guidance while established sessions continue. It resumes
+admission after a later sample falls below the threshold. The sampler is independent of metrics
+scrapes and fails open if Linux RSS or cgroup data is unavailable.
+
+Keep `/up` as Kubernetes readiness so dependency failures remain visible. If the ingress or external
+load balancer supports a separate backend-admission or network-watcher probe, point that probe at
+`/accept-traffic`. Direct admission enforcement remains active even without such a probe.
 
 CPU limits can throttle a pod during the exact reconnect or fanout burst it needs to process.
 Requests plus a memory limit are a reasonable starting point on a dedicated node pool. Add a CPU

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -46,6 +46,30 @@ For endpoint availability details see
 For capacity and operational metrics see
 [Capacity planning — API pod topology](/docs/deployment/capacity-planning#api-pod-topology).
 
+## Memory-pressure connection admission
+
+Memory-pressure admission control is opt-in under `[http_api.accept_traffic]`:
+
+```toml
+[http_api.accept_traffic]
+enabled = true
+memory_threshold = 0.90
+# memory_limit_bytes = 2147483648 # optional; otherwise discover the cgroup limit
+sample_interval_ms = 500
+```
+
+On Linux, Sockudo samples its process RSS on `sample_interval_ms`, independently of Prometheus
+scrapes. It compares RSS with `memory_limit_bytes` when configured, otherwise with the finite cgroup
+v2 `memory.max` or cgroup v1 `memory.limit_in_bytes` value. At or above `memory_threshold`, native
+and Ably WebSocket upgrades return `503`, and the post-upgrade admission gate returns protocol close
+code `4100` if pressure changes during the upgrade. Existing connections remain open.
+
+The sampler fails open when RSS or a finite limit is unavailable, including on non-Linux systems.
+`GET /accept-traffic` exposes the admission decision for a load balancer; `/up` deliberately remains
+a dependency/readiness check and does not fail because of memory pressure. Use
+`sockudo_memory_pressure_shedding` and `sockudo_memory_pressure_rejections_total` to alert on the
+current state and rejected connection count.
+
 ## App manager
 
 | Section | Purpose |

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -107,6 +107,10 @@ url = "${REDIS_URL:-redis://localhost:6379}"
 | `HOSTNAME` | Fallback node identity for Iggy when `INSTANCE_PROCESS_ID` is not set. |
 | `HEALTH_CHECK_TIMEOUT_MS` | Per-dependency timeout for `/up` health checks in milliseconds. Defaults to `2000`. |
 | `HTTP_API_USAGE_ENABLED` | Enables `/usage` and `/stats` operational endpoints. |
+| `HTTP_API_ACCEPT_TRAFFIC_ENABLED` | Enables memory-pressure admission control for new WebSocket connections. Defaults to `false`. |
+| `HTTP_API_ACCEPT_TRAFFIC_MEMORY_THRESHOLD` | Fraction of the effective memory limit that closes new-connection admission. Defaults to `0.9`; valid range is greater than `0` through `1`. |
+| `HTTP_API_ACCEPT_TRAFFIC_MEMORY_LIMIT_BYTES` | Optional explicit memory limit in bytes. When unset, Linux cgroup v2/v1 limits are discovered. |
+| `HTTP_API_ACCEPT_TRAFFIC_SAMPLE_INTERVAL_MS` | Independent memory-pressure sampling interval in milliseconds. Defaults to `500`. |
 
 ## Logging
 

--- a/docs/content/docs/reference/http-endpoints.mdx
+++ b/docs/content/docs/reference/http-endpoints.mdx
@@ -244,6 +244,7 @@ Push list endpoints use cursor pagination with `limit` and opaque `cursor`.
 | Method | Path | Auth | Purpose |
 | --- | --- | --- | --- |
 | `GET` | `/live` | None | Liveness probe. Does not perform dependency checks. |
+| `GET` | `/accept-traffic` | None | New-connection admission probe. Returns `503` while draining or shedding for memory pressure, without closing established connections. |
 | `GET` | `/up` | None | Global health probe. |
 | `GET` | `/up/{appId}` | None | App-specific health probe. |
 | `GET` | `/usage` | None, when enabled | Memory usage snapshot. Enabled by `HTTP_API_USAGE_ENABLED`. |
@@ -259,6 +260,14 @@ Pagination is anchored to interval IDs and a fixed query horizon.
 
 Disable `/usage`, `/operator/stats`, and operator aggregation stats in exposed
 production environments unless they are behind trusted ingress controls.
+
+`/accept-traffic` returns `200 ACCEPTING` when new connections may be admitted, including when the
+memory sampler is disabled or unavailable (fail-open). It returns `503 MEMORY_PRESSURE` while the
+configured RSS threshold is exceeded and `503 DRAINING` during shutdown. The
+`X-Memory-Pressure-Monitor` response header distinguishes `DISABLED`, `UNAVAILABLE`, `AVAILABLE`,
+and `SHEDDING`; `X-Memory-Limit-Source` reports `configured`, `cgroup_v2`, `cgroup_v1`, or
+`unavailable`. Keep `/up` as the dependency/readiness probe unless a load balancer can poll a
+separate admission endpoint.
 
 ## Metrics endpoint
 


### PR DESCRIPTION
## Summary

- add opt-in Linux memory-pressure admission sampling against cgroup v1/v2 or an explicit byte limit
- reject new native and Ably WebSocket connections while preserving established sessions and keeping /up independent
- expose /accept-traffic plus Prometheus shedding and rejection metrics
- add validated config, environment variables, Helm values, tests, and operator documentation

## Verification

- cargo fmt --all -- --check
- cargo test -p sockudo-core memory_pressure
- cargo test -p sockudo-adapter --test integration memory_pressure_rejects_new_connection_without_marking_it_connected
- cargo test -p sockudo accept_traffic_
- cargo check -p sockudo --features ably-compat
- cargo clippy -p sockudo-core -p sockudo-metrics -p sockudo-adapter -p sockudo --all-targets -- -D warnings
- npm run types:check and npm run build in docs
- helm lint and helm template

Closes #411