### PR TITLE
docs: fix homepage card icon alignment

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -703,9 +703,15 @@ body {
 }
 
 .home-card-icon {
+  display: inline-flex;
   width: 2.5rem;
   height: 2.5rem;
-  flex-shrink: 0;
+  flex: 0 0 2.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--app-radius-pill);
+  background: color-mix(in srgb, var(--app-primary) 11%, var(--app-surface));
+  color: var(--app-primary);
 }
 
 .home-card-meta {


### PR DESCRIPTION
## Summary

- restore the homepage card icon flex layout removed during the compatibility redesign
- center Lucide icons inside fixed circular badges
- restore the default badge background and accent color while preserving dark-section overrides

## Verification

- `npm run types:check`
- `npm run build`
- visually verified the capability cards at the reported 1305×761 viewport