### PR TITLE
feat(metrics): add request_type label to horizontal adapter promise counters

### DIFF
--- a/crates/sockudo-adapter/src/handler/recovery.rs
+++ b/crates/sockudo-adapter/src/handler/recovery.rs
@@ -1321,7 +1321,13 @@ mod tests {
         }
         fn mark_ws_message_received(&self, _app_id: &str, _message_size: usize) {}
         fn track_horizontal_adapter_resolve_time(&self, _app_id: &str, _time_ms: f64) {}
-        fn track_horizontal_adapter_resolved_promises(&self, _app_id: &str, _resolved: bool) {}
+        fn track_horizontal_adapter_resolved_promises(
+            &self,
+            _app_id: &str,
+            _resolved: bool,
+            _request_type: &str,
+        ) {
+        }
         fn mark_horizontal_adapter_request_sent(&self, _app_id: &str) {}
         fn mark_horizontal_adapter_request_received(&self, _app_id: &str) {}
         fn mark_horizontal_adapter_response_received(&self, _app_id: &str) {}

--- a/crates/sockudo-adapter/src/horizontal_adapter/operations.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter/operations.rs
@@ -763,7 +763,11 @@ impl HorizontalAdapter {
             metrics.track_horizontal_adapter_resolve_time(app_id, duration_ms);
 
             // Empty results are still resolved — only a timeout is uncomplete
-            metrics.track_horizontal_adapter_resolved_promises(app_id, !timed_out);
+            metrics.track_horizontal_adapter_resolved_promises(
+                app_id,
+                !timed_out,
+                &format!("{:?}", request_type),
+            );
         }
 
         Ok(combined_response)

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
@@ -389,7 +389,11 @@ where
             metrics.track_horizontal_adapter_resolve_time(&app_id, duration_ms);
 
             // Empty results are still resolved — only a timeout is uncomplete
-            metrics.track_horizontal_adapter_resolved_promises(&app_id, !timed_out);
+            metrics.track_horizontal_adapter_resolved_promises(
+                &app_id,
+                !timed_out,
+                &format!("{:?}", request_type),
+            );
         }
 
         Ok(combined_response)

--- a/crates/sockudo-adapter/tests/adapter/async_disconnect_cleanup_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/async_disconnect_cleanup_tests.rs
@@ -61,7 +61,7 @@ impl MetricsInterface for CountingMetrics {
     fn mark_ws_messages_sent_batch(&self, _: &str, _: usize, _: usize) {}
     fn mark_ws_message_received(&self, _: &str, _: usize) {}
     fn track_horizontal_adapter_resolve_time(&self, _: &str, _: f64) {}
-    fn track_horizontal_adapter_resolved_promises(&self, _: &str, _: bool) {}
+    fn track_horizontal_adapter_resolved_promises(&self, _: &str, _: bool, _: &str) {}
     fn mark_horizontal_adapter_request_sent(&self, _: &str) {}
     fn mark_horizontal_adapter_request_received(&self, _: &str) {}
     fn mark_horizontal_adapter_response_received(&self, _: &str) {}

--- a/crates/sockudo-adapter/tests/adapter/connected_gauge_regression_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/connected_gauge_regression_tests.rs
@@ -81,7 +81,7 @@ impl MetricsInterface for CountingMetrics {
     fn mark_ws_messages_sent_batch(&self, _: &str, _: usize, _: usize) {}
     fn mark_ws_message_received(&self, _: &str, _: usize) {}
     fn track_horizontal_adapter_resolve_time(&self, _: &str, _: f64) {}
-    fn track_horizontal_adapter_resolved_promises(&self, _: &str, _: bool) {}
+    fn track_horizontal_adapter_resolved_promises(&self, _: &str, _: bool, _: &str) {}
     fn mark_horizontal_adapter_request_sent(&self, _: &str) {}
     fn mark_horizontal_adapter_request_received(&self, _: &str) {}
     fn mark_horizontal_adapter_response_received(&self, _: &str) {}

--- a/crates/sockudo-adapter/tests/adapter/server_capacity_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/server_capacity_tests.rs
@@ -75,7 +75,7 @@ impl MetricsInterface for CountingMetrics {
     fn mark_ws_messages_sent_batch(&self, _: &str, _: usize, _: usize) {}
     fn mark_ws_message_received(&self, _: &str, _: usize) {}
     fn track_horizontal_adapter_resolve_time(&self, _: &str, _: f64) {}
-    fn track_horizontal_adapter_resolved_promises(&self, _: &str, _: bool) {}
+    fn track_horizontal_adapter_resolved_promises(&self, _: &str, _: bool, _: &str) {}
     fn mark_horizontal_adapter_request_sent(&self, _: &str) {}
     fn mark_horizontal_adapter_request_received(&self, _: &str) {}
     fn mark_horizontal_adapter_response_received(&self, _: &str) {}

--- a/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
+++ b/crates/sockudo-adapter/tests/mocks/connection_handler_mock.rs
@@ -222,7 +222,12 @@ impl MetricsInterface for MockMetricsInterface {
     }
     fn mark_ws_message_received(&self, _app_id: &str, _message_size: usize) {}
     fn track_horizontal_adapter_resolve_time(&self, _app_id: &str, _time_ms: f64) {}
-    fn track_horizontal_adapter_resolved_promises(&self, _app_id: &str, resolved: bool) {
+    fn track_horizontal_adapter_resolved_promises(
+        &self,
+        _app_id: &str,
+        resolved: bool,
+        _request_type: &str,
+    ) {
         if resolved {
             self.horizontal_resolved_promises
                 .fetch_add(1, Ordering::Relaxed);

--- a/crates/sockudo-core/src/metrics.rs
+++ b/crates/sockudo-core/src/metrics.rs
@@ -78,7 +78,12 @@ pub trait MetricsInterface: Send + Sync {
     fn track_horizontal_adapter_resolve_time(&self, app_id: &str, time_ms: f64);
 
     /// Track the fulfillings in which horizontal adapter resolves requests from other nodes
-    fn track_horizontal_adapter_resolved_promises(&self, app_id: &str, resolved: bool);
+    fn track_horizontal_adapter_resolved_promises(
+        &self,
+        app_id: &str,
+        resolved: bool,
+        request_type: &str,
+    );
 
     /// Handle a new horizontal adapter request sent
     fn mark_horizontal_adapter_request_sent(&self, app_id: &str);

--- a/crates/sockudo-metrics/src/prometheus/driver.rs
+++ b/crates/sockudo-metrics/src/prometheus/driver.rs
@@ -458,7 +458,7 @@ impl PrometheusMetricsDriver {
                 format!("{prefix}horizontal_adapter_uncomplete_promises"),
                 "The total amount of promises that were not fulfilled entirely by other nodes"
             ),
-            &["app_id", "port"]
+            &["app_id", "port", "request_type"]
         )
         .unwrap();
 

--- a/crates/sockudo-metrics/src/prometheus/interface.rs
+++ b/crates/sockudo-metrics/src/prometheus/interface.rs
@@ -206,8 +206,12 @@ impl MetricsInterface for PrometheusMetricsDriver {
 
         debug!(app_id, "metrics: horizontal adapter resolve time recorded");
     }
-
-    fn track_horizontal_adapter_resolved_promises(&self, app_id: &str, resolved: bool) {
+    fn track_horizontal_adapter_resolved_promises(
+        &self,
+        app_id: &str,
+        resolved: bool,
+        request_type: &str,
+    ) {
         let tags = self.get_tags(app_id);
 
         if resolved {
@@ -215,14 +219,16 @@ impl MetricsInterface for PrometheusMetricsDriver {
                 .with_label_values(&tags)
                 .inc();
         } else {
+            let mut error_tags = tags.clone();
+            error_tags.push(request_type.to_string());
             self.horizontal_adapter_uncomplete_promises
-                .with_label_values(&tags)
+                .with_label_values(&error_tags)
                 .inc();
         }
 
         debug!(
             app_id,
-            resolved, "metrics: horizontal adapter promise recorded"
+            resolved, request_type, "metrics: horizontal adapter promise recorded"
         );
     }
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
