### PR TITLE
feat: add OMQ horizontal adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5396,6 +5396,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "omq-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6420a63f80eac3235364674f61f3b4a00dbb283354402192406cd22a96b31cd1"
+dependencies = [
+ "bytes",
+ "patricia_tree",
+ "rand 0.10.2",
+ "smallvec",
+ "socket2 0.6.5",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "omq-tokio"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "448ae8e795f28e2f6ca624ff883ab1ebb3054c10aa8f46a72542e7f6b3b1f721"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "concurrent-queue",
+ "futures",
+ "libc",
+ "omq-proto",
+ "parking_lot",
+ "rand 0.10.2",
+ "rustc-hash",
+ "smallvec",
+ "socket2 0.6.5",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
+ "yring",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5726,6 +5763,12 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
+name = "patricia_tree"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df0e43512f12f23a6b08c7b893192b7d6ec937b95ee03af040847907fe5cef7"
 
 [[package]]
 name = "pbkdf2"
@@ -8103,6 +8146,7 @@ dependencies = [
  "mockall",
  "moka",
  "num_cpus",
+ "omq-tokio",
  "opentelemetry",
  "papaya",
  "parking_lot",
@@ -10614,6 +10658,15 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "yring"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5955ee60ab48843f30e961ec82771716a733c8ecb6387f2d6fe9de9545ec9cb8"
+dependencies = [
+ "loom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ tikv-jemallocator = "0.7"
 mockall = "0.13.1"
 moka = { version = "0.12.11", features = ["future", "sync"] }
 lapin = { version = "4.3.0", default-features = false, features = ["rustls", "tokio"] }
+omq-tokio = "0.21.4"
 num_cpus = "1.17.0"
 oxidelta = "0.1.4"
 parking_lot = "0.12.5"

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Common server features:
 | `push` | Push notification runtime and HTTP APIs |
 | `redis`, `redis-cluster` | Redis-backed adapter/cache/queue/rate limit paths |
 | `nats`, `pulsar`, `rabbitmq`, `google-pubsub`, `kafka`, `iggy` | Horizontal adapter and queue integrations |
+| `omq` | Brokerless horizontal adapter integration |
 | `mysql`, `postgres`, `dynamodb`, `surrealdb`, `scylladb` | App, history, version-store, and push storage backends |
 | `sqs`, `sns`, `lambda` | AWS queue, notification, and webhook integrations |
 | `full` | All production integrations wired by the server |

--- a/config/config.toml
+++ b/config/config.toml
@@ -60,6 +60,15 @@ partition_id = 0
 auto_create = true
 start_from_latest = true
 
+[adapter.omq]
+bind_endpoint = "tcp://127.0.0.1:5556"
+connect_endpoints = []
+prefix = "sockudo_adapter"
+request_timeout_ms = 5000
+io_threads = 1
+send_hwm = 100000
+recv_hwm = 100000
+
 [adapter.cluster]
 nodes = []
 prefix = "sockudo_adapter:"

--- a/crates/sockudo-adapter/Cargo.toml
+++ b/crates/sockudo-adapter/Cargo.toml
@@ -16,7 +16,7 @@ delta = ["dep:sockudo-delta"]
 tag-filtering = ["dep:sockudo-filter"]
 recovery = []
 opentelemetry = ["dep:opentelemetry", "dep:tracing-opentelemetry"]
-full = ["redis", "redis-cluster", "nats", "pulsar", "rabbitmq", "google-pubsub", "kafka", "iggy", "v2", "opentelemetry"]
+full = ["redis", "redis-cluster", "nats", "pulsar", "rabbitmq", "google-pubsub", "kafka", "iggy", "omq", "v2", "opentelemetry"]
 redis = ["sockudo-core/redis", "dep:redis"]
 redis-cluster = ["redis", "sockudo-core/redis-cluster"]
 nats = ["sockudo-core/nats", "dep:async-nats"]
@@ -25,6 +25,7 @@ rabbitmq = ["sockudo-core/rabbitmq", "dep:lapin"]
 google-pubsub = ["sockudo-core/google-pubsub", "dep:google-cloud-auth", "dep:google-cloud-pubsub"]
 kafka = ["sockudo-core/kafka", "dep:rdkafka"]
 iggy = ["sockudo-core/iggy", "dep:iggy"]
+omq = ["sockudo-core/omq", "dep:omq-tokio"]
 
 [dependencies]
 sockudo-core = { workspace = true }
@@ -58,6 +59,7 @@ rand = { workspace = true }
 redis = { workspace = true, optional = true }
 rdkafka = { workspace = true, optional = true }
 iggy = { workspace = true, optional = true }
+omq-tokio = { workspace = true, optional = true }
 regex = { workspace = true }
 serde = { workspace = true }
 sockudo-ws = { workspace = true }

--- a/crates/sockudo-adapter/src/factory.rs
+++ b/crates/sockudo-adapter/src/factory.rs
@@ -8,6 +8,8 @@ use crate::kafka_adapter::KafkaAdapter;
 use crate::local_adapter::LocalAdapter;
 #[cfg(feature = "nats")]
 use crate::nats_adapter::NatsAdapter;
+#[cfg(feature = "omq")]
+use crate::omq_adapter::OmqAdapter;
 #[cfg(feature = "pulsar")]
 use crate::pulsar_adapter::PulsarAdapter;
 #[cfg(feature = "rabbitmq")]
@@ -27,6 +29,8 @@ use sockudo_core::options::IggyConfig;
 use sockudo_core::options::KafkaAdapterConfig;
 #[cfg(feature = "nats")]
 use sockudo_core::options::NatsAdapterConfig;
+#[cfg(feature = "omq")]
+use sockudo_core::options::OmqAdapterConfig;
 #[cfg(feature = "pulsar")]
 use sockudo_core::options::PulsarAdapterConfig;
 #[cfg(feature = "rabbitmq")]
@@ -49,6 +53,8 @@ pub enum TypedAdapter {
     RedisCluster(Arc<RedisClusterAdapter>),
     #[cfg(feature = "nats")]
     Nats(Arc<NatsAdapter>),
+    #[cfg(feature = "omq")]
+    Omq(Arc<OmqAdapter>),
     #[cfg(feature = "pulsar")]
     Pulsar(Arc<PulsarAdapter>),
     #[cfg(feature = "google-pubsub")]
@@ -72,6 +78,8 @@ impl TypedAdapter {
             TypedAdapter::RedisCluster(adapter) => adapter.local_adapter.clone(),
             #[cfg(feature = "nats")]
             TypedAdapter::Nats(adapter) => adapter.local_adapter.clone(),
+            #[cfg(feature = "omq")]
+            TypedAdapter::Omq(adapter) => adapter.local_adapter.clone(),
             #[cfg(feature = "pulsar")]
             TypedAdapter::Pulsar(adapter) => adapter.local_adapter.clone(),
             #[cfg(feature = "google-pubsub")]
@@ -133,6 +141,10 @@ impl TypedAdapter {
             TypedAdapter::Nats(adapter) => {
                 adapter.set_cache_manager(cache_manager, idempotency_ttl);
             }
+            #[cfg(feature = "omq")]
+            TypedAdapter::Omq(adapter) => {
+                adapter.set_cache_manager(cache_manager, idempotency_ttl);
+            }
             #[cfg(feature = "pulsar")]
             TypedAdapter::Pulsar(adapter) => {
                 adapter.set_cache_manager(cache_manager, idempotency_ttl);
@@ -174,6 +186,8 @@ impl TypedAdapter {
             TypedAdapter::RedisCluster(adapter) => adapter.set_metrics(metrics).await,
             #[cfg(feature = "nats")]
             TypedAdapter::Nats(adapter) => adapter.set_metrics(metrics).await,
+            #[cfg(feature = "omq")]
+            TypedAdapter::Omq(adapter) => adapter.set_metrics(metrics).await,
             #[cfg(feature = "pulsar")]
             TypedAdapter::Pulsar(adapter) => adapter.set_metrics(metrics).await,
             #[cfg(feature = "google-pubsub")]
@@ -370,6 +384,39 @@ impl AdapterFactory {
                             return Err(e);
                         }
                         warn!(adapter = "nats", error = %e, "failed to initialize adapter, falling back to local");
+                        let local_adapter = Arc::new(LocalAdapter::new_with_buffer_multiplier(
+                            config.buffer_multiplier_per_cpu,
+                        ));
+                        let typed = TypedAdapter::Local(local_adapter.clone());
+                        Ok((local_adapter, typed))
+                    }
+                }
+            }
+            #[cfg(feature = "omq")]
+            AdapterDriver::Omq => {
+                let omq_cfg = OmqAdapterConfig {
+                    bind_endpoint: config.omq.bind_endpoint.clone(),
+                    connect_endpoints: config.omq.connect_endpoints.clone(),
+                    prefix: config.omq.prefix.clone(),
+                    request_timeout_ms: config.omq.request_timeout_ms,
+                    nodes_number: config.omq.nodes_number,
+                    io_threads: config.omq.io_threads,
+                    send_hwm: config.omq.send_hwm,
+                    recv_hwm: config.omq.recv_hwm,
+                };
+                match OmqAdapter::new(omq_cfg).await {
+                    Ok(mut adapter) => {
+                        Self::configure_horizontal_adapter(&mut adapter, config, api_only).await?;
+                        let adapter = Arc::new(adapter);
+                        let typed = TypedAdapter::Omq(adapter.clone());
+                        Ok((adapter, typed))
+                    }
+                    Err(e) => {
+                        if !config.fallback_to_local {
+                            tracing::error!(adapter = "omq", error = %e, "failed to initialize adapter");
+                            return Err(e);
+                        }
+                        warn!(adapter = "omq", error = %e, "failed to initialize adapter, falling back to local");
                         let local_adapter = Arc::new(LocalAdapter::new_with_buffer_multiplier(
                             config.buffer_multiplier_per_cpu,
                         ));
@@ -593,6 +640,23 @@ impl AdapterFactory {
                 }
                 warn!(
                     adapter = "nats",
+                    "adapter requested but not compiled in, falling back to local"
+                );
+                let local_adapter = Arc::new(LocalAdapter::new_with_buffer_multiplier(
+                    config.buffer_multiplier_per_cpu,
+                ));
+                let typed = TypedAdapter::Local(local_adapter.clone());
+                Ok((local_adapter, typed))
+            }
+            #[cfg(not(feature = "omq"))]
+            AdapterDriver::Omq => {
+                if !config.fallback_to_local {
+                    return Err(Error::HorizontalAdapter(
+                        "OMQ adapter requested but not compiled in. Fallback to local adapter is disabled. Build with --features omq or set adapter.fallback_to_local = true".to_string()
+                    ));
+                }
+                warn!(
+                    adapter = "omq",
                     "adapter requested but not compiled in, falling back to local"
                 );
                 let local_adapter = Arc::new(LocalAdapter::new_with_buffer_multiplier(

--- a/crates/sockudo-adapter/src/lib.rs
+++ b/crates/sockudo-adapter/src/lib.rs
@@ -20,6 +20,8 @@ pub mod memory_rate_limiter;
 pub(crate) mod message_predicate;
 #[cfg(feature = "nats")]
 pub mod nats_adapter;
+#[cfg(feature = "omq")]
+pub mod omq_adapter;
 pub mod presence;
 #[cfg(feature = "pulsar")]
 pub mod pulsar_adapter;

--- a/crates/sockudo-adapter/src/omq_adapter.rs
+++ b/crates/sockudo-adapter/src/omq_adapter.rs
@@ -1,0 +1,23 @@
+#[cfg(feature = "omq")]
+pub use inner::*;
+
+#[cfg(feature = "omq")]
+mod inner {
+    use crate::horizontal_adapter_base::HorizontalAdapterBase;
+    use crate::transports::OmqTransport;
+    use sockudo_core::error::Result;
+    pub(crate) use sockudo_core::options::OmqAdapterConfig;
+
+    /// OMQ adapter for brokerless horizontal scaling.
+    pub type OmqAdapter = HorizontalAdapterBase<OmqTransport>;
+
+    impl OmqAdapter {
+        pub async fn with_bind_endpoint(bind_endpoint: String) -> Result<Self> {
+            let config = OmqAdapterConfig {
+                bind_endpoint,
+                ..Default::default()
+            };
+            HorizontalAdapterBase::new(config).await
+        }
+    }
+}

--- a/crates/sockudo-adapter/src/transports/mod.rs
+++ b/crates/sockudo-adapter/src/transports/mod.rs
@@ -6,6 +6,8 @@ pub mod iggy_transport;
 pub mod kafka_transport;
 #[cfg(feature = "nats")]
 pub mod nats_transport;
+#[cfg(feature = "omq")]
+pub mod omq_transport;
 #[cfg(feature = "pulsar")]
 pub mod pulsar_transport;
 #[cfg(feature = "rabbitmq")]
@@ -27,6 +29,8 @@ pub use iggy_transport::IggyTransport;
 pub use kafka_transport::KafkaTransport;
 #[cfg(feature = "nats")]
 pub use nats_transport::NatsTransport;
+#[cfg(feature = "omq")]
+pub use omq_transport::OmqTransport;
 #[cfg(feature = "pulsar")]
 pub use pulsar_transport::PulsarTransport;
 #[cfg(feature = "rabbitmq")]

--- a/crates/sockudo-adapter/src/transports/omq_transport.rs
+++ b/crates/sockudo-adapter/src/transports/omq_transport.rs
@@ -1,0 +1,578 @@
+use crate::horizontal_adapter::{BroadcastMessage, RequestBody, ResponseBody};
+use crate::horizontal_transport::{HorizontalTransport, TransportConfig, TransportHandlers};
+use async_trait::async_trait;
+use bytes::Bytes;
+use omq_tokio::{Context, ContextConfig, Message, Options, Socket, SocketType};
+use sockudo_core::error::{Error, Result};
+use sockudo_core::metrics::MetricsInterface;
+use sockudo_core::options::OmqAdapterConfig;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use tokio::sync::Notify;
+use tracing::{error, info, trace, warn};
+use uuid::Uuid;
+
+/// Brokerless OMQ transport implementation.
+pub struct OmqTransport {
+    context: Context,
+    publisher: Socket,
+    subscriber: Socket,
+    broadcast_topic: String,
+    request_topic: String,
+    response_topic: String,
+    inbox_prefix: String,
+    config: OmqAdapterConfig,
+    metrics: Arc<OnceLock<Arc<dyn MetricsInterface + Send + Sync>>>,
+    shutdown: Arc<Notify>,
+    is_running: Arc<AtomicBool>,
+    owner_count: Arc<AtomicUsize>,
+}
+
+impl Clone for OmqTransport {
+    fn clone(&self) -> Self {
+        self.owner_count.fetch_add(1, Ordering::Relaxed);
+        Self {
+            context: self.context.clone(),
+            publisher: self.publisher.clone(),
+            subscriber: self.subscriber.clone(),
+            broadcast_topic: self.broadcast_topic.clone(),
+            request_topic: self.request_topic.clone(),
+            response_topic: self.response_topic.clone(),
+            inbox_prefix: self.inbox_prefix.clone(),
+            config: self.config.clone(),
+            metrics: self.metrics.clone(),
+            shutdown: self.shutdown.clone(),
+            is_running: self.is_running.clone(),
+            owner_count: self.owner_count.clone(),
+        }
+    }
+}
+
+impl OmqTransport {
+    fn topic(prefix: &str, suffix: &str) -> String {
+        format!("{prefix}.{suffix}")
+    }
+
+    fn node_topic(&self, node_id: &str) -> String {
+        Self::topic(&self.config.prefix, &format!("node.{node_id}"))
+    }
+
+    async fn publish_json<T: serde::Serialize>(
+        publisher: &Socket,
+        topic: &str,
+        value: &T,
+        kind: &str,
+    ) -> Result<()> {
+        let payload = sonic_rs::to_vec(value)
+            .map_err(|e| Error::Other(format!("Failed to serialize {kind}: {e}")))?;
+        publisher
+            .send(Message::multipart([
+                Bytes::from(topic.to_owned()),
+                Bytes::from(payload),
+            ]))
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to publish {kind}: {e}")))?;
+        Ok(())
+    }
+
+    fn parse_message(message: Message) -> Result<(Bytes, Bytes)> {
+        message
+            .try_as_parts::<2>()
+            .map(|[topic, payload]| (topic, payload))
+            .map_err(|e| Error::Other(format!("Invalid OMQ transport message: {e}")))
+    }
+
+    fn mark_dropped(metrics: &Arc<OnceLock<Arc<dyn MetricsInterface + Send + Sync>>>) {
+        if let Some(metrics) = metrics.get() {
+            metrics.mark_horizontal_transport_message_dropped("omq");
+        }
+    }
+}
+
+impl TransportConfig for OmqAdapterConfig {
+    fn request_timeout_ms(&self) -> u64 {
+        self.request_timeout_ms
+    }
+
+    fn prefix(&self) -> &str {
+        &self.prefix
+    }
+}
+
+#[async_trait]
+impl HorizontalTransport for OmqTransport {
+    type Config = OmqAdapterConfig;
+
+    async fn new(config: Self::Config) -> Result<Self> {
+        info!(
+            adapter = "omq",
+            bind_endpoint = %config.bind_endpoint,
+            peer_count = config.connect_endpoints.len(),
+            prefix = %config.prefix,
+            request_timeout_ms = config.request_timeout_ms,
+            io_threads = config.io_threads,
+            "transport initializing"
+        );
+
+        let context = Context::with_config(ContextConfig {
+            io_threads: config.io_threads,
+        });
+        let options = Options::default()
+            .send_hwm(config.send_hwm)
+            .recv_hwm(config.recv_hwm);
+        let publisher = context.socket(SocketType::Pub, options.clone());
+        let subscriber = context.socket(SocketType::Sub, options);
+
+        let bind_endpoint = config.bind_endpoint.parse().map_err(|e| {
+            Error::Other(format!(
+                "Failed to parse OMQ bind endpoint '{}': {e}",
+                config.bind_endpoint
+            ))
+        })?;
+        let resolved = subscriber
+            .bind(bind_endpoint)
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to bind OMQ subscriber: {e}")))?;
+
+        for endpoint in &config.connect_endpoints {
+            let endpoint = endpoint
+                .parse()
+                .map_err(|e| Error::Other(format!("Failed to parse OMQ peer endpoint: {e}")))?;
+            publisher
+                .connect(endpoint)
+                .await
+                .map_err(|e| Error::Internal(format!("Failed to connect OMQ publisher: {e}")))?;
+        }
+
+        info!(
+            adapter = "omq",
+            bind_endpoint = %resolved,
+            peer_count = config.connect_endpoints.len(),
+            "transport initialized"
+        );
+
+        Ok(Self {
+            context,
+            publisher,
+            subscriber,
+            broadcast_topic: Self::topic(&config.prefix, "broadcast"),
+            request_topic: Self::topic(&config.prefix, "requests"),
+            response_topic: Self::topic(&config.prefix, "responses"),
+            inbox_prefix: Self::topic(
+                &config.prefix,
+                &format!("inbox.{}.", Uuid::new_v4().as_simple()),
+            ),
+            config,
+            metrics: Arc::new(OnceLock::new()),
+            shutdown: Arc::new(Notify::new()),
+            is_running: Arc::new(AtomicBool::new(true)),
+            owner_count: Arc::new(AtomicUsize::new(1)),
+        })
+    }
+
+    async fn publish_broadcast(&self, message: &BroadcastMessage) -> Result<()> {
+        Self::publish_json(
+            &self.publisher,
+            &self.broadcast_topic,
+            message,
+            "broadcast message",
+        )
+        .await?;
+        trace!(adapter = "omq", "broadcast message published to transport");
+        Ok(())
+    }
+
+    async fn publish_request(&self, request: &RequestBody) -> Result<()> {
+        Self::publish_json(&self.publisher, &self.request_topic, request, "request").await?;
+        trace!(adapter = "omq", request_id = %request.request_id, "request published to transport");
+        Ok(())
+    }
+
+    async fn publish_response(&self, response: &ResponseBody) -> Result<()> {
+        Self::publish_json(&self.publisher, &self.response_topic, response, "response").await?;
+        trace!(adapter = "omq", "response published to transport");
+        Ok(())
+    }
+
+    async fn start_listeners(&self, handlers: TransportHandlers) -> Result<()> {
+        let node_topic_string = self.node_topic(&handlers.node_id);
+        for topic in [
+            self.broadcast_topic.as_bytes(),
+            self.request_topic.as_bytes(),
+            self.response_topic.as_bytes(),
+            self.inbox_prefix.as_bytes(),
+            node_topic_string.as_bytes(),
+        ] {
+            self.subscriber
+                .subscribe(Bytes::copy_from_slice(topic))
+                .await
+                .map_err(|e| Error::Internal(format!("Failed to subscribe OMQ topic: {e}")))?;
+        }
+
+        let subscriber = self.subscriber.clone();
+        let publisher = self.publisher.clone();
+        let broadcast_topic = Bytes::from(self.broadcast_topic.clone());
+        let request_topic = Bytes::from(self.request_topic.clone());
+        let response_topic = Bytes::from(self.response_topic.clone());
+        let inbox_prefix = Bytes::from(self.inbox_prefix.clone());
+        let node_topic = Bytes::from(node_topic_string.clone());
+        let response_topic_for_publish = self.response_topic.clone();
+        let broadcast_handler = handlers.on_broadcast.clone();
+        let request_handler = handlers.on_request.clone();
+        let response_handler = handlers.on_response.clone();
+        let metrics = self.metrics.clone();
+        let shutdown = self.shutdown.clone();
+        let is_running = self.is_running.clone();
+
+        info!(
+            adapter = "omq",
+            broadcast_topic = %self.broadcast_topic,
+            request_topic = %self.request_topic,
+            response_topic = %self.response_topic,
+            inbox_prefix = %self.inbox_prefix,
+            node_topic = %node_topic_string,
+            "transport subscriptions established"
+        );
+
+        tokio::spawn(async move {
+            loop {
+                if !is_running.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                let message = tokio::select! {
+                    _ = shutdown.notified() => break,
+                    message = subscriber.recv() => message,
+                };
+
+                let message = match message {
+                    Ok(message) => message,
+                    Err(e) => {
+                        warn!(adapter = "omq", error = %e, "subscriber receive failed");
+                        break;
+                    }
+                };
+
+                let (topic, payload) = match Self::parse_message(message) {
+                    Ok(parts) => parts,
+                    Err(e) => {
+                        Self::mark_dropped(&metrics);
+                        error!(adapter = "omq", error = %e, "transport message parse failed");
+                        continue;
+                    }
+                };
+
+                if topic == broadcast_topic {
+                    match sonic_rs::from_slice::<BroadcastMessage>(&payload) {
+                        Ok(broadcast) => {
+                            broadcast_handler(broadcast).await;
+                        }
+                        Err(e) => {
+                            Self::mark_dropped(&metrics);
+                            error!(adapter = "omq", error = %e, "broadcast message parse failed");
+                        }
+                    }
+                } else if topic == request_topic || topic == node_topic {
+                    match sonic_rs::from_slice::<RequestBody>(&payload) {
+                        Ok(request) => {
+                            let reply_to = request.reply_to.clone();
+                            match request_handler(request).await {
+                                Ok(response) => {
+                                    let response_topic = reply_to
+                                        .unwrap_or_else(|| response_topic_for_publish.clone());
+                                    if let Err(e) = Self::publish_json(
+                                        &publisher,
+                                        &response_topic,
+                                        &response,
+                                        "response",
+                                    )
+                                    .await
+                                    {
+                                        warn!(adapter = "omq", error = %e, "response publish failed");
+                                    }
+                                }
+                                Err(
+                                    Error::OwnRequestIgnored
+                                    | Error::RequestNotForThisNode
+                                    | Error::NoResponseNeeded,
+                                ) => {}
+                                Err(e) => {
+                                    warn!(adapter = "omq", error = %e, "request handler failed");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            Self::mark_dropped(&metrics);
+                            error!(adapter = "omq", error = %e, "request message parse failed");
+                        }
+                    }
+                } else if topic == response_topic || topic.starts_with(inbox_prefix.as_ref()) {
+                    match sonic_rs::from_slice::<ResponseBody>(&payload) {
+                        Ok(response) => {
+                            response_handler(response).await;
+                        }
+                        Err(e) => {
+                            Self::mark_dropped(&metrics);
+                            error!(adapter = "omq", error = %e, "response message parse failed");
+                        }
+                    }
+                }
+            }
+            warn!(adapter = "omq", "subscription ended");
+        });
+
+        Ok(())
+    }
+
+    async fn get_node_count(&self) -> Result<usize> {
+        if let Some(nodes) = self.config.nodes_number {
+            return Ok(nodes as usize);
+        }
+        Ok(self.config.connect_endpoints.len() + 1)
+    }
+
+    async fn check_health(&self) -> Result<()> {
+        if self.is_running.load(Ordering::Relaxed) {
+            Ok(())
+        } else {
+            Err(Error::Connection("OMQ transport is closed".to_string()))
+        }
+    }
+
+    fn set_metrics(&self, metrics: Arc<dyn MetricsInterface + Send + Sync>) {
+        let _ = self.metrics.set(metrics);
+    }
+
+    fn new_inbox(&self) -> Option<String> {
+        Some(format!(
+            "{}{}",
+            self.inbox_prefix,
+            Uuid::new_v4().as_simple()
+        ))
+    }
+
+    async fn publish_request_with_reply(
+        &self,
+        request: &RequestBody,
+        reply_to: &str,
+    ) -> Result<()> {
+        let mut request = request.clone();
+        request.reply_to = Some(reply_to.to_string());
+        Self::publish_json(
+            &self.publisher,
+            &self.request_topic,
+            &request,
+            "request with reply",
+        )
+        .await?;
+        trace!(adapter = "omq", request_id = %request.request_id, reply_to = %reply_to, "request with reply published to transport");
+        Ok(())
+    }
+
+    async fn publish_request_to_node(
+        &self,
+        request: &RequestBody,
+        target_node_id: &str,
+    ) -> Result<()> {
+        let topic = self.node_topic(target_node_id);
+        Self::publish_json(&self.publisher, &topic, request, "node request").await?;
+        trace!(adapter = "omq", request_id = %request.request_id, target_node_id = %target_node_id, "request published to node");
+        Ok(())
+    }
+}
+
+impl Drop for OmqTransport {
+    fn drop(&mut self) {
+        if self.owner_count.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.is_running.store(false, Ordering::Relaxed);
+            self.shutdown.notify_waiters();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::horizontal_adapter::RequestType;
+    use ahash::AHashMap;
+    use std::collections::{BTreeMap, HashSet};
+    use std::net::TcpListener;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    fn reserve_endpoint() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve port");
+        let port = listener.local_addr().expect("local addr").port();
+        drop(listener);
+        format!("tcp://127.0.0.1:{port}")
+    }
+
+    fn config(bind_endpoint: String, connect_endpoint: String) -> OmqAdapterConfig {
+        OmqAdapterConfig {
+            bind_endpoint,
+            connect_endpoints: vec![connect_endpoint],
+            prefix: format!("sockudo_test_{}", uuid::Uuid::new_v4().as_simple()),
+            request_timeout_ms: 1000,
+            nodes_number: Some(2),
+            io_threads: 1,
+            send_hwm: 1000,
+            recv_hwm: 1000,
+        }
+    }
+
+    fn broadcast(node_id: &str) -> BroadcastMessage {
+        BroadcastMessage {
+            node_id: node_id.to_string(),
+            app_id: "app".to_string(),
+            channel: "public-room".to_string(),
+            message: "{}".to_string(),
+            presence_replication: None,
+            envelope: None,
+            except_socket_id: None,
+            timestamp_ms: None,
+            compression_metadata: None,
+            idempotency_key: None,
+            ephemeral: false,
+            trace_context: BTreeMap::new(),
+        }
+    }
+
+    fn request(node_id: &str) -> RequestBody {
+        RequestBody {
+            request_id: "req-1".to_string(),
+            node_id: node_id.to_string(),
+            app_id: "app".to_string(),
+            request_type: RequestType::SocketsCount,
+            channel: None,
+            socket_id: None,
+            user_id: None,
+            user_info: None,
+            timestamp: None,
+            dead_node_id: None,
+            target_node_id: None,
+            channels: None,
+            reply_to: None,
+            trace_context: BTreeMap::new(),
+        }
+    }
+
+    fn response(request: &RequestBody, node_id: &str) -> ResponseBody {
+        ResponseBody {
+            request_id: request.request_id.clone(),
+            node_id: node_id.to_string(),
+            app_id: request.app_id.clone(),
+            members: AHashMap::new(),
+            channels_with_sockets_count: AHashMap::new(),
+            socket_ids: Vec::new(),
+            sockets_count: 7,
+            exists: false,
+            channels: HashSet::new(),
+            members_count: 0,
+            responses_received: 1,
+            expected_responses: 1,
+            complete: true,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn omq_transport_delivers_broadcasts_and_request_responses() {
+        let endpoint_a = reserve_endpoint();
+        let endpoint_b = reserve_endpoint();
+        let config_a = config(endpoint_a.clone(), endpoint_b.clone());
+        let mut config_b = config(endpoint_b, endpoint_a);
+        config_b.prefix.clone_from(&config_a.prefix);
+
+        let node_a = OmqTransport::new(config_a).await.expect("node a");
+        let node_b = OmqTransport::new(config_b).await.expect("node b");
+
+        let (broadcast_tx, mut broadcast_rx) = mpsc::channel(1);
+        let (response_tx, mut response_rx) = mpsc::channel(1);
+
+        node_a
+            .start_listeners(TransportHandlers {
+                node_id: "node-a".to_string(),
+                on_broadcast: Arc::new(|_| Box::pin(async {})),
+                on_request: Arc::new(|_| Box::pin(async { Err(Error::NoResponseNeeded) })),
+                on_response: Arc::new(move |response| {
+                    let response_tx = response_tx.clone();
+                    Box::pin(async move {
+                        response_tx.send(response).await.expect("response send");
+                    })
+                }),
+            })
+            .await
+            .expect("node a listeners");
+
+        node_b
+            .start_listeners(TransportHandlers {
+                node_id: "node-b".to_string(),
+                on_broadcast: Arc::new(move |broadcast| {
+                    let broadcast_tx = broadcast_tx.clone();
+                    Box::pin(async move {
+                        broadcast_tx.send(broadcast).await.expect("broadcast send");
+                    })
+                }),
+                on_request: Arc::new(|request| {
+                    Box::pin(async move { Ok(response(&request, "node-b")) })
+                }),
+                on_response: Arc::new(|_| Box::pin(async {})),
+            })
+            .await
+            .expect("node b listeners");
+
+        node_a
+            .publisher
+            .wait_connected(1, Duration::from_secs(2))
+            .await
+            .expect("node a publisher connected");
+        node_a
+            .publisher
+            .wait_subscribed(1, Duration::from_secs(2))
+            .await
+            .expect("node a publisher subscribed");
+        node_b
+            .publisher
+            .wait_connected(1, Duration::from_secs(2))
+            .await
+            .expect("node b publisher connected");
+        node_b
+            .publisher
+            .wait_subscribed(1, Duration::from_secs(2))
+            .await
+            .expect("node b publisher subscribed");
+
+        node_a
+            .publish_broadcast(&broadcast("node-a"))
+            .await
+            .expect("publish broadcast");
+        let received_broadcast = tokio::time::timeout(Duration::from_secs(2), broadcast_rx.recv())
+            .await
+            .expect("broadcast timeout")
+            .expect("broadcast");
+        assert_eq!(received_broadcast.channel, "public-room");
+
+        node_a
+            .publish_request(&request("node-a"))
+            .await
+            .expect("publish request");
+        let received_response = tokio::time::timeout(Duration::from_secs(2), response_rx.recv())
+            .await
+            .expect("response timeout")
+            .expect("response");
+        assert_eq!(received_response.request_id, "req-1");
+        assert_eq!(received_response.sockets_count, 7);
+
+        let inbox = node_a.new_inbox().expect("new inbox");
+        node_a
+            .publish_request_with_reply(&request("node-a"), &inbox)
+            .await
+            .expect("publish request with reply");
+        let received_response = tokio::time::timeout(Duration::from_secs(2), response_rx.recv())
+            .await
+            .expect("inbox response timeout")
+            .expect("inbox response");
+        assert_eq!(received_response.request_id, "req-1");
+        assert_eq!(received_response.sockets_count, 7);
+    }
+}

--- a/crates/sockudo-core/Cargo.toml
+++ b/crates/sockudo-core/Cargo.toml
@@ -20,6 +20,7 @@ full = [
   "google-pubsub",
   "kafka",
   "iggy",
+  "omq",
   "mysql",
   "postgres",
   "dynamodb",
@@ -37,6 +38,7 @@ rabbitmq = []
 google-pubsub = []
 kafka = []
 iggy = []
+omq = []
 mysql = []
 postgres = []
 dynamodb = []

--- a/crates/sockudo-core/src/options/adapter.rs
+++ b/crates/sockudo-core/src/options/adapter.rs
@@ -14,6 +14,7 @@ pub struct AdapterConfig {
     pub google_pubsub: GooglePubSubAdapterConfig,
     pub kafka: KafkaAdapterConfig,
     pub iggy: IggyConfig,
+    pub omq: OmqAdapterConfig,
     #[serde(default = "default_buffer_multiplier_per_cpu")]
     pub buffer_multiplier_per_cpu: usize,
     pub cluster_health: ClusterHealthConfig,
@@ -66,6 +67,7 @@ impl Default for AdapterConfig {
             google_pubsub: GooglePubSubAdapterConfig::default(),
             kafka: KafkaAdapterConfig::default(),
             iggy: IggyConfig::default(),
+            omq: OmqAdapterConfig::default(),
             buffer_multiplier_per_cpu: default_buffer_multiplier_per_cpu(),
             cluster_health: ClusterHealthConfig::default(),
             enable_socket_counting: default_enable_socket_counting(),
@@ -181,6 +183,19 @@ pub struct IggyConfig {
     pub auto_create: bool,
     pub start_from_latest: bool,
     pub nodes_number: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct OmqAdapterConfig {
+    pub bind_endpoint: String,
+    pub connect_endpoints: Vec<String>,
+    pub prefix: String,
+    pub request_timeout_ms: u64,
+    pub nodes_number: Option<u32>,
+    pub io_threads: usize,
+    pub send_hwm: u32,
+    pub recv_hwm: u32,
 }
 
 impl Default for RedisAdapterConfig {
@@ -300,6 +315,21 @@ impl Default for IggyConfig {
             auto_create: true,
             start_from_latest: true,
             nodes_number: None,
+        }
+    }
+}
+
+impl Default for OmqAdapterConfig {
+    fn default() -> Self {
+        Self {
+            bind_endpoint: "tcp://127.0.0.1:5556".to_string(),
+            connect_endpoints: Vec::new(),
+            prefix: "sockudo_adapter".to_string(),
+            request_timeout_ms: 5000,
+            nodes_number: None,
+            io_threads: 1,
+            send_hwm: 100_000,
+            recv_hwm: 100_000,
         }
     }
 }

--- a/crates/sockudo-core/src/options/drivers.rs
+++ b/crates/sockudo-core/src/options/drivers.rs
@@ -18,6 +18,7 @@ pub enum AdapterDriver {
     GooglePubSub,
     Kafka,
     Iggy,
+    Omq,
 }
 
 impl FromStr for AdapterDriver {
@@ -33,6 +34,7 @@ impl FromStr for AdapterDriver {
             "google-pubsub" | "gcp-pubsub" | "pubsub" => Ok(AdapterDriver::GooglePubSub),
             "kafka" => Ok(AdapterDriver::Kafka),
             "iggy" | "apache-iggy" | "apache_iggy" => Ok(AdapterDriver::Iggy),
+            "omq" | "zeromq" | "zero-mq" | "zmq" => Ok(AdapterDriver::Omq),
             _ => Err(format!("Unknown adapter driver: {s}")),
         }
     }

--- a/crates/sockudo-core/src/options/env/adapters.rs
+++ b/crates/sockudo-core/src/options/env/adapters.rs
@@ -227,5 +227,32 @@ pub(super) fn apply(options: &mut ServerOptions) -> Result<(), Box<dyn std::erro
         options.queue.iggy.nodes_number = Some(nodes);
     }
 
+    // --- OMQ Adapter ---
+    if let Ok(endpoint) = std::env::var("OMQ_BIND_ENDPOINT") {
+        options.adapter.omq.bind_endpoint = endpoint;
+    }
+    if let Ok(endpoints) = std::env::var("OMQ_CONNECT_ENDPOINTS") {
+        options.adapter.omq.connect_endpoints = endpoints
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+    }
+    if let Ok(prefix) = std::env::var("OMQ_PREFIX") {
+        options.adapter.omq.prefix = prefix;
+    }
+    options.adapter.omq.request_timeout_ms = parse_env::<u64>(
+        "OMQ_REQUEST_TIMEOUT_MS",
+        options.adapter.omq.request_timeout_ms,
+    );
+    if let Some(nodes) = parse_env_optional::<u32>("OMQ_NODES_NUMBER") {
+        options.adapter.omq.nodes_number = Some(nodes);
+    }
+    options.adapter.omq.io_threads =
+        parse_env::<usize>("OMQ_IO_THREADS", options.adapter.omq.io_threads);
+    options.adapter.omq.send_hwm = parse_env::<u32>("OMQ_SEND_HWM", options.adapter.omq.send_hwm);
+    options.adapter.omq.recv_hwm = parse_env::<u32>("OMQ_RECV_HWM", options.adapter.omq.recv_hwm);
+
     Ok(())
 }

--- a/crates/sockudo-server/Cargo.toml
+++ b/crates/sockudo-server/Cargo.toml
@@ -52,6 +52,7 @@ full = [
   "google-pubsub",
   "kafka",
   "iggy",
+  "omq",
   "mysql",
   "postgres",
   "dynamodb",
@@ -100,6 +101,7 @@ rabbitmq = ["sockudo-core/rabbitmq", "sockudo-adapter/rabbitmq", "sockudo-queue/
 google-pubsub = ["sockudo-core/google-pubsub", "sockudo-adapter/google-pubsub", "sockudo-queue/google-pubsub", "sockudo-push?/google-pubsub"]
 kafka = ["sockudo-core/kafka", "sockudo-adapter/kafka", "sockudo-queue/kafka", "sockudo-push?/kafka"]
 iggy = ["sockudo-core/iggy", "sockudo-adapter/iggy", "sockudo-queue/iggy", "sockudo-push?/iggy"]
+omq = ["sockudo-core/omq", "sockudo-adapter/omq"]
 mysql = ["sockudo-core/mysql", "sockudo-app/mysql", "dep:sqlx", "dep:urlencoding", "sockudo-push?/mysql"]
 postgres = ["sockudo-core/postgres", "sockudo-app/postgres", "dep:sqlx", "dep:urlencoding", "sockudo-push?/postgres"]
 dynamodb = ["sockudo-core/dynamodb", "sockudo-app/dynamodb", "dep:aws-config", "dep:aws-sdk-dynamodb", "sockudo-push?/dynamodb"]

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -179,6 +179,35 @@ the same durable push store used by native push APIs.
 | `[queue]` | Webhook and push background work. |
 | `[rate_limiter]` | Request, connection, event, and push limits. |
 
+## OMQ adapter
+
+`adapter.driver = "omq"` enables brokerless horizontal fanout over OMQ PUB/SUB.
+Each node binds one subscriber endpoint and connects its publisher to every
+other node's subscriber endpoint.
+
+```toml
+[adapter]
+driver = "omq"
+fallback_to_local = false
+
+[adapter.omq]
+bind_endpoint = "tcp://0.0.0.0:5556"
+connect_endpoints = [
+  "tcp://sockudo-1.internal:5556",
+  "tcp://sockudo-2.internal:5556",
+]
+prefix = "sockudo_adapter"
+request_timeout_ms = 5000
+nodes_number = 3
+io_threads = 1
+send_hwm = 100000
+recv_hwm = 100000
+```
+
+OMQ uses transport topics derived from `prefix`: broadcast, request, response,
+and per-node request topics. The adapter is not persistent; if a process or
+network path is unavailable, messages in flight are not retained by a broker.
+
 ## Redis connections, Sentinel, and TLS
 
 `[database.redis]` configures the Redis connection used by the Redis adapter, cache, queue, rate limiter, and delta coordinator. Without Sentinel, `[database.redis.master_tls]` secures the direct Redis data connection for every consumer. When `sentinels` is non-empty, Sockudo connects through Redis Sentinel using a native Sentinel client (rather than a direct URL) and can secure both connection hops independently. Redis Cluster also reuses `master_tls` certificate material; the legacy `cluster.use_tls` switch continues to enable TLS with the default root store.

--- a/docs/content/docs/reference/environment-variables.mdx
+++ b/docs/content/docs/reference/environment-variables.mdx
@@ -413,7 +413,7 @@ change `/live` or `/up`. Invalid Sockudo configuration still fails validation at
 | `QUEUE_SNS_TOPIC_ARN` | SNS topic ARN. |
 | `QUEUE_SNS_ENDPOINT_URL` | SNS custom endpoint URL. |
 
-## NATS, Pulsar, RabbitMQ, Pub/Sub, Kafka, and Iggy
+## NATS, Pulsar, RabbitMQ, Pub/Sub, Kafka, Iggy, and OMQ
 
 | Variable | Purpose |
 | --- | --- |
@@ -468,6 +468,14 @@ change `/live` or `/up`. Invalid Sockudo configuration still fails validation at
 | `IGGY_POLL_BATCH_SIZE` | Apache Iggy poll batch size. |
 | `IGGY_PARTITIONS_COUNT` | Shared Apache Iggy partition count. |
 | `ADAPTER_IGGY_PARTITIONS_COUNT` | Adapter-specific Apache Iggy partition count. |
+| `OMQ_BIND_ENDPOINT` | OMQ subscriber bind endpoint for this node. |
+| `OMQ_CONNECT_ENDPOINTS` | Comma-separated OMQ peer subscriber endpoints. |
+| `OMQ_PREFIX` | OMQ transport topic prefix. |
+| `OMQ_REQUEST_TIMEOUT_MS` | OMQ request timeout. |
+| `OMQ_NODES_NUMBER` | Expected OMQ node count. Defaults to peer endpoint count plus this node. |
+| `OMQ_IO_THREADS` | OMQ data-plane IO threads. |
+| `OMQ_SEND_HWM` | OMQ publisher high-water mark in messages. |
+| `OMQ_RECV_HWM` | OMQ subscriber high-water mark in messages. |
 | `QUEUE_IGGY_PARTITIONS_COUNT` | Queue-specific Apache Iggy partition count. |
 | `IGGY_PARTITION_ID` | Shared Apache Iggy partition ID. |
 | `ADAPTER_IGGY_PARTITION_ID` | Adapter-specific Apache Iggy partition ID. |


### PR DESCRIPTION
- Adds a feature-gated `omq` horizontal adapter backed by `omq-tokio`.
- Uses a brokerless OMQ PUB/SUB mesh for cross-node broadcast, request, response, and per-node targeted request traffic.
- Adds direct reply inbox topics so request/reply paths can avoid global response fanout when the adapter base supports inbox routing.
- Wires `AdapterDriver::Omq` through typed adapter creation, fallback behavior, feature flags, config defaults, environment overrides, and docs.
- Keeps existing adapters unchanged unless the `omq` feature and `adapter.driver = "omq"` are selected.

Benchmarks:
- Full local 3-node Sockudo/k6 run, 900 WebSocket subscribers, 100 channels, 9 client deliveries per publish: 1,000 publishes/s -> 20,000 publishes, 180,000 deliveries, 100% delivery, p95 delivery latency 2 ms, p99 3 ms.
- Same workload at 5,000 publishes/s -> 100,000 publishes, 900,000 deliveries, 100% delivery, p95 delivery latency 70 ms, p99 99 ms.
- Same workload at 6,000 publishes/s -> 120,004 publishes, 1,080,036 deliveries, 100% delivery, p95 delivery latency 159 ms, p99 219 ms.
- Native OMQ transport request/reply loopback: 128 B 2,727/s p95 0.262 ms; 1 KiB 2,644/s p95 0.276 ms; 8 KiB 2,365/s p95 0.301 ms; 64 KiB 1,664/s p95 3.013 ms.
