### PR TITLE
fix(metrics): let resolve_time buckets reach the request timeout

### DIFF
--- a/crates/sockudo-metrics/src/prometheus/recorder.rs
+++ b/crates/sockudo-metrics/src/prometheus/recorder.rs
@@ -6,9 +6,18 @@ use std::sync::OnceLock;
 use tracing::warn;
 
 // Histogram buckets for internal operations (in milliseconds)
-// Optimized for sub-millisecond to low-millisecond measurements
+//
+// Fine at the bottom because the common case is sub-millisecond to low-millisecond, and extended
+// past 1000 because the only metric using these - horizontal_adapter_resolve_time - measures a
+// cross-pod request whose default request_timeout_ms is 1000. Topping out at 10 meant every timed
+// out request landed in +Inf, so histogram_quantile returned the top bucket and p95/p99 were pinned
+// there: exactly the tail the metric exists to show was the part it could not express. On a
+// four-cluster deployment 5-9% of requests exceeded 10ms, which is enough to clip p95 permanently.
+//
+// The original boundaries are all still here, so low-end buckets stay comparable across the change.
 pub(super) const INTERNAL_LATENCY_HISTOGRAM_BUCKETS: &[f64] = &[
-    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0,
+    1000.0, 2500.0,
 ];
 
 // Histogram buckets for end-to-end operations (in milliseconds)


### PR DESCRIPTION
Follow-up to #422. Small, self-contained.

## The problem

`horizontal_adapter_resolve_time` is the **only** user of `INTERNAL_LATENCY_HISTOGRAM_BUCKETS`, and those top out at **10 ms** — while the cross-pod request it measures has a default `request_timeout_ms` of **1000**.

So every timed-out request lands in `+Inf`, `histogram_quantile` returns the top bucket, and p95/p99 sit pinned at 10. The tail the metric exists to show is the one part it cannot express.

Not theoretical. Across four clusters on the redis-cluster adapter:

| cluster | requests above 10 ms |
| --- | --- |
| midgard | 4.98 % |
| vanaheim | 6.09 % |
| alfheim | 7.29 % |
| asgard | 9.11 % |

Anything over 5 % clips p95 by definition, and the panel query returns **exactly 10** for both p95 and p99 on all four.

## The change

Top end moves to 2500 ms, comfortably past the 1000 ms timeout so a timed-out request lands in a real bucket instead of the overflow.

**Every original boundary is kept**, so low-end data stays comparable across the change — that matters here because mean resolve time is 2.7–5.6 ms, so the sub-millisecond buckets are doing real work and I did not want to coarsen them.

## Why the constant and not the registration

Both registration paths reference it:

- `prometheus/driver.rs` — `register_histogram_vec!(… INTERNAL_LATENCY_HISTOGRAM_BUCKETS)`
- `prometheus/recorder.rs` — `set_buckets_for_metric(Matcher::Full(…), INTERNAL_LATENCY_HISTOGRAM_BUCKETS)`

Changing only one would have been a half fix that looked complete.

No other metric shares the constant, and no test asserts on the boundaries — so the blast radius is this one histogram.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -p sockudo-metrics -p sockudo-adapter --all-targets --features sockudo-adapter/redis-cluster -- -D warnings` — clean

## Aside, not changed here

The metric name carries no `_ms` suffix, unlike its neighbour `broadcast_latency_ms`, even though it records `start.elapsed().as_micros() as f64 / 1000.0`. That cost us a dashboard that drew a 10 ms round trip as a 10 **second** spike. Renaming would be breaking so I have left it alone, but the docstring or the name might be worth a look at some point.