### PR TITLE
fix(redis): expose clustered request reply failures

### DIFF
--- a/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
@@ -349,6 +349,7 @@ where
                         request_id = %request_id,
                         request_type = ?request_type,
                         elapsed_ms = start.elapsed().as_millis(),
+                        node_count,
                         responses_received = responses.len(),
                         expected = max_expected_responses,
                         "request timed out"

--- a/crates/sockudo-adapter/src/transports/redis_cluster_sharded_pubsub.rs
+++ b/crates/sockudo-adapter/src/transports/redis_cluster_sharded_pubsub.rs
@@ -21,6 +21,7 @@ use tracing::{info, warn};
 
 const TOPOLOGY_REFRESH_INTERVAL_SECS: u64 = 30;
 const TOPOLOGY_REFRESH_FAILURE_THRESHOLD: u64 = 3;
+const FAN_IN_CAPACITY: usize = 10_000;
 
 type ShardedPushChannelFlavor = mpsc::Array<redis::PushInfo>;
 type ShardedPushSender = crossfire::MAsyncTx<ShardedPushChannelFlavor>;
@@ -378,6 +379,7 @@ pub(crate) async fn shard_listener_loop(mut params: ShardListenerParams) {
     const MAX_RETRY_DELAY: u64 = 10_000;
     let mut reconnection_count = 0u64;
     let mut consecutive_failures: u64 = 0;
+    let mut fan_in_dropped_count = 0u64;
 
     'outer: loop {
         if !params.is_running.load(Ordering::Relaxed) {
@@ -527,8 +529,23 @@ pub(crate) async fn shard_listener_loop(mut params: ShardListenerParams) {
                     match params.fan_in_tx.try_send(push_info) {
                         Ok(()) => {}
                         Err(crossfire::TrySendError::Full(_)) => {
-                            // Bounded fan-in is full; drop this message.
-                            // The 10 000-cap prevents OOM under sustained backpressure.
+                            fan_in_dropped_count = fan_in_dropped_count.saturating_add(1);
+                            if let Some(metrics) = params.metrics.get() {
+                                metrics.mark_horizontal_transport_message_dropped(
+                                    params.mode.metrics_transport(),
+                                );
+                            }
+                            // Keep the first drop immediately visible without producing one
+                            // warning per message during sustained overload.
+                            if fan_in_dropped_count.is_power_of_two() {
+                                warn!(
+                                    adapter = "redis_cluster",
+                                    shard = %params.shard_addr,
+                                    dropped_count = fan_in_dropped_count,
+                                    queue_capacity_count = FAN_IN_CAPACITY,
+                                    "sharded pub/sub fan-in message dropped"
+                                );
+                            }
                         }
                         Err(crossfire::TrySendError::Disconnected(_)) => {
                             break 'outer; // caller dropped the receiver; stop
@@ -653,7 +670,7 @@ impl ShardedSubscriber {
         );
 
         let (fan_tx, fan_rx): (ShardedPushSender, ShardedPushReceiver) =
-            mpsc::bounded_async(10_000);
+            mpsc::bounded_async(FAN_IN_CAPACITY);
 
         let scheme = if self.seed_urls.iter().any(|u| u.starts_with("rediss://")) {
             "rediss"
@@ -706,18 +723,32 @@ impl ShardedSubscriber {
                     refresh_notify: self.refresh_notify.clone(),
                     tls: self.tls.clone(),
                 };
-                shard_map.insert(shard_addr_str, tokio::spawn(shard_listener_loop(params)));
-                ready_receivers.push(ready_rx);
+                let readiness_channels = params.channels.clone();
+                shard_map.insert(
+                    shard_addr_str.clone(),
+                    tokio::spawn(shard_listener_loop(params)),
+                );
+                ready_receivers.push((shard_addr_str, readiness_channels, ready_rx));
             }
             drop(shard_map);
 
-            let readiness = ready_receivers
-                .into_iter()
-                .map(|ready_rx| tokio::time::timeout(Duration::from_secs(5), ready_rx));
-            for result in futures::future::join_all(readiness).await {
+            let readiness =
+                ready_receivers
+                    .into_iter()
+                    .map(|(shard, channels, ready_rx)| async move {
+                        (
+                            shard,
+                            channels,
+                            tokio::time::timeout(Duration::from_secs(5), ready_rx).await,
+                        )
+                    });
+            for (shard, channels, result) in futures::future::join_all(readiness).await {
                 if !matches!(result, Ok(Ok(()))) {
                     warn!(
                         adapter = "redis_cluster",
+                        shard = %shard,
+                        channel_count = channels.len(),
+                        channels = ?channels,
                         "sharded subscriber initial subscription timed out"
                     );
                 }

--- a/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
+++ b/crates/sockudo-adapter/src/transports/redis_cluster_transport.rs
@@ -544,17 +544,30 @@ impl HorizontalTransport for RedisClusterTransport {
                                     if let Ok(response) = response_result
                                         && let Ok(response_json) = sonic_rs::to_string(&response)
                                     {
+                                        let direct_reply = reply_to.is_some();
                                         let target = reply_to.unwrap_or(response_channel_clone);
                                         // Clone connection (cheap, thread-safe per redis-rs docs)
                                         let mut conn = publish_conn.clone();
 
-                                        let result: redis::RedisResult<()> = if sharded {
+                                        let result: redis::RedisResult<i32> = if sharded {
                                             conn.spublish(&target, &response_json).await
                                         } else {
                                             conn.publish(&target, response_json).await
                                         };
-                                        if let Err(e) = result {
-                                            warn!(adapter = "redis_cluster", error = %e, "response publish failed");
+                                        match result {
+                                            Ok(subscriber_count) => {
+                                                trace!(
+                                                    adapter = "redis_cluster",
+                                                    request_id = %response.request_id,
+                                                    channel = %target,
+                                                    direct_reply,
+                                                    subscriber_count,
+                                                    "response published to transport"
+                                                );
+                                            }
+                                            Err(e) => {
+                                                warn!(adapter = "redis_cluster", error = %e, "response publish failed");
+                                            }
                                         }
                                     }
                                 } else if let Some(metrics) = metrics_clone.get() {
@@ -580,10 +593,17 @@ impl HorizontalTransport for RedisClusterTransport {
                         ChannelKind::Reply => {
                             let response_handler = handlers.on_response.clone();
                             let metrics_clone = metrics.clone();
+                            let reply_channel_clone = reply_channel.clone();
 
                             tokio::spawn(async move {
                                 if let Ok(response) = sonic_rs::from_slice::<ResponseBody>(&payload)
                                 {
+                                    trace!(
+                                        adapter = "redis_cluster",
+                                        request_id = %response.request_id,
+                                        reply_channel = %reply_channel_clone,
+                                        "response received on dedicated reply channel"
+                                    );
                                     response_handler(response).await;
                                 } else if let Some(metrics) = metrics_clone.get() {
                                     metrics

--- a/crates/sockudo-metrics/src/prometheus/handles.rs
+++ b/crates/sockudo-metrics/src/prometheus/handles.rs
@@ -133,6 +133,10 @@ pub(super) struct CounterWithLabels {
 }
 
 impl CounterWithLabels {
+    pub(super) fn init(&self) {
+        counter!(self.name.clone(), &self.labels).increment(0);
+    }
+
     pub(super) fn inc(&self) {
         counter!(self.name.clone(), &self.labels).increment(1);
     }

--- a/crates/sockudo-metrics/src/prometheus/interface.rs
+++ b/crates/sockudo-metrics/src/prometheus/interface.rs
@@ -213,17 +213,24 @@ impl MetricsInterface for PrometheusMetricsDriver {
         request_type: &str,
     ) {
         let tags = self.get_tags(app_id);
+        let resolved_promises = self
+            .horizontal_adapter_resolved_promises
+            .with_label_values(&tags);
+        let mut uncomplete_tags = tags.clone();
+        uncomplete_tags.push(request_type.to_string());
+        let uncomplete_promises = self
+            .horizontal_adapter_uncomplete_promises
+            .with_label_values(&uncomplete_tags);
+
+        // Register both sides of the outcome before incrementing either one so
+        // alerts can compare an explicit zero against the non-zero series.
+        resolved_promises.init();
+        uncomplete_promises.init();
 
         if resolved {
-            self.horizontal_adapter_resolved_promises
-                .with_label_values(&tags)
-                .inc();
+            resolved_promises.inc();
         } else {
-            let mut error_tags = tags.clone();
-            error_tags.push(request_type.to_string());
-            self.horizontal_adapter_uncomplete_promises
-                .with_label_values(&error_tags)
-                .inc();
+            uncomplete_promises.inc();
         }
 
         debug!(
@@ -791,5 +798,25 @@ impl MetricsInterface for PrometheusMetricsDriver {
         // Reset individual metrics counters - not fully supported by Prometheus Rust client
         // So we'll just log a message
         debug!("metrics cleared: prometheus metrics cannot be fully reset");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn promise_outcome_tracking_registers_both_counter_series() {
+        let metrics = PrometheusMetricsDriver::new(0, Some("promise_test_")).await;
+
+        metrics.track_horizontal_adapter_resolved_promises("test-app", false, "SocketsCount");
+        let output = metrics.get_metrics_as_plaintext().await;
+
+        assert!(output.contains(
+            "promise_test_horizontal_adapter_resolved_promises{app_id=\"test-app\",port=\"0\"} 0"
+        ));
+        assert!(output.contains(
+            "promise_test_horizontal_adapter_uncomplete_promises{app_id=\"test-app\",port=\"0\",request_type=\"SocketsCount\"} 1"
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- include `node_count` in horizontal request timeout warnings
- initialize both promise outcome counters so zero-valued resolved series remain alertable
- count and rate-limit warnings for bounded sharded Pub/Sub fan-in drops
- include shard and channel context in subscription readiness warnings
- trace dedicated reply publication and receipt with subscriber counts

## Scope

This PR adds the observability requested in #418. It does not change `max_expected_responses` or fix the stale-subscriber over-count, so #418 should remain open after this merges.

## Verification

- `cargo test -p sockudo-metrics`
- `cargo test -p sockudo-adapter --test integration horizontal_adapter_base`
- `cargo test -p sockudo-adapter --features redis-cluster --lib redis_cluster_sharded_pubsub`
- `cargo clippy -p sockudo-adapter -p sockudo-metrics --all-targets --features sockudo-adapter/redis-cluster -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`

The full workspace test run passes until two Redis-backed Ably compatibility tests attempt to connect to a local Redis service, which is not available in this environment.

Related to #418