### PR TITLE
feat(observability): add full OpenTelemetry support

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fixture: [default, ingress, dashboard, ha, external-config]
+        fixture: [default, ingress, dashboard, ha, external-config, opentelemetry]
         kubernetes-version: ["1.29.0", "1.33.0"]
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2823,7 +2835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3243,7 +3255,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -4051,7 +4063,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -5469,6 +5481,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.2",
+ "opentelemetry",
+ "reqwest 0.13.4",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "flate2",
+ "http 1.4.2",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.14.4",
+ "reqwest 0.13.4",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tonic",
+ "tonic-types",
+ "zstd",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "base64",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.14.4",
+ "serde",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5515,7 +5591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6296,7 +6372,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -6337,9 +6413,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6780,6 +6856,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.2",
@@ -7168,7 +7245,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7242,7 +7319,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7522,7 +7599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7916,7 +7993,14 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jsonwebtoken 11.0.0",
+ "metrics",
  "num_cpus",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-http",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "redis",
  "rustls",
  "scylla",
@@ -7950,6 +8034,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "urlencoding",
@@ -8018,6 +8103,7 @@ dependencies = [
  "mockall",
  "moka",
  "num_cpus",
+ "opentelemetry",
  "papaya",
  "parking_lot",
  "pulsar",
@@ -8042,6 +8128,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-opentelemetry",
  "uuid",
 ]
 
@@ -8200,6 +8287,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-exporter-tcp",
  "metrics-util",
+ "opentelemetry",
  "sockudo-core",
  "sonic-rs",
  "tokio",
@@ -8237,6 +8325,7 @@ dependencies = [
  "httpdate",
  "jsonwebtoken 11.0.0",
  "metrics",
+ "opentelemetry",
  "rand 0.9.5",
  "reqwest 0.12.28",
  "ring",
@@ -8250,6 +8339,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "url",
  "web-push-native",
  "zeroize",
@@ -8340,6 +8430,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac 0.13.0",
+ "opentelemetry",
  "parking_lot",
  "regex",
  "reqwest 0.12.28",
@@ -8351,6 +8442,7 @@ dependencies = [
  "sonic-rs",
  "tokio",
  "tracing",
+ "tracing-opentelemetry",
  "url",
  "uuid",
 ]
@@ -9077,7 +9169,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9475,6 +9567,7 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
+ "flate2",
  "h2",
  "http 1.4.2",
  "http-body 1.1.0",
@@ -9494,6 +9587,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -9504,6 +9598,17 @@ checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost 0.14.4",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "tonic",
 ]
 
@@ -9608,8 +9713,10 @@ checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
+ "smallvec",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -10146,7 +10253,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10614,3 +10721,31 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,27 @@ metrics = "0.24.6"
 metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
 metrics-exporter-tcp = "0.11.2"
 metrics-util = "0.20.4"
+opentelemetry = { version = "0.32.0", default-features = false, features = ["logs", "metrics", "trace"] }
+opentelemetry-appender-tracing = { version = "0.32.0", default-features = false, features = ["experimental_metadata_attributes", "experimental_span_attributes"] }
+opentelemetry-http = { version = "0.32.0", default-features = false }
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = [
+  "grpc-tonic",
+  "gzip-http",
+  "gzip-tonic",
+  "http-json",
+  "http-proto",
+  "logs",
+  "metrics",
+  "reqwest-blocking-client",
+  "reqwest-rustls",
+  "tls-ring",
+  "tls-roots",
+  "trace",
+  "zstd-http",
+  "zstd-tonic",
+] }
+opentelemetry-semantic-conventions = "0.32.1"
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["logs", "metrics", "trace"] }
 pulsar = { version = "6.7.2", default-features = false, features = ["tokio-runtime"] }
 rand = "0.9.2"
 rayon = "1.10"
@@ -189,6 +210,7 @@ tower-http = { version = "^0.6.6", features = ["cors"] }
 tower-layer = "0.3.3"
 tower-service = "0.3.3"
 tracing = "0.1"
+tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter", "json"] }
 url = { version = "2.5.7", features = ["serde"] }
 urlencoding = "2.1.3"

--- a/charts/sockudo/README.md
+++ b/charts/sockudo/README.md
@@ -91,6 +91,61 @@ spec:
         key: SOCKUDO_CONFIG_FILE
 ```
 
+## OpenTelemetry
+
+OpenTelemetry export is disabled by default. Enable any combination of stable traces, metrics,
+and logs with `config.openTelemetry`. Export is additive: the Prometheus service and local logs
+continue to work as configured.
+
+```yaml
+config:
+  openTelemetry:
+    enabled: true
+    tracesEnabled: true
+    metricsEnabled: true
+    logsEnabled: true
+    serviceName: sockudo
+    serviceNamespace: realtime
+    deploymentEnvironment: production
+    endpoint: http://otel-collector.observability.svc:4317
+    resourceAttributes:
+      k8s.cluster.name: production-eu
+
+extraEnv:
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: grpc
+  - name: OTEL_TRACES_SAMPLER
+    value: parentbased_traceidratio
+  - name: OTEL_TRACES_SAMPLER_ARG
+    value: "0.10"
+```
+
+`OTEL_EXPORTER_OTLP_PROTOCOL` accepts `grpc`, `http/protobuf`, or `http/json`. For HTTP,
+configure the collector's port (normally `4318`) instead of the gRPC port (`4317`). A common
+`OTEL_EXPORTER_OTLP_ENDPOINT` is treated as a base endpoint; signal-specific
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, and
+`OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` are also supported.
+
+Do not place exporter headers or API keys in chart values.
+Expose them from a Secret with `extraEnvFrom`:
+
+```yaml
+extraEnvFrom:
+  - secretRef:
+      name: sockudo-otel-exporter
+```
+
+For example, that Secret can contain `OTEL_EXPORTER_OTLP_HEADERS`. HTTPS exporters use the bundled
+platform/web PKI roots; custom CA bundles and mTLS exporter configuration are not supported by the
+current Rust SDK integration. If a NetworkPolicy restricts egress, explicitly allow the collector
+address and port. Sockudo does not receive OTLP, so no collector port belongs in the Sockudo
+Service.
+
+Collector failures are fail-open: they do not change `/live`, `/up`, or request handling. Export
+queues are bounded, and graceful shutdown flushes them within the configured timeout. W3C
+`traceparent`/`tracestate` and baggage propagation are enabled by default when OpenTelemetry is
+enabled. OpenTelemetry profiles are not supported.
+
 ## Rollouts and autoscaling
 
 `strategy` is passed straight through to the Deployment. Left unset, Kubernetes applies its

--- a/charts/sockudo/ci/opentelemetry-values.yaml
+++ b/charts/sockudo/ci/opentelemetry-values.yaml
@@ -1,0 +1,20 @@
+config:
+  openTelemetry:
+    enabled: true
+    tracesEnabled: true
+    metricsEnabled: true
+    logsEnabled: true
+    serviceName: sockudo
+    serviceNamespace: realtime
+    deploymentEnvironment: ci
+    endpoint: http://otel-collector.observability.svc:4317
+    resourceAttributes:
+      k8s.cluster.name: chart-ci
+
+extraEnv:
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: grpc
+
+extraEnvFrom:
+  - secretRef:
+      name: sockudo-otel-exporter

--- a/charts/sockudo/templates/configmap.yaml
+++ b/charts/sockudo/templates/configmap.yaml
@@ -54,6 +54,24 @@ data:
           "prefix": {{ .Values.config.metrics.prefix | quote }}
         }
       },
+      "opentelemetry": {
+        "enabled": {{ .Values.config.openTelemetry.enabled }},
+        "traces_enabled": {{ .Values.config.openTelemetry.tracesEnabled }},
+        "metrics_enabled": {{ .Values.config.openTelemetry.metricsEnabled }},
+        "logs_enabled": {{ .Values.config.openTelemetry.logsEnabled }},
+        "service_name": {{ .Values.config.openTelemetry.serviceName | quote }},
+        "service_namespace": {{ if .Values.config.openTelemetry.serviceNamespace }}{{ .Values.config.openTelemetry.serviceNamespace | quote }}{{ else }}null{{ end }},
+        "deployment_environment": {{ if .Values.config.openTelemetry.deploymentEnvironment }}{{ .Values.config.openTelemetry.deploymentEnvironment | quote }}{{ else }}null{{ end }},
+        "resource_attributes": {{ .Values.config.openTelemetry.resourceAttributes | toJson }},
+        "endpoint": {{ if .Values.config.openTelemetry.endpoint }}{{ .Values.config.openTelemetry.endpoint | quote }}{{ else }}null{{ end }},
+        "export_timeout_ms": {{ .Values.config.openTelemetry.exportTimeoutMs | int64 }},
+        "batch_scheduled_delay_ms": {{ .Values.config.openTelemetry.batchScheduledDelayMs | int64 }},
+        "batch_max_queue_size": {{ .Values.config.openTelemetry.batchMaxQueueSize | int64 }},
+        "batch_max_export_batch_size": {{ .Values.config.openTelemetry.batchMaxExportBatchSize | int64 }},
+        "metric_export_interval_ms": {{ .Values.config.openTelemetry.metricExportIntervalMs | int64 }},
+        "propagation_trace_context": {{ .Values.config.openTelemetry.propagationTraceContext }},
+        "propagation_baggage": {{ .Values.config.openTelemetry.propagationBaggage }}
+      },
       "websocket": {
         "max_payload_kb": {{ .Values.config.websocket.maxPayloadKb | int64 }},
         "max_messages": {{ .Values.config.websocket.maxMessages | int64 }},

--- a/charts/sockudo/templates/deployment.yaml
+++ b/charts/sockudo/templates/deployment.yaml
@@ -142,6 +142,45 @@ spec:
             - name: METRICS_PROMETHEUS_PREFIX
               value: {{ .Values.config.metrics.prefix | quote }}
             {{- end }}
+            # OpenTelemetry
+            {{- if .Values.config.openTelemetry.enabled }}
+            - name: SOCKUDO_OTEL_ENABLED
+              value: "true"
+            - name: SOCKUDO_OTEL_TRACES_ENABLED
+              value: {{ .Values.config.openTelemetry.tracesEnabled | quote }}
+            - name: SOCKUDO_OTEL_METRICS_ENABLED
+              value: {{ .Values.config.openTelemetry.metricsEnabled | quote }}
+            - name: SOCKUDO_OTEL_LOGS_ENABLED
+              value: {{ .Values.config.openTelemetry.logsEnabled | quote }}
+            - name: SOCKUDO_OTEL_SERVICE_NAME
+              value: {{ .Values.config.openTelemetry.serviceName | quote }}
+            {{- with .Values.config.openTelemetry.serviceNamespace }}
+            - name: SOCKUDO_OTEL_SERVICE_NAMESPACE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.config.openTelemetry.deploymentEnvironment }}
+            - name: SOCKUDO_OTEL_DEPLOYMENT_ENVIRONMENT
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.config.openTelemetry.endpoint }}
+            - name: SOCKUDO_OTEL_ENDPOINT
+              value: {{ . | quote }}
+            {{- end }}
+            - name: SOCKUDO_OTEL_EXPORT_TIMEOUT_MS
+              value: {{ .Values.config.openTelemetry.exportTimeoutMs | quote }}
+            - name: SOCKUDO_OTEL_BATCH_SCHEDULED_DELAY_MS
+              value: {{ .Values.config.openTelemetry.batchScheduledDelayMs | quote }}
+            - name: SOCKUDO_OTEL_BATCH_MAX_QUEUE_SIZE
+              value: {{ .Values.config.openTelemetry.batchMaxQueueSize | quote }}
+            - name: SOCKUDO_OTEL_BATCH_MAX_EXPORT_BATCH_SIZE
+              value: {{ .Values.config.openTelemetry.batchMaxExportBatchSize | quote }}
+            - name: SOCKUDO_OTEL_METRIC_EXPORT_INTERVAL_MS
+              value: {{ .Values.config.openTelemetry.metricExportIntervalMs | quote }}
+            - name: SOCKUDO_OTEL_PROPAGATION_TRACE_CONTEXT
+              value: {{ .Values.config.openTelemetry.propagationTraceContext | quote }}
+            - name: SOCKUDO_OTEL_PROPAGATION_BAGGAGE
+              value: {{ .Values.config.openTelemetry.propagationBaggage | quote }}
+            {{- end }}
             # Redis
             {{- if .Values.redis.host }}
             - name: DATABASE_REDIS_HOST

--- a/charts/sockudo/values.yaml
+++ b/charts/sockudo/values.yaml
@@ -120,6 +120,27 @@ config:
     driver: prometheus
     prefix: "sockudo_"
 
+  # -- OpenTelemetry OTLP export. Disabled by default and additive to Prometheus
+  # and local logging. Use extraEnv for standard non-secret OTEL_* exporter
+  # settings and extraEnvFrom for exporter headers or credentials.
+  openTelemetry:
+    enabled: false
+    tracesEnabled: true
+    metricsEnabled: true
+    logsEnabled: true
+    serviceName: sockudo
+    serviceNamespace: ""
+    deploymentEnvironment: ""
+    resourceAttributes: {}
+    endpoint: ""
+    exportTimeoutMs: 10000
+    batchScheduledDelayMs: 5000
+    batchMaxQueueSize: 2048
+    batchMaxExportBatchSize: 512
+    metricExportIntervalMs: 60000
+    propagationTraceContext: true
+    propagationBaggage: true
+
   # -- SSL/TLS settings (typically terminated at ingress)
   ssl:
     enabled: false
@@ -146,6 +167,9 @@ config:
       - Content-Type
       - X-Requested-With
       - Accept
+      - traceparent
+      - tracestate
+      - baggage
 
 # -- Full Sockudo config content (JSON). If set, mounted as /app/config/config.json.
 # Takes precedence over individual config.* values above and is the preferred

--- a/config/config.toml
+++ b/config/config.toml
@@ -389,6 +389,28 @@ host = "127.0.0.1"
 port = 5000
 buffer_size = 1024
 
+# OpenTelemetry is additive to the local logs and Prometheus endpoint above.
+# It is disabled by default. When enabled, traces, metrics, and logs are
+# exported with OTLP; collector outages do not affect request handling or
+# health/readiness checks.
+[opentelemetry]
+enabled = false
+traces_enabled = true
+metrics_enabled = true
+logs_enabled = true
+service_name = "sockudo"
+# service_namespace = "realtime"
+# deployment_environment = "production"
+resource_attributes = {}
+# endpoint = "http://127.0.0.1:4317"
+export_timeout_ms = 10000
+batch_scheduled_delay_ms = 5000
+batch_max_queue_size = 2048
+batch_max_export_batch_size = 512
+metric_export_interval_ms = 60000
+propagation_trace_context = true
+propagation_baggage = true
+
 [ssl]
 enabled = false
 
@@ -419,6 +441,9 @@ allowed_headers = [
   "X-Sockudo-Push-Capability",
   "X-Sockudo-Device-Identity-Token",
   "X-Sockudo-Rotate-Device-Identity-Token",
+  "traceparent",
+  "tracestate",
+  "baggage",
 ]
 
 [channel_limits]

--- a/crates/sockudo-adapter/Cargo.toml
+++ b/crates/sockudo-adapter/Cargo.toml
@@ -15,7 +15,8 @@ v2 = ["delta", "tag-filtering", "recovery"]
 delta = ["dep:sockudo-delta"]
 tag-filtering = ["dep:sockudo-filter"]
 recovery = []
-full = ["redis", "redis-cluster", "nats", "pulsar", "rabbitmq", "google-pubsub", "kafka", "iggy", "v2"]
+opentelemetry = ["dep:opentelemetry", "dep:tracing-opentelemetry"]
+full = ["redis", "redis-cluster", "nats", "pulsar", "rabbitmq", "google-pubsub", "kafka", "iggy", "v2", "opentelemetry"]
 redis = ["sockudo-core/redis", "dep:redis"]
 redis-cluster = ["redis", "sockudo-core/redis-cluster"]
 nats = ["sockudo-core/nats", "dep:async-nats"]
@@ -50,6 +51,7 @@ lapin = { workspace = true, optional = true }
 mockall = { workspace = true }
 moka = { workspace = true }
 num_cpus = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 pulsar = { workspace = true, optional = true }
 rand = { workspace = true }
@@ -63,6 +65,7 @@ sonic-rs = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/sockudo-adapter/src/handler/connection_management.rs
+++ b/crates/sockudo-adapter/src/handler/connection_management.rs
@@ -1415,6 +1415,7 @@ mod tests {
             compression_metadata: None,
             idempotency_key: None,
             ephemeral: true,
+            trace_context: Default::default(),
         };
         assert!(broadcast.ephemeral);
 
@@ -1439,6 +1440,7 @@ mod tests {
             compression_metadata: None,
             idempotency_key: None,
             ephemeral: false,
+            trace_context: Default::default(),
         };
 
         // Verify serialization omits ephemeral when false (skip_serializing_if)
@@ -1468,6 +1470,7 @@ mod tests {
             compression_metadata: None,
             idempotency_key: None,
             ephemeral: false,
+            trace_context: Default::default(),
         };
 
         let encoded = sonic_rs::to_string(&broadcast).unwrap();

--- a/crates/sockudo-adapter/src/handler/mod.rs
+++ b/crates/sockudo-adapter/src/handler/mod.rs
@@ -755,6 +755,8 @@ impl ConnectionHandler {
 
         // Initialize socket with atomic quota check
         let socket_id = SocketId::new();
+        tracing::Span::current().record("app_id", app_config.id.as_str());
+        tracing::Span::current().record("socket_id", socket_id.to_string());
         self.initialize_socket_with_quota_check(
             socket_id,
             socket_tx,
@@ -1029,6 +1031,19 @@ impl ConnectionHandler {
         Ok(())
     }
 
+    #[tracing::instrument(
+        name = "websocket.message",
+        target = "sockudo_telemetry",
+        level = "trace",
+        skip_all,
+        fields(
+            otel.kind = "consumer",
+            messaging.operation.name = "process",
+            network.protocol.name = "websocket",
+            app_id = %app_config.id,
+            socket_id = %socket_id,
+        )
+    )]
     async fn handle_message(
         &self,
         message: Message,

--- a/crates/sockudo-adapter/src/horizontal_adapter/mod.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter/mod.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use sockudo_core::channel::PresenceMemberInfo;
 use sockudo_core::metrics::MetricsInterface;
 use sockudo_core::websocket::SocketId;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
@@ -103,6 +103,9 @@ pub struct RequestBody {
     // Inbox channel for targeted response routing, falls back to global channel
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reply_to: Option<String>,
+    /// W3C propagation fields for horizontal request/reply continuity.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub trace_context: BTreeMap<String, String>,
 }
 
 /// Response body for horizontal requests
@@ -157,6 +160,10 @@ pub struct BroadcastMessage {
     /// in the recovery replay buffer.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub ephemeral: bool,
+    /// W3C propagation fields for cross-node trace continuity. This is never
+    /// exposed on the Pusher/Sockudo client wire protocol.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub trace_context: BTreeMap<String, String>,
 }
 
 /// Metadata for delta compression in broadcasts

--- a/crates/sockudo-adapter/src/horizontal_adapter/operations.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter/operations.rs
@@ -671,6 +671,7 @@ impl HorizontalAdapter {
             dead_node_id: None,
             target_node_id: None,
             reply_to: None,
+            trace_context: crate::telemetry::current_context(),
             channels: None,
         };
 

--- a/crates/sockudo-adapter/src/horizontal_adapter/tests/mod.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter/tests/mod.rs
@@ -4,6 +4,42 @@ use std::sync::atomic::Ordering;
 use std::time::Instant;
 use tokio::time::{Duration, sleep, timeout};
 
+#[test]
+fn legacy_horizontal_payloads_default_to_empty_trace_context() {
+    let request: RequestBody = sonic_rs::from_str(
+        r#"{
+            "request_id":"request-1",
+            "node_id":"node-1",
+            "app_id":"app-1",
+            "request_type":"Heartbeat",
+            "channel":null,
+            "socket_id":null,
+            "user_id":null,
+            "user_info":null,
+            "timestamp":1,
+            "dead_node_id":null,
+            "target_node_id":null
+        }"#,
+    )
+    .expect("legacy horizontal request should deserialize");
+    assert!(request.trace_context.is_empty());
+
+    let broadcast: BroadcastMessage = sonic_rs::from_str(
+        r#"{
+            "node_id":"node-1",
+            "app_id":"app-1",
+            "channel":"channel-1",
+            "message":"{}",
+            "except_socket_id":null
+        }"#,
+    )
+    .expect("legacy horizontal broadcast should deserialize");
+    assert!(broadcast.trace_context.is_empty());
+
+    let encoded = sonic_rs::to_string(&broadcast).expect("broadcast should serialize");
+    assert!(!encoded.contains("trace_context"));
+}
+
 #[tokio::test]
 async fn request_cleanup_operates_on_live_pending_requests() {
     let adapter = HorizontalAdapter::new();

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/connection_manager_impl.rs
@@ -158,6 +158,7 @@ where
             compression_metadata: None,
             idempotency_key,
             ephemeral,
+            trace_context: crate::telemetry::current_context(),
         };
 
         // Skip broadcasting to other nodes if we're in single-node mode
@@ -209,6 +210,7 @@ where
             compression_metadata: None,
             idempotency_key,
             ephemeral,
+            trace_context: crate::telemetry::current_context(),
         };
         if !self.should_skip_horizontal_communication().await {
             self.transport.publish_broadcast(&broadcast).await?;
@@ -238,6 +240,7 @@ where
                 compression_metadata: None,
                 idempotency_key: None,
                 ephemeral: true,
+                trace_context: crate::telemetry::current_context(),
             })
             .await
     }
@@ -388,6 +391,7 @@ where
             }),
             idempotency_key,
             ephemeral,
+            trace_context: crate::telemetry::current_context(),
         };
 
         // Skip broadcasting to other nodes if we're in single-node mode
@@ -661,6 +665,7 @@ where
             dead_node_id: None,
             target_node_id: None,
             reply_to: None,
+            trace_context: crate::telemetry::current_context(),
             channels: Some(channels.iter().map(|c| c.to_string()).collect()),
         };
 
@@ -973,6 +978,7 @@ where
             dead_node_id: Some(self.node_id.clone()),
             target_node_id: None,
             reply_to: None,
+            trace_context: crate::telemetry::current_context(),
             channels: None,
         };
 

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/core.rs
@@ -430,6 +430,7 @@ where
             dead_node_id: None,
             target_node_id: None,
             reply_to: None,
+            trace_context: crate::telemetry::current_context(),
             channels: None,
         };
         self.send_request_with_body(request).await
@@ -459,6 +460,7 @@ where
         let handlers = TransportHandlers {
             node_id: self.node_id.clone(),
             on_broadcast: Arc::new(move |broadcast| {
+                let consumer_span = crate::telemetry::broadcast_consumer_span(&broadcast);
                 let horizontal_clone = broadcast_horizontal.clone();
                 let cache_manager_clone = broadcast_cache_manager.clone();
                 let realtime_egress_tap = broadcast_realtime_egress_tap.clone();
@@ -678,9 +680,10 @@ where
                         )
                         .await;
                     }
-                })
+                }.instrument(consumer_span))
             }),
             on_request: Arc::new(move |request| {
+                let consumer_span = crate::telemetry::request_consumer_span(&request);
                 let horizontal_clone = request_horizontal.clone();
                 let transport_clone = transport_for_request.clone();
                 Box::pin(async move {
@@ -724,7 +727,7 @@ where
                             {
                                 error!(node_id = %new_node_id, error = %e, "failed to sync presence state to new node");
                             }
-                        });
+                        }.in_current_span());
                     }
 
                     // No peer is waiting for a response, skip publishing.
@@ -733,7 +736,7 @@ where
                     }
 
                     Ok(response)
-                })
+                }.instrument(consumer_span))
             }),
             on_response: Arc::new(move |response| {
                 let horizontal_clone = response_horizontal.clone();
@@ -867,6 +870,7 @@ where
                             dead_node_id: None,
                             target_node_id: None,
                             reply_to: None,
+                            trace_context: crate::telemetry::current_context(),
                             channels: None,
                         };
                         let _ = transport.publish_request(&request).await;
@@ -906,6 +910,7 @@ where
                     dead_node_id: None,
                     target_node_id: None,
                     reply_to: None,
+                    trace_context: crate::telemetry::current_context(),
                     channels: None,
                 };
 
@@ -1049,6 +1054,7 @@ where
                                     dead_node_id: Some(dead_node_id.clone()),
                                     target_node_id: None,
                                     reply_to: None,
+                                    trace_context: crate::telemetry::current_context(),
                                     channels: None,
                                 };
 

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/interface_impl.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/interface_impl.rs
@@ -42,6 +42,7 @@ impl<T: HorizontalTransport> HorizontalAdapterInterface for HorizontalAdapterBas
             dead_node_id: None,
             target_node_id: None,
             reply_to: None,
+            trace_context: crate::telemetry::current_context(),
             channels: None,
         };
 
@@ -85,6 +86,7 @@ impl<T: HorizontalTransport> HorizontalAdapterInterface for HorizontalAdapterBas
             dead_node_id: None,
             target_node_id: None,
             reply_to: None,
+            trace_context: crate::telemetry::current_context(),
             channels: None,
         };
 
@@ -132,6 +134,7 @@ impl<T: HorizontalTransport> HorizontalAdapterInterface for HorizontalAdapterBas
             dead_node_id: None,
             target_node_id: None,
             reply_to: None,
+            trace_context: crate::telemetry::current_context(),
             channels: None,
         };
 

--- a/crates/sockudo-adapter/src/horizontal_adapter_base/mod.rs
+++ b/crates/sockudo-adapter/src/horizontal_adapter_base/mod.rs
@@ -34,7 +34,7 @@ use sockudo_core::websocket::{SocketId, WebSocketRef};
 use sockudo_protocol::messages::PusherMessage;
 use sockudo_ws::axum_integration::WebSocketWriter;
 use tokio::sync::Notify;
-use tracing::{debug, error, info, warn};
+use tracing::{Instrument, debug, error, info, warn};
 use uuid::Uuid;
 
 /// Maximum hash-based spread (ms) when staggering presence-state sync on new-node detection

--- a/crates/sockudo-adapter/src/horizontal_transport.rs
+++ b/crates/sockudo-adapter/src/horizontal_transport.rs
@@ -127,6 +127,7 @@ pub(crate) async fn send_presence_state_to_node<T: HorizontalTransport>(
         timestamp: None,
         dead_node_id: None,
         reply_to: None,
+        trace_context: crate::telemetry::current_context(),
         channels: None,
     };
 

--- a/crates/sockudo-adapter/src/lib.rs
+++ b/crates/sockudo-adapter/src/lib.rs
@@ -32,6 +32,7 @@ pub mod redis_cluster_adapter;
 #[cfg(feature = "recovery")]
 pub mod replay_buffer;
 pub mod services;
+mod telemetry;
 pub mod transports;
 pub(crate) mod v2_broadcast;
 pub mod watchlist;

--- a/crates/sockudo-adapter/src/telemetry.rs
+++ b/crates/sockudo-adapter/src/telemetry.rs
@@ -1,0 +1,104 @@
+use crate::horizontal_adapter::{BroadcastMessage, RequestBody};
+use std::collections::BTreeMap;
+use tracing::Span;
+
+#[cfg(feature = "opentelemetry")]
+use opentelemetry::global;
+#[cfg(feature = "opentelemetry")]
+use opentelemetry::propagation::{Extractor, Injector};
+#[cfg(feature = "opentelemetry")]
+use tracing::trace_span;
+#[cfg(feature = "opentelemetry")]
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+pub(crate) fn current_context() -> BTreeMap<String, String> {
+    #[cfg(feature = "opentelemetry")]
+    {
+        let mut carrier = TraceCarrier::default();
+        global::get_text_map_propagator(|propagator| {
+            propagator.inject_context(&Span::current().context(), &mut carrier);
+        });
+        carrier.0
+    }
+
+    #[cfg(not(feature = "opentelemetry"))]
+    BTreeMap::new()
+}
+
+pub(crate) fn broadcast_consumer_span(broadcast: &BroadcastMessage) -> Span {
+    #[cfg(feature = "opentelemetry")]
+    {
+        let span = trace_span!(
+            target: "sockudo_telemetry",
+            "messaging.receive",
+            otel.kind = "consumer",
+            otel.name = "sockudo broadcast receive",
+            messaging.system = "sockudo.horizontal",
+            messaging.operation.name = "receive",
+            app_id = %broadcast.app_id,
+            channel = %broadcast.channel,
+        );
+        let parent = global::get_text_map_propagator(|propagator| {
+            propagator.extract(&TraceCarrierRef(&broadcast.trace_context))
+        });
+        let _ = span.set_parent(parent);
+        span
+    }
+
+    #[cfg(not(feature = "opentelemetry"))]
+    {
+        let _ = broadcast;
+        Span::none()
+    }
+}
+
+pub(crate) fn request_consumer_span(request: &RequestBody) -> Span {
+    #[cfg(feature = "opentelemetry")]
+    {
+        let span = trace_span!(
+            target: "sockudo_telemetry",
+            "messaging.receive",
+            otel.kind = "consumer",
+            otel.name = "sockudo request receive",
+            messaging.system = "sockudo.horizontal",
+            messaging.operation.name = "receive",
+            app_id = %request.app_id,
+        );
+        let parent = global::get_text_map_propagator(|propagator| {
+            propagator.extract(&TraceCarrierRef(&request.trace_context))
+        });
+        let _ = span.set_parent(parent);
+        span
+    }
+
+    #[cfg(not(feature = "opentelemetry"))]
+    {
+        let _ = request;
+        Span::none()
+    }
+}
+
+#[cfg(feature = "opentelemetry")]
+#[derive(Default)]
+struct TraceCarrier(BTreeMap<String, String>);
+
+#[cfg(feature = "opentelemetry")]
+impl Injector for TraceCarrier {
+    fn set(&mut self, key: &str, value: String) {
+        self.0.insert(key.to_owned(), value);
+    }
+}
+
+#[cfg(feature = "opentelemetry")]
+struct TraceCarrierRef<'a>(&'a BTreeMap<String, String>);
+
+#[cfg(feature = "opentelemetry")]
+impl Extractor for TraceCarrierRef<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(String::as_str).collect()
+    }
+}

--- a/crates/sockudo-adapter/src/transports/nats_transport.rs
+++ b/crates/sockudo-adapter/src/transports/nats_transport.rs
@@ -768,6 +768,7 @@ impl HorizontalTransport for NatsTransport {
                 timestamp: None,
                 dead_node_id: None,
                 reply_to: None,
+                trace_context: crate::telemetry::current_context(),
                 channels: None,
             };
 

--- a/crates/sockudo-adapter/tests/adapter/dead_node_detection_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/dead_node_detection_tests.rs
@@ -37,6 +37,7 @@ async fn test_heartbeat_tracking_updates_node_registry() {
         dead_node_id: None,
         target_node_id: None,
         reply_to: None,
+        trace_context: Default::default(),
         channels: None,
     };
 
@@ -424,6 +425,7 @@ async fn test_follower_cleanup_only_removes_registry_data() {
         dead_node_id: Some(dead_node_id.to_string()),
         target_node_id: None,
         reply_to: None,
+        trace_context: Default::default(),
         channels: None,
     };
 

--- a/crates/sockudo-adapter/tests/adapter/graceful_departure_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/graceful_departure_tests.rs
@@ -67,6 +67,7 @@ async fn test_receiving_node_dead_prunes_peer_heartbeat() {
         dead_node_id: Some("peer-node".to_string()),
         target_node_id: None,
         reply_to: None,
+        trace_context: Default::default(),
         channels: None,
     };
 

--- a/crates/sockudo-adapter/tests/adapter/presence_state_consistency_tests.rs
+++ b/crates/sockudo-adapter/tests/adapter/presence_state_consistency_tests.rs
@@ -114,6 +114,7 @@ async fn test_presence_state_with_clock_skew() {
         dead_node_id: None,
         target_node_id: None,
         reply_to: None,
+        trace_context: Default::default(),
         channels: None,
     };
 
@@ -130,6 +131,7 @@ async fn test_presence_state_with_clock_skew() {
         dead_node_id: None,
         target_node_id: None,
         reply_to: None,
+        trace_context: Default::default(),
         channels: None,
     };
 

--- a/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
+++ b/crates/sockudo-adapter/tests/adapter/transports/test_helpers.rs
@@ -82,6 +82,7 @@ pub fn create_test_broadcast(event: &str) -> BroadcastMessage {
         compression_metadata: None,
         idempotency_key: None,
         ephemeral: false,
+        trace_context: Default::default(),
     }
 }
 
@@ -100,6 +101,7 @@ pub fn create_test_request() -> RequestBody {
         dead_node_id: None,
         target_node_id: None,
         reply_to: None,
+        trace_context: Default::default(),
         channels: None,
     }
 }

--- a/crates/sockudo-core/src/options/env.rs
+++ b/crates/sockudo-core/src/options/env.rs
@@ -78,22 +78,44 @@ mod tests {
         "SOCKUDO_SKIP_INLINE_APPS",
         "APP_MANAGER_REGISTER_INLINE_APPS",
     ];
+    const OPENTELEMETRY_ENV_KEYS: &[&str] = &[
+        "SOCKUDO_OTEL_ENABLED",
+        "SOCKUDO_OTEL_TRACES_ENABLED",
+        "SOCKUDO_OTEL_METRICS_ENABLED",
+        "SOCKUDO_OTEL_LOGS_ENABLED",
+        "SOCKUDO_OTEL_SERVICE_NAME",
+        "SOCKUDO_OTEL_SERVICE_NAMESPACE",
+        "SOCKUDO_OTEL_DEPLOYMENT_ENVIRONMENT",
+        "SOCKUDO_OTEL_RESOURCE_ATTRIBUTES",
+        "SOCKUDO_OTEL_ENDPOINT",
+        "SOCKUDO_OTEL_EXPORT_TIMEOUT_MS",
+        "SOCKUDO_OTEL_BATCH_SCHEDULED_DELAY_MS",
+        "SOCKUDO_OTEL_BATCH_MAX_QUEUE_SIZE",
+        "SOCKUDO_OTEL_BATCH_MAX_EXPORT_BATCH_SIZE",
+        "SOCKUDO_OTEL_METRIC_EXPORT_INTERVAL_MS",
+        "SOCKUDO_OTEL_PROPAGATION_TRACE_CONTEXT",
+        "SOCKUDO_OTEL_PROPAGATION_BAGGAGE",
+        "OTEL_SERVICE_NAME",
+    ];
 
     struct EnvGuard {
         previous: Vec<(&'static str, Option<String>)>,
     }
 
     impl EnvGuard {
-        fn app_bootstrap(overrides: &[(&'static str, &'static str)]) -> Self {
-            let previous = APP_BOOTSTRAP_ENV_KEYS
+        fn isolated(
+            keys: &'static [&'static str],
+            overrides: &[(&'static str, &'static str)],
+        ) -> Self {
+            let previous = keys
                 .iter()
                 .map(|key| (*key, std::env::var(key).ok()))
                 .collect();
 
-            // SAFETY: These tests isolate the app-bootstrap environment keys
+            // SAFETY: These tests isolate the selected environment keys
             // before applying per-test overrides and restore them in Drop.
             unsafe {
-                for key in APP_BOOTSTRAP_ENV_KEYS {
+                for key in keys {
                     std::env::remove_var(key);
                 }
                 for (key, value) in overrides {
@@ -102,6 +124,10 @@ mod tests {
             }
 
             Self { previous }
+        }
+
+        fn app_bootstrap(overrides: &[(&'static str, &'static str)]) -> Self {
+            Self::isolated(APP_BOOTSTRAP_ENV_KEYS, overrides)
         }
     }
 
@@ -207,5 +233,78 @@ mod tests {
             options.rate_limiter.websocket_rate_limit.trust_hops,
             Some(2)
         );
+    }
+
+    #[tokio::test]
+    async fn opentelemetry_env_overrides_are_sockudo_scoped() {
+        {
+            let _env = EnvGuard::isolated(
+                OPENTELEMETRY_ENV_KEYS,
+                &[("OTEL_SERVICE_NAME", "sdk-owned-service")],
+            );
+            let mut options = ServerOptions::default();
+
+            options.override_from_env().await.unwrap();
+
+            assert_eq!(options.opentelemetry.service_name, "sockudo");
+        }
+
+        {
+            let _env = EnvGuard::isolated(
+                OPENTELEMETRY_ENV_KEYS,
+                &[
+                    ("SOCKUDO_OTEL_ENABLED", "true"),
+                    ("SOCKUDO_OTEL_TRACES_ENABLED", "false"),
+                    ("SOCKUDO_OTEL_METRICS_ENABLED", "false"),
+                    ("SOCKUDO_OTEL_LOGS_ENABLED", "false"),
+                    ("SOCKUDO_OTEL_SERVICE_NAME", "realtime-server"),
+                    ("SOCKUDO_OTEL_SERVICE_NAMESPACE", "sockudo-cloud"),
+                    ("SOCKUDO_OTEL_DEPLOYMENT_ENVIRONMENT", "staging"),
+                    (
+                        "SOCKUDO_OTEL_RESOURCE_ATTRIBUTES",
+                        "region=eu-central-1,instance.type=api",
+                    ),
+                    ("SOCKUDO_OTEL_ENDPOINT", "http://collector:4317"),
+                    ("SOCKUDO_OTEL_EXPORT_TIMEOUT_MS", "11000"),
+                    ("SOCKUDO_OTEL_BATCH_SCHEDULED_DELAY_MS", "6000"),
+                    ("SOCKUDO_OTEL_BATCH_MAX_QUEUE_SIZE", "4096"),
+                    ("SOCKUDO_OTEL_BATCH_MAX_EXPORT_BATCH_SIZE", "1024"),
+                    ("SOCKUDO_OTEL_METRIC_EXPORT_INTERVAL_MS", "61000"),
+                    ("SOCKUDO_OTEL_PROPAGATION_TRACE_CONTEXT", "false"),
+                    ("SOCKUDO_OTEL_PROPAGATION_BAGGAGE", "false"),
+                ],
+            );
+            let mut options = ServerOptions::default();
+
+            options.override_from_env().await.unwrap();
+
+            let config = options.opentelemetry;
+            assert!(config.enabled);
+            assert!(!config.traces_enabled);
+            assert!(!config.metrics_enabled);
+            assert!(!config.logs_enabled);
+            assert_eq!(config.service_name, "realtime-server");
+            assert_eq!(config.service_namespace.as_deref(), Some("sockudo-cloud"));
+            assert_eq!(config.deployment_environment.as_deref(), Some("staging"));
+            assert_eq!(
+                config.resource_attributes.get("region").map(String::as_str),
+                Some("eu-central-1")
+            );
+            assert_eq!(
+                config
+                    .resource_attributes
+                    .get("instance.type")
+                    .map(String::as_str),
+                Some("api")
+            );
+            assert_eq!(config.endpoint.as_deref(), Some("http://collector:4317"));
+            assert_eq!(config.export_timeout_ms, 11_000);
+            assert_eq!(config.batch_scheduled_delay_ms, 6_000);
+            assert_eq!(config.batch_max_queue_size, 4_096);
+            assert_eq!(config.batch_max_export_batch_size, 1_024);
+            assert_eq!(config.metric_export_interval_ms, 61_000);
+            assert!(!config.propagation_trace_context);
+            assert!(!config.propagation_baggage);
+        }
     }
 }

--- a/crates/sockudo-core/src/options/env/runtime.rs
+++ b/crates/sockudo-core/src/options/env/runtime.rs
@@ -1,5 +1,44 @@
 use super::*;
 
+fn optional_string_env(name: &str) -> Option<Option<String>> {
+    std::env::var(name).ok().map(|value| {
+        if value.trim().is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    })
+}
+
+fn apply_opentelemetry_resource_attributes(options: &mut ServerOptions) {
+    let Ok(value) = std::env::var("SOCKUDO_OTEL_RESOURCE_ATTRIBUTES") else {
+        return;
+    };
+
+    let mut attributes = std::collections::BTreeMap::new();
+    let mut invalid_count = 0_u64;
+    for entry in value.split(',') {
+        let Some((key, value)) = entry.split_once('=') else {
+            invalid_count += 1;
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            invalid_count += 1;
+            continue;
+        }
+        attributes.insert(key.to_string(), value.trim().to_string());
+    }
+
+    if invalid_count > 0 {
+        warn!(
+            env_var = "SOCKUDO_OTEL_RESOURCE_ATTRIBUTES",
+            invalid_count, "env config contains invalid resource attributes"
+        );
+    }
+    options.opentelemetry.resource_attributes = attributes;
+}
+
 pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::error::Error>> {
     // --- SSL Configuration ---
     options.ssl.enabled = parse_bool_env("SSL_ENABLED", options.ssl.enabled);
@@ -75,6 +114,63 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
     if let Some(buffer_size) = parse_env_optional::<usize>("METRICS_TCP_EXPORTER_BUFFER_SIZE") {
         options.metrics.tcp_exporter.buffer_size = Some(buffer_size);
     }
+
+    // --- OpenTelemetry ---
+    options.opentelemetry.enabled =
+        parse_bool_env("SOCKUDO_OTEL_ENABLED", options.opentelemetry.enabled);
+    options.opentelemetry.traces_enabled = parse_bool_env(
+        "SOCKUDO_OTEL_TRACES_ENABLED",
+        options.opentelemetry.traces_enabled,
+    );
+    options.opentelemetry.metrics_enabled = parse_bool_env(
+        "SOCKUDO_OTEL_METRICS_ENABLED",
+        options.opentelemetry.metrics_enabled,
+    );
+    options.opentelemetry.logs_enabled = parse_bool_env(
+        "SOCKUDO_OTEL_LOGS_ENABLED",
+        options.opentelemetry.logs_enabled,
+    );
+    if let Ok(value) = std::env::var("SOCKUDO_OTEL_SERVICE_NAME") {
+        options.opentelemetry.service_name = value;
+    }
+    if let Some(value) = optional_string_env("SOCKUDO_OTEL_SERVICE_NAMESPACE") {
+        options.opentelemetry.service_namespace = value;
+    }
+    if let Some(value) = optional_string_env("SOCKUDO_OTEL_DEPLOYMENT_ENVIRONMENT") {
+        options.opentelemetry.deployment_environment = value;
+    }
+    apply_opentelemetry_resource_attributes(options);
+    if let Some(value) = optional_string_env("SOCKUDO_OTEL_ENDPOINT") {
+        options.opentelemetry.endpoint = value;
+    }
+    options.opentelemetry.export_timeout_ms = parse_env::<u64>(
+        "SOCKUDO_OTEL_EXPORT_TIMEOUT_MS",
+        options.opentelemetry.export_timeout_ms,
+    );
+    options.opentelemetry.batch_scheduled_delay_ms = parse_env::<u64>(
+        "SOCKUDO_OTEL_BATCH_SCHEDULED_DELAY_MS",
+        options.opentelemetry.batch_scheduled_delay_ms,
+    );
+    options.opentelemetry.batch_max_queue_size = parse_env::<usize>(
+        "SOCKUDO_OTEL_BATCH_MAX_QUEUE_SIZE",
+        options.opentelemetry.batch_max_queue_size,
+    );
+    options.opentelemetry.batch_max_export_batch_size = parse_env::<usize>(
+        "SOCKUDO_OTEL_BATCH_MAX_EXPORT_BATCH_SIZE",
+        options.opentelemetry.batch_max_export_batch_size,
+    );
+    options.opentelemetry.metric_export_interval_ms = parse_env::<u64>(
+        "SOCKUDO_OTEL_METRIC_EXPORT_INTERVAL_MS",
+        options.opentelemetry.metric_export_interval_ms,
+    );
+    options.opentelemetry.propagation_trace_context = parse_bool_env(
+        "SOCKUDO_OTEL_PROPAGATION_TRACE_CONTEXT",
+        options.opentelemetry.propagation_trace_context,
+    );
+    options.opentelemetry.propagation_baggage = parse_bool_env(
+        "SOCKUDO_OTEL_PROPAGATION_BAGGAGE",
+        options.opentelemetry.propagation_baggage,
+    );
 
     // --- HTTP API ---
     options.http_api.usage_enabled =

--- a/crates/sockudo-core/src/options/runtime.rs
+++ b/crates/sockudo-core/src/options/runtime.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use sockudo_protocol::constants::PONG_TIMEOUT;
+use std::collections::BTreeMap;
 
 use super::{CacheDriver, MetricsDriver, RedisConfig};
 
@@ -95,6 +96,27 @@ pub struct MetricsTcpExporterConfig {
 pub struct LoggingConfig {
     pub colors_enabled: bool,
     pub include_target: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct OpenTelemetryConfig {
+    pub enabled: bool,
+    pub traces_enabled: bool,
+    pub metrics_enabled: bool,
+    pub logs_enabled: bool,
+    pub service_name: String,
+    pub service_namespace: Option<String>,
+    pub deployment_environment: Option<String>,
+    pub resource_attributes: BTreeMap<String, String>,
+    pub endpoint: Option<String>,
+    pub export_timeout_ms: u64,
+    pub batch_scheduled_delay_ms: u64,
+    pub batch_max_queue_size: usize,
+    pub batch_max_export_batch_size: usize,
+    pub metric_export_interval_ms: u64,
+    pub propagation_trace_context: bool,
+    pub propagation_baggage: bool,
 }
 
 /// WebSocket connection buffer configuration
@@ -480,6 +502,59 @@ impl Default for LoggingConfig {
             colors_enabled: true,
             include_target: true,
         }
+    }
+}
+
+impl Default for OpenTelemetryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            traces_enabled: true,
+            metrics_enabled: true,
+            logs_enabled: true,
+            service_name: "sockudo".to_string(),
+            service_namespace: None,
+            deployment_environment: None,
+            resource_attributes: BTreeMap::new(),
+            endpoint: None,
+            export_timeout_ms: 10_000,
+            batch_scheduled_delay_ms: 5_000,
+            batch_max_queue_size: 2_048,
+            batch_max_export_batch_size: 512,
+            metric_export_interval_ms: 60_000,
+            propagation_trace_context: true,
+            propagation_baggage: true,
+        }
+    }
+}
+
+impl OpenTelemetryConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.enabled && self.service_name.trim().is_empty() {
+            return Err("service_name must not be empty when enabled".to_string());
+        }
+        if self.export_timeout_ms == 0 {
+            return Err("export_timeout_ms must be greater than 0".to_string());
+        }
+        if self.batch_scheduled_delay_ms == 0 {
+            return Err("batch_scheduled_delay_ms must be greater than 0".to_string());
+        }
+        if self.batch_max_queue_size == 0 {
+            return Err("batch_max_queue_size must be greater than 0".to_string());
+        }
+        if self.batch_max_export_batch_size == 0 {
+            return Err("batch_max_export_batch_size must be greater than 0".to_string());
+        }
+        if self.metric_export_interval_ms == 0 {
+            return Err("metric_export_interval_ms must be greater than 0".to_string());
+        }
+        if self.batch_max_export_batch_size > self.batch_max_queue_size {
+            return Err(
+                "batch_max_export_batch_size must not exceed batch_max_queue_size".to_string(),
+            );
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/sockudo-core/src/options/server.rs
+++ b/crates/sockudo-core/src/options/server.rs
@@ -60,6 +60,7 @@ pub struct ServerOptions {
     pub logging: Option<LoggingConfig>,
     pub max_connections: u32,
     pub metrics: MetricsConfig,
+    pub opentelemetry: OpenTelemetryConfig,
     pub mode: String,
     pub server_role: ServerRole,
     pub port: u16,
@@ -116,6 +117,7 @@ impl Default for ServerOptions {
             logging: None,
             max_connections: 0,
             metrics: MetricsConfig::default(),
+            opentelemetry: OpenTelemetryConfig::default(),
             mode: "production".to_string(),
             server_role: ServerRole::default(),
             port: 6001,
@@ -171,6 +173,9 @@ impl ServerOptions {
             .accept_traffic
             .validate()
             .map_err(|error| format!("http_api.accept_traffic: {error}"))?;
+        self.opentelemetry
+            .validate()
+            .map_err(|error| format!("opentelemetry: {error}"))?;
         if self.ai_transport.enabled {
             self.ai_transport.validate_deployment_matrix(
                 &self.adapter,
@@ -454,6 +459,120 @@ mod tests {
     #[test]
     fn default_health_check_timeout_leaves_probe_headroom() {
         assert_eq!(ServerOptions::default().health_check_timeout_ms, 2000);
+    }
+
+    #[test]
+    fn opentelemetry_defaults_are_backward_compatible() {
+        let options: ServerOptions = toml::from_str("").unwrap();
+        let legacy_json: ServerOptions = sonic_rs::from_str("{}").unwrap();
+        let config = options.opentelemetry;
+
+        assert_eq!(legacy_json.opentelemetry, config);
+
+        assert!(!config.enabled);
+        assert!(config.traces_enabled);
+        assert!(config.metrics_enabled);
+        assert!(config.logs_enabled);
+        assert_eq!(config.service_name, "sockudo");
+        assert_eq!(config.service_namespace, None);
+        assert_eq!(config.deployment_environment, None);
+        assert!(config.resource_attributes.is_empty());
+        assert_eq!(config.endpoint, None);
+        assert_eq!(config.export_timeout_ms, 10_000);
+        assert_eq!(config.batch_scheduled_delay_ms, 5_000);
+        assert_eq!(config.batch_max_queue_size, 2_048);
+        assert_eq!(config.batch_max_export_batch_size, 512);
+        assert_eq!(config.metric_export_interval_ms, 60_000);
+        assert!(config.propagation_trace_context);
+        assert!(config.propagation_baggage);
+    }
+
+    #[test]
+    fn opentelemetry_partial_configuration_uses_field_defaults() {
+        let options: ServerOptions = toml::from_str(
+            r#"
+            [opentelemetry]
+            enabled = true
+            service_namespace = "realtime"
+            "#,
+        )
+        .unwrap();
+
+        assert!(options.opentelemetry.enabled);
+        assert_eq!(
+            options.opentelemetry.service_namespace.as_deref(),
+            Some("realtime")
+        );
+        assert_eq!(options.opentelemetry.service_name, "sockudo");
+        assert_eq!(options.opentelemetry.batch_max_queue_size, 2_048);
+    }
+
+    #[test]
+    fn opentelemetry_configuration_is_validated() {
+        let mut options = ServerOptions::default();
+        options.opentelemetry.service_name = "  ".to_string();
+        options.validate().unwrap();
+
+        options.opentelemetry.enabled = true;
+        assert_eq!(
+            options.validate().unwrap_err(),
+            "opentelemetry: service_name must not be empty when enabled"
+        );
+
+        options.opentelemetry = OpenTelemetryConfig::default();
+        options.opentelemetry.export_timeout_ms = 0;
+        assert!(
+            options
+                .validate()
+                .unwrap_err()
+                .contains("export_timeout_ms")
+        );
+
+        options.opentelemetry = OpenTelemetryConfig::default();
+        options.opentelemetry.batch_scheduled_delay_ms = 0;
+        assert!(
+            options
+                .validate()
+                .unwrap_err()
+                .contains("batch_scheduled_delay_ms")
+        );
+
+        options.opentelemetry = OpenTelemetryConfig::default();
+        options.opentelemetry.batch_max_queue_size = 0;
+        assert!(
+            options
+                .validate()
+                .unwrap_err()
+                .contains("batch_max_queue_size")
+        );
+
+        options.opentelemetry = OpenTelemetryConfig::default();
+        options.opentelemetry.batch_max_export_batch_size = 0;
+        assert!(
+            options
+                .validate()
+                .unwrap_err()
+                .contains("batch_max_export_batch_size")
+        );
+
+        options.opentelemetry = OpenTelemetryConfig::default();
+        options.opentelemetry.metric_export_interval_ms = 0;
+        assert!(
+            options
+                .validate()
+                .unwrap_err()
+                .contains("metric_export_interval_ms")
+        );
+
+        options.opentelemetry = OpenTelemetryConfig::default();
+        options.opentelemetry.batch_max_queue_size = 100;
+        options.opentelemetry.batch_max_export_batch_size = 101;
+        assert!(
+            options
+                .validate()
+                .unwrap_err()
+                .contains("must not exceed batch_max_queue_size")
+        );
     }
 
     #[test]

--- a/crates/sockudo-core/src/webhook_types.rs
+++ b/crates/sockudo-core/src/webhook_types.rs
@@ -1,6 +1,7 @@
 use ahash::AHashMap;
 use serde::{Deserialize, Serialize};
 use sonic_rs::Value;
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
 
@@ -142,6 +143,10 @@ pub struct JobData {
     pub app_key: String,
     pub app_id: String,
     pub app_secret: String,
+    /// W3C propagation fields carried through durable queues. These are never
+    /// included in the user-facing webhook body.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub trace_context: BTreeMap<String, String>,
     pub payload: JobPayload,
     pub original_signature: String,
 }
@@ -179,6 +184,7 @@ mod tests {
         let legacy = r#"{"app_key":"key","app_id":"app","app_secret":"secret","payload":{"time_ms":1,"events":[]},"original_signature":"signature"}"#;
         let job: JobData = sonic_rs::from_str(legacy).expect("legacy job data should deserialize");
         assert_eq!(job.job_id, None);
+        assert!(job.trace_context.is_empty());
     }
 
     fn empty_filter() -> WebhookFilter {

--- a/crates/sockudo-metrics/Cargo.toml
+++ b/crates/sockudo-metrics/Cargo.toml
@@ -7,6 +7,10 @@ rust-version.workspace = true
 repository.workspace = true
 license-file.workspace = true
 
+[features]
+default = []
+opentelemetry = ["dep:opentelemetry"]
+
 [dependencies]
 sockudo-core = { workspace = true }
 
@@ -16,6 +20,7 @@ metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 metrics-exporter-tcp = { workspace = true }
 metrics-util = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
 sonic-rs = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/sockudo-metrics/src/lib.rs
+++ b/crates/sockudo-metrics/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "opentelemetry")]
+mod opentelemetry;
 pub mod prometheus;
 
 pub use prometheus::{PrometheusMetricsDriver, TcpExporterOptions};

--- a/crates/sockudo-metrics/src/opentelemetry.rs
+++ b/crates/sockudo-metrics/src/opentelemetry.rs
@@ -1,0 +1,196 @@
+//! Bridge from the workspace's `metrics` facade to the OpenTelemetry metrics API.
+
+use metrics::{
+    Counter, CounterFn, Gauge, GaugeFn, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder,
+    SharedString, Unit,
+};
+use opentelemetry::{KeyValue, global, metrics::Meter};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+#[derive(Clone, Debug)]
+struct MetricMetadata {
+    unit: Option<Unit>,
+    description: SharedString,
+}
+
+/// Records every metric emitted through `metrics` into the configured global
+/// OpenTelemetry meter provider.
+#[derive(Clone, Debug)]
+pub(crate) struct OpenTelemetryRecorder {
+    meter: Meter,
+    metadata: Arc<Mutex<HashMap<KeyName, MetricMetadata>>>,
+}
+
+impl OpenTelemetryRecorder {
+    pub(crate) fn new() -> Self {
+        Self {
+            meter: global::meter("sockudo"),
+            metadata: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn metadata(&self) -> MutexGuard<'_, HashMap<KeyName, MetricMetadata>> {
+        self.metadata
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn attributes(key: &Key) -> Vec<KeyValue> {
+        key.labels()
+            .map(|label| KeyValue::new(label.key().to_owned(), label.value().to_owned()))
+            .collect()
+    }
+}
+
+impl Recorder for OpenTelemetryRecorder {
+    fn describe_counter(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.metadata()
+            .insert(key, MetricMetadata { unit, description });
+    }
+
+    fn describe_gauge(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.metadata()
+            .insert(key, MetricMetadata { unit, description });
+    }
+
+    fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.metadata()
+            .insert(key, MetricMetadata { unit, description });
+    }
+
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
+        let mut builder = self.meter.u64_counter(key.name().to_owned());
+        if let Some(metadata) = self.metadata().get(key.name()).cloned() {
+            if let Some(unit) = metadata.unit {
+                builder = builder.with_unit(unit.as_canonical_label());
+            }
+            builder = builder.with_description(metadata.description.to_string());
+        }
+
+        Counter::from_arc(Arc::new(OtelCounter {
+            instrument: builder.build(),
+            attributes: Self::attributes(key),
+            value: AtomicU64::new(0),
+        }))
+    }
+
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
+        let mut builder = self.meter.f64_gauge(key.name().to_owned());
+        if let Some(metadata) = self.metadata().get(key.name()).cloned() {
+            if let Some(unit) = metadata.unit {
+                builder = builder.with_unit(unit.as_canonical_label());
+            }
+            builder = builder.with_description(metadata.description.to_string());
+        }
+
+        Gauge::from_arc(Arc::new(OtelGauge {
+            instrument: builder.build(),
+            attributes: Self::attributes(key),
+            value: AtomicU64::new(0_f64.to_bits()),
+        }))
+    }
+
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
+        let mut builder = self.meter.f64_histogram(key.name().to_owned());
+        if let Some(metadata) = self.metadata().get(key.name()).cloned() {
+            if let Some(unit) = metadata.unit {
+                builder = builder.with_unit(unit.as_canonical_label());
+            }
+            builder = builder.with_description(metadata.description.to_string());
+        }
+
+        Histogram::from_arc(Arc::new(OtelHistogram {
+            instrument: builder.build(),
+            attributes: Self::attributes(key),
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct OtelCounter {
+    instrument: opentelemetry::metrics::Counter<u64>,
+    attributes: Vec<KeyValue>,
+    value: AtomicU64,
+}
+
+impl CounterFn for OtelCounter {
+    fn increment(&self, value: u64) {
+        self.value.fetch_add(value, Ordering::Relaxed);
+        self.instrument.add(value, &self.attributes);
+    }
+
+    fn absolute(&self, value: u64) {
+        let mut previous = self.value.load(Ordering::Relaxed);
+        while value > previous {
+            match self.value.compare_exchange_weak(
+                previous,
+                value,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    self.instrument.add(value - previous, &self.attributes);
+                    return;
+                }
+                Err(observed) => previous = observed,
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct OtelGauge {
+    instrument: opentelemetry::metrics::Gauge<f64>,
+    attributes: Vec<KeyValue>,
+    value: AtomicU64,
+}
+
+impl OtelGauge {
+    fn update(&self, update: impl Fn(f64) -> f64) {
+        let mut current = self.value.load(Ordering::Relaxed);
+        loop {
+            let next = update(f64::from_bits(current));
+            match self.value.compare_exchange_weak(
+                current,
+                next.to_bits(),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    self.instrument.record(next, &self.attributes);
+                    return;
+                }
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
+impl GaugeFn for OtelGauge {
+    fn increment(&self, value: f64) {
+        self.update(|current| current + value);
+    }
+
+    fn decrement(&self, value: f64) {
+        self.update(|current| current - value);
+    }
+
+    fn set(&self, value: f64) {
+        self.value.store(value.to_bits(), Ordering::Relaxed);
+        self.instrument.record(value, &self.attributes);
+    }
+}
+
+#[derive(Debug)]
+struct OtelHistogram {
+    instrument: opentelemetry::metrics::Histogram<f64>,
+    attributes: Vec<KeyValue>,
+}
+
+impl HistogramFn for OtelHistogram {
+    fn record(&self, value: f64) {
+        self.instrument.record(value, &self.attributes);
+    }
+}

--- a/crates/sockudo-metrics/src/prometheus/driver.rs
+++ b/crates/sockudo-metrics/src/prometheus/driver.rs
@@ -211,7 +211,7 @@ pub struct PrometheusMetricsDriver {
 impl PrometheusMetricsDriver {
     /// Creates a new Prometheus metrics driver
     pub async fn new(port: u16, prefix_opt: Option<&str>) -> Self {
-        Self::with_tcp_exporter(port, prefix_opt, None).await
+        Self::with_exporters(port, prefix_opt, None, false).await
     }
 
     /// Creates a new Prometheus metrics driver with an optional TCP exporter fanout.
@@ -219,6 +219,16 @@ impl PrometheusMetricsDriver {
         port: u16,
         prefix_opt: Option<&str>,
         tcp_exporter: Option<TcpExporterOptions>,
+    ) -> Self {
+        Self::with_exporters(port, prefix_opt, tcp_exporter, false).await
+    }
+
+    /// Creates a metrics driver that can fan out to Prometheus, TCP, and OpenTelemetry.
+    pub async fn with_exporters(
+        port: u16,
+        prefix_opt: Option<&str>,
+        tcp_exporter: Option<TcpExporterOptions>,
+        export_to_opentelemetry: bool,
     ) -> Self {
         let prefix = prefix_opt.unwrap_or("sockudo_").to_string();
         let tcp_exporter = if let Some(options) = tcp_exporter {
@@ -231,7 +241,7 @@ impl PrometheusMetricsDriver {
         } else {
             None
         };
-        let handle = install_prometheus_recorder(&prefix, tcp_exporter);
+        let handle = install_prometheus_recorder(&prefix, tcp_exporter, export_to_opentelemetry);
 
         // Initialize process metrics (standard Prometheus naming, no prefix)
         let process_resident_memory_bytes = register_gauge!(Opts::new(

--- a/crates/sockudo-metrics/src/prometheus/recorder.rs
+++ b/crates/sockudo-metrics/src/prometheus/recorder.rs
@@ -48,6 +48,7 @@ pub(super) struct ResolvedTcpExporterOptions {
 pub(super) fn install_prometheus_recorder(
     prefix: &str,
     tcp_exporter: Option<ResolvedTcpExporterOptions>,
+    export_to_opentelemetry: bool,
 ) -> PrometheusHandle {
     PROMETHEUS_HANDLE
         .get_or_init(|| {
@@ -90,6 +91,17 @@ pub(super) fn install_prometheus_recorder(
 
             let prometheus_recorder = builder.build_recorder();
             let handle = prometheus_recorder.handle();
+            let fanout = FanoutBuilder::default().add_recorder(prometheus_recorder);
+
+            #[cfg(feature = "opentelemetry")]
+            let fanout = if export_to_opentelemetry {
+                fanout.add_recorder(crate::opentelemetry::OpenTelemetryRecorder::new())
+            } else {
+                fanout
+            };
+
+            #[cfg(not(feature = "opentelemetry"))]
+            let _ = export_to_opentelemetry;
 
             if let Some(tcp_exporter) = tcp_exporter {
                 let tcp_recorder = TcpBuilder::new()
@@ -99,11 +111,7 @@ pub(super) fn install_prometheus_recorder(
 
                 match tcp_recorder {
                     Ok(tcp_recorder) => {
-                        let fanout = FanoutBuilder::default()
-                            .add_recorder(prometheus_recorder)
-                            .add_recorder(tcp_recorder)
-                            .build();
-                        metrics::set_global_recorder(fanout)
+                        metrics::set_global_recorder(fanout.add_recorder(tcp_recorder).build())
                             .expect("failed to install metrics-rs fanout recorder");
                     }
                     Err(error) => {
@@ -112,13 +120,13 @@ pub(super) fn install_prometheus_recorder(
                             error = %error,
                             "failed to start metrics tcp exporter, continuing with prometheus only"
                         );
-                        metrics::set_global_recorder(prometheus_recorder)
-                            .expect("failed to install metrics-rs Prometheus recorder");
+                        metrics::set_global_recorder(fanout.build())
+                            .expect("failed to install metrics-rs fanout recorder");
                     }
                 }
             } else {
-                metrics::set_global_recorder(prometheus_recorder)
-                    .expect("failed to install metrics-rs Prometheus recorder");
+                metrics::set_global_recorder(fanout.build())
+                    .expect("failed to install metrics-rs fanout recorder");
             }
 
             handle

--- a/crates/sockudo-push/Cargo.toml
+++ b/crates/sockudo-push/Cargo.toml
@@ -12,6 +12,7 @@ default = ["memory"]
 memory = []
 testing = []
 monolith = []
+opentelemetry = ["dep:opentelemetry", "dep:tracing-opentelemetry"]
 push-fcm = ["dep:jsonwebtoken", "dep:reqwest", "jsonwebtoken/aws_lc_rs"]
 push-apns = ["dep:reqwest"]
 push-webpush = ["dep:reqwest", "dep:web-push-native"]
@@ -53,6 +54,7 @@ reqwest = { workspace = true, optional = true }
 aws-lc-rs = { workspace = true }
 aws-sdk-dynamodb = { workspace = true, optional = true }
 metrics = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
 scylla = { workspace = true, optional = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
@@ -63,6 +65,7 @@ surrealdb-types = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
 url = { workspace = true }
 web-push-native = { workspace = true, optional = true }
 zeroize = { workspace = true }

--- a/crates/sockudo-push/src/dispatch/http.rs
+++ b/crates/sockudo-push/src/dispatch/http.rs
@@ -21,9 +21,43 @@ use std::time::Duration;
 use async_trait::async_trait;
 use url::{Host, Url};
 
+#[cfg(all(
+    feature = "opentelemetry",
+    any(
+        feature = "push-fcm",
+        feature = "push-apns",
+        feature = "push-webpush",
+        feature = "push-hms",
+        feature = "push-wns"
+    )
+))]
+use opentelemetry::{global, propagation::Injector};
+#[cfg(all(
+    feature = "opentelemetry",
+    any(
+        feature = "push-fcm",
+        feature = "push-apns",
+        feature = "push-webpush",
+        feature = "push-hms",
+        feature = "push-wns"
+    )
+))]
+use tracing::{Instrument, field, info_span};
+#[cfg(all(
+    feature = "opentelemetry",
+    any(
+        feature = "push-fcm",
+        feature = "push-apns",
+        feature = "push-webpush",
+        feature = "push-hms",
+        feature = "push-wns"
+    )
+))]
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
 use crate::domain::{ProviderError, ProviderFailureClass, SecretString};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ProviderHttpMethod {
     Get,
     Post,
@@ -135,23 +169,61 @@ impl ReqwestProviderHttpClient {
 impl ProviderHttpClient for ReqwestProviderHttpClient {
     async fn send(&self, request: ProviderHttpRequest) -> Result<ProviderHttpResponse, String> {
         validate_delivery_destination(&request.url).await?;
+        #[cfg(feature = "opentelemetry")]
+        let server_address = Url::parse(&request.url)
+            .ok()
+            .and_then(|url| url.host_str().map(ToOwned::to_owned))
+            .unwrap_or_else(|| "unknown".to_string());
+        #[cfg(feature = "opentelemetry")]
+        let method_name = match request.method {
+            ProviderHttpMethod::Get => "GET",
+            ProviderHttpMethod::Post => "POST",
+        };
+        #[cfg(feature = "opentelemetry")]
+        let span = info_span!(
+            target: "sockudo_telemetry",
+            "http.client.request",
+            otel.kind = "client",
+            otel.name = %format!("{method_name} push provider"),
+            http.request.method = method_name,
+            server.address = %server_address,
+            http.response.status_code = field::Empty,
+            otel.status_code = field::Empty,
+        );
         let method = match request.method {
             ProviderHttpMethod::Get => reqwest::Method::GET,
             ProviderHttpMethod::Post => reqwest::Method::POST,
         };
         let mut builder = self.client.request(method, &request.url);
-        for (name, value) in request.headers {
+        let mut headers = request.headers;
+        #[cfg(feature = "opentelemetry")]
+        global::get_text_map_propagator(|propagator| {
+            propagator.inject_context(&span.context(), &mut PushHeaderInjector(&mut headers));
+        });
+        for (name, value) in headers {
             builder = builder.header(name, value);
         }
         if let Some(authorization) = request.authorization {
             builder = builder.header("authorization", authorization.expose_secret());
         }
-        let response = builder
-            .body(request.body)
-            .send()
-            .await
-            .map_err(reqwest_error_chain)?;
+        let response = builder.body(request.body).send();
+        #[cfg(feature = "opentelemetry")]
+        let response = response.instrument(span.clone()).await;
+        #[cfg(not(feature = "opentelemetry"))]
+        let response = response.await;
+        let response = response.map_err(|error| {
+            #[cfg(feature = "opentelemetry")]
+            span.record("otel.status_code", "ERROR");
+            reqwest_error_chain(error)
+        })?;
         let status = response.status().as_u16();
+        #[cfg(feature = "opentelemetry")]
+        {
+            span.record("http.response.status_code", status);
+            if status >= 400 {
+                span.record("otel.status_code", "ERROR");
+            }
+        }
         let headers = response
             .headers()
             .iter()
@@ -168,6 +240,34 @@ impl ProviderHttpClient for ReqwestProviderHttpClient {
             headers,
             body: body.to_vec(),
         })
+    }
+}
+
+#[cfg(all(
+    feature = "opentelemetry",
+    any(
+        feature = "push-fcm",
+        feature = "push-apns",
+        feature = "push-webpush",
+        feature = "push-hms",
+        feature = "push-wns"
+    )
+))]
+struct PushHeaderInjector<'a>(&'a mut BTreeMap<String, String>);
+
+#[cfg(all(
+    feature = "opentelemetry",
+    any(
+        feature = "push-fcm",
+        feature = "push-apns",
+        feature = "push-webpush",
+        feature = "push-hms",
+        feature = "push-wns"
+    )
+))]
+impl Injector for PushHeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        self.0.insert(key.to_owned(), value);
     }
 }
 

--- a/crates/sockudo-queue/examples/queue_bench.rs
+++ b/crates/sockudo-queue/examples/queue_bench.rs
@@ -175,6 +175,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 app_key: "bench".to_string(),
                 app_id: "bench".to_string(),
                 app_secret: "not-a-secret".to_string(),
+                trace_context: Default::default(),
                 payload: JobPayload {
                     time_ms: i64::try_from(now_ms()).unwrap_or(i64::MAX),
                     events: Vec::new(),

--- a/crates/sockudo-queue/src/memory_queue_manager.rs
+++ b/crates/sockudo-queue/src/memory_queue_manager.rs
@@ -583,6 +583,7 @@ mod tests {
             app_key: "test-key".to_string(),
             app_id: "test-id".to_string(),
             app_secret: "test-secret".to_string(),
+            trace_context: Default::default(),
             payload: JobPayload::default(),
             original_signature: "signature".to_string(),
         }

--- a/crates/sockudo-queue/tests/iggy_queue_live_test.rs
+++ b/crates/sockudo-queue/tests/iggy_queue_live_test.rs
@@ -29,6 +29,7 @@ fn test_job(signature: &str) -> JobData {
         app_key: "test-key".to_string(),
         app_id: "test-app".to_string(),
         app_secret: "test-secret".to_string(),
+        trace_context: Default::default(),
         payload: JobPayload {
             time_ms: chrono::Utc::now().timestamp_millis(),
             events: vec![sonic_rs::json!({

--- a/crates/sockudo-queue/tests/redis_queue_live_test.rs
+++ b/crates/sockudo-queue/tests/redis_queue_live_test.rs
@@ -177,6 +177,7 @@ fn job(signature: &str) -> JobData {
         app_key: "key".to_string(),
         app_id: "app".to_string(),
         app_secret: "secret".to_string(),
+        trace_context: Default::default(),
         payload: JobPayload {
             time_ms: 0,
             events: Vec::new(),

--- a/crates/sockudo-server/Cargo.toml
+++ b/crates/sockudo-server/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 license-file.workspace = true
 
 [features]
-default = ["local", "v2"]
+default = ["local", "v2", "opentelemetry"]
 versioned-messages = []
 ai-transport = ["sockudo-core/ai-transport", "sockudo-protocol/ai-transport", "sockudo-adapter/ai-transport", "versioned-messages"]
 ably-compat = [
@@ -33,6 +33,7 @@ push-hms = ["push", "sockudo-push/push-hms"]
 push-wns = ["push", "sockudo-push/push-wns"]
 monolith = ["push", "sockudo-push/monolith"]
 full = [
+  "opentelemetry",
   "v2",
   "versioned-messages",
   "ai-transport",
@@ -59,6 +60,20 @@ full = [
   "sqs",
   "sns",
   "lambda",
+]
+
+opentelemetry = [
+  "dep:opentelemetry",
+  "dep:opentelemetry-appender-tracing",
+  "dep:opentelemetry-http",
+  "dep:opentelemetry-otlp",
+  "dep:opentelemetry-semantic-conventions",
+  "dep:opentelemetry_sdk",
+  "dep:tracing-opentelemetry",
+  "sockudo-adapter/opentelemetry",
+  "sockudo-metrics/opentelemetry",
+  "sockudo-push?/opentelemetry",
+  "sockudo-webhook/opentelemetry",
 ]
 
 redis = [
@@ -128,6 +143,13 @@ http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 num_cpus = { workspace = true }
+metrics = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry-appender-tracing = { workspace = true, optional = true }
+opentelemetry-http = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry-semantic-conventions = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -141,6 +163,7 @@ tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true, optional = true }

--- a/crates/sockudo-server/src/bootstrap/mod.rs
+++ b/crates/sockudo-server/src/bootstrap/mod.rs
@@ -28,13 +28,15 @@ impl MetricsFactory {
         port: u16,
         prefix: Option<&str>,
         tcp_exporter: Option<sockudo_metrics::TcpExporterOptions>,
+        export_to_opentelemetry: bool,
     ) -> Option<Arc<dyn MetricsInterface + Send + Sync>> {
         match driver_type.to_lowercase().as_str() {
             "prometheus" => {
-                let driver = sockudo_metrics::PrometheusMetricsDriver::with_tcp_exporter(
+                let driver = sockudo_metrics::PrometheusMetricsDriver::with_exporters(
                     port,
                     prefix,
                     tcp_exporter,
+                    export_to_opentelemetry,
                 )
                 .await;
                 Some(Arc::new(driver))

--- a/crates/sockudo-server/src/bootstrap/push/queue.rs
+++ b/crates/sockudo-server/src/bootstrap/push/queue.rs
@@ -4,6 +4,8 @@ use sonic_rs::JsonValueTrait;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
+#[cfg(all(feature = "push", feature = "opentelemetry"))]
+use tracing::Instrument;
 
 #[cfg(feature = "push")]
 const LOCAL_READY_CAP_PER_STAGE: usize = 4_096;
@@ -252,7 +254,9 @@ impl QueueManagerPushQueue {
         envelope: PushQueueEnvelope,
     ) -> sockudo_push::PushQueueResult<()> {
         let queue_name = envelope.stage.logical_topic();
-        let job = push_queue_job_data(&envelope)?;
+        let mut job = push_queue_job_data(&envelope)?;
+        #[cfg(feature = "opentelemetry")]
+        crate::telemetry::capture_job_context(&mut job);
         let delay_ms = envelope
             .not_before_ms
             .map(|not_before| not_before.saturating_sub(push_queue_now_ms()))
@@ -295,6 +299,8 @@ impl QueueManagerPushQueue {
         }
 
         let queue_name = stage.logical_topic();
+        #[cfg(feature = "opentelemetry")]
+        let telemetry_queue_name = queue_name.clone();
         let queue = self.clone();
         match self
             .manager
@@ -302,12 +308,19 @@ impl QueueManagerPushQueue {
                 &queue_name,
                 Box::new(move |job| {
                     let queue = queue.clone();
-                    Box::pin(async move {
+                    #[cfg(feature = "opentelemetry")]
+                    let consumer_span =
+                        crate::telemetry::push_job_consumer_span(&job, &telemetry_queue_name);
+                    let future = async move {
                         queue
                             .handle_queue_job(job)
                             .await
                             .map_err(|error| Error::Internal(error.to_string()))
-                    })
+                    };
+                    #[cfg(feature = "opentelemetry")]
+                    return Box::pin(future.instrument(consumer_span));
+                    #[cfg(not(feature = "opentelemetry"))]
+                    Box::pin(future)
                 }),
             )
             .await
@@ -858,6 +871,7 @@ fn push_queue_job_data(
         app_key: String::new(),
         app_id: push_queue_payload_app_id(&envelope.payload),
         app_secret: String::new(),
+        trace_context: Default::default(),
         payload: sockudo_core::webhook_types::JobPayload {
             time_ms: push_queue_now_ms().min(i64::MAX as u64) as i64,
             events: vec![push_queue_envelope_value(envelope)?],

--- a/crates/sockudo-server/src/bootstrap/router.rs
+++ b/crates/sockudo-server/src/bootstrap/router.rs
@@ -85,6 +85,23 @@ impl SockudoServer {
     }
 
     pub(crate) fn configure_http_routes(&self) -> Router {
+        let mut allowed_headers = self
+            .config
+            .cors
+            .allowed_headers
+            .iter()
+            .map(|s| HeaderName::from_str(s).expect("Failed to parse CORS header"))
+            .collect::<Vec<_>>();
+        if self.config.opentelemetry.enabled {
+            allowed_headers.extend([
+                HeaderName::from_static("traceparent"),
+                HeaderName::from_static("tracestate"),
+            ]);
+            if self.config.opentelemetry.propagation_baggage {
+                allowed_headers.push(HeaderName::from_static("baggage"));
+            }
+        }
+
         let mut cors_builder = CorsLayer::new()
             .allow_methods(
                 self.config
@@ -94,14 +111,7 @@ impl SockudoServer {
                     .map(|s| Method::from_str(s).expect("Failed to parse CORS method"))
                     .collect::<Vec<_>>(),
             )
-            .allow_headers(
-                self.config
-                    .cors
-                    .allowed_headers
-                    .iter()
-                    .map(|s| HeaderName::from_str(s).expect("Failed to parse CORS header"))
-                    .collect::<Vec<_>>(),
-            );
+            .allow_headers(allowed_headers);
 
         let use_allow_origin_any = self
             .config
@@ -667,6 +677,13 @@ impl SockudoServer {
         // Return plain text 404 for unmatched routes.
         // Without this, Axum returns an empty-body 404 which nginx may serve as a file download.
         router = router.fallback(fallback_404);
+
+        #[cfg(feature = "opentelemetry")]
+        if self.config.opentelemetry.enabled && self.config.opentelemetry.traces_enabled {
+            router = router.layer(axum_middleware::from_fn(
+                crate::telemetry::trace_http_request,
+            ));
+        }
 
         router.with_state(self.handler.clone())
     }

--- a/crates/sockudo-server/src/bootstrap/server.rs
+++ b/crates/sockudo-server/src/bootstrap/server.rs
@@ -91,7 +91,10 @@ impl SockudoServer {
 
         let auth_validator = Arc::new(AuthValidator::new(app_manager.clone()));
 
-        let metrics = if config.metrics.enabled {
+        let export_metrics_to_opentelemetry = cfg!(feature = "opentelemetry")
+            && config.opentelemetry.enabled
+            && config.opentelemetry.metrics_enabled;
+        let metrics = if config.metrics.enabled || export_metrics_to_opentelemetry {
             info!(metrics_driver = ?config.metrics.driver, "initializing metrics");
             match MetricsFactory::create(
                 config.metrics.driver.as_ref(),
@@ -106,6 +109,7 @@ impl SockudoServer {
                         port: config.metrics.tcp_exporter.port,
                         buffer_size: config.metrics.tcp_exporter.buffer_size,
                     }),
+                export_metrics_to_opentelemetry,
             )
             .await
             {

--- a/crates/sockudo-server/src/logging.rs
+++ b/crates/sockudo-server/src/logging.rs
@@ -3,6 +3,14 @@ use tracing_subscriber::{
     EnvFilter, Layer, Registry, fmt, layer::SubscriberExt, reload, util::SubscriberInitExt,
 };
 
+#[cfg(feature = "opentelemetry")]
+use tracing_subscriber::filter::filter_fn;
+
+#[cfg(feature = "opentelemetry")]
+use crate::telemetry::Telemetry;
+#[cfg(feature = "opentelemetry")]
+use opentelemetry_appender_tracing::layer::{OpenTelemetryTracingBridge, TracingSpanAttributes};
+
 const DEBUG_FILTER: &str = "info,sockudo=debug,tower_http=debug";
 const PRODUCTION_FILTER: &str = "info";
 
@@ -40,24 +48,83 @@ pub(crate) struct LoggingReloadHandles {
     format_handle: reload::Handle<FormatLayer, FilteredRegistry>,
 }
 
-pub(crate) fn init() -> Result<LoggingReloadHandles, String> {
-    let mut config = ServerOptions {
-        debug: bootstrap_debug(),
-        ..Default::default()
-    };
-    let logging = config.logging.get_or_insert_default();
-    logging.include_target = bool_env("LOG_INCLUDE_TARGET", logging.include_target);
-    logging.colors_enabled = bool_env("LOG_COLORS_ENABLED", logging.colors_enabled);
+#[cfg(feature = "opentelemetry")]
+pub(crate) fn init(
+    config: &ServerOptions,
+    telemetry: &Telemetry,
+) -> Result<LoggingReloadHandles, String> {
+    init_inner(config, Some(telemetry))
+}
 
+#[cfg(not(feature = "opentelemetry"))]
+pub(crate) fn init(config: &ServerOptions) -> Result<LoggingReloadHandles, String> {
+    init_inner(config)
+}
+
+fn init_inner(
+    config: &ServerOptions,
+    #[cfg(feature = "opentelemetry")] telemetry: Option<&Telemetry>,
+) -> Result<LoggingReloadHandles, String> {
     let output_format = output_format(std::env::var("LOG_OUTPUT_FORMAT").ok().as_deref());
-    let resolved = resolve(&config, output_format);
+    let resolved = resolve(config, output_format);
     let filter = EnvFilter::new(&resolved.filter);
     let (filter_layer, filter_handle) = reload::Layer::new(filter);
     let (format_layer, format_handle) = reload::Layer::new(format_layer(output_format, &resolved));
-
-    tracing_subscriber::registry()
+    let subscriber = tracing_subscriber::registry()
         .with(filter_layer)
-        .with(format_layer)
+        .with(format_layer);
+
+    #[cfg(feature = "opentelemetry")]
+    match (
+        telemetry.and_then(Telemetry::tracer),
+        telemetry.and_then(Telemetry::logger_provider),
+    ) {
+        (Some(tracer), Some(logger_provider)) => subscriber
+            .with(
+                tracing_opentelemetry::layer()
+                    .with_tracer(tracer)
+                    .with_filter(filter_fn(exportable_target)),
+            )
+            .with(
+                OpenTelemetryTracingBridge::builder(logger_provider)
+                    .with_tracing_span_attributes(TracingSpanAttributes::allowlist([
+                        "app_id",
+                        "socket_id",
+                        "channel",
+                        "user_id",
+                        "worker_id",
+                    ]))
+                    .build()
+                    .with_filter(filter_fn(exportable_target)),
+            )
+            .try_init(),
+        (Some(tracer), None) => subscriber
+            .with(
+                tracing_opentelemetry::layer()
+                    .with_tracer(tracer)
+                    .with_filter(filter_fn(exportable_target)),
+            )
+            .try_init(),
+        (None, Some(logger_provider)) => subscriber
+            .with(
+                OpenTelemetryTracingBridge::builder(logger_provider)
+                    .with_tracing_span_attributes(TracingSpanAttributes::allowlist([
+                        "app_id",
+                        "socket_id",
+                        "channel",
+                        "user_id",
+                        "worker_id",
+                    ]))
+                    .build()
+                    .with_filter(filter_fn(exportable_target)),
+            )
+            .try_init(),
+        (None, None) => subscriber.try_init(),
+    }
+    .map_err(|error| format!("failed to install global logging subscriber: {error}"))?;
+
+    #[cfg(not(feature = "opentelemetry"))]
+    subscriber
         .try_init()
         .map_err(|error| format!("failed to install global logging subscriber: {error}"))?;
 
@@ -66,6 +133,18 @@ pub(crate) fn init() -> Result<LoggingReloadHandles, String> {
         filter_handle,
         format_handle,
     })
+}
+
+#[cfg(feature = "opentelemetry")]
+fn exportable_target(metadata: &tracing::Metadata<'_>) -> bool {
+    !matches!(
+        metadata.target(),
+        target if target.starts_with("opentelemetry")
+            || target.starts_with("hyper")
+            || target.starts_with("h2")
+            || target.starts_with("tonic")
+            || target.starts_with("reqwest")
+    )
 }
 
 pub(crate) fn reload(
@@ -102,11 +181,15 @@ fn format_layer(output_format: OutputFormat, resolved: &ResolvedLogging) -> Form
 }
 
 fn resolve(config: &ServerOptions, output_format: OutputFormat) -> ResolvedLogging {
-    let filter = resolved_filter(
+    let mut filter = resolved_filter(
         config.debug,
         std::env::var("RUST_LOG").ok(),
         std::env::var("SOCKUDO_LOG_DEBUG").ok(),
         std::env::var("SOCKUDO_LOG_PROD").ok(),
+    );
+    filter = with_telemetry_span_filter(
+        filter,
+        config.opentelemetry.enabled && config.opentelemetry.traces_enabled,
     );
     let include_target = config
         .logging
@@ -148,6 +231,15 @@ fn resolved_filter(
     })
 }
 
+fn with_telemetry_span_filter(mut filter: String, telemetry_traces_enabled: bool) -> String {
+    if telemetry_traces_enabled {
+        // Keep explicit instrumentation spans independent from local log verbosity. The formatter
+        // does not emit span lifecycle events, so this does not turn trace-level logs on.
+        filter.push_str(",sockudo_telemetry=trace");
+    }
+    filter
+}
+
 fn bootstrap_debug() -> bool {
     if std::env::var_os("DEBUG").is_some() {
         bool_env("DEBUG", false)
@@ -187,6 +279,18 @@ mod tests {
         );
         assert_eq!(resolved_filter(false, None, None, None), PRODUCTION_FILTER);
         assert_eq!(resolved_filter(true, None, None, None), DEBUG_FILTER);
+    }
+
+    #[test]
+    fn telemetry_spans_are_independent_from_local_log_verbosity() {
+        assert_eq!(
+            with_telemetry_span_filter("warn".to_string(), true),
+            "warn,sockudo_telemetry=trace"
+        );
+        assert_eq!(
+            with_telemetry_span_filter("warn".to_string(), false),
+            "warn"
+        );
     }
 
     #[test]

--- a/crates/sockudo-server/src/main.rs
+++ b/crates/sockudo-server/src/main.rs
@@ -11,6 +11,8 @@ mod middleware;
 mod presence_history;
 #[cfg(feature = "push")]
 mod push_http;
+#[cfg(feature = "opentelemetry")]
+mod telemetry;
 mod ws_handler;
 
 pub use bootstrap::MetricsFactory;
@@ -36,8 +38,6 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-
-    let logging_handles = logging::init().map_err(Error::Internal)?;
 
     // Initialize crypto provider at the very beginning for any TLS usage
     rustls::crypto::ring::default_provider()
@@ -85,6 +85,33 @@ async fn main() -> Result<()> {
         }
     }
 
+    if let Err(e) = config.validate() {
+        return Err(Error::ConfigFile(format!(
+            "Configuration validation failed: {}",
+            e
+        )));
+    }
+
+    #[cfg(not(feature = "opentelemetry"))]
+    if config.opentelemetry.enabled {
+        return Err(Error::ConfigFile(
+            "OpenTelemetry is enabled in configuration, but this binary was built without the opentelemetry feature"
+                .to_string(),
+        ));
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    let telemetry =
+        telemetry::Telemetry::initialize(&config.opentelemetry, &config.instance.process_id)
+            .map_err(|error| {
+                Error::Internal(format!("OpenTelemetry initialization failed: {error}"))
+            })?;
+
+    #[cfg(feature = "opentelemetry")]
+    let logging_handles = logging::init(&config, &telemetry).map_err(Error::Internal)?;
+    #[cfg(not(feature = "opentelemetry"))]
+    let logging_handles = logging::init(&config).map_err(Error::Internal)?;
+
     let resolved_logging = logging::reload(&logging_handles, &config).map_err(Error::Internal)?;
     info!(
         output_format = resolved_logging.output_format,
@@ -93,22 +120,34 @@ async fn main() -> Result<()> {
         include_target = resolved_logging.include_target,
         colors_enabled = resolved_logging.colors_enabled,
         source_location = resolved_logging.source_location,
-        "Logging reloaded with resolved configuration"
+        "logging initialized with resolved configuration"
     );
     if config.logging.is_some() {
-        info!("Custom logging configuration applied");
+        info!("custom logging configuration applied");
     }
 
-    if let Err(e) = config.validate() {
-        error!(error = %e, "configuration validation failed");
-        return Err(Error::ConfigFile(format!(
-            "Configuration validation failed: {}",
-            e
-        )));
+    #[cfg(feature = "opentelemetry")]
+    {
+        let (traces_enabled, metrics_enabled, logs_enabled) = telemetry.enabled_signals();
+        info!(
+            enabled = config.opentelemetry.enabled,
+            traces_enabled, metrics_enabled, logs_enabled, "opentelemetry initialized"
+        );
     }
 
     info!(debug = config.debug, "configuration loading complete");
 
+    let result = run_server(config).await;
+
+    #[cfg(feature = "opentelemetry")]
+    if let Err(error) = telemetry.shutdown().await {
+        error!(error = %error, "opentelemetry shutdown failed");
+    }
+
+    result
+}
+
+async fn run_server(config: ServerOptions) -> Result<()> {
     info!("Starting Sockudo server initialization process with resolved configuration...");
 
     let server = match SockudoServer::new(config).await {

--- a/crates/sockudo-server/src/telemetry.rs
+++ b/crates/sockudo-server/src/telemetry.rs
@@ -1,0 +1,601 @@
+use axum::body::Body;
+use axum::extract::MatchedPath;
+use axum::http::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use opentelemetry::propagation::{
+    Extractor, Injector, TextMapCompositePropagator, TextMapPropagator,
+};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::{KeyValue, global};
+use opentelemetry_http::HeaderExtractor;
+use opentelemetry_otlp::{Protocol, WithExportConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::logs::{
+    BatchConfigBuilder as LogBatchConfigBuilder, BatchLogProcessor, SdkLoggerProvider,
+};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::propagation::{BaggagePropagator, TraceContextPropagator};
+use opentelemetry_sdk::resource::{
+    EnvResourceDetector, SdkProvidedResourceDetector, TelemetryResourceDetector,
+};
+use opentelemetry_sdk::trace::{
+    BatchConfigBuilder as TraceBatchConfigBuilder, BatchSpanProcessor, SdkTracer, SdkTracerProvider,
+};
+use sockudo_core::options::OpenTelemetryConfig;
+use std::collections::BTreeMap;
+use std::time::Duration;
+use tracing::{Instrument, field, info_span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+#[derive(Debug, Clone, Copy)]
+enum Signal {
+    Traces,
+    Metrics,
+    Logs,
+}
+
+impl Signal {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Traces => "traces",
+            Self::Metrics => "metrics",
+            Self::Logs => "logs",
+        }
+    }
+
+    const fn protocol_env(self) -> &'static str {
+        match self {
+            Self::Traces => "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+            Self::Metrics => "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+            Self::Logs => "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
+        }
+    }
+
+    const fn endpoint_env(self) -> &'static str {
+        match self {
+            Self::Traces => "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            Self::Metrics => "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            Self::Logs => "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+        }
+    }
+
+    const fn timeout_env(self) -> &'static str {
+        match self {
+            Self::Traces => "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT",
+            Self::Metrics => "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT",
+            Self::Logs => "OTEL_EXPORTER_OTLP_LOGS_TIMEOUT",
+        }
+    }
+
+    const fn exporter_env(self) -> &'static str {
+        match self {
+            Self::Traces => "OTEL_TRACES_EXPORTER",
+            Self::Metrics => "OTEL_METRICS_EXPORTER",
+            Self::Logs => "OTEL_LOGS_EXPORTER",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Transport {
+    Grpc,
+    HttpProtobuf,
+    HttpJson,
+}
+
+impl Transport {
+    const fn protocol(self) -> Protocol {
+        match self {
+            Self::Grpc => Protocol::Grpc,
+            Self::HttpProtobuf => Protocol::HttpBinary,
+            Self::HttpJson => Protocol::HttpJson,
+        }
+    }
+}
+
+/// Owns every OpenTelemetry provider so all buffered signals can be flushed on shutdown.
+#[derive(Debug)]
+pub(crate) struct Telemetry {
+    tracer_provider: Option<SdkTracerProvider>,
+    meter_provider: Option<SdkMeterProvider>,
+    logger_provider: Option<SdkLoggerProvider>,
+    shutdown_timeout: Duration,
+}
+
+impl Telemetry {
+    pub(crate) fn initialize(
+        config: &OpenTelemetryConfig,
+        service_instance_id: &str,
+    ) -> Result<Self, String> {
+        let shutdown_timeout = Duration::from_millis(config.export_timeout_ms);
+        if !config.enabled || sdk_disabled() {
+            configure_propagation(config);
+            return Ok(Self {
+                tracer_provider: None,
+                meter_provider: None,
+                logger_provider: None,
+                shutdown_timeout,
+            });
+        }
+
+        configure_propagation(config);
+        let resource = resource(config, service_instance_id);
+        let traces_enabled = signal_enabled(config.traces_enabled, Signal::Traces)?;
+        let metrics_enabled = signal_enabled(config.metrics_enabled, Signal::Metrics)?;
+        let logs_enabled = signal_enabled(config.logs_enabled, Signal::Logs)?;
+
+        // Validate and construct all exporters before starting any processor threads. This keeps a
+        // later signal's configuration error from leaving an earlier signal partially initialized.
+        let span_exporter = traces_enabled
+            .then(|| build_span_exporter(config))
+            .transpose()?;
+        let metric_exporter = metrics_enabled
+            .then(|| build_metric_exporter(config))
+            .transpose()?;
+        let log_exporter = logs_enabled
+            .then(|| build_log_exporter(config))
+            .transpose()?;
+
+        let tracer_provider = if let Some(exporter) = span_exporter {
+            let processor = BatchSpanProcessor::builder(exporter)
+                .with_batch_config(trace_batch_config(config))
+                .build();
+            let provider = SdkTracerProvider::builder()
+                .with_resource(resource.clone())
+                .with_span_processor(processor)
+                .build();
+            global::set_tracer_provider(provider.clone());
+            Some(provider)
+        } else {
+            None
+        };
+
+        let meter_provider = if let Some(exporter) = metric_exporter {
+            let mut reader = PeriodicReader::builder(exporter);
+            if std::env::var_os("OTEL_METRIC_EXPORT_INTERVAL").is_none() {
+                reader =
+                    reader.with_interval(Duration::from_millis(config.metric_export_interval_ms));
+            }
+            let provider = SdkMeterProvider::builder()
+                .with_resource(resource.clone())
+                .with_reader(reader.build())
+                .build();
+            global::set_meter_provider(provider.clone());
+            Some(provider)
+        } else {
+            None
+        };
+
+        let logger_provider = if let Some(exporter) = log_exporter {
+            let processor = BatchLogProcessor::builder(exporter)
+                .with_batch_config(log_batch_config(config))
+                .build();
+            Some(
+                SdkLoggerProvider::builder()
+                    .with_resource(resource)
+                    .with_log_processor(processor)
+                    .build(),
+            )
+        } else {
+            None
+        };
+
+        Ok(Self {
+            tracer_provider,
+            meter_provider,
+            logger_provider,
+            shutdown_timeout,
+        })
+    }
+
+    pub(crate) fn tracer(&self) -> Option<SdkTracer> {
+        self.tracer_provider
+            .as_ref()
+            .map(|provider| provider.tracer("sockudo"))
+    }
+
+    pub(crate) fn logger_provider(&self) -> Option<&SdkLoggerProvider> {
+        self.logger_provider.as_ref()
+    }
+
+    pub(crate) fn enabled_signals(&self) -> (bool, bool, bool) {
+        (
+            self.tracer_provider.is_some(),
+            self.meter_provider.is_some(),
+            self.logger_provider.is_some(),
+        )
+    }
+
+    pub(crate) async fn shutdown(self) -> Result<(), String> {
+        let Self {
+            tracer_provider,
+            meter_provider,
+            logger_provider,
+            shutdown_timeout,
+        } = self;
+
+        tokio::task::spawn_blocking(move || {
+            let mut errors = Vec::new();
+            if let Some(provider) = tracer_provider
+                && let Err(error) = provider.shutdown_with_timeout(shutdown_timeout)
+            {
+                errors.push(format!("traces: {error}"));
+            }
+            if let Some(provider) = logger_provider
+                && let Err(error) = provider.shutdown_with_timeout(shutdown_timeout)
+            {
+                errors.push(format!("logs: {error}"));
+            }
+            if let Some(provider) = meter_provider
+                && let Err(error) = provider.shutdown_with_timeout(shutdown_timeout)
+            {
+                errors.push(format!("metrics: {error}"));
+            }
+            if errors.is_empty() {
+                Ok(())
+            } else {
+                Err(errors.join("; "))
+            }
+        })
+        .await
+        .map_err(|error| format!("telemetry shutdown worker failed: {error}"))?
+    }
+}
+
+/// Creates an HTTP server span using only low-cardinality route templates.
+pub(crate) async fn trace_http_request(request: Request<Body>, next: Next) -> Response {
+    if matches!(
+        request.uri().path(),
+        "/live" | "/up" | "/accept-traffic" | "/metrics"
+    ) {
+        return next.run(request).await;
+    }
+
+    let method = request.method().clone();
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(MatchedPath::as_str)
+        .unwrap_or("unmatched")
+        .to_owned();
+    let operation_name = format!("{} {route}", method.as_str());
+    let parent = global::get_text_map_propagator(|propagator| {
+        propagator.extract(&HeaderExtractor(request.headers()))
+    });
+    let span = info_span!(
+        target: "sockudo_telemetry",
+        "http.server.request",
+        otel.kind = "server",
+        otel.name = %operation_name,
+        http.request.method = %method,
+        http.route = %route,
+        http.response.status_code = field::Empty,
+        otel.status_code = field::Empty,
+    );
+    let _ = span.set_parent(parent);
+    let started = std::time::Instant::now();
+    let response = next.run(request).instrument(span.clone()).await;
+    let status = response.status();
+    span.record("http.response.status_code", status.as_u16());
+    if status.is_server_error() {
+        span.record("otel.status_code", "ERROR");
+    }
+    metrics::histogram!(
+        "http.server.request.duration",
+        "http.request.method" => method.as_str().to_owned(),
+        "http.route" => route,
+    )
+    .record(started.elapsed().as_secs_f64());
+    response
+}
+
+pub(crate) fn capture_job_context(job: &mut sockudo_core::webhook_types::JobData) {
+    if !job.trace_context.is_empty() {
+        return;
+    }
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(
+            &tracing::Span::current().context(),
+            &mut MapInjector(&mut job.trace_context),
+        );
+    });
+}
+
+pub(crate) fn push_job_consumer_span(
+    job: &sockudo_core::webhook_types::JobData,
+    queue_name: &str,
+) -> tracing::Span {
+    let span = info_span!(
+        target: "sockudo_telemetry",
+        "messaging.process",
+        otel.kind = "consumer",
+        otel.name = "push job process",
+        messaging.system = "sockudo.queue",
+        messaging.destination.name = queue_name,
+        messaging.operation.name = "process",
+        app_id = %job.app_id,
+    );
+    let parent = global::get_text_map_propagator(|propagator| {
+        propagator.extract(&MapExtractor(&job.trace_context))
+    });
+    let _ = span.set_parent(parent);
+    span
+}
+
+struct MapInjector<'a>(&'a mut BTreeMap<String, String>);
+
+impl Injector for MapInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        self.0.insert(key.to_owned(), value);
+    }
+}
+
+struct MapExtractor<'a>(&'a BTreeMap<String, String>);
+
+impl Extractor for MapExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(String::as_str).collect()
+    }
+}
+
+fn resource(config: &OpenTelemetryConfig, service_instance_id: &str) -> Resource {
+    let mut attributes = config
+        .resource_attributes
+        .iter()
+        .map(|(key, value)| KeyValue::new(key.clone(), value.clone()))
+        .collect::<Vec<_>>();
+    attributes.push(KeyValue::new("service.name", config.service_name.clone()));
+    attributes.push(KeyValue::new("service.version", env!("CARGO_PKG_VERSION")));
+    if !service_instance_id.is_empty() {
+        attributes.push(KeyValue::new(
+            "service.instance.id",
+            service_instance_id.to_owned(),
+        ));
+    }
+    if let Some(namespace) = &config.service_namespace {
+        attributes.push(KeyValue::new("service.namespace", namespace.clone()));
+    }
+    if let Some(environment) = &config.deployment_environment {
+        attributes.push(KeyValue::new(
+            "deployment.environment.name",
+            environment.clone(),
+        ));
+    }
+
+    Resource::builder_empty()
+        .with_attributes(attributes)
+        .with_detector(Box::new(SdkProvidedResourceDetector))
+        .with_detector(Box::new(TelemetryResourceDetector))
+        // Standard OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES win over Sockudo fallbacks.
+        .with_detector(Box::new(EnvResourceDetector::new()))
+        .build()
+}
+
+fn trace_batch_config(config: &OpenTelemetryConfig) -> opentelemetry_sdk::trace::BatchConfig {
+    let mut builder = TraceBatchConfigBuilder::default();
+    if std::env::var_os("OTEL_BSP_SCHEDULE_DELAY").is_none() {
+        builder =
+            builder.with_scheduled_delay(Duration::from_millis(config.batch_scheduled_delay_ms));
+    }
+    if std::env::var_os("OTEL_BSP_MAX_QUEUE_SIZE").is_none() {
+        builder = builder.with_max_queue_size(config.batch_max_queue_size);
+    }
+    if std::env::var_os("OTEL_BSP_MAX_EXPORT_BATCH_SIZE").is_none() {
+        builder = builder.with_max_export_batch_size(config.batch_max_export_batch_size);
+    }
+    builder.build()
+}
+
+fn log_batch_config(config: &OpenTelemetryConfig) -> opentelemetry_sdk::logs::BatchConfig {
+    let mut builder = LogBatchConfigBuilder::default();
+    if std::env::var_os("OTEL_BLRP_SCHEDULE_DELAY").is_none() {
+        builder =
+            builder.with_scheduled_delay(Duration::from_millis(config.batch_scheduled_delay_ms));
+    }
+    if std::env::var_os("OTEL_BLRP_MAX_QUEUE_SIZE").is_none() {
+        builder = builder.with_max_queue_size(config.batch_max_queue_size);
+    }
+    if std::env::var_os("OTEL_BLRP_MAX_EXPORT_BATCH_SIZE").is_none() {
+        builder = builder.with_max_export_batch_size(config.batch_max_export_batch_size);
+    }
+    builder.build()
+}
+
+fn sdk_disabled() -> bool {
+    std::env::var("OTEL_SDK_DISABLED")
+        .ok()
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"))
+}
+
+fn signal_enabled(config_enabled: bool, signal: Signal) -> Result<bool, String> {
+    if !config_enabled {
+        return Ok(false);
+    }
+    match std::env::var(signal.exporter_env()) {
+        Ok(value) if value.eq_ignore_ascii_case("none") => Ok(false),
+        Ok(value) if value.eq_ignore_ascii_case("otlp") => Ok(true),
+        Ok(value) => Err(format!(
+            "{} contains unsupported exporter {value:?}; supported values are otlp and none",
+            signal.exporter_env()
+        )),
+        Err(_) => Ok(true),
+    }
+}
+
+fn configure_propagation(config: &OpenTelemetryConfig) {
+    let requested = std::env::var("OTEL_PROPAGATORS").ok();
+    let trace_context = requested
+        .as_ref()
+        .map_or(config.propagation_trace_context, |value| {
+            value
+                .split(',')
+                .any(|name| name.trim().eq_ignore_ascii_case("tracecontext"))
+        });
+    let baggage = requested
+        .as_ref()
+        .map_or(config.propagation_baggage, |value| {
+            value
+                .split(',')
+                .any(|name| name.trim().eq_ignore_ascii_case("baggage"))
+        });
+
+    let mut propagators: Vec<Box<dyn TextMapPropagator + Send + Sync>> = Vec::new();
+    if trace_context {
+        propagators.push(Box::new(TraceContextPropagator::new()));
+    }
+    if baggage {
+        propagators.push(Box::new(BaggagePropagator::new()));
+    }
+    global::set_text_map_propagator(TextMapCompositePropagator::new(propagators));
+}
+
+fn transport(signal: Signal) -> Result<Transport, String> {
+    let value = std::env::var(signal.protocol_env())
+        .ok()
+        .or_else(|| std::env::var("OTEL_EXPORTER_OTLP_PROTOCOL").ok());
+    parse_transport(value.as_deref(), signal)
+}
+
+fn parse_transport(value: Option<&str>, signal: Signal) -> Result<Transport, String> {
+    match value.map(str::trim) {
+        Some("grpc") => Ok(Transport::Grpc),
+        Some("http/json") => Ok(Transport::HttpJson),
+        Some("http/protobuf") | None => Ok(Transport::HttpProtobuf),
+        Some(value) => Err(format!(
+            "unsupported OTLP protocol {value:?} for {}; supported values are grpc, http/protobuf, and http/json",
+            signal.name()
+        )),
+    }
+}
+
+fn endpoint_override(
+    config: &OpenTelemetryConfig,
+    signal: Signal,
+    transport: Transport,
+) -> Option<String> {
+    if std::env::var_os(signal.endpoint_env()).is_some()
+        || std::env::var_os("OTEL_EXPORTER_OTLP_ENDPOINT").is_some()
+    {
+        return None;
+    }
+    let endpoint = config.endpoint.as_ref()?;
+    Some(endpoint_for_transport(endpoint, signal, transport))
+}
+
+fn endpoint_for_transport(endpoint: &str, signal: Signal, transport: Transport) -> String {
+    match transport {
+        Transport::Grpc => endpoint.to_owned(),
+        Transport::HttpProtobuf | Transport::HttpJson => {
+            format!("{}/v1/{}", endpoint.trim_end_matches('/'), signal.name())
+        }
+    }
+}
+
+fn exporter_timeout_override(config: &OpenTelemetryConfig, signal: Signal) -> Option<Duration> {
+    (std::env::var_os(signal.timeout_env()).is_none()
+        && std::env::var_os("OTEL_EXPORTER_OTLP_TIMEOUT").is_none())
+    .then(|| Duration::from_millis(config.export_timeout_ms))
+}
+
+macro_rules! build_exporter {
+    ($exporter:ident, $config:expr, $signal:expr) => {{
+        let transport = transport($signal)?;
+        let endpoint = endpoint_override($config, $signal, transport);
+        let timeout = exporter_timeout_override($config, $signal);
+        let exporter = match transport {
+            Transport::Grpc => {
+                let mut builder = opentelemetry_otlp::$exporter::builder()
+                    .with_tonic()
+                    .with_protocol(Protocol::Grpc);
+                if let Some(endpoint) = endpoint {
+                    builder = builder.with_endpoint(endpoint);
+                }
+                if let Some(timeout) = timeout {
+                    builder = builder.with_timeout(timeout);
+                }
+                builder.build()
+            }
+            Transport::HttpProtobuf | Transport::HttpJson => {
+                let mut builder = opentelemetry_otlp::$exporter::builder()
+                    .with_http()
+                    .with_protocol(transport.protocol());
+                if let Some(endpoint) = endpoint {
+                    builder = builder.with_endpoint(endpoint);
+                }
+                if let Some(timeout) = timeout {
+                    builder = builder.with_timeout(timeout);
+                }
+                builder.build()
+            }
+        };
+        exporter.map_err(|error| {
+            format!(
+                "failed to configure OTLP {} exporter: {error}",
+                $signal.name()
+            )
+        })
+    }};
+}
+
+fn build_span_exporter(
+    config: &OpenTelemetryConfig,
+) -> Result<opentelemetry_otlp::SpanExporter, String> {
+    build_exporter!(SpanExporter, config, Signal::Traces)
+}
+
+fn build_metric_exporter(
+    config: &OpenTelemetryConfig,
+) -> Result<opentelemetry_otlp::MetricExporter, String> {
+    build_exporter!(MetricExporter, config, Signal::Metrics)
+}
+
+fn build_log_exporter(
+    config: &OpenTelemetryConfig,
+) -> Result<opentelemetry_otlp::LogExporter, String> {
+    build_exporter!(LogExporter, config, Signal::Logs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_base_endpoint_gets_signal_path() {
+        let config = OpenTelemetryConfig {
+            endpoint: Some("http://collector:4318/".to_string()),
+            ..OpenTelemetryConfig::default()
+        };
+        assert_eq!(
+            endpoint_for_transport(
+                config.endpoint.as_deref().unwrap(),
+                Signal::Traces,
+                Transport::HttpProtobuf,
+            ),
+            "http://collector:4318/v1/traces"
+        );
+        assert_eq!(
+            endpoint_for_transport(
+                config.endpoint.as_deref().unwrap(),
+                Signal::Metrics,
+                Transport::HttpJson,
+            ),
+            "http://collector:4318/v1/metrics"
+        );
+    }
+
+    #[test]
+    fn unsupported_otlp_protocol_is_rejected() {
+        assert_eq!(
+            parse_transport(Some("grpc"), Signal::Traces).unwrap(),
+            Transport::Grpc
+        );
+        let error = parse_transport(Some("zipkin"), Signal::Traces).unwrap_err();
+        assert!(error.contains("unsupported OTLP protocol"));
+        assert!(error.contains("traces"));
+    }
+}

--- a/crates/sockudo-server/src/ws_handler.rs
+++ b/crates/sockudo-server/src/ws_handler.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use sockudo_protocol::{AppendMode, ProtocolVersion, WireFormat};
 use sockudo_ws::axum_integration::WebSocketUpgrade;
 use std::sync::Arc;
-use tracing::error;
+use tracing::{Instrument, error, field, info_span};
 
 #[derive(Debug, Deserialize)]
 pub struct ConnectionQuery {
@@ -107,36 +107,52 @@ pub async fn handle_ws_upgrade(
     };
     let ws_cfg = websocket_config_for_protocol(server_options, protocol_version);
 
+    let connection_span = info_span!(
+        target: "sockudo_telemetry",
+        "websocket.connection",
+        otel.kind = "server",
+        otel.name = "websocket connection",
+        network.protocol.name = "websocket",
+        sockudo.protocol.version = protocol_version as u8,
+        app_id = field::Empty,
+        socket_id = field::Empty,
+        otel.status_code = field::Empty,
+    );
+
     ws.config(ws_cfg)
-        .on_upgrade(move |socket| async move {
-            if let Err(e) = handler
-                .handle_socket(
-                    socket,
-                    app_key.clone(),
-                    origin,
-                    protocol_version,
-                    wire_format,
-                    echo_messages,
-                    append_mode,
-                    params.token,
-                )
-                .await
-            {
-                error!(error = %e, "socket handling failed");
-                if let Some(metrics) = handler.metrics() {
-                    match &e {
-                        sockudo_core::error::Error::ApplicationNotFound
-                        | sockudo_core::error::Error::ApplicationDisabled
-                        | sockudo_core::error::Error::OriginNotAllowed
-                        | sockudo_core::error::Error::Auth(_)
-                        | sockudo_core::error::Error::InvalidMessageFormat(_)
-                        | sockudo_core::error::Error::InvalidEventName(_) => {}
-                        _ => {
-                            metrics.mark_connection_error(&app_key, "socket_handling_failed");
+        .on_upgrade(move |socket| {
+            async move {
+                if let Err(e) = handler
+                    .handle_socket(
+                        socket,
+                        app_key.clone(),
+                        origin,
+                        protocol_version,
+                        wire_format,
+                        echo_messages,
+                        append_mode,
+                        params.token,
+                    )
+                    .await
+                {
+                    error!(error = %e, "socket handling failed");
+                    tracing::Span::current().record("otel.status_code", "ERROR");
+                    if let Some(metrics) = handler.metrics() {
+                        match &e {
+                            sockudo_core::error::Error::ApplicationNotFound
+                            | sockudo_core::error::Error::ApplicationDisabled
+                            | sockudo_core::error::Error::OriginNotAllowed
+                            | sockudo_core::error::Error::Auth(_)
+                            | sockudo_core::error::Error::InvalidMessageFormat(_)
+                            | sockudo_core::error::Error::InvalidEventName(_) => {}
+                            _ => {
+                                metrics.mark_connection_error(&app_key, "socket_handling_failed");
+                            }
                         }
                     }
                 }
             }
+            .instrument(connection_span)
         })
         .into_response()
 }

--- a/crates/sockudo-webhook/Cargo.toml
+++ b/crates/sockudo-webhook/Cargo.toml
@@ -12,6 +12,7 @@ default = ["local"]
 local = []
 full = ["lambda"]
 lambda = ["sockudo-core/lambda", "dep:aws-config", "dep:aws-sdk-lambda", "dep:dashmap"]
+opentelemetry = ["dep:opentelemetry", "dep:tracing-opentelemetry"]
 
 [dependencies]
 sockudo-core = { workspace = true }
@@ -24,6 +25,7 @@ chrono = { workspace = true }
 dashmap = { workspace = true, optional = true }
 hex = { workspace = true }
 hmac = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
@@ -32,6 +34,7 @@ sonic-rs = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
 url = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/sockudo-webhook/benches/webhook_hot_paths.rs
+++ b/crates/sockudo-webhook/benches/webhook_hot_paths.rs
@@ -92,6 +92,7 @@ fn sample_job(index: usize) -> JobData {
         app_key: "bench-key".to_string(),
         app_id: "bench-app".to_string(),
         app_secret: "bench-secret".to_string(),
+        trace_context: Default::default(),
         payload: JobPayload {
             time_ms: index as i64,
             events: vec![sonic_rs::json!({

--- a/crates/sockudo-webhook/src/integration.rs
+++ b/crates/sockudo-webhook/src/integration.rs
@@ -11,7 +11,7 @@ use sonic_rs::{Value, json};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::interval;
-use tracing::{debug, error, warn};
+use tracing::{Instrument, debug, error, warn};
 
 const WEBHOOK_QUEUE_NAME: &str = "webhooks";
 
@@ -152,16 +152,20 @@ impl WebhookIntegration {
         let sender_clone = webhook_sender.clone();
 
         let processor: JobProcessorFnAsync = Box::new(move |job_data| {
+            let consumer_span = crate::telemetry::consumer_span(&job_data);
             let sender_for_task = sender_clone.clone();
-            Box::pin(async move {
-                debug!(
-                    app_id = %job_data.app_id,
-                    webhook_job_id = job_data.job_id.as_deref().unwrap_or("legacy"),
-                    event_count = job_data.payload.events.len(),
-                    "webhook job processing started"
-                );
-                sender_for_task.process_webhook_job(job_data).await
-            })
+            Box::pin(
+                async move {
+                    debug!(
+                        app_id = %job_data.app_id,
+                        webhook_job_id = job_data.job_id.as_deref().unwrap_or("legacy"),
+                        event_count = job_data.payload.events.len(),
+                        "webhook job processing started"
+                    );
+                    sender_for_task.process_webhook_job(job_data).await
+                }
+                .instrument(consumer_span),
+            )
         });
 
         queue_manager
@@ -218,6 +222,7 @@ impl WebhookIntegration {
         if !self.is_enabled() {
             return Ok(());
         }
+        crate::telemetry::capture(&mut job_data);
         if self.config.batching.enabled {
             self.batched_webhooks.lock().push(job_data);
         } else if let Some(qm) = &self.queue_manager {
@@ -235,10 +240,11 @@ impl WebhookIntegration {
     ///
     /// AI lifecycle traffic bypasses the optional in-process batching vector so
     /// producer backpressure and queue retry policy remain authoritative.
-    async fn add_bounded_webhook(&self, job_data: JobData) -> Result<()> {
+    async fn add_bounded_webhook(&self, mut job_data: JobData) -> Result<()> {
         if !self.is_enabled() {
             return Ok(());
         }
+        crate::telemetry::capture(&mut job_data);
         let Some(queue_manager) = &self.queue_manager else {
             return Err(Error::Internal(
                 "Queue manager not initialized for webhooks".to_string(),
@@ -261,6 +267,7 @@ impl WebhookIntegration {
                         if existing.app_id == chunk.app_id
                             && existing.app_key == chunk.app_key
                             && existing.app_secret == chunk.app_secret
+                            && existing.trace_context == chunk.trace_context
                             && existing.payload.events.len() + chunk.payload.events.len()
                                 <= batch_size =>
                     {
@@ -301,6 +308,7 @@ impl WebhookIntegration {
             app_key,
             app_id,
             app_secret,
+            trace_context,
             payload,
             original_signature,
         } = job;
@@ -316,6 +324,7 @@ impl WebhookIntegration {
                 app_key: app_key.clone(),
                 app_id: app_id.clone(),
                 app_secret: app_secret.clone(),
+                trace_context: trace_context.clone(),
                 payload: JobPayload {
                     time_ms,
                     events: events.by_ref().take(batch_size).collect(),
@@ -342,6 +351,7 @@ impl WebhookIntegration {
             app_key: app.key.clone(),
             app_id: app.id.clone(),
             app_secret: app.secret.clone(),
+            trace_context: Default::default(),
             payload: job_payload,
             original_signature: original_signature_for_queue.to_string(),
         }
@@ -1221,6 +1231,7 @@ mod tests {
                 app_key: "key-a".to_string(),
                 app_id: "app-a".to_string(),
                 app_secret: "secret-a".to_string(),
+                trace_context: Default::default(),
                 payload: JobPayload {
                     time_ms: 10,
                     events: vec![json!({"name": "channel_occupied", "channel": "one"})],
@@ -1232,6 +1243,7 @@ mod tests {
                 app_key: "key-a".to_string(),
                 app_id: "app-a".to_string(),
                 app_secret: "secret-a".to_string(),
+                trace_context: Default::default(),
                 payload: JobPayload {
                     time_ms: 20,
                     events: vec![json!({"name": "channel_vacated", "channel": "two"})],
@@ -1243,6 +1255,7 @@ mod tests {
                 app_key: "key-b".to_string(),
                 app_id: "app-b".to_string(),
                 app_secret: "secret-b".to_string(),
+                trace_context: Default::default(),
                 payload: JobPayload {
                     time_ms: 30,
                     events: vec![json!({"name": "channel_occupied", "channel": "three"})],
@@ -1424,6 +1437,7 @@ mod tests {
             app_key: "key-a".to_string(),
             app_id: "app-a".to_string(),
             app_secret: "secret-a".to_string(),
+            trace_context: Default::default(),
             payload: JobPayload {
                 time_ms: 10,
                 events: vec![

--- a/crates/sockudo-webhook/src/lib.rs
+++ b/crates/sockudo-webhook/src/lib.rs
@@ -2,6 +2,7 @@ pub mod integration;
 #[cfg(feature = "lambda")]
 pub mod lambda_sender;
 pub mod sender;
+mod telemetry;
 
 pub use integration::{BatchingConfig, WebhookConfig, WebhookIntegration};
 #[cfg(feature = "lambda")]

--- a/crates/sockudo-webhook/src/sender.rs
+++ b/crates/sockudo-webhook/src/sender.rs
@@ -17,7 +17,7 @@ use sonic_rs::prelude::*;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Semaphore;
-use tracing::{debug, error, warn};
+use tracing::{Instrument, debug, error, field, info_span, warn};
 
 const MAX_CONCURRENT_WEBHOOKS: usize = 20;
 
@@ -289,22 +289,25 @@ impl WebhookSender {
             .map(|h| h.headers.clone())
             .unwrap_or_default();
 
-        tokio::spawn(async move {
-            let _permit = params.permit;
-            let _ = send_pusher_webhook(
-                &client,
-                PusherWebhookRequest {
-                    url: url_str,
-                    app_key: params.app_key,
-                    signature: params.signature,
-                    json_body: params.body_to_send,
-                    custom_headers,
-                    request_timeout_ms,
-                    retry_config: retry_policy,
-                },
-            )
-            .await;
-        })
+        tokio::spawn(
+            async move {
+                let _permit = params.permit;
+                let _ = send_pusher_webhook(
+                    &client,
+                    PusherWebhookRequest {
+                        url: url_str,
+                        app_key: params.app_key,
+                        signature: params.signature,
+                        json_body: params.body_to_send,
+                        custom_headers,
+                        request_timeout_ms,
+                        retry_config: retry_policy,
+                    },
+                )
+                .await;
+            }
+            .in_current_span(),
+        )
     }
 
     #[cfg(feature = "lambda")]
@@ -319,26 +322,29 @@ impl WebhookSender {
         let webhook_clone = webhook_config.clone();
         let payload_for_lambda: Value = sonic_rs::from_str(&body_to_send).unwrap_or(json!({}));
 
-        tokio::spawn(async move {
-            let _permit = permit;
-            if let Err(e) = lambda_sender
-                .invoke_lambda(&webhook_clone, "batch_events", &app_id, payload_for_lambda)
-                .await
-            {
-                error!(
-                    delivery_method = "lambda",
-                    app_id = %app_id,
-                    error = %e,
-                    "lambda webhook invocation failed"
-                );
-            } else {
-                debug!(
-                    delivery_method = "lambda",
-                    app_id = %app_id,
-                    "lambda webhook invoked successfully"
-                );
+        tokio::spawn(
+            async move {
+                let _permit = permit;
+                if let Err(e) = lambda_sender
+                    .invoke_lambda(&webhook_clone, "batch_events", &app_id, payload_for_lambda)
+                    .await
+                {
+                    error!(
+                        delivery_method = "lambda",
+                        app_id = %app_id,
+                        error = %e,
+                        "lambda webhook invocation failed"
+                    );
+                } else {
+                    debug!(
+                        delivery_method = "lambda",
+                        app_id = %app_id,
+                        "lambda webhook invoked successfully"
+                    );
+                }
             }
-        })
+            .in_current_span(),
+        )
     }
 }
 
@@ -477,6 +483,20 @@ async fn send_pusher_webhook_once(
     custom_headers_config: &AHashMap<String, String>,
     request_timeout: Duration,
 ) -> Result<()> {
+    let server_address = url::Url::parse(url)
+        .ok()
+        .and_then(|url| url.host_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| "unknown".to_string());
+    let span = info_span!(
+        target: "sockudo_telemetry",
+        "http.client.request",
+        otel.kind = "client",
+        otel.name = "POST webhook",
+        http.request.method = "POST",
+        server.address = %server_address,
+        http.response.status_code = field::Empty,
+        otel.status_code = field::Empty,
+    );
     let mut request_builder = client
         .post(url)
         .header(header::CONTENT_TYPE, "application/json")
@@ -488,9 +508,19 @@ async fn send_pusher_webhook_once(
         request_builder = request_builder.header(key, value);
     }
 
-    match request_builder.body(json_body.to_string()).send().await {
+    let mut propagation_headers = header::HeaderMap::new();
+    crate::telemetry::inject_http_headers(&span, &mut propagation_headers);
+    request_builder = request_builder.headers(propagation_headers);
+
+    match request_builder
+        .body(json_body.to_string())
+        .send()
+        .instrument(span.clone())
+        .await
+    {
         Ok(response) => {
             let status = response.status();
+            span.record("http.response.status_code", status.as_u16());
             if status.is_success() {
                 debug!(
                     delivery_method = "http",
@@ -499,6 +529,7 @@ async fn send_pusher_webhook_once(
                 );
                 Ok(())
             } else {
+                span.record("otel.status_code", "ERROR");
                 let _ = response.text().await;
                 if should_retry_status(status) {
                     debug!(
@@ -522,6 +553,7 @@ async fn send_pusher_webhook_once(
             }
         }
         Err(e) => {
+            span.record("otel.status_code", "ERROR");
             let ec = request_error_class(&e);
             debug!(
                 delivery_method = "http",
@@ -616,6 +648,7 @@ mod tests {
             app_id: "test_app".to_string(),
             app_key: "test_key".to_string(),
             app_secret: "test_secret".to_string(),
+            trace_context: Default::default(),
             payload: JobPayload {
                 time_ms: 1234567890,
                 events: vec![],
@@ -640,6 +673,7 @@ mod tests {
             app_id: "test_app".to_string(),
             app_key: "test_key".to_string(),
             app_secret: "test_secret".to_string(),
+            trace_context: Default::default(),
             payload: JobPayload {
                 time_ms: 1234567890,
                 events: vec![sonic_rs::json!({
@@ -665,6 +699,7 @@ mod tests {
             app_id: "non_existent_app".to_string(),
             app_key: "test_key".to_string(),
             app_secret: "test_secret".to_string(),
+            trace_context: Default::default(),
             payload: JobPayload {
                 time_ms: 1234567890,
                 events: vec![],
@@ -695,6 +730,7 @@ mod tests {
                 app_id: "test_app".to_string(),
                 app_key: "test_key".to_string(),
                 app_secret: "test_secret".to_string(),
+                trace_context: Default::default(),
                 payload: JobPayload {
                     time_ms: 1234567890 + i,
                     events: vec![sonic_rs::json!({

--- a/crates/sockudo-webhook/src/telemetry.rs
+++ b/crates/sockudo-webhook/src/telemetry.rs
@@ -13,16 +13,18 @@ use tracing::info_span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 pub(crate) fn capture(job: &mut JobData) {
-    if !job.trace_context.is_empty() {
-        return;
-    }
     #[cfg(feature = "opentelemetry")]
-    global::get_text_map_propagator(|propagator| {
-        propagator.inject_context(
-            &Span::current().context(),
-            &mut TraceCarrier(&mut job.trace_context),
-        );
-    });
+    if job.trace_context.is_empty() {
+        global::get_text_map_propagator(|propagator| {
+            propagator.inject_context(
+                &Span::current().context(),
+                &mut TraceCarrier(&mut job.trace_context),
+            );
+        });
+    }
+
+    #[cfg(not(feature = "opentelemetry"))]
+    let _ = job;
 }
 
 pub(crate) fn consumer_span(job: &JobData) -> Span {

--- a/crates/sockudo-webhook/src/telemetry.rs
+++ b/crates/sockudo-webhook/src/telemetry.rs
@@ -1,0 +1,104 @@
+use sockudo_core::webhook_types::JobData;
+#[cfg(feature = "opentelemetry")]
+use std::collections::BTreeMap;
+use tracing::Span;
+
+#[cfg(feature = "opentelemetry")]
+use opentelemetry::global;
+#[cfg(feature = "opentelemetry")]
+use opentelemetry::propagation::{Extractor, Injector};
+#[cfg(feature = "opentelemetry")]
+use tracing::info_span;
+#[cfg(feature = "opentelemetry")]
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+pub(crate) fn capture(job: &mut JobData) {
+    if !job.trace_context.is_empty() {
+        return;
+    }
+    #[cfg(feature = "opentelemetry")]
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(
+            &Span::current().context(),
+            &mut TraceCarrier(&mut job.trace_context),
+        );
+    });
+}
+
+pub(crate) fn consumer_span(job: &JobData) -> Span {
+    #[cfg(feature = "opentelemetry")]
+    {
+        let span = info_span!(
+            target: "sockudo_telemetry",
+            "messaging.process",
+            otel.kind = "consumer",
+            otel.name = "webhook process",
+            messaging.system = "sockudo.queue",
+            messaging.destination.name = "webhooks",
+            messaging.operation.name = "process",
+            app_id = %job.app_id,
+            webhook_job_id = job.job_id.as_deref().unwrap_or("legacy"),
+        );
+        let parent = global::get_text_map_propagator(|propagator| {
+            propagator.extract(&TraceCarrierRef(&job.trace_context))
+        });
+        let _ = span.set_parent(parent);
+        span
+    }
+
+    #[cfg(not(feature = "opentelemetry"))]
+    {
+        let _ = job;
+        Span::none()
+    }
+}
+
+#[cfg(feature = "opentelemetry")]
+pub(crate) fn inject_http_headers(span: &Span, headers: &mut reqwest::header::HeaderMap) {
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&span.context(), &mut HeaderInjector(headers));
+    });
+}
+
+#[cfg(not(feature = "opentelemetry"))]
+pub(crate) fn inject_http_headers(_span: &Span, _headers: &mut reqwest::header::HeaderMap) {}
+
+#[cfg(feature = "opentelemetry")]
+struct TraceCarrier<'a>(&'a mut BTreeMap<String, String>);
+
+#[cfg(feature = "opentelemetry")]
+impl Injector for TraceCarrier<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        self.0.insert(key.to_owned(), value);
+    }
+}
+
+#[cfg(feature = "opentelemetry")]
+struct TraceCarrierRef<'a>(&'a BTreeMap<String, String>);
+
+#[cfg(feature = "opentelemetry")]
+impl Extractor for TraceCarrierRef<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(String::as_str).collect()
+    }
+}
+
+#[cfg(feature = "opentelemetry")]
+struct HeaderInjector<'a>(&'a mut reqwest::header::HeaderMap);
+
+#[cfg(feature = "opentelemetry")]
+impl Injector for HeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        let Ok(name) = reqwest::header::HeaderName::from_bytes(key.as_bytes()) else {
+            return;
+        };
+        let Ok(value) = reqwest::header::HeaderValue::from_str(&value) else {
+            return;
+        };
+        self.0.insert(name, value);
+    }
+}

--- a/docker-compose.opentelemetry.yml
+++ b/docker-compose.opentelemetry.yml
@@ -1,0 +1,23 @@
+# Development overlay for inspecting Sockudo traces, metrics, and logs locally.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.opentelemetry.yml up --build
+services:
+  sockudo:
+    environment:
+      SOCKUDO_OTEL_ENABLED: "true"
+      SOCKUDO_OTEL_ENDPOINT: "http://otel-collector:4317"
+      OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
+      OTEL_RESOURCE_ATTRIBUTES: "deployment.environment.name=compose"
+    depends_on:
+      otel-collector:
+        condition: service_started
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.159.0
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./ops/opentelemetry/collector.yaml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - sockudo-network

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -454,8 +454,63 @@ metadata is inspected through `/apps/{appId}/push/deadLetters`. Cleanup is bound
 | `[metrics]` | Enables metrics and configures the Prometheus scrape endpoint. |
 | `[metrics.prometheus]` | Prometheus metric naming options. |
 | `[metrics.tcp_exporter]` | Optional metrics-rs TCP event exporter for live clients and sidecars. |
+| `[opentelemetry]` | Optional OTLP traces, metrics, logs, resource identity, batching, and propagation. |
 | `[logging]` | Controls ANSI colors and tracing-target inclusion for text/JSON output. |
 | [logging environment](/docs/reference/logging) | Runtime filters, structured output, lifecycle fields, and data-safety policy. |
+
+OpenTelemetry is disabled by default and is additive to Prometheus and local logs:
+
+```toml
+[opentelemetry]
+enabled = true
+traces_enabled = true
+metrics_enabled = true
+logs_enabled = true
+service_name = "sockudo"
+service_namespace = "realtime"
+deployment_environment = "production"
+resource_attributes = { "cloud.region" = "eu-central-1" }
+endpoint = "http://otel-collector:4317"
+export_timeout_ms = 10000
+batch_scheduled_delay_ms = 5000
+batch_max_queue_size = 2048
+batch_max_export_batch_size = 512
+metric_export_interval_ms = 60000
+propagation_trace_context = true
+propagation_baggage = true
+```
+
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `enabled` | `false` | Initializes OpenTelemetry and enables the selected signals. |
+| `traces_enabled` | `true` | Exports spans when OpenTelemetry is enabled. |
+| `metrics_enabled` | `true` | Exports Sockudo metrics through OTLP independently of the Prometheus listener. |
+| `logs_enabled` | `true` | Exports structured log records while retaining local output. |
+| `service_name` | `sockudo` | OpenTelemetry `service.name`. Must not be empty when enabled. |
+| `service_namespace` | unset | Optional `service.namespace`. |
+| `deployment_environment` | unset | Optional `deployment.environment.name`. |
+| `resource_attributes` | `{}` | Additional string-valued resource attributes. Never store secrets here. |
+| `endpoint` | unset | Optional common OTLP endpoint. When unset, standard SDK/exporter configuration applies. |
+| `export_timeout_ms` | `10000` | Timeout for one exporter request. |
+| `batch_scheduled_delay_ms` | `5000` | Maximum span/log batching delay. |
+| `batch_max_queue_size` | `2048` | Bounded batch processor queue capacity. |
+| `batch_max_export_batch_size` | `512` | Maximum export batch size; cannot exceed the queue capacity. |
+| `metric_export_interval_ms` | `60000` | Periodic metric export interval. |
+| `propagation_trace_context` | `true` | Extracts and injects W3C `traceparent` and `tracestate`. |
+| `propagation_baggage` | `true` | Extracts and injects W3C baggage. Do not place secrets in baggage. |
+
+Use standard `OTEL_*` environment variables for the OTLP protocol (`grpc`, `http/protobuf`, or
+`http/json`), signal-specific endpoints, headers, compression, sampling, and SDK limits.
+The complete mapping is in the
+[environment variable reference](/docs/reference/environment-variables#opentelemetry).
+HTTPS exporters use platform/web PKI roots; custom CA bundles and mTLS exporter configuration are
+not supported by the current Rust SDK integration.
+The shipped CORS configuration allows `traceparent`, `tracestate`, and `baggage`; retain those
+headers in a custom allowlist when browser clients participate in distributed traces.
+
+Collector failures are fail-open: export uses bounded queues and does not change request handling,
+`/live`, or `/up`. Invalid static settings are still rejected during startup. Stable traces,
+metrics, and logs are supported; OpenTelemetry profiles are not.
 
 ## Example production skeleton
 

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -125,6 +125,75 @@ url = "${REDIS_URL:-redis://localhost:6379}"
 
 See [Logging](/docs/reference/logging) for level policy, stable lifecycle fields, and data-safety requirements.
 
+## OpenTelemetry
+
+OpenTelemetry is disabled unless `[opentelemetry].enabled` or `SOCKUDO_OTEL_ENABLED` is true.
+When enabled, Sockudo can export the stable OpenTelemetry traces, metrics, and logs signals over
+OTLP. Export is additive to local logs and the Prometheus `/metrics` endpoint. OpenTelemetry
+profiles are not supported.
+
+### Sockudo controls
+
+These variables map directly to the `[opentelemetry]` configuration block:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SOCKUDO_OTEL_ENABLED` | `false` | Enables OpenTelemetry initialization and export. |
+| `SOCKUDO_OTEL_TRACES_ENABLED` | `true` | Enables trace export while OpenTelemetry is enabled. |
+| `SOCKUDO_OTEL_METRICS_ENABLED` | `true` | Enables OTLP metric export while preserving Prometheus independently. |
+| `SOCKUDO_OTEL_LOGS_ENABLED` | `true` | Enables OTLP log export while preserving local log output. |
+| `SOCKUDO_OTEL_SERVICE_NAME` | `sockudo` | Sets the `service.name` resource attribute. |
+| `SOCKUDO_OTEL_SERVICE_NAMESPACE` | unset | Sets `service.namespace`. An empty value clears it. |
+| `SOCKUDO_OTEL_DEPLOYMENT_ENVIRONMENT` | unset | Sets `deployment.environment.name`. An empty value clears it. |
+| `SOCKUDO_OTEL_RESOURCE_ATTRIBUTES` | unset | Comma-separated `key=value` resource attributes. Invalid entries are ignored with a warning. |
+| `SOCKUDO_OTEL_ENDPOINT` | SDK default | Common OTLP collector endpoint used by enabled signals. |
+| `SOCKUDO_OTEL_EXPORT_TIMEOUT_MS` | `10000` | Request timeout for an OTLP export attempt. |
+| `SOCKUDO_OTEL_BATCH_SCHEDULED_DELAY_MS` | `5000` | Maximum trace/log batching delay. |
+| `SOCKUDO_OTEL_BATCH_MAX_QUEUE_SIZE` | `2048` | Bounded trace/log export queue capacity. |
+| `SOCKUDO_OTEL_BATCH_MAX_EXPORT_BATCH_SIZE` | `512` | Maximum trace/log records per export batch; cannot exceed queue capacity. |
+| `SOCKUDO_OTEL_METRIC_EXPORT_INTERVAL_MS` | `60000` | Periodic metric export interval. |
+| `SOCKUDO_OTEL_PROPAGATION_TRACE_CONTEXT` | `true` | Enables W3C `traceparent` and `tracestate` extraction and injection. |
+| `SOCKUDO_OTEL_PROPAGATION_BAGGAGE` | `true` | Enables W3C baggage extraction and injection. |
+
+### Standard OpenTelemetry SDK and OTLP variables
+
+Sockudo also honors the standard `OTEL_*` SDK and exporter variables implemented by the bundled
+Rust SDK. Use these for protocol, sampling, per-signal endpoints, compression, and authenticated
+collector headers. A
+signal-specific exporter value is more specific than its common OTLP equivalent.
+
+| Variable or family | Purpose |
+| --- | --- |
+| `OTEL_SDK_DISABLED` | Hard-disables the OpenTelemetry SDK when true. |
+| `OTEL_SERVICE_NAME` | Standard `service.name` resource setting. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Standard comma-separated resource attributes. |
+| `OTEL_PROPAGATORS` | Comma-separated `tracecontext` and `baggage` propagators. Other propagator names are ignored. |
+| `OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`, `OTEL_LOGS_EXPORTER` | Selects `otlp` or disables an individual signal with `none`. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Common OTLP endpoint. For HTTP it is a base URL and the SDK appends `/v1/traces`, `/v1/metrics`, or `/v1/logs`. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc`, `http/protobuf`, or `http/json`. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Comma-separated exporter headers. Treat the complete value as a secret. |
+| `OTEL_EXPORTER_OTLP_COMPRESSION` | Export compression: `gzip` or `zstd`. |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | Common exporter timeout in milliseconds. |
+| `OTEL_EXPORTER_OTLP_TRACES_*` | Trace-specific endpoint, protocol, headers, compression, and timeout. |
+| `OTEL_EXPORTER_OTLP_METRICS_*` | Metric-specific endpoint, protocol, headers, compression, timeout, and temporality preference. |
+| `OTEL_EXPORTER_OTLP_LOGS_*` | Log-specific endpoint, protocol, headers, compression, and timeout. |
+| `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` | Head sampler and its argument; for example `parentbased_traceidratio` and `0.10`. |
+| `OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BSP_MAX_QUEUE_SIZE`, `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | Batch span processor settings. The delay is in milliseconds. |
+| `OTEL_BLRP_SCHEDULE_DELAY`, `OTEL_BLRP_MAX_QUEUE_SIZE`, `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` | Batch log-record processor settings. The delay is in milliseconds. |
+| `OTEL_METRIC_EXPORT_INTERVAL` | Periodic metric reader interval in milliseconds. |
+| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | Metric temporality preference. |
+| `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`, `OTEL_SPAN_EVENT_COUNT_LIMIT`, `OTEL_SPAN_LINK_COUNT_LIMIT` | Trace span limits implemented by the bundled SDK. |
+
+The standard signal-specific endpoint is used exactly as supplied. With HTTP, include its final
+signal path when setting a signal-specific endpoint. Keep `OTEL_EXPORTER_OTLP_HEADERS` and private
+API tokens in a secret store rather than a configuration file or command line. HTTPS exporters use
+the bundled platform/web PKI roots. Custom CA bundles, client certificates, and mTLS exporter
+configuration are not supported by the current Rust SDK integration.
+
+Exporter connection failures, timeouts, and bounded-queue drops do not fail requests and do not
+change `/live` or `/up`. Invalid Sockudo configuration still fails validation at startup. See
+[Logging](/docs/reference/logging#opentelemetry-export) for log correlation and data-safety details.
+
 ## Driver selection
 
 | Variable | Purpose |

--- a/docs/content/docs/reference/logging.mdx
+++ b/docs/content/docs/reference/logging.mdx
@@ -40,6 +40,28 @@ With `LOG_OUTPUT_FORMAT=json`, each line is a JSON object. Application event att
 }
 ```
 
+## OpenTelemetry export
+
+When `[opentelemetry].enabled` and `logs_enabled` are true, the same structured tracing events are
+also emitted as OpenTelemetry log records. OTLP export does not replace stdout/stderr logging and
+does not change `LOG_OUTPUT_FORMAT`. Log records created inside a sampled trace carry its trace and
+span context, allowing an OpenTelemetry backend to correlate logs with request, WebSocket,
+horizontal-fanout, webhook, and queue spans.
+
+Explicit `sockudo_telemetry` instrumentation spans remain enabled while trace export is active,
+independently of the local `RUST_LOG` verbosity. This preserves distributed trace continuity
+without enabling debug or trace log events on stdout/stderr.
+
+Sockudo supports the stable OpenTelemetry traces, metrics, and logs signals over OTLP gRPC,
+HTTP/protobuf, and HTTP/JSON. W3C `traceparent`/`tracestate` propagation and baggage are enabled by
+default when telemetry is active. OpenTelemetry profiles are not supported.
+
+Export is asynchronous, bounded, and fail-open. Collector connection failures, exporter timeouts,
+or a full telemetry queue never make `/live` or `/up` fail and do not block normal request handling.
+Sockudo attempts a bounded flush during graceful shutdown. Configure collectors, protocols,
+sampling, and credentials with the
+[OpenTelemetry environment variables](/docs/reference/environment-variables#opentelemetry).
+
 ## Severity levels
 
 | Level | Meaning | Monitoring guidance |
@@ -84,4 +106,6 @@ Logs may contain operational IDs, channel names, user IDs, and event names. Logs
 keys or secrets, signatures, tokens, authorization data, request or response bodies, message
 payloads, raw queries, webhook URLs, provider credentials, device tokens, or private keys. This
 applies at every level: enabling `debug` or `trace` never permits payload, credential, or token
-logging.
+logging. The same rule applies to OpenTelemetry logs, span attributes, events, resource attributes,
+baggage, and exporter diagnostics. Store OTLP headers and client private keys outside the config
+file, and do not put secrets or user payloads in `OTEL_RESOURCE_ATTRIBUTES` or baggage.

--- a/ops/README.md
+++ b/ops/README.md
@@ -7,8 +7,18 @@ Current contents:
 
 - `grafana/` for dashboards and Grafana provisioning
 - `monitoring/` for Prometheus config and alert rules
+- `opentelemetry/` for the local OTLP collector example
 - `nginx/` for reverse-proxy configs and SSL assets
 - `migrations/` for canonical fresh-schema files and backend bootstrap notes
+
+Run the local OpenTelemetry example with:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.opentelemetry.yml up --build
+```
+
+The example accepts OTLP gRPC on `4317` and OTLP HTTP on `4318`, then prints basic trace, metric,
+and log summaries from the collector. The debug exporter is for development only.
 
 Possible future contents:
 

--- a/ops/opentelemetry/collector.yaml
+++ b/ops/opentelemetry/collector.yaml
@@ -1,0 +1,31 @@
+# Development collector: accepts all stable OTLP signals and writes summaries
+# to its own logs. Replace the debug exporter with your production backend.
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]


### PR DESCRIPTION
## Summary

- export stable OpenTelemetry traces, metrics, and logs through OTLP gRPC, HTTP/protobuf, or HTTP/JSON
- propagate W3C trace context and baggage through HTTP, WebSockets, horizontal fanout, durable queue jobs, webhooks, and push-provider requests
- preserve local logs and Prometheus while adding correlated OTLP logs, metrics fanout, bounded batching, resource identity, standard `OTEL_*` controls, and graceful shutdown flushing
- add configuration, environment reference, Helm values/templates, a Compose overlay, and a validated local collector example

## Verification

- `cargo check -p sockudo --features full`
- `cargo check -p sockudo --no-default-features --features local,v2`
- `cargo test --workspace`
- focused telemetry, logging, adapter compatibility, and webhook tests
- `cargo clippy --workspace --all-targets -- -D warnings -A dead-code` (only pre-existing macOS/Linux-helper dead-code warnings exempted)
- docs type-check and production build
- Helm lint, kubeconform, Compose rendering, and collector configuration validation
- live OpenTelemetry Collector smoke test received traces, metrics, and logs, including with `RUST_LOG=warn`

## Scope notes

OpenTelemetry profiles are not included because profiles are not yet a stable signal. Custom exporter CA bundles and mTLS are documented as unsupported by the current OpenTelemetry Rust SDK integration.