### PR TITLE
fix(push): compile provider HTTP without telemetry

### DIFF
--- a/crates/sockudo-push/src/dispatch/http.rs
+++ b/crates/sockudo-push/src/dispatch/http.rs
@@ -195,11 +195,15 @@ impl ProviderHttpClient for ReqwestProviderHttpClient {
             ProviderHttpMethod::Post => reqwest::Method::POST,
         };
         let mut builder = self.client.request(method, &request.url);
-        let mut headers = request.headers;
+        let headers = request.headers;
         #[cfg(feature = "opentelemetry")]
-        global::get_text_map_propagator(|propagator| {
-            propagator.inject_context(&span.context(), &mut PushHeaderInjector(&mut headers));
-        });
+        let headers = {
+            let mut headers = headers;
+            global::get_text_map_propagator(|propagator| {
+                propagator.inject_context(&span.context(), &mut PushHeaderInjector(&mut headers));
+            });
+            headers
+        };
         for (name, value) in headers {
             builder = builder.header(name, value);
         }


### PR DESCRIPTION
## Summary

- keep provider request headers immutable when OpenTelemetry is disabled
- scope mutable headers to the trace-context injection block
- restore the push-only feature-matrix Clippy build after #424

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p sockudo-push --all-targets --features push-fcm,push-apns,push-webpush,push-hms,push-wns,dynamodb,surrealdb,scylladb,postgres,mysql -- -D warnings`
- `cargo check -p sockudo-push --all-features`