### PR TITLE
fix(redis): add startup retry with backoff for cluster connections

### DIFF
--- a/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
+++ b/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
@@ -91,19 +91,13 @@ impl HorizontalTransport for RedisClusterTransport {
 
         // Create a persistent connection for publishing
         // This connection will be reused for all publish operations to avoid connection storms
-        let publish_connection = client.get_async_connection().await.map_err(|e| {
-            Error::Redis(format!(
-                "Failed to create Redis Cluster publish connection: {e}"
-            ))
-        })?;
+        let publish_connection =
+            sockudo_core::redis_client::cluster_connect_with_retry(&client).await?;
 
         // Create a dedicated connection for health checks
         // This prevents health check timeouts under high publish load (10K+ msg/s)
-        let health_check_connection = client.get_async_connection().await.map_err(|e| {
-            Error::Redis(format!(
-                "Failed to create Redis Cluster health check connection: {e}"
-            ))
-        })?;
+        let health_check_connection =
+            sockudo_core::redis_client::cluster_connect_with_retry(&client).await?;
 
         let broadcast_channel = format!("{}:#broadcast", config.prefix);
         let request_channel = format!("{}:#requests", config.prefix);

--- a/crates/sockudo-cache/src/redis_cluster_cache_manager.rs
+++ b/crates/sockudo-cache/src/redis_cluster_cache_manager.rs
@@ -61,10 +61,7 @@ impl RedisClusterCacheManager {
             .build()
             .map_err(|e| Error::Cache(format!("Failed to create Redis Cluster client: {e}")))?;
 
-        let connection = client
-            .get_async_connection()
-            .await
-            .map_err(|e| Error::Cache(format!("Failed to connect to Redis Cluster: {e}")))?;
+        let connection = sockudo_core::redis_client::cluster_connect_with_retry(&client).await?;
 
         Ok(Self {
             client,

--- a/crates/sockudo-core/src/redis_client.rs
+++ b/crates/sockudo-core/src/redis_client.rs
@@ -2,6 +2,9 @@
 //!
 //! Command connections are cached and cheap to clone. Worker/listener paths can
 //! request a fresh connection so a blocking command never stalls unrelated work.
+//!
+//! Cluster connections do not retry initial node discovery on their own;
+//! use [`cluster_connect_with_retry`] at startup.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -10,10 +13,29 @@ use parking_lot::Mutex;
 use redis::aio::{ConnectionManager, ConnectionManagerConfig, MultiplexedConnection, PubSub};
 use redis::sentinel::{SentinelClient, SentinelClientBuilder, SentinelServerType};
 use redis::{ClientTlsConfig, ConnectionAddr, IntoConnectionInfo, TlsCertificates, TlsMode};
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::error::{Error, Result};
 use crate::options::{RedisTlsOptions, SentinelSpec};
+
+/// Maximum number of connection attempts before giving up.
+const CONNECT_MAX_RETRIES: usize = 5;
+
+/// Exponential backoff multiplier between retries.
+const CONNECT_EXPONENT_BASE: f32 = 2.0;
+
+/// Upper bound on the delay between retries.
+const CONNECT_MAX_DELAY: Duration = Duration::from_millis(5_000);
+
+/// Initial delay (ms) for the cluster startup retry loop.
+const CLUSTER_CONNECT_BASE_DELAY_MS: u64 = 200;
+
+pub fn connection_manager_config() -> ConnectionManagerConfig {
+    ConnectionManagerConfig::new()
+        .set_number_of_retries(CONNECT_MAX_RETRIES)
+        .set_exponent_base(CONNECT_EXPONENT_BASE)
+        .set_max_delay(CONNECT_MAX_DELAY)
+}
 
 enum ClientSource {
     Standalone(redis::Client),
@@ -53,10 +75,7 @@ impl RedisClient {
     pub async fn from_client(client: redis::Client) -> Result<Self> {
         Self::from_source(
             ClientSource::Standalone(client),
-            ConnectionManagerConfig::new()
-                .set_number_of_retries(5)
-                .set_exponent_base(2.0)
-                .set_max_delay(Duration::from_millis(5_000)),
+            connection_manager_config(),
         )
         .await
     }
@@ -75,11 +94,8 @@ impl RedisClient {
 
     /// Connects with explicit direct-TLS and timeout settings.
     pub async fn connect_with_options(url: &str, options: RedisClientOptions) -> Result<Self> {
-        let manager_config = ConnectionManagerConfig::new()
-            .set_number_of_retries(5)
-            .set_exponent_base(2.0)
-            .set_max_delay(Duration::from_millis(5_000))
-            .set_response_timeout(options.response_timeout);
+        let manager_config =
+            connection_manager_config().set_response_timeout(options.response_timeout);
 
         let source = match options.sentinel {
             Some(spec) => {
@@ -327,6 +343,48 @@ pub async fn configure_cluster_builder(
         builder = builder.certs(certificates);
     }
     Ok(builder)
+}
+
+/// Wraps `ClusterClient::get_async_connection` with exponential-backoff retry.
+/// The cluster client does not retry initial node discovery on its own.
+pub async fn cluster_connect_with_retry(
+    client: &redis::cluster::ClusterClient,
+) -> Result<redis::cluster_async::ClusterConnection> {
+    let mut delay_ms = CLUSTER_CONNECT_BASE_DELAY_MS;
+    let mut last_err = None;
+
+    for attempt in 1..=CONNECT_MAX_RETRIES {
+        match client.get_async_connection().await {
+            Ok(conn) => {
+                if attempt > 1 {
+                    info!(attempt, "redis cluster connection established after retry");
+                }
+                return Ok(conn);
+            }
+            Err(e) => {
+                warn!(
+                    attempt,
+                    max_retries = CONNECT_MAX_RETRIES,
+                    retry_in_ms = delay_ms,
+                    error = %e,
+                    "redis cluster initial connection failed, retrying"
+                );
+                last_err = Some(e);
+                let jitter = (delay_ms / 4) as i64;
+                let jittered = (delay_ms as i64 + rand::random_range(-jitter..=jitter)).max(50);
+                tokio::time::sleep(Duration::from_millis(jittered as u64)).await;
+                delay_ms = delay_ms
+                    .saturating_mul(2)
+                    .min(CONNECT_MAX_DELAY.as_millis() as u64);
+            }
+        }
+    }
+
+    Err(Error::Redis(format!(
+        "redis cluster connection failed after {} attempts: {}",
+        CONNECT_MAX_RETRIES,
+        last_err.expect("at least one attempt was made")
+    )))
 }
 
 async fn build_sentinel_client(spec: &SentinelSpec) -> Result<SentinelClient> {

--- a/crates/sockudo-delta/src/coordination/redis_coordinator.rs
+++ b/crates/sockudo-delta/src/coordination/redis_coordinator.rs
@@ -113,10 +113,7 @@ impl RedisClusterCoordinator {
             .build()
             .map_err(|e| Error::Redis(format!("Failed to create Redis Cluster client: {}", e)))?;
 
-        let connection = client
-            .get_async_connection()
-            .await
-            .map_err(|e| Error::Redis(format!("Failed to connect to Redis Cluster: {}", e)))?;
+        let connection = sockudo_core::redis_client::cluster_connect_with_retry(&client).await?;
 
         Ok(Self {
             connection: Arc::new(tokio::sync::Mutex::new(

--- a/crates/sockudo-queue/src/redis_connection.rs
+++ b/crates/sockudo-queue/src/redis_connection.rs
@@ -133,12 +133,8 @@ impl ClusterRedisProvider {
             &tls,
         )
         .await?;
-        let connection = command_client
-            .get_async_connection()
-            .await
-            .map_err(|error| {
-                Error::Connection(format!("failed to connect to Redis Cluster: {error}"))
-            })?;
+        let connection =
+            sockudo_core::redis_client::cluster_connect_with_retry(&command_client).await?;
         Ok(Self {
             inner: Arc::new(ClusterInner {
                 command_client,

--- a/crates/sockudo-rate-limiter/src/redis_cluster_limiter.rs
+++ b/crates/sockudo-rate-limiter/src/redis_cluster_limiter.rs
@@ -49,10 +49,7 @@ impl RedisClusterRateLimiter {
         prefix: String,
         config: RateLimitConfig,
     ) -> Result<Self> {
-        let connection = client
-            .get_async_connection()
-            .await
-            .map_err(|e| Error::Redis(format!("Failed to connect to Redis: {e}")))?;
+        let connection = sockudo_core::redis_client::cluster_connect_with_retry(&client).await?;
 
         Ok(Self {
             client,


### PR DESCRIPTION
`ClusterClient::get_async_connection` does not retry initial node discovery, unlike `ConnectionManager` for standalone Redis. This causes immediate crash-loop on transient network delays at startup (e.g. CNI IP assignment race on Kubernetes).

Add `cluster_connect_with_retry()` in sockudo-core with exponential backoff and jitter, sharing retry constants with `ConnectionManager`. Replace bare `get_async_connection()` at all 5 cluster startup sites: adapter transport, cache, rate limiter, queue, and delta coordinator.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
