### PR TITLE
feat(kotlin-sdk): add typed connection and channel event listeners

### DIFF
--- a/client-sdks/sockudo-kotlin/CHANGELOG.md
+++ b/client-sdks/sockudo-kotlin/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added Pusher-style connection/error listeners (`SockudoConnectionEventListener`, `SockudoError`) while preserving the raw Pusher-compatible `state_change` event.
+- Added typed channel event and auth listeners (`SockudoChannelEventListener.onEvent`, `onSubscriptionSucceeded`, `onAuthenticationFailure`, `onError`) while preserving the raw `bind`/`on` event API.
+
 ## 2.2.0 - 2026-08-17
 
 - Added `RECONNECTING`, bounded reconnect attempts, configurable retry gaps, and quadratic backoff

--- a/client-sdks/sockudo-kotlin/README.md
+++ b/client-sdks/sockudo-kotlin/README.md
@@ -62,12 +62,37 @@ val client =
     )
 
 val channel = client.subscribe("public-updates")
-channel.bind("price-updated") { data, _ ->
-    println(data)
-}
+channel.bindChannelListener(
+    object : SockudoChannelEventListener {
+        override fun onEvent(channel: SockudoChannel, event: SockudoEvent) {
+            println("${event.event}: ${event.data}")
+        }
+    },
+)
 
 client.connect()
 ```
+
+Connection state exposes the current value directly, plus a Pusher-style listener API for transitions and errors.
+Listeners run synchronously on the thread performing the transition — an OkHttp callback or background coroutine
+thread — so UI consumers must switch context when needed.
+
+```kotlin
+client.bindConnectionListener(object : SockudoConnectionEventListener {
+    override fun onConnectionStateChange(change: ConnectionStateChange) {
+        println("${change.previous} -> ${change.current}")
+    }
+
+    override fun onError(error: SockudoError) {
+        println("connection error: ${error.message}")
+    }
+})
+
+val current = client.connectionState
+```
+
+Remove listeners with `unbindConnectionListener(token)`. The Pusher-compatible `bind("state_change", ...)` event remains
+available for consumers that need the raw event API.
 
 Protocol V2 heartbeat behavior:
 

--- a/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/Channels.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/Channels.kt
@@ -2,6 +2,7 @@ package io.sockudo.client
 
 import com.iwebpp.crypto.TweetNaclFast
 import java.util.Base64
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -12,6 +13,8 @@ open class SockudoChannel internal constructor(
     internal val dispatcher = EventDispatcher { event, _ ->
         SockudoLogger.debug("No callbacks on $name for $event")
     }
+    internal val listeners =
+        CopyOnWriteArrayList<Pair<EventBindingToken, SockudoChannelEventListener>>()
 
     var isSubscribed: Boolean = false
         internal set
@@ -38,6 +41,16 @@ open class SockudoChannel internal constructor(
     fun onGlobal(callback: (String, Any?) -> Unit): EventBindingToken = dispatcher.bindGlobal(callback)
 
     fun bindGlobal(callback: (String, Any?) -> Unit): EventBindingToken = onGlobal(callback)
+
+    fun bindChannelListener(listener: SockudoChannelEventListener): EventBindingToken {
+        val token = EventBindingToken()
+        listeners += token to listener
+        return token
+    }
+
+    fun unbindChannelListener(token: EventBindingToken) {
+        listeners.removeIf { it.first == token }
+    }
 
     fun off(eventName: String? = null, token: EventBindingToken? = null) {
         dispatcher.unbind(eventName, token)
@@ -103,13 +116,17 @@ open class SockudoChannel internal constructor(
             client.sendEvent(client.p.event("subscribe"), payload, null)
         } catch (error: Throwable) {
             subscriptionPending = false
+            val message = error.message ?: "Unknown auth error"
             dispatcher.emit(
                 client.p.event("subscription_error"),
                 mapOf(
                     "type" to "AuthError",
-                    "error" to (error.message ?: "Unknown auth error"),
+                    "error" to message,
                 ),
             )
+            listeners.forEach { (_, listener) ->
+                listener.onAuthenticationFailure(this, SockudoAuthError(message = message, cause = error))
+            }
         }
     }
 
@@ -263,6 +280,7 @@ open class SockudoChannel internal constructor(
                 } else {
                     attachSerial = parseAttachSerial(event.data)
                     dispatcher.emit(p.event("subscription_succeeded"), event.data)
+                    listeners.forEach { (_, listener) -> listener.onSubscriptionSucceeded(this) }
                 }
             }
 
@@ -288,6 +306,7 @@ open class SockudoChannel internal constructor(
 
             else -> {
                 dispatcher.emit(event.event, event.data, EventMetadata(userId = event.userId))
+                listeners.forEach { (_, listener) -> listener.onEvent(this, event) }
             }
         }
     }
@@ -416,6 +435,7 @@ class PresenceChannel internal constructor(
                     attachSerial = parseAttachSerial(payload)
                     members.applySubscriptionData(payload)
                     dispatcher.emit(p.event("subscription_succeeded"), members)
+                    listeners.forEach { (_, listener) -> listener.onSubscriptionSucceeded(this) }
                 }
             }
 

--- a/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/Models.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/Models.kt
@@ -31,6 +31,34 @@ enum class ConnectionState {
     FAILED,
 }
 
+data class ConnectionStateChange(
+    val previous: ConnectionState,
+    val current: ConnectionState,
+)
+
+data class SockudoError(
+    val message: String,
+    val code: String? = null,
+    val cause: Throwable? = null,
+)
+
+data class SockudoAuthError(
+    val message: String,
+    val cause: Throwable? = null,
+)
+
+interface SockudoConnectionEventListener {
+    fun onConnectionStateChange(change: ConnectionStateChange) = Unit
+    fun onError(error: SockudoError) = Unit
+}
+
+interface SockudoChannelEventListener {
+    fun onSubscriptionSucceeded(channel: SockudoChannel) = Unit
+    fun onAuthenticationFailure(channel: SockudoChannel, error: SockudoAuthError) = Unit
+    fun onError(channel: SockudoChannel, error: SockudoError) = Unit
+    fun onEvent(channel: SockudoChannel, event: SockudoEvent) = Unit
+}
+
 enum class DeltaAlgorithm { fossil, xdelta3 }
 
 sealed class AuthValue {

--- a/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/SockudoClient.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/SockudoClient.kt
@@ -18,6 +18,7 @@ import okhttp3.WebSocketListener
 import okhttp3.MediaType.Companion.toMediaType
 import okio.ByteString.Companion.toByteString
 import java.net.URI
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -38,6 +39,8 @@ class SockudoClient(
     internal val p = ProtocolPrefix(options.protocolVersion)
     internal val config = ResolvedConfiguration(options, httpClient)
     private val dispatcher = EventDispatcher()
+    private val connectionStateListeners =
+        CopyOnWriteArrayList<Pair<EventBindingToken, SockudoConnectionEventListener>>()
     private val channels = linkedMapOf<String, SockudoChannel>()
     private var webSocket: WebSocket? = null
     private var activityJob: Job? = null
@@ -85,6 +88,16 @@ class SockudoClient(
 
     fun bindGlobal(callback: (String, Any?) -> Unit): EventBindingToken = onGlobal(callback)
 
+    fun bindConnectionListener(listener: SockudoConnectionEventListener): EventBindingToken {
+        val token = EventBindingToken()
+        connectionStateListeners += token to listener
+        return token
+    }
+
+    fun unbindConnectionListener(token: EventBindingToken) {
+        connectionStateListeners.removeIf { it.first == token }
+    }
+
     fun off(eventName: String? = null, token: EventBindingToken? = null) {
         dispatcher.unbind(eventName, token)
     }
@@ -92,7 +105,7 @@ class SockudoClient(
     fun unbind(eventName: String? = null, token: EventBindingToken? = null) = off(eventName, token)
 
     fun unbindAll() {
-        dispatcher.unbind()
+        off()
     }
 
     fun channel(name: String): SockudoChannel? = channels[name]
@@ -156,7 +169,7 @@ class SockudoClient(
                     openWebSocket(transports.first())
                     setUnavailableTimer()
                 }.onFailure { error ->
-                    dispatcher.emit("error", error)
+                    reportError(error)
                     updateState(ConnectionState.FAILED)
                 }
             }
@@ -512,7 +525,7 @@ class SockudoClient(
         scope.launch {
             runCatching {
                 refreshAuthToken(reason, sendRefreshFrame = true)
-            }.onFailure { dispatcher.emit("error", it) }
+            }.onFailure { reportError(it) }
         }
     }
 
@@ -550,7 +563,7 @@ class SockudoClient(
                 }
                 runCatching {
                     refreshAuthToken(ClientAuthTokenReason.REFRESH, sendRefreshFrame = true)
-                }.onFailure { dispatcher.emit("error", it) }
+                }.onFailure { reportError(it) }
             }
     }
 
@@ -595,7 +608,7 @@ class SockudoClient(
                     }
 
                     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-                        dispatcher.emit("error", t)
+                        reportError(t)
                         handleSocketClosed(1006, t.message)
                     }
 
@@ -669,7 +682,7 @@ class SockudoClient(
                     if (isTokenExpiredPayload(event.data)) {
                         launchAuthRefresh(ClientAuthTokenReason.EXPIRED)
                     }
-                    dispatcher.emit("error", event.data)
+                    reportError(event.data)
                 }
                 eventName == p.event("auth_success") -> dispatcher.emit(eventName, event.data)
                 eventName == p.event("token_expired") -> {
@@ -752,7 +765,7 @@ class SockudoClient(
                 }
             }
         } catch (error: Throwable) {
-            dispatcher.emit("error", error)
+            reportError(error)
         }
     }
 
@@ -793,7 +806,7 @@ class SockudoClient(
         }
 
         if (!reason.isNullOrBlank()) {
-            dispatcher.emit("error", SockudoException.ConnectionUnavailable)
+            reportError(SockudoException.ConnectionUnavailable)
             SockudoLogger.warn("Socket closed", code, reason)
         }
     }
@@ -985,7 +998,7 @@ class SockudoClient(
                             setUnavailableTimer()
                         }
                     }.onFailure {
-                        dispatcher.emit("error", it)
+                        reportError(it)
                         updateState(ConnectionState.FAILED)
                     }
                 } else {
@@ -1009,13 +1022,38 @@ class SockudoClient(
     }
 
     private fun updateState(state: ConnectionState, metadata: Map<String, Any?>? = null) {
-        val previous = connectionState
+        val change = ConnectionStateChange(
+            previous = connectionState,
+            current = state,
+        )
         connectionState = state
+        connectionStateListeners.forEach { (_, listener) -> listener.onConnectionStateChange(change) }
         dispatcher.emit(
             "state_change",
-            mapOf("previous" to previous.name.lowercase(), "current" to state.name.lowercase())
+            mapOf(
+                "previous" to change.previous.name.lowercase(),
+                "current" to change.current.name.lowercase(),
+            ),
         )
         dispatcher.emit(state.name.lowercase(), metadata)
+    }
+
+    private fun reportError(raw: Any?) {
+        val error = when (raw) {
+            is SockudoError -> raw
+            is Throwable -> SockudoError(message = raw.message ?: raw.toString(), cause = raw)
+            is Map<*, *> -> {
+                val code =
+                    parseSockudoLong(raw["code"] ?: raw["status"] ?: raw["error_code"])?.toString()
+                        ?: (raw["code"] ?: raw["status"] ?: raw["error_code"])?.toString()
+                val message = (raw["message"] ?: raw["error"])?.toString() ?: raw.toString()
+                SockudoError(message = message, code = code)
+            }
+
+            else -> SockudoError(message = raw?.toString() ?: "Unknown error")
+        }
+        dispatcher.emit("error", raw)
+        connectionStateListeners.forEach { (_, listener) -> listener.onError(error) }
     }
 
     class UserFacade {

--- a/client-sdks/sockudo-kotlin/lib/src/test/kotlin/io/sockudo/client/ReconnectionTest.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/test/kotlin/io/sockudo/client/ReconnectionTest.kt
@@ -23,6 +23,73 @@ class ReconnectionTest {
     }
 
     @Test
+    fun `connectionState exposes the latest state`() {
+        val client = testClient()
+        assertEquals(ConnectionState.INITIALIZED, client.connectionState)
+
+        client.disconnect()
+
+        assertEquals(ConnectionState.DISCONNECTED, client.connectionState)
+    }
+
+    @Test
+    fun `channel listener receives app events on channel handle`() {
+        val client = testClient()
+        val channel = client.subscribe("private-test")
+        val received = mutableListOf<SockudoEvent>()
+
+        channel.bindChannelListener(
+            object : SockudoChannelEventListener {
+                override fun onEvent(channel: SockudoChannel, event: SockudoEvent) {
+                    received += event
+                }
+            },
+        )
+
+        val event = SockudoEvent(
+            event = "call-started",
+            channel = "private-test",
+            data = mapOf("id" to 42),
+            rawMessage = """{"event":"call-started","channel":"private-test","data":{"id":42}}""",
+        )
+        channel.handle(event)
+
+        assertEquals(listOf(event), received)
+    }
+
+    @Test
+    fun `connection state listener receives previous and current state`() {
+        val client = testClient()
+        val changes = mutableListOf<ConnectionStateChange>()
+        client.bindConnectionListener(
+            object : SockudoConnectionEventListener {
+                override fun onConnectionStateChange(change: ConnectionStateChange) {
+                    changes += change
+                }
+            },
+        )
+
+        client.disconnect()
+
+        assertEquals(
+            listOf(ConnectionStateChange(ConnectionState.INITIALIZED, ConnectionState.DISCONNECTED)),
+            changes,
+        )
+    }
+
+    @Test
+    fun `connection state listener preserves raw state_change event`() {
+        val client = testClient()
+        var rawChange: Map<*, *>? = null
+        client.bind("state_change") { data, _ -> rawChange = data as? Map<*, *> }
+
+        client.disconnect()
+
+        assertEquals("initialized", rawChange?.get("previous"))
+        assertEquals("disconnected", rawChange?.get("current"))
+    }
+
+    @Test
     fun `SockudoOptions maxReconnectAttempts defaults to 6`() {
         val options = SockudoOptions(cluster = "test")
         assertEquals(6, options.maxReconnectAttempts)


### PR DESCRIPTION
Add listener APIs alongside the raw event API:

- Connection listeners: SockudoConnectionEventListener, bound with bindConnectionListener and removed with unbindConnectionListener. Exposes onConnectionStateChange and onError.
- Channel listeners: SockudoChannelEventListener, bound with bindChannelListener and removed with unbindChannelListener. Exposes onEvent, onSubscriptionSucceeded, onAuthenticationFailure, and onError.
- New value types: ConnectionStateChange, SockudoError, and SockudoAuthError.

The raw state_change and bind/on event APIs are preserved.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
