### PR TITLE
feat: add Laravel broadcasting adapter

### DIFF
--- a/.github/workflows/mirror-laravel-sdk.yml
+++ b/.github/workflows/mirror-laravel-sdk.yml
@@ -1,0 +1,117 @@
+name: Mirror Laravel SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Git ref, tag, or SHA to mirror"
+        required: false
+        default: master
+      mirror_tag:
+        description: "Optional mirror tag to publish, for example v1.0.0"
+        required: false
+        default: ""
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/mirror-laravel-sdk.yml"
+      - "server-sdks/sockudo-laravel/**"
+    tags:
+      - "server-laravel-v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: laravel-sdk-mirror-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  LARAVEL_SDK_PATH: server-sdks/sockudo-laravel
+  MIRROR_REPOSITORY: sockudo/sockudo-laravel
+  MIRROR_BRANCH: main
+
+jobs:
+  mirror:
+    name: Mirror subtree
+    runs-on: ubuntu-24.04
+    if: github.repository == 'sockudo/sockudo'
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+          ref: ${{ inputs.source_ref || github.ref }}
+
+      - name: Install git-filter-repo
+        run: |
+          python3 -m venv "$RUNNER_TEMP/git-filter-repo"
+          "$RUNNER_TEMP/git-filter-repo/bin/pip" install git-filter-repo==2.47.0
+          echo "$RUNNER_TEMP/git-filter-repo/bin" >> "$GITHUB_PATH"
+
+      - name: Mirror Laravel SDK
+        env:
+          MIRROR_TOKEN: ${{ secrets.LARAVEL_SDK_MIRROR_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          MANUAL_MIRROR_TAG: ${{ inputs.mirror_tag || '' }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${MIRROR_TOKEN}" ]; then
+            if [ "${EVENT_NAME}" = "push" ] && [ "${REF_TYPE}" = "branch" ]; then
+              echo "::warning::LARAVEL_SDK_MIRROR_TOKEN is not configured; skipping branch mirror."
+              exit 0
+            fi
+            echo "LARAVEL_SDK_MIRROR_TOKEN is required to push to ${MIRROR_REPOSITORY}." >&2
+            exit 1
+          fi
+
+          split_repo="$(mktemp -d)"
+          trap 'rm -rf "${split_repo}"' EXIT
+
+          git clone --no-local --no-hardlinks . "${split_repo}"
+          cd "${split_repo}"
+
+          git filter-repo \
+            --path "${LARAVEL_SDK_PATH}/" \
+            --path-rename "${LARAVEL_SDK_PATH}/:" \
+            --force
+
+          git remote add mirror "https://github.com/${MIRROR_REPOSITORY}.git"
+          git fetch --no-tags mirror \
+            "${MIRROR_BRANCH}:refs/remotes/mirror/${MIRROR_BRANCH}" || true
+
+          mirror_tag="${MANUAL_MIRROR_TAG}"
+          if [ "${EVENT_NAME}" = "push" ] && [ "${REF_TYPE}" = "tag" ]; then
+            mirror_tag="${REF_NAME#server-laravel-}"
+          fi
+
+          git remote set-url mirror \
+            "https://x-access-token:${MIRROR_TOKEN}@github.com/${MIRROR_REPOSITORY}.git"
+          git config user.name "sockudo-mirror[bot]"
+          git config user.email "sockudo-mirror[bot]@users.noreply.github.com"
+
+          if [ -n "${mirror_tag}" ]; then
+            if [[ ! "${mirror_tag}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+ ]]; then
+              echo "Mirror tag must look like v1.0.0; got ${mirror_tag}." >&2
+              exit 1
+            fi
+
+            git tag --force --annotate "${mirror_tag}" \
+              --message "Mirror ${REF_NAME} from sockudo/sockudo@${GITHUB_SHA}"
+            git push --force mirror "refs/tags/${mirror_tag}"
+            exit 0
+          fi
+
+          if git rev-parse --verify "refs/remotes/mirror/${MIRROR_BRANCH}" >/dev/null 2>&1; then
+            lease="$(git rev-parse "refs/remotes/mirror/${MIRROR_BRANCH}")"
+            git push mirror "HEAD:refs/heads/${MIRROR_BRANCH}" \
+              --force-with-lease="refs/heads/${MIRROR_BRANCH}:${lease}"
+          else
+            git push --force mirror "HEAD:refs/heads/${MIRROR_BRANCH}"
+          fi

--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/sdk-ci.yml"
       - ".github/workflows/sdk-release.yml"
       - ".github/workflows/mirror-php-sdk.yml"
+      - ".github/workflows/mirror-laravel-sdk.yml"
       - ".github/workflows/mirror-swift-sdks.yml"
       - "client-sdks/**"
       - "server-sdks/**"
@@ -17,6 +18,7 @@ on:
       - ".github/workflows/sdk-ci.yml"
       - ".github/workflows/sdk-release.yml"
       - ".github/workflows/mirror-php-sdk.yml"
+      - ".github/workflows/mirror-laravel-sdk.yml"
       - ".github/workflows/mirror-swift-sdks.yml"
       - "client-sdks/**"
       - "server-sdks/**"
@@ -63,6 +65,7 @@ jobs:
           .github/workflows/sdk-ci.yml
           .github/workflows/sdk-release.yml
           .github/workflows/mirror-php-sdk.yml
+          .github/workflows/mirror-laravel-sdk.yml
           .github/workflows/mirror-swift-sdks.yml
 
   dependency-review:
@@ -398,6 +401,47 @@ jobs:
           composer install --no-interaction --prefer-dist
           vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no
           vendor/bin/phplint src tests
+          vendor/bin/phpunit
+
+  laravel-server-sdk:
+    name: Laravel SDK / Laravel ${{ matrix.laravel }} / PHP ${{ matrix.php }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - laravel: "12"
+            php: "8.2"
+            testbench: "^10.0"
+            phpunit: "^11.0"
+          - laravel: "13"
+            php: "8.3"
+            testbench: "^11.0"
+            phpunit: "^12.0"
+    defaults:
+      run:
+        shell: bash
+        working-directory: server-sdks/sockudo-laravel
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2
+          extensions: curl, json, sodium
+
+      - name: Verify Laravel package
+        run: |
+          composer validate --strict --no-check-lock
+          composer update --no-interaction --prefer-dist \
+            --with "orchestra/testbench:${{ matrix.testbench }}" \
+            --with "phpunit/phpunit:${{ matrix.phpunit }}"
+          vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no
+          vendor/bin/phplint src config tests
           vendor/bin/phpunit
 
   ruby-server-sdk:

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -20,6 +20,7 @@ on:
           - server-node
           - server-python
           - server-php
+          - server-laravel
           - server-ruby
           - server-go
           - server-rust
@@ -43,6 +44,7 @@ on:
       - "server-node-v*"
       - "server-python-v*"
       - "server-php-v*"
+      - "server-laravel-v*"
       - "server-ruby-v*"
       - "server-sdks/sockudo-http-go/v*"
       - "server-rust-v*"
@@ -688,6 +690,46 @@ jobs:
         if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
         run: |
           echo "Packagist publishes from the PHP mirror. Ensure Packagist is hooked to https://github.com/sockudo/sockudo-http-php."
+
+  server-laravel:
+    name: Gate sockudo/laravel
+    runs-on: ubuntu-24.04
+    environment: packagist
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' && (inputs.package == 'all' || inputs.package == 'server-laravel')) ||
+        startsWith(github.ref_name, 'server-laravel-v')
+      }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: server-sdks/sockudo-laravel
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+          tools: composer:v2
+          extensions: curl, json, sodium
+
+      - name: Verify package
+        run: |
+          composer validate --strict --no-check-lock
+          composer update --no-interaction --prefer-dist \
+            --with "orchestra/testbench:^11.0" \
+            --with "phpunit/phpunit:^12.0"
+          vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no
+          vendor/bin/phplint src config tests
+          vendor/bin/phpunit
+
+      - name: Packagist publish notice
+        if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
+        run: |
+          echo "Packagist publishes from the Laravel mirror. Ensure Packagist is hooked to https://github.com/sockudo/sockudo-laravel."
 
   server-go:
     name: Gate sockudo-http-go

--- a/docs/content/docs/server-sdks/index.mdx
+++ b/docs/content/docs/server-sdks/index.mdx
@@ -23,6 +23,16 @@ archived/legacy mirrors.
 | .NET | `SockudoServer` | [.NET](/docs/server-sdks/dotnet) |
 | Swift | `Sockudo` via SwiftPM | [Swift](/docs/server-sdks/swift) |
 
+## Framework integrations
+
+| Framework | Package | Guide |
+| --- | --- | --- |
+| Laravel 12–13 | `sockudo/laravel` | [Laravel](/docs/server-sdks/laravel) |
+
+The Laravel package registers a native `sockudo` broadcasting connection and
+exposes the PHP server SDK through Laravel's container and a facade. Laravel
+Echo continues to use Sockudo's Pusher-compatible Protocol V1 connection.
+
 These packages share the Sockudo/Pusher HTTP signing protocol but differ in
 their typed helpers. When a new Sockudo endpoint is not yet wrapped by a
 language SDK, use its generic signed-request helper or generated signed URI

--- a/docs/content/docs/server-sdks/laravel.mdx
+++ b/docs/content/docs/server-sdks/laravel.mdx
@@ -1,0 +1,160 @@
+---
+title: Laravel
+description: Use Sockudo as a first-class Laravel broadcaster with Echo-compatible auth and access to native history, mutable-message, annotation, and push APIs.
+icon: RadioTower
+---
+
+The official Laravel integration registers a `sockudo` broadcasting connection
+backed by the PHP server SDK. Existing Laravel broadcast events keep their
+normal semantics, while trusted backend code can use Sockudo-native APIs from
+the service container or facade.
+
+## Install
+
+```bash
+composer require sockudo/laravel
+php artisan sockudo:install
+```
+
+The service provider is auto-discovered. Configure credentials through your
+environment or secret manager:
+
+```bash
+BROADCAST_CONNECTION=sockudo
+
+SOCKUDO_APP_ID=app-id
+SOCKUDO_APP_KEY=app-key
+SOCKUDO_APP_SECRET=app-secret
+SOCKUDO_HOST=127.0.0.1
+SOCKUDO_PORT=6001
+SOCKUDO_SCHEME=http
+```
+
+Use `https` when the signed HTTP API crosses an untrusted network. Confirm the
+configuration and API connectivity without exposing credentials:
+
+```bash
+php artisan sockudo:check
+```
+
+Use `php artisan sockudo:check --config-only` when Sockudo is intentionally
+unreachable during image builds.
+
+The install command warns when Laravel's `routes/channels.php` broadcasting
+scaffold is absent. Install Laravel broadcasting routes before using private or
+presence channels; the Sockudo package supplies the backend connection but
+does not silently rewrite application route authorization.
+
+## Broadcast events
+
+Laravel's existing event contracts work unchanged:
+
+```php
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+final class OrderUpdated implements ShouldBroadcast
+{
+    public function __construct(public readonly string $orderId) {}
+
+    public function broadcastOn(): PrivateChannel
+    {
+        return new PrivateChannel("orders.{$this->orderId}");
+    }
+}
+```
+
+The driver supports queued broadcasting, `ShouldBroadcastNow`, `toOthers()`,
+public channels, private channels, presence channels, encrypted private
+channels, and user authentication. Define authorization callbacks in
+`routes/channels.php` as usual:
+
+```php
+use Illuminate\Support\Facades\Broadcast;
+
+Broadcast::channel('orders.{order}', function ($user, $order) {
+    return $user->can('view', $order);
+});
+```
+
+Signing proves that Laravel approved a subscription; your channel callback is
+still responsible for tenant and resource authorization.
+
+## Connect Laravel Echo
+
+Laravel Echo uses the Pusher connector for Sockudo Protocol V1:
+
+```js
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+window.Pusher = Pusher;
+
+window.Echo = new Echo({
+  broadcaster: 'pusher',
+  key: import.meta.env.VITE_SOCKUDO_APP_KEY,
+  wsHost: import.meta.env.VITE_SOCKUDO_HOST,
+  wsPort: Number(import.meta.env.VITE_SOCKUDO_PORT ?? 6001),
+  wssPort: Number(import.meta.env.VITE_SOCKUDO_PORT ?? 443),
+  forceTLS: (import.meta.env.VITE_SOCKUDO_SCHEME ?? 'https') === 'https',
+  enabledTransports: ['ws', 'wss'],
+});
+```
+
+Echo sends private and presence authorization requests to Laravel's standard
+`/broadcasting/auth` endpoint. Never expose `SOCKUDO_APP_SECRET` to JavaScript.
+
+Protocol V2 recovery, rewind, filters, deltas, and mutable-message projections
+require a Sockudo-native realtime client rather than Laravel Echo.
+
+## Native APIs
+
+The facade proxies calls to the configured PHP server SDK client:
+
+```php
+use Sockudo\Laravel\Facades\Sockudo;
+
+$history = Sockudo::getChannelHistory('orders', ['limit' => 50]);
+
+Sockudo::updateMessage('orders', $messageSerial, [
+    'data' => ['status' => 'paid'],
+]);
+
+Sockudo::publishAnnotation('orders', $messageSerial, [
+    'type' => 'reaction',
+    'name' => 'confirmed',
+]);
+
+$publish = Sockudo::publishPush([
+    'recipients' => [['type' => 'channel', 'channel' => 'orders']],
+    'payload' => ['title' => 'Order updated'],
+    'idempotency_key' => 'order-updated:ord-123:v4',
+]);
+```
+
+Inject `Sockudo\SockudoInterface` when constructor injection is preferable. The
+binding resolves the connection named by `SOCKUDO_CONNECTION`, which defaults
+to `sockudo`.
+
+## Multiple Sockudo apps
+
+Define additional `driver => sockudo` entries in
+`config/broadcasting.php`, then select one explicitly:
+
+```php
+$client = Sockudo::connection('sockudo-eu');
+$client->trigger('orders', 'order.updated', ['id' => 'ord-123']);
+```
+
+Each connection has its own credentials, host, TLS options, and HTTP client
+settings. Keep all secrets out of committed configuration and logs.
+
+## Deployment notes
+
+- Run broadcasts on Laravel queues when request latency should not depend on
+  the realtime API.
+- Keep the SDK timeout below the queue-job timeout.
+- Restart long-lived queue workers after changing cached configuration.
+- Use stable, business-derived idempotency keys for retryable native publishes.
+- Test public, private, presence, encrypted, `toOthers()`, and queued flows
+  before switching production traffic.

--- a/docs/content/docs/server-sdks/meta.json
+++ b/docs/content/docs/server-sdks/meta.json
@@ -6,6 +6,7 @@
     "node",
     "python",
     "php",
+    "laravel",
     "ruby",
     "go",
     "rust",

--- a/docs/content/docs/server-sdks/php.mdx
+++ b/docs/content/docs/server-sdks/php.mdx
@@ -15,14 +15,16 @@ composer require sockudo/sockudo-php-server:^2.0
 ```php
 use Sockudo\Sockudo;
 
-$sockudo = new Sockudo([
-    'app_id' => 'app-id',
-    'key' => 'app-key',
-    'secret' => 'app-secret',
-    'host' => '127.0.0.1',
-    'port' => 6001,
-    'useTLS' => false,
-]);
+$sockudo = new Sockudo(
+    'app-key',
+    'app-secret',
+    'app-id',
+    [
+        'host' => '127.0.0.1',
+        'port' => 6001,
+        'useTLS' => false,
+    ],
+);
 ```
 
 Create the client once in your framework service container and reuse it. The
@@ -45,7 +47,13 @@ $http = new GuzzleHttp\Client([
     'connect_timeout' => 2.0,
 ]);
 
-$sockudo = new Sockudo($config, $http);
+$sockudo = new Sockudo(
+    'app-key',
+    'app-secret',
+    'app-id',
+    ['host' => '127.0.0.1', 'port' => 6001, 'useTLS' => false],
+    $http,
+);
 ```
 
 ## Publish
@@ -138,6 +146,18 @@ Treat application state as an operational snapshot. Keep history pages bounded
 and pass cursors back unchanged.
 
 ## Laravel broadcasting
+
+For a first-class `sockudo` broadcasting connection, auto-discovered service
+provider, configuration check, and native SDK facade, install the
+[Laravel integration](/docs/server-sdks/laravel):
+
+```bash
+composer require sockudo/laravel
+php artisan sockudo:install
+```
+
+The Pusher-compatible connection below remains supported for existing
+applications that do not want the Laravel integration package:
 
 ```php
 'pusher' => [

--- a/docs/release-5.0.0.md
+++ b/docs/release-5.0.0.md
@@ -18,6 +18,7 @@ release built from it. Do not create any release tag until that exact commit is 
 | Node server SDK `sockudo` | 2.2.0 | `server-node-v2.2.0` |
 | `sockudo-http-python` | 2.2.0 | `server-python-v2.2.0` |
 | `sockudo/sockudo-php-server` | 2.2.0 | `server-php-v2.2.0` |
+| `sockudo/laravel` | 1.0.0 | `server-laravel-v1.0.0` |
 | Ruby server SDK `sockudo` | 2.2.0 | `server-ruby-v2.2.0` |
 | Go server SDK v2 | 2.2.0 | `server-sdks/sockudo-http-go/v2.2.0` |
 | `sockudo-http` Rust server SDK | 2.2.0 | `server-rust-v2.2.0` |
@@ -26,7 +27,8 @@ release built from it. Do not create any release tag until that exact commit is 
 | Swift server SDK `Sockudo` | 2.2.0 | `server-swift-v2.2.0` |
 
 AI Transport 3.0.0 and the Swift client 3.0.0 carry real breaking changes documented in their
-package changelogs. The other SDK changes are additive and remain on the 2.x line. The Go module
+package changelogs. The Laravel integration is a new 1.0.0 package. The other SDK changes are
+additive and remain on the 2.x line. The Go module
 stays on `/v2`; moving it to 3.0.0 would require a breaking `/v3` import path.
 
 ## Required Gates
@@ -59,7 +61,7 @@ workflow package and publish the full set in dependency order.
 3. Run released-binary compatibility verification against `v5.0.0` and retain the reports.
 4. Publish `@sockudo/client` 2.2.0 before `@sockudo/ai-transport` 3.0.0.
 5. Create the remaining client tags from the same SHA.
-6. Create the nine server SDK tags from the same SHA. The PHP and Swift mirror workflows must
+6. Create the ten server SDK tags from the same SHA. The PHP, Laravel, and Swift mirror workflows must
    finish before checking Packagist or SwiftPM availability.
 7. Verify registry metadata, provenance, install snippets, mirrored tags, and package contents for
    every entry in the matrix.
@@ -81,6 +83,6 @@ preceding release has completed; do not publish the whole train with an unreview
 - [ ] pull and smoke-test both `ghcr.io/sockudo/sockudo:5.0.0` and `sockudo/sockudo:5.0.0`
 - [ ] verify Linux GNU/musl archives and detached SHA-256 files for x86_64 and ARM64
 - [ ] install each SDK from its public registry or SwiftPM mirror at the matrix version
-- [ ] confirm the PHP mirror exposes `v2.2.0` and both Swift mirrors expose their expected tags
+- [ ] confirm the PHP mirror exposes `v2.2.0`, the Laravel mirror exposes `v1.0.0`, and both Swift mirrors expose their expected tags
 - [ ] mark the published-artifact and released-binary items green in the compatibility scorecard
 - [ ] announce breaking AI Transport and Swift actor-isolation migrations beside the release notes

--- a/docs/sdk-publishing-2026.md
+++ b/docs/sdk-publishing-2026.md
@@ -45,6 +45,7 @@ or signing credentials:
 | `MAVEN_GPG_PASSPHRASE` | Maven Central | signing key passphrase |
 | `CRATES_IO_TOKEN` | crates.io | fallback token used only when trusted publishing is not configured |
 | `PHP_SDK_MIRROR_TOKEN` | Packagist/PHP mirror | fine-grained PAT or GitHub App token with contents write access to `sockudo/sockudo-http-php` |
+| `LARAVEL_SDK_MIRROR_TOKEN` | Packagist/Laravel mirror | fine-grained PAT or GitHub App token with contents write access to `sockudo/sockudo-laravel` |
 | `SWIFT_SDK_MIRROR_TOKEN` | SwiftPM mirrors | fine-grained PAT or GitHub App token with contents and workflows write access to `sockudo/sockudo-swift` and `sockudo/sockudo-http-swift` |
 
 ## Browser Setup Checklist
@@ -146,31 +147,42 @@ configured yet, it falls back to `CRATES_IO_TOKEN`.
 
 ### Packagist
 
-Package: `sockudo/sockudo-php-server`
+Packages: `sockudo/sockudo-php-server`, `sockudo/laravel`
 
 Packagist publishes from VCS tags and repository hooks, not from an uploaded artifact. Public
 Packagist.org does not publish packages from a subdirectory, so the monorepo is the source of truth
 and `.github/workflows/mirror-php-sdk.yml` mirrors `server-sdks/sockudo-http-php` to the root of the
 standalone `sockudo/sockudo-http-php` repository.
 
+The same rule applies to the Laravel integration:
+`.github/workflows/mirror-laravel-sdk.yml` mirrors
+`server-sdks/sockudo-laravel` to the root of `sockudo/sockudo-laravel`.
+
 Submit this repository URL to Packagist:
 
 ```text
 https://github.com/sockudo/sockudo-http-php
+https://github.com/sockudo/sockudo-laravel
 ```
 
 Stable Packagist versions come from Composer-compatible mirror tags such as `v2.2.0`. Create PHP
 release tags in this monorepo as `server-php-vX.Y.Z`; the mirror workflow publishes the matching
 `vX.Y.Z` tag to `sockudo/sockudo-http-php`.
 
+Create Laravel integration release tags as `server-laravel-vX.Y.Z`; its mirror
+workflow publishes the matching `vX.Y.Z` tag to `sockudo/sockudo-laravel`.
+
 Before pushing a PHP release tag, run the PHP release dry run:
 
 ```bash
 gh workflow run sdk-release.yml -f package=server-php -f dry_run=true
+gh workflow run sdk-release.yml -f package=server-laravel -f dry_run=true
 ```
 
-The mirror workflow requires `PHP_SDK_MIRROR_TOKEN`. Configure the mirror repository description as
-read-only and direct issues and pull requests back to this monorepo.
+The mirror workflows require `PHP_SDK_MIRROR_TOKEN` and
+`LARAVEL_SDK_MIRROR_TOKEN`, respectively. Configure both mirror repository
+descriptions as read-only and direct issues and pull requests back to this
+monorepo.
 
 ### Go Modules
 
@@ -217,6 +229,7 @@ read-only and direct issues and pull requests back to this monorepo.
 | `sockudo` Node server SDK | npm lint/typecheck/local-test and `npm pack --dry-run` | `server-node-vX.Y.Z` |
 | `sockudo-http-python` | Ruff format/check, pytest, build, twine check | `server-python-vX.Y.Z` |
 | `sockudo/sockudo-php-server` | Composer validate, PHP-CS-Fixer, PHPLint, PHPUnit | `server-php-vX.Y.Z` |
+| `sockudo/laravel` | Laravel 12–13 Composer matrix, PHP-CS-Fixer, PHPLint, PHPUnit | `server-laravel-vX.Y.Z` |
 | `sockudo` Ruby gem | RuboCop, RSpec, gem build | `server-ruby-vX.Y.Z` |
 | `github.com/sockudo/sockudo/server-sdks/sockudo-http-go/v2` | gofmt, go vet, go test | `server-sdks/sockudo-http-go/vX.Y.Z` |
 | `sockudo-http` | cargo fmt, clippy, test, package | `server-rust-vX.Y.Z` |

--- a/server-sdks/README.md
+++ b/server-sdks/README.md
@@ -22,6 +22,7 @@ expects `Package.swift` at the repository root.
 | `io.sockudo:sockudo-http-java` | `server-sdks/sockudo-http-java` |
 | `sockudo` | `server-sdks/sockudo-http-node` |
 | `sockudo/sockudo-php-server` | `server-sdks/sockudo-http-php` |
+| `sockudo/laravel` | `server-sdks/sockudo-laravel` |
 | `sockudo-http-python` | `server-sdks/sockudo-http-python` |
 | `sockudo` | `server-sdks/sockudo-http-ruby` |
 | `sockudo-http` | `server-sdks/sockudo-http-rust` |

--- a/server-sdks/sockudo-http-php/README.md
+++ b/server-sdks/sockudo-http-php/README.md
@@ -41,14 +41,16 @@ Then run `composer update sockudo/sockudo-php-server`.
 ```php
 use Sockudo\Sockudo;
 
-$sockudo = new Sockudo([
-    'app_id'  => 'your-app-id',
-    'key'     => 'your-app-key',
-    'secret'  => 'your-app-secret',
-    'host'    => '127.0.0.1',
-    'port'    => 6001,
-    'useTLS'  => false,
-]);
+$sockudo = new Sockudo(
+    'your-app-key',
+    'your-app-secret',
+    'your-app-id',
+    [
+        'host'    => '127.0.0.1',
+        'port'    => 6001,
+        'useTLS'  => false,
+    ],
+);
 ```
 
 ### Options
@@ -244,8 +246,11 @@ $guzzle = new GuzzleHttp\Client([
 ]);
 
 $sockudo = new Sockudo(
-    ['app_id' => '...', 'key' => '...', 'secret' => '...'],
-    $guzzle
+    'app-key',
+    'app-secret',
+    'app-id',
+    ['host' => '127.0.0.1', 'port' => 6001, 'useTLS' => false],
+    $guzzle,
 );
 ```
 

--- a/server-sdks/sockudo-http-php/src/SockudoInterface.php
+++ b/server-sdks/sockudo-http-php/src/SockudoInterface.php
@@ -69,6 +69,36 @@ interface SockudoInterface
     public function triggerBatchAsync(array $batch = [], bool $already_encoded = false): PromiseInterface;
 
     /**
+     * Send an event to every active connection for a user.
+     */
+    public function sendToUser(string $user_id, string $event, $data, bool $already_encoded = false): object;
+
+    /**
+     * Asynchronously send an event to every active connection for a user.
+     */
+    public function sendToUserAsync(string $user_id, string $event, $data, bool $already_encoded = false): PromiseInterface;
+
+    /**
+     * Terminate every active connection for a user.
+     */
+    public function terminateUserConnections(string $user_id): object;
+
+    /**
+     * Asynchronously terminate every active connection for a user.
+     */
+    public function terminateUserConnectionsAsync(string $user_id): PromiseInterface;
+
+    /**
+     * Force every active connection for a user to reconnect.
+     */
+    public function forceReconnectUser(string $user_id): object;
+
+    /**
+     * Asynchronously force every active connection for a user to reconnect.
+     */
+    public function forceReconnectUserAsync(string $user_id): PromiseInterface;
+
+    /**
      * Get information, such as subscriber and user count, for a channel.
      *
      * @param string $channel The name of the channel
@@ -299,6 +329,23 @@ interface SockudoInterface
      * @return mixed See Sockudo API docs
      */
     public function get(string $path, array $params = [], bool $associative = false);
+
+    /**
+     * Create a signed user-authentication response.
+     *
+     * @param array<string, mixed> $user_data
+     */
+    public function authenticateUser(string $socket_id, array $user_data): string;
+
+    /**
+     * Create a signed private or encrypted channel authorization response.
+     */
+    public function authorizeChannel(string $channel, string $socket_id, ?string $custom_data = null): string;
+
+    /**
+     * Create a signed presence channel authorization response.
+     */
+    public function authorizePresenceChannel(string $channel, string $socket_id, string $user_id, $user_info = null): string;
 
     /**
      * Creates a socket signature.

--- a/server-sdks/sockudo-laravel/.gitignore
+++ b/server-sdks/sockudo-laravel/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/composer.lock
+/.phpunit.cache/
+/.phplint.cache/
+/.php-cs-fixer.cache

--- a/server-sdks/sockudo-laravel/.php-cs-fixer.dist.php
+++ b/server-sdks/sockudo-laravel/.php-cs-fixer.dist.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+return (new Config())
+    ->setRiskyAllowed(false)
+    ->setRules([
+        '@PER-CS2.0' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => true,
+    ])
+    ->setFinder(
+        (new Finder())
+            ->in([__DIR__.'/src', __DIR__.'/config', __DIR__.'/tests'])
+    );

--- a/server-sdks/sockudo-laravel/CHANGELOG.md
+++ b/server-sdks/sockudo-laravel/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 1.0.0 - Unreleased
+
+- Add the auto-discovered `sockudo` Laravel broadcasting driver.
+- Support queued and immediate events, socket exclusion, private channels,
+  presence channels, encrypted channels, and user authentication.
+- Bind the connection-aware Sockudo PHP SDK manager and facade.
+- Add configuration publishing plus `sockudo:install` and `sockudo:check`.
+- Test against maintained Laravel 12 and 13 releases.

--- a/server-sdks/sockudo-laravel/LICENSE
+++ b/server-sdks/sockudo-laravel/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sockudo Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/server-sdks/sockudo-laravel/README.md
+++ b/server-sdks/sockudo-laravel/README.md
@@ -1,0 +1,163 @@
+# Sockudo for Laravel
+
+Official Laravel broadcasting driver and service-container integration for
+[Sockudo](https://github.com/sockudo/sockudo).
+
+The package keeps normal Laravel events on Sockudo's Pusher-compatible Protocol
+V1 surface while exposing native history, mutable messages, annotations, and
+push APIs through the Sockudo facade.
+
+## Requirements
+
+- PHP 8.2 or newer
+- Laravel 12 or 13
+- A reachable Sockudo server and configured application credentials
+
+## Install
+
+```bash
+composer require sockudo/laravel
+php artisan sockudo:install
+```
+
+Configure the application without committing secrets:
+
+```dotenv
+BROADCAST_CONNECTION=sockudo
+
+SOCKUDO_APP_ID=app-id
+SOCKUDO_APP_KEY=app-key
+SOCKUDO_APP_SECRET=app-secret
+SOCKUDO_HOST=127.0.0.1
+SOCKUDO_PORT=6001
+SOCKUDO_SCHEME=http
+```
+
+Use HTTPS whenever the HTTP API crosses an untrusted network. Validate the
+configuration and signed HTTP API connection with:
+
+```bash
+php artisan sockudo:check
+```
+
+The package auto-discovers its service provider and adds a `sockudo`
+broadcasting connection unless the application already defines one with that
+name. Publish `config/sockudo.php` when you need to customize the connection.
+If `routes/channels.php` is absent, install Laravel's broadcasting routes before
+using private or presence channels; `sockudo:install` reports this condition.
+
+## Broadcast Laravel events
+
+Existing Laravel events work without Sockudo-specific interfaces:
+
+```php
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+final class OrderUpdated implements ShouldBroadcast
+{
+    public function __construct(public readonly string $orderId)
+    {
+    }
+
+    public function broadcastOn(): PrivateChannel
+    {
+        return new PrivateChannel("orders.{$this->orderId}");
+    }
+}
+```
+
+`ShouldBroadcastNow`, queued broadcasts, `broadcast(...)->toOthers()`, private
+channels, presence channels, user authentication, and encrypted private
+channels use Laravel's normal broadcasting behavior.
+
+Define private and presence authorization in `routes/channels.php` as usual:
+
+```php
+use Illuminate\Support\Facades\Broadcast;
+
+Broadcast::channel('orders.{order}', function ($user, $order) {
+    return $user->can('view', $order);
+});
+```
+
+## Configure Laravel Echo
+
+Protocol V1 remains compatible with Laravel Echo's Pusher connector:
+
+```js
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+window.Pusher = Pusher;
+
+window.Echo = new Echo({
+    broadcaster: 'pusher',
+    key: import.meta.env.VITE_SOCKUDO_APP_KEY,
+    wsHost: import.meta.env.VITE_SOCKUDO_HOST,
+    wsPort: Number(import.meta.env.VITE_SOCKUDO_PORT ?? 6001),
+    wssPort: Number(import.meta.env.VITE_SOCKUDO_PORT ?? 443),
+    forceTLS: (import.meta.env.VITE_SOCKUDO_SCHEME ?? 'https') === 'https',
+    enabledTransports: ['ws', 'wss'],
+});
+```
+
+Private and presence subscriptions still authorize through Laravel's
+`/broadcasting/auth` route. Do not expose the app secret to JavaScript.
+
+## Use native Sockudo APIs
+
+The facade proxies to the default `sockudo` connection:
+
+```php
+use Sockudo\Laravel\Facades\Sockudo;
+
+$page = Sockudo::getChannelHistory('orders', ['limit' => 50]);
+
+Sockudo::updateMessage('orders', $messageSerial, [
+    'data' => ['status' => 'paid'],
+]);
+
+Sockudo::publishAnnotation('orders', $messageSerial, [
+    'type' => 'reaction',
+    'name' => 'confirmed',
+]);
+
+$publish = Sockudo::publishPush([
+    'recipients' => [['type' => 'channel', 'channel' => 'orders']],
+    'payload' => ['title' => 'Order updated'],
+    'idempotency_key' => 'order-updated:ord-123:v4',
+]);
+```
+
+Dependency injection is also available:
+
+```php
+use Sockudo\SockudoInterface;
+
+final class LoadOrderHistory
+{
+    public function __construct(private SockudoInterface $sockudo)
+    {
+    }
+}
+```
+
+For multiple apps, define additional `driver => sockudo` connections under
+`broadcasting.connections`, then select one explicitly:
+
+```php
+$client = Sockudo::connection('sockudo-eu');
+```
+
+## Testing
+
+```bash
+composer install
+vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no
+vendor/bin/phplint src config tests
+vendor/bin/phpunit
+```
+
+Development happens in the Sockudo monorepo under
+`server-sdks/sockudo-laravel`. Report issues in the main Sockudo repository.

--- a/server-sdks/sockudo-laravel/composer.json
+++ b/server-sdks/sockudo-laravel/composer.json
@@ -1,0 +1,58 @@
+{
+    "name": "sockudo/laravel",
+    "description": "Official Laravel broadcasting driver and service-container integration for Sockudo",
+    "keywords": [
+        "sockudo",
+        "laravel",
+        "broadcasting",
+        "websocket",
+        "realtime",
+        "pusher"
+    ],
+    "license": "MIT",
+    "type": "library",
+    "support": {
+        "issues": "https://github.com/sockudo/sockudo/issues",
+        "source": "https://github.com/sockudo/sockudo/tree/master/server-sdks/sockudo-laravel"
+    },
+    "require": {
+        "php": "^8.2",
+        "guzzlehttp/guzzle": "^7.15.3",
+        "illuminate/broadcasting": "^12.0|^13.0",
+        "illuminate/console": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "sockudo/sockudo-php-server": "^2.2"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.80",
+        "orchestra/testbench": "^10.0|^11.0",
+        "overtrue/phplint": "^9.7",
+        "phpunit/phpunit": "^11.0|^12.0|^13.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Sockudo\\Laravel\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Sockudo\\Laravel\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Sockudo\\Laravel\\SockudoServiceProvider"
+            ]
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        },
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}

--- a/server-sdks/sockudo-laravel/config/sockudo.php
+++ b/server-sdks/sockudo-laravel/config/sockudo.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+$scheme = env('SOCKUDO_SCHEME', 'http');
+
+return [
+    /*
+    | Laravel's default broadcaster when config/broadcasting.php has not been
+    | published yet. Existing application configuration always wins.
+    */
+    'default' => env('BROADCAST_CONNECTION', 'null'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Native SDK connection
+    |--------------------------------------------------------------------------
+    |
+    | The facade and SockudoManager use this named broadcasting connection.
+    | Laravel events use it when BROADCAST_CONNECTION=sockudo.
+    |
+    */
+    'connection' => env('SOCKUDO_CONNECTION', 'sockudo'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Sockudo broadcasting connection
+    |--------------------------------------------------------------------------
+    |
+    | The service provider adds this connection at runtime when the application
+    | has not defined broadcasting.connections.sockudo itself.
+    |
+    */
+    'broadcasting' => [
+        'driver' => 'sockudo',
+        'key' => env('SOCKUDO_APP_KEY'),
+        'secret' => env('SOCKUDO_APP_SECRET'),
+        'app_id' => env('SOCKUDO_APP_ID'),
+        'options' => [
+            'host' => env('SOCKUDO_HOST', '127.0.0.1'),
+            'port' => (int) env('SOCKUDO_PORT', $scheme === 'https' ? 443 : 6001),
+            'scheme' => $scheme,
+            'useTLS' => $scheme === 'https',
+            'path' => env('SOCKUDO_PATH', ''),
+            'timeout' => (int) env('SOCKUDO_TIMEOUT', 30),
+            'encryption_master_key_base64' => env('SOCKUDO_ENCRYPTION_MASTER_KEY_BASE64', ''),
+        ],
+        'client_options' => [
+            'connect_timeout' => (float) env('SOCKUDO_CONNECT_TIMEOUT', 5),
+        ],
+    ],
+];

--- a/server-sdks/sockudo-laravel/phpunit.xml.dist
+++ b/server-sdks/sockudo-laravel/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true"
+         failOnWarning="true"
+         beStrictAboutOutputDuringTests="true"
+>
+    <testsuites>
+        <testsuite name="Sockudo Laravel">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/server-sdks/sockudo-laravel/src/Commands/CheckCommand.php
+++ b/server-sdks/sockudo-laravel/src/Commands/CheckCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sockudo\Laravel\Commands;
+
+use Illuminate\Console\Command;
+use Sockudo\Laravel\SockudoManager;
+use Throwable;
+
+class CheckCommand extends Command
+{
+    protected $signature = 'sockudo:check
+        {--connection= : Named Sockudo broadcasting connection}
+        {--config-only : Validate configuration without contacting Sockudo}';
+
+    protected $description = 'Validate the Sockudo configuration and API connection';
+
+    public function __construct(private readonly SockudoManager $manager)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        try {
+            $name = $this->option('connection');
+            $client = $this->manager->connection(is_string($name) && $name !== '' ? $name : null);
+            $client->getSettings();
+
+            if ($this->option('config-only')) {
+                $this->components->info('Sockudo configuration is valid.');
+
+                return self::SUCCESS;
+            }
+
+            $client->getChannels();
+        } catch (Throwable) {
+            $this->components->error('Sockudo check failed. Verify the connection name, server availability, TLS settings, and credentials.');
+
+            return self::FAILURE;
+        }
+
+        $this->components->info('Sockudo API connection is healthy.');
+
+        return self::SUCCESS;
+    }
+}

--- a/server-sdks/sockudo-laravel/src/Commands/InstallCommand.php
+++ b/server-sdks/sockudo-laravel/src/Commands/InstallCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sockudo\Laravel\Commands;
+
+use Illuminate\Console\Command;
+use Sockudo\Laravel\SockudoServiceProvider;
+
+class InstallCommand extends Command
+{
+    protected $signature = 'sockudo:install {--force : Overwrite the published configuration file}';
+
+    protected $description = 'Publish the Sockudo configuration and show the required environment variables';
+
+    public function handle(): int
+    {
+        $arguments = [
+            '--provider' => SockudoServiceProvider::class,
+            '--tag' => 'sockudo-config',
+        ];
+
+        if ($this->option('force')) {
+            $arguments['--force'] = true;
+        }
+
+        $this->call('vendor:publish', $arguments);
+        $this->newLine();
+        $this->components->info('Sockudo Laravel integration installed.');
+        $this->line('Set BROADCAST_CONNECTION=sockudo and configure SOCKUDO_APP_ID, SOCKUDO_APP_KEY, SOCKUDO_APP_SECRET, and SOCKUDO_HOST.');
+
+        if (!file_exists(base_path('routes/channels.php'))) {
+            $this->components->warn('Laravel broadcasting routes are not installed. Run php artisan install:broadcasting before using private or presence channels.');
+        }
+
+        $this->line('Run php artisan sockudo:check after configuration.');
+
+        return self::SUCCESS;
+    }
+}

--- a/server-sdks/sockudo-laravel/src/Facades/Sockudo.php
+++ b/server-sdks/sockudo-laravel/src/Facades/Sockudo.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sockudo\Laravel\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Sockudo\Laravel\SockudoManager;
+
+/**
+ * @method static \Sockudo\SockudoInterface connection(?string $name = null)
+ * @method static void purge(?string $name = null)
+ * @method static object trigger(array|string $channels, string $event, mixed $data, array $params = [], bool $already_encoded = false)
+ * @method static object getChannelHistory(string $channel, array $params = [])
+ * @method static object getPresenceHistory(string $channel, array $params = [])
+ * @method static object getMessage(string $channel, string $messageSerial)
+ * @method static object updateMessage(string $channel, string $messageSerial, array $params = [])
+ * @method static object deleteMessage(string $channel, string $messageSerial, array $params = [])
+ * @method static object appendMessage(string $channel, string $messageSerial, array $params = [])
+ * @method static object publishAnnotation(string $channel, string $messageSerial, array $params)
+ * @method static object publishPush(array $request)
+ * @method static object getPublishStatus(string $publishId)
+ *
+ * @see SockudoManager
+ */
+class Sockudo extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return SockudoManager::class;
+    }
+}

--- a/server-sdks/sockudo-laravel/src/SockudoBroadcaster.php
+++ b/server-sdks/sockudo-laravel/src/SockudoBroadcaster.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sockudo\Laravel;
+
+use Illuminate\Broadcasting\Broadcasters\Broadcaster;
+use Illuminate\Broadcasting\Broadcasters\UsePusherChannelConventions;
+use Illuminate\Broadcasting\BroadcastException;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
+use JsonException;
+use Sockudo\SockudoInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Throwable;
+
+class SockudoBroadcaster extends Broadcaster
+{
+    use UsePusherChannelConventions;
+
+    public function __construct(
+        private SockudoInterface $sockudo,
+        private readonly bool $allowJsonp = false,
+    ) {}
+
+    public function resolveAuthenticatedUser($request)
+    {
+        $user = parent::resolveAuthenticatedUser($request);
+
+        if (!$user) {
+            return null;
+        }
+
+        if ($user instanceof Arrayable) {
+            $user = $user->toArray();
+        }
+
+        if (!is_array($user)) {
+            throw new BroadcastException('Sockudo user authentication data must be an array.');
+        }
+
+        return $this->decodeResponse($request, $this->sockudo->authenticateUser($request->socket_id, $user));
+    }
+
+    public function auth($request)
+    {
+        $channelName = $this->normalizeChannelName($request->channel_name);
+
+        if (empty($request->channel_name)
+            || ($this->isGuardedChannel($request->channel_name)
+                && !$this->retrieveUser($request, $channelName))) {
+            throw new AccessDeniedHttpException();
+        }
+
+        return parent::verifyUserCanAccessChannel($request, $channelName);
+    }
+
+    public function validAuthenticationResponse($request, $result)
+    {
+        if (str_starts_with($request->channel_name, 'private')) {
+            return $this->decodeResponse(
+                $request,
+                $this->sockudo->authorizeChannel($request->channel_name, $request->socket_id),
+            );
+        }
+
+        $channelName = $this->normalizeChannelName($request->channel_name);
+        $user = $this->retrieveUser($request, $channelName);
+        $broadcastIdentifier = method_exists($user, 'getAuthIdentifierForBroadcasting')
+            ? $user->getAuthIdentifierForBroadcasting()
+            : $user->getAuthIdentifier();
+
+        return $this->decodeResponse(
+            $request,
+            $this->sockudo->authorizePresenceChannel(
+                $request->channel_name,
+                $request->socket_id,
+                (string) $broadcastIdentifier,
+                $result,
+            ),
+        );
+    }
+
+    public function broadcast(array $channels, $event, array $payload = []): void
+    {
+        $socket = Arr::pull($payload, 'socket');
+        $parameters = $socket !== null ? ['socket_id' => $socket] : [];
+        $channels = $this->formatChannels($channels);
+
+        try {
+            foreach (array_chunk($channels, 100) as $chunk) {
+                $this->sockudo->trigger($chunk, $event, $payload, $parameters);
+            }
+        } catch (Throwable) {
+            // Transport errors may contain signed URLs or response bodies. Do
+            // not copy or chain them into Laravel's rendered exception.
+            throw new BroadcastException('Sockudo publish failed.');
+        }
+    }
+
+    public function getSockudo(): SockudoInterface
+    {
+        return $this->sockudo;
+    }
+
+    public function setSockudo(SockudoInterface $sockudo): void
+    {
+        $this->sockudo = $sockudo;
+    }
+
+    /**
+     * @return array<string, mixed>|mixed
+     */
+    private function decodeResponse($request, string $response): mixed
+    {
+        try {
+            $decoded = json_decode($response, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $error) {
+            throw new BroadcastException('Sockudo returned an invalid authentication response.', previous: $error);
+        }
+
+        if (!$request->input('callback', false) || !$this->allowJsonp) {
+            return $decoded;
+        }
+
+        return response()->json($decoded)->withCallback($request->callback);
+    }
+}

--- a/server-sdks/sockudo-laravel/src/SockudoManager.php
+++ b/server-sdks/sockudo-laravel/src/SockudoManager.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sockudo\Laravel;
+
+use GuzzleHttp\Client;
+use Illuminate\Contracts\Container\Container;
+use InvalidArgumentException;
+use Sockudo\Sockudo;
+use Sockudo\SockudoInterface;
+
+class SockudoManager
+{
+    /**
+     * @var array<string, SockudoInterface>
+     */
+    private array $connections = [];
+
+    public function __construct(private readonly Container $app) {}
+
+    public function connection(?string $name = null): SockudoInterface
+    {
+        $name ??= (string) $this->app['config']->get('sockudo.connection', 'sockudo');
+
+        if (isset($this->connections[$name])) {
+            return $this->connections[$name];
+        }
+
+        $config = $this->app['config']->get("broadcasting.connections.{$name}");
+
+        if (!is_array($config) || ($config['driver'] ?? null) !== 'sockudo') {
+            throw new InvalidArgumentException("Sockudo broadcasting connection [{$name}] is not defined.");
+        }
+
+        return $this->connections[$name] = $this->make($config);
+    }
+
+    /**
+     * Resolve a named connection when Laravel provides only its config array.
+     *
+     * @param array<string, mixed> $config
+     */
+    public function connectionForConfig(array $config): SockudoInterface
+    {
+        $connections = $this->app['config']->get('broadcasting.connections', []);
+
+        if (is_array($connections)) {
+            foreach ($connections as $name => $candidate) {
+                if (is_string($name) && $candidate === $config) {
+                    return $this->connection($name);
+                }
+            }
+        }
+
+        return $this->make($config);
+    }
+
+    /**
+     * Create an SDK client from a Laravel broadcasting connection.
+     *
+     * @param array<string, mixed> $config
+     */
+    public function make(array $config): SockudoInterface
+    {
+        $key = $this->requiredString($config, 'key');
+        $secret = $this->requiredString($config, 'secret');
+        $appId = $this->requiredString($config, 'app_id');
+        $options = is_array($config['options'] ?? null) ? $config['options'] : [];
+        $clientOptions = is_array($config['client_options'] ?? null) ? $config['client_options'] : [];
+
+        if (!array_key_exists('timeout', $clientOptions) && isset($options['timeout'])) {
+            $clientOptions['timeout'] = $options['timeout'];
+        }
+
+        $httpClient = $clientOptions === [] ? null : new Client($clientOptions);
+
+        return new Sockudo($key, $secret, $appId, $options, $httpClient);
+    }
+
+    public function purge(?string $name = null): void
+    {
+        $name ??= (string) $this->app['config']->get('sockudo.connection', 'sockudo');
+        unset($this->connections[$name]);
+    }
+
+    /**
+     * Proxy native SDK calls to the default Sockudo connection.
+     *
+     * @param array<int, mixed> $parameters
+     */
+    public function __call(string $method, array $parameters): mixed
+    {
+        return $this->connection()->{$method}(...$parameters);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function requiredString(array $config, string $key): string
+    {
+        $value = $config[$key] ?? null;
+
+        if (!is_string($value) || trim($value) === '') {
+            throw new InvalidArgumentException("Sockudo connection is missing [{$key}].");
+        }
+
+        return $value;
+    }
+}

--- a/server-sdks/sockudo-laravel/src/SockudoServiceProvider.php
+++ b/server-sdks/sockudo-laravel/src/SockudoServiceProvider.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sockudo\Laravel;
+
+use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\ServiceProvider;
+use Sockudo\Laravel\Commands\CheckCommand;
+use Sockudo\Laravel\Commands\InstallCommand;
+use Sockudo\SockudoInterface;
+
+class SockudoServiceProvider extends ServiceProvider
+{
+    /**
+     * @throws BindingResolutionException
+     */
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../config/sockudo.php', 'sockudo');
+
+        $this->app->singleton(SockudoManager::class, fn($app): SockudoManager => new SockudoManager($app));
+        $this->app->alias(SockudoManager::class, 'sockudo');
+        $this->app->bind(
+            SockudoInterface::class,
+            fn($app): SockudoInterface => $app->make(SockudoManager::class)->connection(),
+        );
+
+        $this->registerDefaultBroadcastConnection();
+    }
+
+    public function boot(BroadcastManager $broadcastManager): void
+    {
+        $broadcastManager->extend('sockudo', function ($app, array $config): SockudoBroadcaster {
+            $client = $app->make(SockudoManager::class)->connectionForConfig($config);
+
+            return new SockudoBroadcaster($client, (bool) ($config['jsonp'] ?? false));
+        });
+
+        $this->publishes([
+            __DIR__ . '/../config/sockudo.php' => config_path('sockudo.php'),
+        ], 'sockudo-config');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([InstallCommand::class, CheckCommand::class]);
+        }
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    private function registerDefaultBroadcastConnection(): void
+    {
+        /** @var ConfigRepository $config */
+        $config = $this->app->make('config');
+        $name = (string) $config->get('sockudo.connection', 'sockudo');
+
+        if (!$config->has('broadcasting.default')) {
+            $config->set('broadcasting.default', $config->get('sockudo.default', 'null'));
+        }
+
+        if ($config->has("broadcasting.connections.{$name}")) {
+            return;
+        }
+
+        $connection = $config->get('sockudo.broadcasting', []);
+
+        if (is_array($connection)) {
+            $config->set("broadcasting.connections.{$name}", $connection);
+        }
+    }
+}

--- a/server-sdks/sockudo-laravel/tests/Feature/SockudoServiceProviderTest.php
+++ b/server-sdks/sockudo-laravel/tests/Feature/SockudoServiceProviderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sockudo\Laravel\Tests\Feature;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Broadcasting\BroadcastManager;
+use Sockudo\Laravel\SockudoBroadcaster;
+use Sockudo\Laravel\SockudoManager;
+use Sockudo\Laravel\Tests\TestCase;
+use Sockudo\SockudoInterface;
+
+class SockudoServiceProviderTest extends TestCase
+{
+    public function testItRegistersTheDefaultBroadcastConnection(): void
+    {
+        $connection = $this->app['config']->get('broadcasting.connections.sockudo');
+
+        self::assertIsArray($connection);
+        self::assertSame('sockudo', $connection['driver']);
+        self::assertSame('test-key', $connection['key']);
+    }
+
+    public function testLaravelResolvesTheSockudoBroadcaster(): void
+    {
+        $broadcaster = $this->app->make(BroadcastManager::class)->connection('sockudo');
+        $manager = $this->app->make(SockudoManager::class);
+
+        self::assertInstanceOf(SockudoBroadcaster::class, $broadcaster);
+        self::assertSame('test-app', $broadcaster->getSockudo()->getSettings()['app_id']);
+        self::assertSame($manager->connection(), $broadcaster->getSockudo());
+    }
+
+    public function testItBindsTheManagerAndDefaultSdkClient(): void
+    {
+        $manager = $this->app->make(SockudoManager::class);
+        $client = $this->app->make(SockudoInterface::class);
+
+        self::assertSame($client, $manager->connection());
+        self::assertSame('127.0.0.1', $client->getSettings()['host']);
+    }
+
+    public function testConfigurationCheckDoesNotRequireNetworkAccess(): void
+    {
+        $this->artisan('sockudo:check', ['--config-only' => true])
+            ->expectsOutputToContain('Sockudo configuration is valid.')
+            ->assertExitCode(0);
+    }
+
+    public function testSdkTimeoutIsAppliedToTheConfiguredHttpClient(): void
+    {
+        $history = [];
+        $handler = HandlerStack::create(new MockHandler([new Response(200, [], '{}')]));
+        $handler->push(Middleware::history($history));
+
+        $client = $this->app->make(SockudoManager::class)->make([
+            'driver' => 'sockudo',
+            'key' => 'test-key',
+            'secret' => 'test-secret',
+            'app_id' => 'test-app',
+            'options' => [
+                'host' => '127.0.0.1',
+                'port' => 6001,
+                'scheme' => 'http',
+                'timeout' => 12,
+            ],
+            'client_options' => [
+                'connect_timeout' => 2,
+                'handler' => $handler,
+            ],
+        ]);
+
+        $client->trigger('orders', 'test', ['ok' => true]);
+
+        self::assertCount(1, $history);
+        self::assertSame(12, $history[0]['options']['timeout']);
+        self::assertSame(2, $history[0]['options']['connect_timeout']);
+    }
+}

--- a/server-sdks/sockudo-laravel/tests/TestCase.php
+++ b/server-sdks/sockudo-laravel/tests/TestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sockudo\Laravel\Tests;
+
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Sockudo\Laravel\SockudoServiceProvider;
+
+abstract class TestCase extends OrchestraTestCase
+{
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     *
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [SockudoServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('sockudo.connection', 'sockudo');
+        $app['config']->set('broadcasting.connections.sockudo', [
+            'driver' => 'sockudo',
+            'key' => 'test-key',
+            'secret' => 'test-secret',
+            'app_id' => 'test-app',
+            'options' => [
+                'host' => '127.0.0.1',
+                'port' => 6001,
+                'scheme' => 'http',
+                'useTLS' => false,
+            ],
+        ]);
+    }
+}

--- a/server-sdks/sockudo-laravel/tests/Unit/SockudoBroadcasterTest.php
+++ b/server-sdks/sockudo-laravel/tests/Unit/SockudoBroadcasterTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sockudo\Laravel\Tests\Unit;
+
+use Illuminate\Broadcasting\BroadcastException;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Sockudo\ApiErrorException;
+use Sockudo\Laravel\SockudoBroadcaster;
+use Sockudo\Sockudo;
+
+class SockudoBroadcasterTest extends TestCase
+{
+    public function testItBroadcastsLaravelChannelsAndExcludesTheOriginatingSocket(): void
+    {
+        $client = $this->createMock(Sockudo::class);
+        $client->expects(self::once())
+            ->method('trigger')
+            ->with(
+                ['orders', 'private-users.42'],
+                'order.updated',
+                ['order_id' => 'ord-123'],
+                ['socket_id' => '123.456'],
+            )
+            ->willReturn((object) ['ok' => true]);
+
+        $broadcaster = new SockudoBroadcaster($client);
+        $broadcaster->broadcast(
+            [new Channel('orders'), new PrivateChannel('users.42')],
+            'order.updated',
+            ['order_id' => 'ord-123', 'socket' => '123.456'],
+        );
+    }
+
+    public function testItChunksBroadcastsAtTheSockudoChannelLimit(): void
+    {
+        $channels = array_map(static fn(int $index): string => "channel-{$index}", range(1, 101));
+        $calls = 0;
+        $client = $this->createMock(Sockudo::class);
+        $client->expects(self::exactly(2))
+            ->method('trigger')
+            ->willReturnCallback(function (array $chunk) use (&$calls): object {
+                ++$calls;
+                self::assertCount($calls === 1 ? 100 : 1, $chunk);
+
+                return (object) ['ok' => true];
+            });
+
+        (new SockudoBroadcaster($client))->broadcast($channels, 'test', []);
+    }
+
+    public function testItReturnsPrivateChannelAuthorization(): void
+    {
+        $client = $this->createMock(Sockudo::class);
+        $client->expects(self::once())
+            ->method('authorizeChannel')
+            ->with('private-orders', '123.456')
+            ->willReturn('{"auth":"test-key:signature"}');
+
+        $broadcaster = new SockudoBroadcaster($client);
+        $broadcaster->channel('orders', static fn(): bool => true);
+
+        $request = Request::create('/broadcasting/auth', 'POST', [
+            'channel_name' => 'private-orders',
+            'socket_id' => '123.456',
+        ]);
+        $request->setUserResolver(static fn(): object => (object) ['id' => 42]);
+
+        self::assertSame(['auth' => 'test-key:signature'], $broadcaster->auth($request));
+    }
+
+    public function testItReturnsPresenceChannelAuthorization(): void
+    {
+        $user = new class {
+            public function getAuthIdentifier(): int
+            {
+                return 42;
+            }
+        };
+        $client = $this->createMock(Sockudo::class);
+        $client->expects(self::once())
+            ->method('authorizePresenceChannel')
+            ->with('presence-room', '123.456', '42', ['name' => 'Ada'])
+            ->willReturn('{"auth":"test-key:signature","channel_data":"data"}');
+
+        $broadcaster = new SockudoBroadcaster($client);
+        $broadcaster->channel('room', static fn(): array => ['name' => 'Ada']);
+
+        $request = Request::create('/broadcasting/auth', 'POST', [
+            'channel_name' => 'presence-room',
+            'socket_id' => '123.456',
+        ]);
+        $request->setUserResolver(static fn() => $user);
+
+        self::assertSame(
+            ['auth' => 'test-key:signature', 'channel_data' => 'data'],
+            $broadcaster->auth($request),
+        );
+    }
+
+    public function testItReturnsDecodedUserAuthentication(): void
+    {
+        $client = $this->createMock(Sockudo::class);
+        $client->expects(self::once())
+            ->method('authenticateUser')
+            ->with('123.456', ['id' => '42', 'name' => 'Ada'])
+            ->willReturn('{"auth":"test-key:signature","user_data":"{\\"id\\":\\"42\\"}"}');
+
+        $broadcaster = new SockudoBroadcaster($client);
+        $broadcaster->resolveAuthenticatedUserUsing(
+            static fn(): array => ['id' => '42', 'name' => 'Ada'],
+        );
+        $request = Request::create('/broadcasting/user-auth', 'POST', ['socket_id' => '123.456']);
+
+        self::assertSame(
+            ['auth' => 'test-key:signature', 'user_data' => '{"id":"42"}'],
+            $broadcaster->resolveAuthenticatedUser($request),
+        );
+    }
+
+    public function testItWrapsPublishErrorsWithoutCopyingTheResponseBody(): void
+    {
+        $error = new ApiErrorException('response body that must not be surfaced', 500);
+        $client = $this->createMock(Sockudo::class);
+        $client->expects(self::once())->method('trigger')->willThrowException($error);
+
+        try {
+            (new SockudoBroadcaster($client))->broadcast(['orders'], 'test', []);
+            self::fail('Expected a BroadcastException.');
+        } catch (BroadcastException $exception) {
+            self::assertSame('Sockudo publish failed.', $exception->getMessage());
+            self::assertNull($exception->getPrevious());
+            self::assertStringNotContainsString('response body', $exception->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a first-party `sockudo/laravel` package for Laravel 12 and 13. The package provides a Sockudo broadcasting driver, private/presence/user authentication, socket exclusion, multi-connection management, native SDK facade access, install and health-check commands, package documentation, and release/mirror automation.

Also completes the existing PHP SDK interface with the authentication and user methods already implemented by its concrete client, and corrects its constructor examples.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual testing completed

Verified:

- Laravel 12 and Laravel 13 package matrices: 11 tests, 39 assertions per lane
- PHP SDK suite: 168 tests, 186 assertions; 78 live-service tests skipped as expected
- PHP CS Fixer, PHPLint, Composer validation, and Composer security audit
- Documentation type-check and production build (208 pages)
- Workflow YAML lint and `git diff --check`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist

- [x] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts

A bot comment will appear with build instructions once this PR is created.

## Additional Notes

Laravel 11 is intentionally excluded because its currently resolvable dependency combinations have active security advisories. Existing Laravel 11 applications can continue using Sockudo through the Pusher-compatible driver.

Public installation additionally requires creating the `sockudo/sockudo-laravel` mirror repository, configuring `LARAVEL_SDK_MIRROR_TOKEN`, and submitting the mirror to Packagist.