### PR TITLE
fix(adapter): expire dead nodes locally regardless of leader or broadcast

### DIFF
--- a/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+/// How long to wait for a NodeDead broadcast before giving up on it.
+///
+/// Deliberately short. The broadcast is an optimisation - it lets followers drop a departed node at
+/// once instead of waiting out their own node_timeout_ms - so a slow publish must never hold up a
+/// cleanup round. Before this bound existed, a publish that never resolved stranded every remaining
+/// dead node in the leader's heartbeat map indefinitely, with nothing logged.
+const NODE_DEAD_PUBLISH_TIMEOUT: Duration = Duration::from_secs(5);
+
 impl<T: HorizontalTransport + 'static> HorizontalAdapterBase<T>
 where
     T::Config: TransportConfig,
@@ -931,6 +939,32 @@ where
                 let dead_nodes = horizontal.get_dead_nodes(node_timeout_ms).await;
 
                 if !dead_nodes.is_empty() {
+                    // Expire locally FIRST, on EVERY node, before any network work.
+                    //
+                    // This used to live inside the `is_leader` branch below, after an unbounded
+                    // publish await, which gave `node_count` two ways to stay wrong forever:
+                    //
+                    //   1. A FOLLOWER never expired anything locally at all - it waited for the
+                    //      leader's NodeDead broadcast. A departed node therefore stayed in its
+                    //      heartbeat map, and get_effective_node_count (heartbeats.len() + 1)
+                    //      stayed too high for as long as that broadcast failed to arrive.
+                    //   2. The LEADER expired one entry per iteration and then awaited the NodeDead
+                    //      publish with no timeout. If that publish never resolved, the loop never
+                    //      reached the remaining entries - and because a pending future is not an
+                    //      error, nothing was logged.
+                    //
+                    // Local expiry is a purely local fact: this heartbeat is already older than
+                    // node_timeout_ms. It has no reason to depend on leader election or on any
+                    // network call succeeding. Doing it up front makes the node count converge even
+                    // when the notification path is broken, which is the property that was missing.
+                    //
+                    // Safe before the election: is_cleanup_leader already excludes `dead_nodes` from
+                    // the pool via `retain`, so removing them from the map first makes that filter a
+                    // no-op rather than changing who wins.
+                    for dead_node_id in &dead_nodes {
+                        horizontal.remove_dead_node(dead_node_id).await;
+                    }
+
                     // Single leader election for entire cleanup round
                     let is_leader = horizontal.is_cleanup_leader(&dead_nodes).await;
 
@@ -945,8 +979,9 @@ where
                         for dead_node_id in dead_nodes {
                             debug!(node_id = %dead_node_id, "processing dead node");
 
-                            // 1. Remove from local heartbeat tracking
-                            horizontal.remove_dead_node(&dead_node_id).await;
+                            // The local heartbeat entry is already gone - expired above, on every
+                            // node, before any network work. What is left here is leader-only: the
+                            // presence-registry cleanup and the single broadcast to followers.
 
                             // 2. Get orphaned members and clean up local registry
                             let cleanup_tasks = match horizontal
@@ -1017,9 +1052,29 @@ where
                                     channels: None,
                                 };
 
-                                if let Err(e) = transport.publish_request(&dead_node_request).await
+                                // BOUNDED. An unbounded await here is what turned a slow
+                                // notification into a permanently wrong node count: the future
+                                // stayed pending, so the loop never reached the next dead node and
+                                // nothing was logged. A timeout makes that silence a logged failure,
+                                // and - now that local expiry happens up front - losing this
+                                // broadcast costs only promptness on followers, not correctness.
+                                match tokio::time::timeout(
+                                    NODE_DEAD_PUBLISH_TIMEOUT,
+                                    transport.publish_request(&dead_node_request),
+                                )
+                                .await
                                 {
-                                    error!(error = %e, "failed to send dead node notification");
+                                    Ok(Ok(())) => {}
+                                    Ok(Err(e)) => {
+                                        error!(error = %e, "failed to send dead node notification");
+                                    }
+                                    Err(_) => {
+                                        error!(
+                                            dead_node_id = %dead_node_id,
+                                            timeout_ms = NODE_DEAD_PUBLISH_TIMEOUT.as_millis() as u64,
+                                            "timed out publishing dead node notification; followers will expire this node locally instead"
+                                        );
+                                    }
                                 }
                             }
                         }

--- a/crates/sockudo-adapter/tests/adapter/dead_node_detection_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/dead_node_detection_tests.rs
@@ -456,3 +456,79 @@ async fn test_follower_cleanup_only_removes_registry_data() {
         );
     }
 }
+
+/// A NodeDead broadcast that never resolves must not stop nodes expiring dead peers locally.
+///
+/// REGRESSION. The cleanup loop used to remove a node from local heartbeat tracking INSIDE the
+/// `is_leader` branch, one node per iteration, and then `.await` the NodeDead publish with no
+/// timeout. Two ways that left `node_count` permanently too high:
+///
+///   1. A follower never expired anything locally at all - it waited for the leader's broadcast.
+///   2. A leader expired one entry, then hung on the publish, so the loop never reached the rest.
+///      Because a pending future is not an error, nothing was logged.
+///
+/// Observed in production as `expected=2, responses_received=1` on every cross-pod request for
+/// 36 minutes against a 30-second node timeout, with the pod otherwise healthy: one decrement,
+/// then frozen.
+///
+/// Local expiry is a purely local fact - the heartbeat is older than node_timeout_ms - so it must
+/// not depend on leader election or on any network call completing.
+#[tokio::test]
+async fn test_dead_nodes_expire_locally_when_node_dead_publish_hangs() {
+    let mut adapter = HorizontalAdapterBase::<MockTransport>::new(MockConfig::default())
+        .await
+        .unwrap();
+
+    // Every NodeDead publish from here on hangs instead of completing.
+    adapter.transport.hang_node_dead_publish();
+
+    // Short intervals so the cleanup round runs well inside the test, but they MUST satisfy
+    // ClusterHealthConfig::validate: heartbeat_interval_ms <= node_timeout_ms / 3 and
+    // cleanup_interval_ms <= node_timeout_ms. A config that fails validation is not rejected -
+    // set_cluster_health logs a warning and returns Ok(()) while keeping the previous settings -
+    // so an invalid config here silently leaves node_timeout_ms at its 30s default and the test
+    // waits for something that cannot happen in time.
+    let cluster_config = ClusterHealthConfig {
+        enabled: true,
+        heartbeat_interval_ms: 100,
+        node_timeout_ms: 300,
+        cleanup_interval_ms: 100,
+    };
+    adapter.set_cluster_health(&cluster_config).await.unwrap();
+
+    // TWO stale peers, deliberately. With one, a loop that removes an entry and then hangs is
+    // indistinguishable from a loop that works; the second entry is what proves the round
+    // completed rather than stalling after the first removal.
+    {
+        let horizontal = adapter.horizontal.clone();
+        horizontal
+            .add_discovered_node_for_test("stale-node-a".to_string())
+            .await;
+        horizontal
+            .add_discovered_node_for_test("stale-node-b".to_string())
+            .await;
+    }
+
+    adapter.start_listeners().await.unwrap();
+
+    // Past node_timeout_ms plus several cleanup intervals. Generous on purpose: the assertion is
+    // about whether expiry happens at all, not about how promptly.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let horizontal = adapter.horizontal.clone();
+    let heartbeats = horizontal.node_heartbeats.read().await;
+    assert!(
+        heartbeats.is_empty(),
+        "both stale peers should have expired locally even though the NodeDead publish never \
+         resolves; still tracked: {:?}",
+        heartbeats.keys().collect::<Vec<_>>()
+    );
+
+    // And the count the request path actually reads must be back to just this node.
+    drop(heartbeats);
+    assert_eq!(
+        horizontal.get_effective_node_count().await,
+        1,
+        "node_count must converge to 1 (ourselves) with no reachable peers"
+    );
+}

--- a/crates/sockudo-adapter/tests/adapter/horizontal_adapter_helpers.rs
+++ b/crates/sockudo-adapter/tests/adapter/horizontal_adapter_helpers.rs
@@ -1,4 +1,5 @@
 use ahash::AHashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use async_trait::async_trait;
 use sockudo_adapter::horizontal_adapter::{
     BroadcastMessage, RequestBody, RequestType, ResponseBody,
@@ -158,9 +159,25 @@ pub struct MockTransport {
     published_responses: Arc<Mutex<Vec<ResponseBody>>>,
     healthy: Arc<Mutex<bool>>,
     node_count: Arc<Mutex<usize>>,
+    /// When set, a NodeDead publish never resolves. Reproduces the defect where an unbounded
+    /// `.await` on that publish stalled the dead-node cleanup loop: the future stays PENDING,
+    /// so no error path is taken and nothing is logged.
+    ///
+    /// A field on the transport rather than on MockConfig on purpose - MockConfig is built with
+    /// explicit struct literals in several test files, so a new field there is a compile error in
+    /// all of them for a flag only one test needs.
+    hang_node_dead_publish: Arc<AtomicBool>,
 }
 
 impl MockTransport {
+    /// Make every subsequent NodeDead publish hang forever instead of completing.
+    ///
+    /// Reproduces the defect this guards: an unbounded `.await` on that publish stalled the
+    /// dead-node cleanup loop, and because a pending future is not an error, nothing was logged.
+    pub fn hang_node_dead_publish(&self) {
+        self.hang_node_dead_publish.store(true, Ordering::SeqCst);
+    }
+
     /// Create a new MockTransport with shared state for multi-node simulation
     pub fn new_with_shared_state(
         config: MockConfig,
@@ -174,6 +191,7 @@ impl MockTransport {
             published_responses: Arc::new(Mutex::new(Vec::new())),
             healthy: Arc::new(Mutex::new(true)),
             node_count: Arc::new(Mutex::new(1)),
+            hang_node_dead_publish: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -471,6 +489,7 @@ impl HorizontalTransport for MockTransport {
             healthy: Arc::new(Mutex::new(config.healthy)),
             // Match production semantics: node count includes the local node.
             node_count: Arc::new(Mutex::new(config.node_states.len() + 1)),
+            hang_node_dead_publish: Arc::new(AtomicBool::new(false)),
             config,
             handlers: Arc::new(Mutex::new(None)),
             published_broadcasts: Arc::new(Mutex::new(Vec::new())),
@@ -509,6 +528,14 @@ impl HorizontalTransport for MockTransport {
     async fn publish_request(&self, request: &RequestBody) -> Result<()> {
         if self.config.simulate_failures && request.app_id == "fail_request" {
             return Err(Error::Internal("Simulated request failure".to_string()));
+        }
+
+        // Never resolves. Reproduces a NodeDead broadcast that hangs rather than failing -
+        // the shape that stalled dead-node cleanup, because a pending future is not an error.
+        if request.request_type == RequestType::NodeDead
+            && self.hang_node_dead_publish.load(Ordering::SeqCst)
+        {
+            std::future::pending::<()>().await;
         }
 
         self.published_requests.lock().await.push(request.clone());
@@ -553,6 +580,7 @@ impl HorizontalTransport for MockTransport {
                         published_responses: Arc::new(Mutex::new(Vec::new())),
                         healthy: Arc::new(Mutex::new(true)),
                         node_count: Arc::new(Mutex::new(1)),
+                        hang_node_dead_publish: Arc::new(AtomicBool::new(false)),
                     };
 
                     let response = dummy_transport.create_realistic_response(&node_state, &request);

--- a/crates/sockudo-adapter/tests/adapter/horizontal_adapter_helpers.rs
+++ b/crates/sockudo-adapter/tests/adapter/horizontal_adapter_helpers.rs
@@ -1,5 +1,4 @@
 use ahash::AHashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
 use async_trait::async_trait;
 use sockudo_adapter::horizontal_adapter::{
     BroadcastMessage, RequestBody, RequestType, ResponseBody,
@@ -14,6 +13,7 @@ use sockudo_core::websocket::SocketId;
 use sonic_rs::{Value, json};
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::Mutex;
 


### PR DESCRIPTION
Fixes the defect behind #418. Builds on the instrumentation from #419, which is what made it findable.

## The bug

A node's heartbeat table could keep entries for pods that no longer exist, indefinitely. Since `get_effective_node_count` is `node_heartbeats.len() + 1` and `max_expected_responses` is `node_count - 1`, every cross-pod request then waited for a response that was never coming and timed out — permanently — while the node stayed healthy in every other respect. Broadcast was unaffected, so delivery looked fine and only presence/count queries broke.

**Two independent paths caused it**, both in the dead-node cleanup loop:

**1. A follower never expired anything locally.** `remove_dead_node` was called only inside the `is_leader` branch, so a non-leader's table shrank only when the leader's `NodeDead` broadcast arrived. One unhealthy leader therefore inflated `node_count` on *every* node in the cluster — which is why we saw both replicas go deaf simultaneously, something the hang alone doesn't explain.

**2. The leader expired one entry per iteration, then awaited the publish with no timeout.** If that publish never resolved, the loop never reached the remaining entries. Because a pending future is not an error, nothing was logged.

## The change

Local expiry is a purely local fact — the heartbeat is already older than `node_timeout_ms`. It has no reason to depend on leader election or on a network call completing. It now happens up front, on every node, before any network work:

```rust
for dead_node_id in &dead_nodes {
    horizontal.remove_dead_node(dead_node_id).await;
}

let is_leader = horizontal.is_cleanup_leader(&dead_nodes).await;
```

**The reorder is safe:** `is_cleanup_leader` already excludes `dead_nodes` from the election pool via `retain`, so pruning them from the map first makes that filter a no-op rather than changing which node wins.

The `NodeDead` publish is additionally bounded at 5s. Losing the broadcast now costs only promptness on followers — they expire the node themselves on their next round — rather than correctness.

Leader-only work (presence-registry cleanup, the orphaned-member event, the broadcast) is untouched.

## Regression test

`test_dead_nodes_expire_locally_when_node_dead_publish_hangs` drives a transport whose `NodeDead` publish never resolves, and asserts both stale peers still expire.

Without the fix it fails with **exactly one entry remaining**:

```
both stale peers should have expired locally even though the NodeDead publish
never resolves; still tracked: ["stale-node-a"]
```

That is the production signature — a single decrement followed by a frozen count — reproduced in 1.5s.

The hang flag lives on `MockTransport` rather than `MockConfig` deliberately: `MockConfig` is built with explicit struct literals in several test files, so a new field there is a compile error in all of them for a flag one test needs.

## Verification

- `cargo test -p sockudo-adapter` — **287 passed, 0 failed**
- Production: ElastiCache Serverless, redis-cluster adapter, 2 replicas. A pod held `expected=2, responses_received=1` on every request for **36 minutes** against a 30-second node timeout, logging no reconnect, no topology refresh and no resubscribe throughout.
- Rolling the deployment reproduces it on demand. Before: the count sticks. After: converges in **13–19s** across four consecutive rollouts.

## One unrelated thing worth a look

`set_cluster_health` **logs a warning and returns `Ok(())`** when the config fails validation, silently keeping the previous settings. My first version of the test used `heartbeat_interval_ms: 100` with `node_timeout_ms: 200`, which trips the `heartbeat <= node_timeout / 3` rule — so the config was rejected, `node_timeout_ms` stayed at its 30s default, and the test waited for something that could not happen. Nothing in the return value says so. Not touched here, but it is an easy trap.