### PR TITLE
feat(sockudo-js): add `reconnectJitter `to spread reconnect delays

### DIFF
--- a/client-sdks/sockudo-dotnet/README.md
+++ b/client-sdks/sockudo-dotnet/README.md
@@ -423,7 +423,8 @@ var client = new SockudoClient(
     new SockudoOptions(
         Cluster: "local",
         MaxReconnectAttempts: 10,
-        MaxReconnectGapInSeconds: 60
+        MaxReconnectGapInSeconds: 60,
+        ReconnectJitter: 0.5
     )
 );
 
@@ -442,6 +443,11 @@ Unexpected disconnects retry with a quadratic delay of 0s, 1s, 4s, 9s, up to
 immediately. The default limit is six attempts; set `MaxReconnectAttempts` to
 `null` for unlimited retries. The counter resets after a successful connection
 and on explicit connect or disconnect calls.
+
+Because that delay is identical for every client, clients dropped by a single
+event retry in lockstep. Set `ReconnectJitter` to randomize each delay by that
+fraction and spread the retries out - `0.5` picks uniformly from 50-100% of the
+delay, `1.0` from 0-100%. It defaults to `0.0`, which keeps the delays exact.
 
 ### Protocol V2
 

--- a/client-sdks/sockudo-dotnet/src/Sockudo.Client/Models.cs
+++ b/client-sdks/sockudo-dotnet/src/Sockudo.Client/Models.cs
@@ -613,10 +613,17 @@ public sealed record SockudoOptions(
     int? AppendRollupWindow = null,
     int? MaxReconnectAttempts = 6,
     double MaxReconnectGapInSeconds = 120.0,
-    TokenAuthenticationOptions? TokenAuthentication = null
+    TokenAuthenticationOptions? TokenAuthentication = null,
+    double ReconnectJitter = 0.0
 )
 {
     private static readonly int[] AllowedAppendRollupWindows = { 0, 20, 40, 100, 500 };
+
+    /// <summary>
+    /// <see cref="ReconnectJitter"/> clamped to the 0 (off) through 1 (full jitter) range.
+    /// </summary>
+    public double EffectiveReconnectJitter =>
+        double.IsFinite(ReconnectJitter) && ReconnectJitter > 0 ? Math.Min(ReconnectJitter, 1.0) : 0.0;
 
     public TimeSpan EffectiveActivityTimeout => ActivityTimeout ?? TimeSpan.FromSeconds(120);
     public TimeSpan EffectivePongTimeout => PongTimeout ?? TimeSpan.FromSeconds(30);

--- a/client-sdks/sockudo-dotnet/src/Sockudo.Client/SockudoClient.cs
+++ b/client-sdks/sockudo-dotnet/src/Sockudo.Client/SockudoClient.cs
@@ -809,7 +809,16 @@ public sealed class SockudoClient : IAsyncDisposable
         }
 
         var intervalSeconds = (double)_reconnectAttempts * _reconnectAttempts;
-        return TimeSpan.FromSeconds(Math.Min(intervalSeconds, Options.MaxReconnectGapInSeconds));
+        var seconds = Math.Min(intervalSeconds, Options.MaxReconnectGapInSeconds);
+
+        // Spread retries so clients dropped by one event do not return in lockstep.
+        var jitter = Options.EffectiveReconnectJitter;
+        if (jitter <= 0 || seconds <= 0)
+        {
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        return TimeSpan.FromSeconds(seconds - Random.Shared.NextDouble() * seconds * jitter);
     }
 
     private Task ScheduleRetryAsync(TimeSpan delay)

--- a/client-sdks/sockudo-dotnet/tests/Sockudo.Client.Tests/ReconnectionTests.cs
+++ b/client-sdks/sockudo-dotnet/tests/Sockudo.Client.Tests/ReconnectionTests.cs
@@ -16,6 +16,7 @@ public sealed class ReconnectionTests
         Assert.Equal("reconnecting", ConnectionState.Reconnecting.ToString().ToLowerInvariant());
         Assert.Equal(6, options.MaxReconnectAttempts);
         Assert.Equal(120.0, options.MaxReconnectGapInSeconds);
+        Assert.Equal(0.0, options.ReconnectJitter);
         Assert.Null(unlimited.MaxReconnectAttempts);
     }
 
@@ -76,9 +77,61 @@ public sealed class ReconnectionTests
         Assert.Equal(0, GetReconnectAttempts(client));
     }
 
+    [Fact]
+    public void JitterRandomizesDelayWithinConfiguredFraction()
+    {
+        var client = TestClient(maxReconnectAttempts: null, reconnectJitter: 0.5);
+        SetReconnectAttempts(client, 3);
+
+        // Half of the 9s delay is randomized away, so it lands in [4.5, 9].
+        var seen = new HashSet<double>();
+        for (var i = 0; i < 200; i++)
+        {
+            var delay = InvokeReconnectDelay(client, null).TotalSeconds;
+            Assert.InRange(delay, 4.5, 9.0);
+            seen.Add(delay);
+        }
+
+        Assert.True(seen.Count > 1, "expected jittered delays to vary");
+    }
+
+    [Fact]
+    public void FullJitterStaysWithinCapAndSkipsImmediateRetries()
+    {
+        var client = TestClient(maxReconnectAttempts: null, maxReconnectGapInSeconds: 5.0, reconnectJitter: 1.0);
+        SetReconnectAttempts(client, 20);
+
+        for (var i = 0; i < 200; i++)
+        {
+            Assert.InRange(InvokeReconnectDelay(client, null).TotalSeconds, 0.0, 5.0);
+        }
+
+        Assert.Equal(TimeSpan.Zero, InvokeReconnectDelay(client, InvokeCloseAction(4200)));
+        Assert.Equal(TimeSpan.Zero, InvokeReconnectDelay(client, InvokeCloseAction(4000)));
+    }
+
+    [Fact]
+    public void DelaysStayExactWhenJitterIsNotConfigured()
+    {
+        var client = TestClient(maxReconnectAttempts: null);
+        SetReconnectAttempts(client, 3);
+
+        Assert.Equal(TimeSpan.FromSeconds(9), InvokeReconnectDelay(client, null));
+    }
+
+    [Fact]
+    public void JitterIsClamped()
+    {
+        Assert.Equal(1.0, new SockudoOptions(Cluster: "local", ReconnectJitter: 5.0).EffectiveReconnectJitter);
+        Assert.Equal(0.0, new SockudoOptions(Cluster: "local", ReconnectJitter: -1.0).EffectiveReconnectJitter);
+        Assert.Equal(0.0, new SockudoOptions(Cluster: "local", ReconnectJitter: double.NaN).EffectiveReconnectJitter);
+        Assert.Equal(0.25, new SockudoOptions(Cluster: "local", ReconnectJitter: 0.25).EffectiveReconnectJitter);
+    }
+
     private static SockudoClient TestClient(
         int? maxReconnectAttempts = 6,
-        double maxReconnectGapInSeconds = 120.0
+        double maxReconnectGapInSeconds = 120.0,
+        double reconnectJitter = 0.0
     ) => new(
         "app-key",
         new SockudoOptions(
@@ -88,7 +141,8 @@ public sealed class ReconnectionTests
             WsHost: "127.0.0.1",
             WsPort: 1,
             MaxReconnectAttempts: maxReconnectAttempts,
-            MaxReconnectGapInSeconds: maxReconnectGapInSeconds
+            MaxReconnectGapInSeconds: maxReconnectGapInSeconds,
+            ReconnectJitter: reconnectJitter
         )
     );
 

--- a/client-sdks/sockudo-flutter/README.md
+++ b/client-sdks/sockudo-flutter/README.md
@@ -366,6 +366,7 @@ final client = SockudoClient(
     cluster: 'local',
     maxReconnectAttempts: 10,
     maxReconnectGapInSeconds: 60,
+    reconnectJitter: 0.5,
   ),
 );
 
@@ -374,6 +375,11 @@ client.bind('reconnecting', (_, _) => print('reconnecting'));
 
 The attempt counter resets after a successful connection and on explicit
 `connect()` or `disconnect()` calls.
+
+Because that delay is identical for every client, clients dropped by a single
+event retry in lockstep. Set `reconnectJitter` to randomize each delay by that
+fraction and spread the retries out — `0.5` picks uniformly from 50-100% of the
+delay, `1.0` from 0-100%. It defaults to `0.0`, which keeps the delays exact.
 
 ### Encrypted Channels
 

--- a/client-sdks/sockudo-flutter/lib/src/client.dart
+++ b/client-sdks/sockudo-flutter/lib/src/client.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
@@ -17,6 +18,15 @@ import 'protocol_prefix.dart';
 import 'support.dart';
 
 int _nextGeneratedMessageId = 0;
+
+final math.Random _random = math.Random();
+
+double _clampJitter(double jitter) {
+  if (!jitter.isFinite || jitter <= 0) {
+    return 0.0;
+  }
+  return jitter < 1.0 ? jitter : 1.0;
+}
 
 String _generatedMessageId() {
   final next = ++_nextGeneratedMessageId;
@@ -88,6 +98,7 @@ class SockudoOptions {
     this.appendRollupWindow,
     this.maxReconnectAttempts = 6,
     this.maxReconnectGapInSeconds = 120.0,
+    this.reconnectJitter = 0.0,
     this.channelAuthorization = const ChannelAuthorizationOptions(),
     this.userAuthentication = const UserAuthenticationOptions(),
     this.presenceHistory,
@@ -125,6 +136,9 @@ class SockudoOptions {
   final int? appendRollupWindow;
   final int? maxReconnectAttempts;
   final double maxReconnectGapInSeconds;
+
+  /// Fraction of the reconnect delay to randomize, 0 (off) to 1 (full jitter).
+  final double reconnectJitter;
   final ChannelAuthorizationOptions channelAuthorization;
   final UserAuthenticationOptions userAuthentication;
   final PresenceHistoryOptions? presenceHistory;
@@ -855,8 +869,13 @@ class SockudoClient {
     final cappedSeconds = intervalSeconds < _config.maxReconnectGapInSeconds
         ? intervalSeconds
         : _config.maxReconnectGapInSeconds;
+    // Spread retries so clients dropped by one event do not return in lockstep.
+    final jitter = _config.reconnectJitter;
+    final seconds = jitter <= 0 || cappedSeconds <= 0
+        ? cappedSeconds
+        : cappedSeconds - _random.nextDouble() * cappedSeconds * jitter;
     return Duration(
-      microseconds: (cappedSeconds * Duration.microsecondsPerSecond).round(),
+      microseconds: (seconds * Duration.microsecondsPerSecond).round(),
     );
   }
 
@@ -1704,6 +1723,7 @@ class ResolvedConfiguration {
       unavailableTimeout = options.unavailableTimeout,
       maxReconnectAttempts = options.maxReconnectAttempts,
       maxReconnectGapInSeconds = options.maxReconnectGapInSeconds,
+      reconnectJitter = _clampJitter(options.reconnectJitter),
       enableStats = options.enableStats,
       statsHost = options.statsHost,
       timelineParams = options.timelineParams,
@@ -1727,6 +1747,7 @@ class ResolvedConfiguration {
   final Duration unavailableTimeout;
   final int? maxReconnectAttempts;
   final double maxReconnectGapInSeconds;
+  final double reconnectJitter;
   final bool enableStats;
   final String statsHost;
   final Map<String, AuthValue> timelineParams;

--- a/client-sdks/sockudo-flutter/test/sockudo_flutter_test.dart
+++ b/client-sdks/sockudo-flutter/test/sockudo_flutter_test.dart
@@ -493,6 +493,7 @@ void main() {
     expect(ConnectionState.reconnecting.name, 'reconnecting');
     expect(options.maxReconnectAttempts, 6);
     expect(options.maxReconnectGapInSeconds, 120.0);
+    expect(options.reconnectJitter, 0.0);
   });
 
   test('retries emit reconnecting and stop at the configured limit', () async {

--- a/client-sdks/sockudo-js/README.md
+++ b/client-sdks/sockudo-js/README.md
@@ -137,11 +137,17 @@ bounded quadratic delay: 0s, 1s, 4s, 9s, up to 120s. Protocol retry and
 TLS-upgrade close codes reconnect immediately. The default retry limit is six;
 set `maxReconnectAttempts: null` for unlimited retries.
 
+Because that delay is the same for every client, clients dropped by a single
+event retry in lockstep. Set `reconnectJitter` to randomize each delay by that 
+fraction and spread the retries out: `0.5` picks uniformly from 50–100% of 
+the delay, `1` from 0–100%. It defaults to `0`, which keeps the delays exact.
+
 ```ts
 const client = new Sockudo("app-key", {
   cluster: "local",
   maxReconnectAttempts: 10,
   maxReconnectGapInSeconds: 60,
+  reconnectJitter: 0.5,
 });
 
 client.connection.bind("reconnecting", () => {

--- a/client-sdks/sockudo-js/README.md
+++ b/client-sdks/sockudo-js/README.md
@@ -138,10 +138,9 @@ TLS-upgrade close codes reconnect immediately. The default retry limit is six;
 set `maxReconnectAttempts: null` for unlimited retries.
 
 Because that delay is the same for every client, clients dropped by a single
-event — a broker restart, a rolling deploy, a load balancer blip — retry in
-lockstep. Set `reconnectJitter` to randomize each delay by that fraction and
-spread the retries out: `0.5` picks uniformly from 50–100% of the delay, `1`
-from 0–100%. It defaults to `0`, which keeps the delays exact.
+event retry in lockstep. Set `reconnectJitter` to randomize each delay by that
+fraction and spread the retries out: `0.5` picks uniformly from 50–100% of
+the delay, `1` from 0–100%. It defaults to `0`, which keeps the delays exact.
 
 ```ts
 const client = new Sockudo("app-key", {

--- a/client-sdks/sockudo-js/README.md
+++ b/client-sdks/sockudo-js/README.md
@@ -138,9 +138,10 @@ TLS-upgrade close codes reconnect immediately. The default retry limit is six;
 set `maxReconnectAttempts: null` for unlimited retries.
 
 Because that delay is the same for every client, clients dropped by a single
-event retry in lockstep. Set `reconnectJitter` to randomize each delay by that 
-fraction and spread the retries out: `0.5` picks uniformly from 50–100% of 
-the delay, `1` from 0–100%. It defaults to `0`, which keeps the delays exact.
+event — a broker restart, a rolling deploy, a load balancer blip — retry in
+lockstep. Set `reconnectJitter` to randomize each delay by that fraction and
+spread the retries out: `0.5` picks uniformly from 50–100% of the delay, `1`
+from 0–100%. It defaults to `0`, which keeps the delays exact.
 
 ```ts
 const client = new Sockudo("app-key", {

--- a/client-sdks/sockudo-js/src/core/config.ts
+++ b/client-sdks/sockudo-js/src/core/config.ts
@@ -28,6 +28,7 @@ export interface Config {
   unavailableTimeout: number;
   maxReconnectAttempts: number | null;
   maxReconnectGapInSeconds: number;
+  reconnectJitter: number;
   useTLS: boolean;
   wsHost: string;
   wsPath: string;
@@ -69,6 +70,7 @@ export function getConfig(opts: Options, sockudo): Config {
         ? Defaults.maxReconnectAttempts
         : opts.maxReconnectAttempts,
     maxReconnectGapInSeconds: opts.maxReconnectGapInSeconds ?? Defaults.maxReconnectGapInSeconds,
+    reconnectJitter: clampJitter(opts.reconnectJitter ?? Defaults.reconnectJitter),
     wsPath: opts.wsPath || Defaults.wsPath,
     wsPort: opts.wsPort || Defaults.wsPort,
     wssPort: opts.wssPort || Defaults.wssPort,
@@ -101,6 +103,13 @@ export function getConfig(opts: Options, sockudo): Config {
   }
 
   return config;
+}
+
+function clampJitter(jitter: number): number {
+  if (!Number.isFinite(jitter) || jitter <= 0) {
+    return 0;
+  }
+  return Math.min(jitter, 1);
 }
 
 function getHttpHost(opts: Options): string {

--- a/client-sdks/sockudo-js/src/core/connection/connection_manager.ts
+++ b/client-sdks/sockudo-js/src/core/connection/connection_manager.ts
@@ -39,6 +39,7 @@ import { prefixedEvent } from "../protocol_prefix";
  * - pongTimeout - time for server to respond with pong before reconnecting
  * - maxReconnectAttempts - maximum retries before disconnecting; null is unlimited
  * - maxReconnectGapInSeconds - cap for quadratic reconnect delay
+ * - reconnectJitter - fraction of the delay to randomize, 0 (off) to 1 (full jitter)
  *
  * @param {String} key application key
  * @param {Object} options
@@ -276,7 +277,13 @@ export default class ConnectionManager extends EventsDispatcher {
       return 0;
     }
     const intervalSeconds = this.reconnectAttempts * this.reconnectAttempts;
-    return Math.min(intervalSeconds, this.options.maxReconnectGapInSeconds) * 1000;
+    const delay = Math.min(intervalSeconds, this.options.maxReconnectGapInSeconds) * 1000;
+    // Spread retries so clients dropped by one event do not return in lockstep.
+    const jitter = this.options.reconnectJitter;
+    if (!jitter || delay <= 0) {
+      return delay;
+    }
+    return delay - Runtime.randomInt(Math.round(delay * jitter) + 1);
   }
 
   private clearRetryTimer() {

--- a/client-sdks/sockudo-js/src/core/connection/connection_manager_options.ts
+++ b/client-sdks/sockudo-js/src/core/connection/connection_manager_options.ts
@@ -11,6 +11,7 @@ interface ConnectionManagerOptions {
   useTLS: boolean;
   maxReconnectAttempts: number | null;
   maxReconnectGapInSeconds: number;
+  reconnectJitter: number;
   beforeConnect?: (reason: "initial" | "reconnect") => void | Promise<void>;
 }
 

--- a/client-sdks/sockudo-js/src/core/defaults.ts
+++ b/client-sdks/sockudo-js/src/core/defaults.ts
@@ -20,6 +20,7 @@ export interface DefaultConfig {
   unavailableTimeout: number;
   maxReconnectAttempts: number;
   maxReconnectGapInSeconds: number;
+  reconnectJitter: number;
   userAuthentication: UserAuthenticationOptions;
   channelAuthorization: ChannelAuthorizationOptions;
 
@@ -51,6 +52,7 @@ const Defaults: DefaultConfig = {
   unavailableTimeout: 10000,
   maxReconnectAttempts: 6,
   maxReconnectGapInSeconds: 120,
+  reconnectJitter: 0,
   userAuthentication: {
     endpoint: "/sockudo/user-auth",
     transport: "fetch",

--- a/client-sdks/sockudo-js/src/core/options.ts
+++ b/client-sdks/sockudo-js/src/core/options.ts
@@ -85,6 +85,8 @@ export interface Options {
   connectionRecovery?: boolean;
   maxReconnectAttempts?: number | null;
   maxReconnectGapInSeconds?: number;
+  /** Fraction of the reconnect delay to randomize, 0 (off) to 1 (full jitter). */
+  reconnectJitter?: number;
   echoMessages?: boolean;
   enableStats?: boolean;
   disableStats?: boolean;

--- a/client-sdks/sockudo-js/src/core/sockudo.ts
+++ b/client-sdks/sockudo-js/src/core/sockudo.ts
@@ -170,6 +170,7 @@ export default class Sockudo {
       useTLS: Boolean(this.config.useTLS),
       maxReconnectAttempts: this.config.maxReconnectAttempts,
       maxReconnectGapInSeconds: this.config.maxReconnectGapInSeconds,
+      reconnectJitter: this.config.reconnectJitter,
       beforeConnect:
         options.authCallback || options.authUrl
           ? (reason) => this.prepareCapabilityToken(reason)

--- a/client-sdks/sockudo-js/test/connection-manager-reconnection.test.ts
+++ b/client-sdks/sockudo-js/test/connection-manager-reconnection.test.ts
@@ -93,14 +93,57 @@ describe("connection manager reconnection", () => {
 
     expect(reasons).toEqual(["initial", "reconnect"]);
   });
-
   it("keeps delays exact when jitter is not configured", () => {
     const { manager, timeline } = createManager({ maxReconnectAttempts: null });
     const internals = manager as unknown as { reconnectAttempts: number };
     internals.reconnectAttempts = 3;
+
     manager.errorCallbacks.backoff({ action: "backoff" });
 
     expect(timeline.info).toHaveBeenLastCalledWith({ action: "retry", delay: 9000 });
+  });
+
+  it("randomizes the delay downwards within the configured fraction", () => {
+    const randomInt = vi.spyOn(Runtime, "randomInt");
+    const { manager, timeline } = createManager({
+      maxReconnectAttempts: null,
+      reconnectJitter: 0.5,
+    });
+    const internals = manager as unknown as { reconnectAttempts: number };
+
+    const delays: number[] = [];
+    for (const value of [0, 2500, 4500]) {
+      randomInt.mockReturnValueOnce(value);
+      internals.reconnectAttempts = 3;
+      manager.errorCallbacks.backoff({ action: "backoff" });
+      delays.push(lastRetryDelay(timeline));
+    }
+
+    // Half of 9000 is randomized away, so delays land in [4500, 9000].
+    expect(randomInt).toHaveBeenCalledWith(4501);
+    expect(delays).toEqual([9000, 6500, 4500]);
+    randomInt.mockRestore();
+  });
+
+  it("never jitters past the cap or below zero at full jitter", () => {
+    const randomInt = vi.spyOn(Runtime, "randomInt");
+    const { manager, timeline } = createManager({
+      maxReconnectAttempts: null,
+      maxReconnectGapInSeconds: 5,
+      reconnectJitter: 1,
+    });
+    const internals = manager as unknown as { reconnectAttempts: number };
+
+    for (const value of [0, 5000]) {
+      randomInt.mockReturnValueOnce(value);
+      internals.reconnectAttempts = 10;
+      manager.errorCallbacks.backoff({ action: "backoff" });
+      const delay = lastRetryDelay(timeline);
+      expect(delay).toBeGreaterThanOrEqual(0);
+      expect(delay).toBeLessThanOrEqual(5000);
+    }
+
+    randomInt.mockRestore();
   });
 
   it("clamps out-of-range jitter values", () => {

--- a/client-sdks/sockudo-js/test/connection-manager-reconnection.test.ts
+++ b/client-sdks/sockudo-js/test/connection-manager-reconnection.test.ts
@@ -4,6 +4,7 @@ import ConnectionManager from "../src/core/connection/connection_manager";
 import EventsDispatcher from "../src/core/events/dispatcher";
 import type Strategy from "../src/core/strategies/strategy";
 import type Timeline from "../src/core/timeline/timeline";
+import Runtime from "runtime";
 
 describe("connection manager reconnection", () => {
   afterEach(() => {
@@ -16,6 +17,7 @@ describe("connection manager reconnection", () => {
 
     expect(defaults.maxReconnectAttempts).toBe(6);
     expect(defaults.maxReconnectGapInSeconds).toBe(120);
+    expect(defaults.reconnectJitter).toBe(0);
     expect(unlimited.maxReconnectAttempts).toBeNull();
   });
 
@@ -91,12 +93,51 @@ describe("connection manager reconnection", () => {
 
     expect(reasons).toEqual(["initial", "reconnect"]);
   });
+
+  it("keeps delays exact when jitter is not configured", () => {
+    const { manager, timeline } = createManager({ maxReconnectAttempts: null });
+    const internals = manager as unknown as { reconnectAttempts: number };
+    internals.reconnectAttempts = 3;
+    manager.errorCallbacks.backoff({ action: "backoff" });
+
+    expect(timeline.info).toHaveBeenLastCalledWith({ action: "retry", delay: 9000 });
+  });
+
+  it("clamps out-of-range jitter values", () => {
+    expect(getConfig({ cluster: "local", reconnectJitter: 5 }, {}).reconnectJitter).toBe(1);
+    expect(getConfig({ cluster: "local", reconnectJitter: -1 }, {}).reconnectJitter).toBe(0);
+    expect(getConfig({ cluster: "local", reconnectJitter: NaN }, {}).reconnectJitter).toBe(0);
+  });
+
+  it("leaves immediate retry and TLS-upgrade paths un-jittered", () => {
+    const randomInt = vi.spyOn(Runtime, "randomInt");
+    const { manager, timeline } = createManager({
+      maxReconnectAttempts: null,
+      reconnectJitter: 1,
+    });
+
+    manager.errorCallbacks.retry({ action: "retry" });
+    expect(timeline.info).toHaveBeenLastCalledWith({ action: "retry", delay: 0 });
+
+    manager.errorCallbacks.tls_only({ action: "tls_only" });
+    expect(timeline.info).toHaveBeenLastCalledWith({ action: "retry", delay: 0 });
+
+    expect(randomInt).not.toHaveBeenCalled();
+    randomInt.mockRestore();
+  });
 });
+
+function lastRetryDelay(timeline: { info: ReturnType<typeof vi.fn> }): number {
+  const lastCall = timeline.info.mock.lastCall;
+  expect(lastCall).toBeDefined();
+  return (lastCall as [{ delay: number }])[0].delay;
+}
 
 function createManager(
   overrides: Partial<{
     maxReconnectAttempts: number | null;
     maxReconnectGapInSeconds: number;
+    reconnectJitter: number;
     beforeConnect: (reason: "initial" | "reconnect") => Promise<void>;
   }> = {},
 ) {
@@ -122,6 +163,7 @@ function createManager(
     maxReconnectAttempts:
       overrides.maxReconnectAttempts === undefined ? 6 : overrides.maxReconnectAttempts,
     maxReconnectGapInSeconds: overrides.maxReconnectGapInSeconds ?? 120,
+    reconnectJitter: overrides.reconnectJitter ?? 0,
     beforeConnect: overrides.beforeConnect,
   });
 

--- a/client-sdks/sockudo-js/test/connection-manager-reconnection.test.ts
+++ b/client-sdks/sockudo-js/test/connection-manager-reconnection.test.ts
@@ -4,7 +4,6 @@ import ConnectionManager from "../src/core/connection/connection_manager";
 import EventsDispatcher from "../src/core/events/dispatcher";
 import type Strategy from "../src/core/strategies/strategy";
 import type Timeline from "../src/core/timeline/timeline";
-import Runtime from "runtime";
 
 describe("connection manager reconnection", () => {
   afterEach(() => {
@@ -93,40 +92,38 @@ describe("connection manager reconnection", () => {
 
     expect(reasons).toEqual(["initial", "reconnect"]);
   });
+
   it("keeps delays exact when jitter is not configured", () => {
     const { manager, timeline } = createManager({ maxReconnectAttempts: null });
     const internals = manager as unknown as { reconnectAttempts: number };
     internals.reconnectAttempts = 3;
-
     manager.errorCallbacks.backoff({ action: "backoff" });
 
     expect(timeline.info).toHaveBeenLastCalledWith({ action: "retry", delay: 9000 });
   });
 
   it("randomizes the delay downwards within the configured fraction", () => {
-    const randomInt = vi.spyOn(Runtime, "randomInt");
     const { manager, timeline } = createManager({
       maxReconnectAttempts: null,
       reconnectJitter: 0.5,
     });
     const internals = manager as unknown as { reconnectAttempts: number };
 
-    const delays: number[] = [];
-    for (const value of [0, 2500, 4500]) {
-      randomInt.mockReturnValueOnce(value);
+    // Half of the 9s delay is randomized away, so delays land in [4500, 9000].
+    const delays = new Set<number>();
+    for (let i = 0; i < 200; i++) {
       internals.reconnectAttempts = 3;
       manager.errorCallbacks.backoff({ action: "backoff" });
-      delays.push(lastRetryDelay(timeline));
+      const delay = lastRetryDelay(timeline);
+      expect(delay).toBeGreaterThanOrEqual(4500);
+      expect(delay).toBeLessThanOrEqual(9000);
+      delays.add(delay);
     }
 
-    // Half of 9000 is randomized away, so delays land in [4500, 9000].
-    expect(randomInt).toHaveBeenCalledWith(4501);
-    expect(delays).toEqual([9000, 6500, 4500]);
-    randomInt.mockRestore();
+    expect(delays.size).toBeGreaterThan(1);
   });
 
   it("never jitters past the cap or below zero at full jitter", () => {
-    const randomInt = vi.spyOn(Runtime, "randomInt");
     const { manager, timeline } = createManager({
       maxReconnectAttempts: null,
       maxReconnectGapInSeconds: 5,
@@ -134,16 +131,13 @@ describe("connection manager reconnection", () => {
     });
     const internals = manager as unknown as { reconnectAttempts: number };
 
-    for (const value of [0, 5000]) {
-      randomInt.mockReturnValueOnce(value);
+    for (let i = 0; i < 200; i++) {
       internals.reconnectAttempts = 10;
       manager.errorCallbacks.backoff({ action: "backoff" });
       const delay = lastRetryDelay(timeline);
       expect(delay).toBeGreaterThanOrEqual(0);
       expect(delay).toBeLessThanOrEqual(5000);
     }
-
-    randomInt.mockRestore();
   });
 
   it("clamps out-of-range jitter values", () => {
@@ -153,20 +147,18 @@ describe("connection manager reconnection", () => {
   });
 
   it("leaves immediate retry and TLS-upgrade paths un-jittered", () => {
-    const randomInt = vi.spyOn(Runtime, "randomInt");
     const { manager, timeline } = createManager({
       maxReconnectAttempts: null,
       reconnectJitter: 1,
     });
+    const internals = manager as unknown as { reconnectAttempts: number };
+    internals.reconnectAttempts = 10;
 
     manager.errorCallbacks.retry({ action: "retry" });
     expect(timeline.info).toHaveBeenLastCalledWith({ action: "retry", delay: 0 });
 
     manager.errorCallbacks.tls_only({ action: "tls_only" });
     expect(timeline.info).toHaveBeenLastCalledWith({ action: "retry", delay: 0 });
-
-    expect(randomInt).not.toHaveBeenCalled();
-    randomInt.mockRestore();
   });
 });
 

--- a/client-sdks/sockudo-js/types/core/config.d.ts
+++ b/client-sdks/sockudo-js/types/core/config.d.ts
@@ -15,6 +15,7 @@ export interface Config {
     unavailableTimeout: number;
     maxReconnectAttempts: number | null;
     maxReconnectGapInSeconds: number;
+    reconnectJitter: number;
     useTLS: boolean;
     wsHost: string;
     wsPath: string;

--- a/client-sdks/sockudo-js/types/core/connection/connection_manager_options.d.ts
+++ b/client-sdks/sockudo-js/types/core/connection/connection_manager_options.d.ts
@@ -9,6 +9,7 @@ interface ConnectionManagerOptions {
     useTLS: boolean;
     maxReconnectAttempts: number | null;
     maxReconnectGapInSeconds: number;
+    reconnectJitter: number;
     beforeConnect?: (reason: 'initial' | 'reconnect') => void | Promise<void>;
 }
 export default ConnectionManagerOptions;

--- a/client-sdks/sockudo-js/types/core/defaults.d.ts
+++ b/client-sdks/sockudo-js/types/core/defaults.d.ts
@@ -18,6 +18,7 @@ export interface DefaultConfig {
     unavailableTimeout: number;
     maxReconnectAttempts: number;
     maxReconnectGapInSeconds: number;
+    reconnectJitter: number;
     userAuthentication: UserAuthenticationOptions;
     channelAuthorization: ChannelAuthorizationOptions;
     cdn_http?: string;

--- a/client-sdks/sockudo-js/types/core/options.d.ts
+++ b/client-sdks/sockudo-js/types/core/options.d.ts
@@ -50,6 +50,8 @@ export interface Options {
     connectionRecovery?: boolean;
     maxReconnectAttempts?: number | null;
     maxReconnectGapInSeconds?: number;
+    /** Fraction of the reconnect delay to randomize, 0 (off) to 1 (full jitter). */
+    reconnectJitter?: number;
     echoMessages?: boolean;
     enableStats?: boolean;
     disableStats?: boolean;

--- a/client-sdks/sockudo-kotlin/README.md
+++ b/client-sdks/sockudo-kotlin/README.md
@@ -361,6 +361,7 @@ val client =
             cluster = "local",
             maxReconnectAttempts = 10,
             maxReconnectGapInSeconds = 60.0,
+            reconnectJitter = 0.5,
         ),
     )
 
@@ -369,6 +370,11 @@ client.bind("reconnecting") { _, _ -> println("reconnecting") }
 
 The attempt counter resets after a successful connection and on explicit
 `connect()` or `disconnect()` calls.
+
+Because that delay is identical for every client, clients dropped by a single
+event retry in lockstep. Set `reconnectJitter` to randomize each delay by that
+fraction and spread the retries out — `0.5` picks uniformly from 50-100% of the
+delay, `1.0` from 0-100%. It defaults to `0.0`, which keeps the delays exact.
 
 ### Encrypted Channels
 

--- a/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/Models.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/Models.kt
@@ -524,9 +524,14 @@ data class SockudoOptions(
     val appendRollupWindow: Int? = null,
     val maxReconnectAttempts: Int? = 6,
     val maxReconnectGapInSeconds: Double = 120.0,
+    /** Fraction of the reconnect delay to randomize, 0 (off) to 1 (full jitter). */
+    val reconnectJitter: Double = 0.0,
     val authToken: String? = null,
     val authTokenProvider: ClientAuthTokenProvider? = null,
 ) {
+    internal val effectiveReconnectJitter: Double
+        get() = if (reconnectJitter.isFinite() && reconnectJitter > 0) minOf(reconnectJitter, 1.0) else 0.0
+
     init {
         if (protocolVersion < 2 && (authToken != null || authTokenProvider != null)) {
             throw SockudoException.InvalidOptions(

--- a/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/SockudoClient.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/SockudoClient.kt
@@ -20,6 +20,7 @@ import okio.ByteString.Companion.toByteString
 import java.net.URI
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
+import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -957,7 +958,10 @@ class SockudoClient(
         if (action == CloseAction.TlsOnly) return Duration.ZERO
         val intervalSeconds = (reconnectAttempts * reconnectAttempts).toDouble()
         val cappedSeconds = minOf(intervalSeconds, options.maxReconnectGapInSeconds)
-        return cappedSeconds.seconds
+        // Spread retries so clients dropped by one event do not return in lockstep.
+        val jitter = options.effectiveReconnectJitter
+        if (jitter <= 0.0 || cappedSeconds <= 0.0) return cappedSeconds.seconds
+        return (cappedSeconds - Random.nextDouble(cappedSeconds * jitter)).seconds
     }
 
     private fun scheduleRetry(after: Duration) {

--- a/client-sdks/sockudo-kotlin/lib/src/test/kotlin/io/sockudo/client/ReconnectionTest.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/test/kotlin/io/sockudo/client/ReconnectionTest.kt
@@ -102,6 +102,21 @@ class ReconnectionTest {
     }
 
     @Test
+    fun `SockudoOptions reconnectJitter defaults to 0`() {
+        val options = SockudoOptions(cluster = "test")
+        assertEquals(0.0, options.reconnectJitter)
+        assertEquals(0.0, options.effectiveReconnectJitter)
+    }
+
+    @Test
+    fun `SockudoOptions reconnectJitter is clamped to 0 through 1`() {
+        assertEquals(1.0, SockudoOptions(cluster = "test", reconnectJitter = 5.0).effectiveReconnectJitter)
+        assertEquals(0.0, SockudoOptions(cluster = "test", reconnectJitter = -1.0).effectiveReconnectJitter)
+        assertEquals(0.0, SockudoOptions(cluster = "test", reconnectJitter = Double.NaN).effectiveReconnectJitter)
+        assertEquals(0.25, SockudoOptions(cluster = "test", reconnectJitter = 0.25).effectiveReconnectJitter)
+    }
+
+    @Test
     fun `SockudoOptions maxReconnectAttempts accepts null for unlimited`() {
         val options = SockudoOptions(cluster = "test", maxReconnectAttempts = null)
         assertNull(options.maxReconnectAttempts)

--- a/client-sdks/sockudo-python/README.md
+++ b/client-sdks/sockudo-python/README.md
@@ -382,6 +382,11 @@ unlimited) and `max_reconnect_gap_in_seconds` in `SockudoOptions`. The attempt
 counter resets after a successful connection and on explicit connect or
 disconnect calls.
 
+Because that delay is identical for every client, clients dropped by a single
+event retry in lockstep. Set `reconnect_jitter` to randomize each delay by that
+fraction and spread the retries out — `0.5` picks uniformly from 50-100% of the
+delay, `1.0` from 0-100%. It defaults to `0.0`, which keeps the delays exact.
+
 ### Protocol V2
 
 V2 is the default. To explicitly request it or to downgrade to V1 for strict Pusher SDK compatibility:

--- a/client-sdks/sockudo-python/src/sockudo_python/client.py
+++ b/client-sdks/sockudo-python/src/sockudo_python/client.py
@@ -5,6 +5,8 @@ import base64
 import binascii
 import inspect
 import json
+import math
+import random
 import struct
 import time
 import urllib.parse
@@ -498,6 +500,8 @@ class SockudoOptions:
     append_rollup_window: Optional[int] = None
     max_reconnect_attempts: Optional[int] = 6
     max_reconnect_gap_in_seconds: float = 120.0
+    """Fraction of the reconnect delay to randomize, 0 (off) to 1 (full jitter)."""
+    reconnect_jitter: float = 0.0
     token: Optional[str] = None
     auth_callback: Optional[TokenAuthCallback] = None
     auth_refresh_leeway_seconds: float = 30.0
@@ -1938,6 +1942,7 @@ class _ResolvedConfiguration:
         self.unavailable_timeout = options.unavailable_timeout
         self.max_reconnect_attempts = options.max_reconnect_attempts
         self.max_reconnect_gap_in_seconds = options.max_reconnect_gap_in_seconds
+        self.reconnect_jitter = _clamp_jitter(options.reconnect_jitter)
         self.enabled_transports = options.enabled_transports
         self.disabled_transports = options.disabled_transports
         self.channel_options = options.channel_authorization
@@ -2828,7 +2833,12 @@ class SockudoClient:
         if action in {_CloseAction.RETRY, _CloseAction.TLS_ONLY}:
             return 0.0
         interval_seconds = float(self._reconnect_attempts**2)
-        return min(interval_seconds, self.config.max_reconnect_gap_in_seconds)
+        delay = min(interval_seconds, self.config.max_reconnect_gap_in_seconds)
+        # Spread retries so clients dropped by one event do not return in lockstep.
+        jitter = self.config.reconnect_jitter
+        if not jitter or delay <= 0:
+            return delay
+        return delay - random.uniform(0.0, delay * jitter)
 
     async def _schedule_retry(self, after_seconds: float) -> None:
         if self._manually_disconnected:
@@ -3260,6 +3270,12 @@ class SockudoClient:
 
 
 _MAX_SAFE_FLOAT_INT = 2**53 - 1
+
+
+def _clamp_jitter(jitter: float) -> float:
+    if not math.isfinite(jitter) or jitter <= 0:
+        return 0.0
+    return min(jitter, 1.0)
 
 
 def _coerce_int(value: Any) -> Optional[int]:

--- a/client-sdks/sockudo-python/tests/test_client.py
+++ b/client-sdks/sockudo-python/tests/test_client.py
@@ -6,6 +6,7 @@ from typing import Optional
 import httpx
 import pytest
 
+import sockudo_python.client as client_module
 from sockudo_python.client import (
     AppendMode,
     ChannelHistoryOptions,
@@ -28,6 +29,7 @@ from sockudo_python.client import (
     TokenAuthData,
     VersionedMessageAck,
     VersionedMessageOptions,
+    _CloseAction,
 )
 
 
@@ -218,6 +220,7 @@ def test_reconnection_options_and_state_defaults() -> None:
     assert ConnectionState.RECONNECTING.value == "reconnecting"
     assert options.max_reconnect_attempts == 6
     assert options.max_reconnect_gap_in_seconds == 120.0
+    assert options.reconnect_jitter == 0.0
 
 
 @pytest.mark.asyncio
@@ -281,6 +284,62 @@ async def test_close_actions_use_quadratic_capped_delay() -> None:
     assert delays == [5.0, 0.0, 0.0]
     assert client.config.use_tls is True
     await client.config.close()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_jitter_randomizes_delay_downwards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SockudoClient(
+        "app-key",
+        SockudoOptions(
+            cluster="local",
+            force_tls=False,
+            max_reconnect_attempts=None,
+            reconnect_jitter=0.5,
+        ),
+    )
+    client._reconnect_attempts = 3
+
+    # Half of the 9s delay is randomized away, so it lands in [4.5, 9.0].
+    monkeypatch.setattr(client_module.random, "uniform", lambda low, high: high)
+    assert client._reconnect_delay(None) == pytest.approx(4.5)
+
+    monkeypatch.setattr(client_module.random, "uniform", lambda low, high: low)
+    assert client._reconnect_delay(None) == pytest.approx(9.0)
+
+    await client.config.close()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_jitter_stays_within_cap_and_skips_immediate_retries() -> None:
+    client = SockudoClient(
+        "app-key",
+        SockudoOptions(
+            cluster="local",
+            force_tls=False,
+            max_reconnect_attempts=None,
+            max_reconnect_gap_in_seconds=5.0,
+            reconnect_jitter=1.0,
+        ),
+    )
+    client._reconnect_attempts = 10
+
+    for _ in range(50):
+        delay = client._reconnect_delay(None)
+        assert 0.0 <= delay <= 5.0
+
+    assert client._reconnect_delay(_CloseAction.RETRY) == 0.0
+    assert client._reconnect_delay(_CloseAction.TLS_ONLY) == 0.0
+
+    await client.config.close()
+
+
+def test_reconnect_jitter_is_clamped() -> None:
+    assert client_module._clamp_jitter(5.0) == 1.0
+    assert client_module._clamp_jitter(-1.0) == 0.0
+    assert client_module._clamp_jitter(float("nan")) == 0.0
+    assert client_module._clamp_jitter(0.25) == 0.25
 
 
 @pytest.mark.asyncio

--- a/client-sdks/sockudo-swift/README.md
+++ b/client-sdks/sockudo-swift/README.md
@@ -448,6 +448,8 @@ On disconnect, the client reconnects automatically using quadratic backoff:
 - Maximum delay: 120 seconds (configurable via `Options.maxReconnectGapInSeconds`)
 - Maximum attempts: 6 (configurable via `Options.maxReconnectAttempts`, `nil` = unlimited)
 - Counter resets on a successful connection and on explicit `connect()` or `disconnect()` calls
+- Jitter: none by default; set `Options.reconnectJitter` (0 to 1) to randomize each
+  delay by that fraction so clients dropped by one event do not retry in lockstep
 
 ```swift
 let client = try SockudoClient(
@@ -455,7 +457,8 @@ let client = try SockudoClient(
     options: .init(
         cluster: "local",
         maxReconnectAttempts: 10,
-        maxReconnectGapInSeconds: 60
+        maxReconnectGapInSeconds: 60,
+        reconnectJitter: 0.5
     )
 )
 ```

--- a/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoClient.swift
+++ b/client-sdks/sockudo-swift/Sources/SockudoSwift/SockudoClient.swift
@@ -37,6 +37,8 @@ import Network
     public var appendRollupWindow: Int?
     public var maxReconnectAttempts: Int? = 6
     public var maxReconnectGapInSeconds: Double = 120
+    /// Fraction of the reconnect delay to randomize, 0 (off) to 1 (full jitter).
+    public var reconnectJitter: Double = 0
 
     public init(
       cluster: String,
@@ -72,7 +74,8 @@ import Network
       appendMode: SockudoAppendMode = .delta,
       appendRollupWindow: Int? = nil,
       maxReconnectAttempts: Int? = 6,
-      maxReconnectGapInSeconds: Double = 120
+      maxReconnectGapInSeconds: Double = 120,
+      reconnectJitter: Double = 0
     ) {
       self.cluster = cluster
       self.protocolVersion = protocolVersion
@@ -108,6 +111,7 @@ import Network
       self.appendRollupWindow = appendRollupWindow
       self.maxReconnectAttempts = maxReconnectAttempts
       self.maxReconnectGapInSeconds = maxReconnectGapInSeconds
+      self.reconnectJitter = reconnectJitter
     }
   }
 
@@ -805,7 +809,11 @@ import Network
     if action == .retry { return 0 }  // close codes 4200-4299: reconnect immediately
     if action == .tlsOnly { return 0 }  // TLS upgrade: reconnect immediately
     let interval = Double(reconnectAttempts * reconnectAttempts)
-    return min(interval, config.maxReconnectGapInSeconds)
+    let delay = min(interval, config.maxReconnectGapInSeconds)
+    // Spread retries so clients dropped by one event do not return in lockstep.
+    let jitter = config.reconnectJitter
+    if jitter <= 0 || delay <= 0 { return delay }
+    return delay - Double.random(in: 0...(delay * jitter))
   }
 
   private func closeAction(for code: URLSessionWebSocketTask.CloseCode) -> CloseAction? {
@@ -1130,6 +1138,11 @@ import Network
   }
 }
 
+func clampJitter(_ jitter: Double) -> Double {
+  guard jitter.isFinite, jitter > 0 else { return 0 }
+  return min(jitter, 1)
+}
+
 extension SockudoClient {
   fileprivate static func decodeCapabilityTokenAuthData(_ raw: Any?) -> CapabilityTokenAuthData {
     let payload = raw as? [String: Any] ?? [:]
@@ -1242,6 +1255,7 @@ extension SockudoClient {
     let connectionRecovery: Bool
     let maxReconnectAttempts: Int?
     let maxReconnectGapInSeconds: Double
+    let reconnectJitter: Double
 
     init(options: Options) {
       cluster = options.cluster
@@ -1275,6 +1289,7 @@ extension SockudoClient {
       connectionRecovery = options.connectionRecovery
       maxReconnectAttempts = options.maxReconnectAttempts
       maxReconnectGapInSeconds = options.maxReconnectGapInSeconds
+      reconnectJitter = clampJitter(options.reconnectJitter)
       channelAuthorizer =
         options.channelAuthorization.customHandler
         ?? Self.makeChannelAuthorizer(options.channelAuthorization)

--- a/client-sdks/sockudo-swift/Tests/SockudoSwiftTests/SockudoSwiftTests.swift
+++ b/client-sdks/sockudo-swift/Tests/SockudoSwiftTests/SockudoSwiftTests.swift
@@ -1739,6 +1739,62 @@ struct ReconnectBackoffTests {
     #expect(client.reconnectDelay(for: .backoff) == 10)
   }
 
+  @Test func delaysAreExactWhenJitterIsNotConfigured() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local", maxReconnectAttempts: nil)
+    )
+    client.reconnectAttempts = 3
+    #expect(client.reconnectDelay(for: .backoff) == 9)
+  }
+
+  @Test func jitterKeepsDelayWithinTheConfiguredFraction() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local", maxReconnectAttempts: nil, reconnectJitter: 0.5)
+    )
+    client.reconnectAttempts = 3
+
+    // Half of the 9s delay is randomized away, so it lands in [4.5, 9].
+    var sawVariation = false
+    var first: Double?
+    for _ in 0..<200 {
+      let delay = client.reconnectDelay(for: .backoff)
+      #expect(delay >= 4.5)
+      #expect(delay <= 9)
+      if let first { sawVariation = sawVariation || delay != first } else { first = delay }
+    }
+    #expect(sawVariation)
+  }
+
+  @Test func fullJitterNeverExceedsCapOrGoesNegative() throws {
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local", maxReconnectGapInSeconds: 5, reconnectJitter: 1)
+    )
+    client.reconnectAttempts = 20
+    for _ in 0..<200 {
+      let delay = client.reconnectDelay(for: .backoff)
+      #expect(delay >= 0)
+      #expect(delay <= 5)
+    }
+  }
+
+  @Test func jitterIsClampedAndImmediateRetriesStayZero() throws {
+    #expect(clampJitter(5) == 1)
+    #expect(clampJitter(-1) == 0)
+    #expect(clampJitter(.nan) == 0)
+    #expect(clampJitter(0.25) == 0.25)
+
+    let client = try SockudoClient(
+      "app-key",
+      options: .init(cluster: "local", reconnectJitter: 1)
+    )
+    client.reconnectAttempts = 10
+    #expect(client.reconnectDelay(for: .retry) == 0)
+    #expect(client.reconnectDelay(for: .tlsOnly) == 0)
+  }
+
   @Test func maxAttemptsReachedTransitionsToDisconnected() throws {
     let client = try SockudoClient(
       "app-key",


### PR DESCRIPTION
`ConnectionManager.reconnectDelay` is deterministic — every client computes the
same delay from the same attempt count:

```ts
const intervalSeconds = this.reconnectAttempts * this.reconnectAttempts;
return Math.min(intervalSeconds, this.options.maxReconnectGapInSeconds) * 1000;
```

So clients dropped by a single event (broker restart, rolling deploy, LB blip)
all come back at the same instant, and once the curve saturates at
`maxReconnectGapInSeconds` they settle into a synchronized pulse at exactly that
interval.

Adds a `reconnectJitter` option — the fraction of each delay to randomize away,
`0` (off) to `1` (full jitter):

```ts
const client = new Sockudo("app-key", {
  maxReconnectGapInSeconds: 60,
  reconnectJitter: 0.5, // each delay lands uniformly in [50%, 100%]
});
```