### PR TITLE
fix(kotlin-sdk): offload callbacks off the WebSocket reader thread

### DIFF
--- a/client-sdks/sockudo-kotlin/CHANGELOG.md
+++ b/client-sdks/sockudo-kotlin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added Pusher-style connection/error listeners (`SockudoConnectionEventListener`, `SockudoError`) while preserving the raw Pusher-compatible `state_change` event.
 - Added typed channel event and auth listeners (`SockudoChannelEventListener.onEvent`, `onSubscriptionSucceeded`, `onAuthenticationFailure`, `onError`) while preserving the raw `bind`/`on` event API.
+- Offloaded decoding and subscriber callbacks onto a dedicated `sockudo-event` thread, with a bounded queue so the WebSocket reader never blocks; queue overflow surfaces a `client_overloaded` error.
 
 ## 2.2.0 - 2026-08-17
 

--- a/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/SockudoClient.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/main/kotlin/io/sockudo/client/SockudoClient.kt
@@ -1,10 +1,13 @@
 package io.sockudo.client
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -19,10 +22,13 @@ import okhttp3.MediaType.Companion.toMediaType
 import okio.ByteString.Companion.toByteString
 import java.net.URI
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+
+private const val INBOX_CAPACITY = 256
 
 class SockudoClient(
     val key: String,
@@ -36,7 +42,16 @@ class SockudoClient(
         }
     }
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val eventDispatcher: CoroutineDispatcher =
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "sockudo-event").apply { isDaemon = true }
+        }.asCoroutineDispatcher()
+
+    private val scope = CoroutineScope(SupervisorJob() + eventDispatcher)
+
+    // Decode and subscriber callbacks run on the event dispatcher, never on OkHttp's reader thread.
+    private val inbox = Channel<Any>(capacity = INBOX_CAPACITY)
+
     internal val p = ProtocolPrefix(options.protocolVersion)
     internal val config = ResolvedConfiguration(options, httpClient)
     private val dispatcher = EventDispatcher()
@@ -78,6 +93,19 @@ class SockudoClient(
     init {
         user.attach(this)
         watchlist.attach(this)
+        startEventLoop()
+    }
+
+    private fun startEventLoop() {
+        scope.launch {
+            for (raw in inbox) {
+                try {
+                    handleRawMessage(raw)
+                } catch (error: Throwable) {
+                    reportError(error)
+                }
+            }
+        }
     }
 
     fun on(eventName: String, callback: (Any?, EventMetadata?) -> Unit): EventBindingToken =
@@ -223,6 +251,7 @@ class SockudoClient(
 
     fun close() {
         disconnect()
+        inbox.close()
         scope.cancel()
     }
 
@@ -601,11 +630,15 @@ class SockudoClient(
                     override fun onOpen(webSocket: WebSocket, response: Response) = Unit
 
                     override fun onMessage(webSocket: WebSocket, text: String) {
-                        handleRawMessage(text)
+                        if (inbox.trySend(text).isFailure) {
+                            onInboxOverflow()
+                        }
                     }
 
                     override fun onMessage(webSocket: WebSocket, bytes: okio.ByteString) {
-                        handleRawMessage(bytes)
+                        if (inbox.trySend(bytes).isFailure) {
+                            onInboxOverflow()
+                        }
                     }
 
                     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
@@ -618,6 +651,15 @@ class SockudoClient(
                     }
                 },
             )
+    }
+
+    private fun onInboxOverflow() {
+        reportError(
+            SockudoError(
+                message = "Inbound event queue overflow; frames were dropped",
+                code = "client_overloaded",
+            ),
+        )
     }
 
     private fun handleRawMessage(rawMessage: Any) {

--- a/client-sdks/sockudo-kotlin/lib/src/test/kotlin/io/sockudo/client/EventLoopTest.kt
+++ b/client-sdks/sockudo-kotlin/lib/src/test/kotlin/io/sockudo/client/EventLoopTest.kt
@@ -1,0 +1,86 @@
+package io.sockudo.client
+
+import java.lang.reflect.InvocationTargetException
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+
+class EventLoopTest {
+
+    @Test
+    fun `subscriber callbacks run on the dedicated event thread`() = runBlocking {
+        val client = testClient()
+        val callbackThread = AtomicReference<String?>()
+        client.bind("chat-message") { _, _ -> callbackThread.set(Thread.currentThread().name) }
+
+        inbox(client).trySend("""{"event":"chat-message","data":{"id":42}}""")
+
+        waitFor { callbackThread.get() != null }
+        val name = callbackThread.get()!!
+        assertTrue(name.startsWith("sockudo-event"), "Expected event thread, got: $name")
+        client.close()
+    }
+
+    @Test
+    fun `inbox overflow reports an overload error to connection listeners`() = runBlocking {
+        val client = testClient()
+        val errors = CopyOnWriteArrayList<SockudoError>()
+        client.bindConnectionListener(
+            object : SockudoConnectionEventListener {
+                override fun onError(error: SockudoError) {
+                    errors += error
+                }
+            },
+        )
+
+        onInboxOverflow(client)
+
+        assertEquals(listOf("client_overloaded"), errors.map { it.code })
+        client.close()
+    }
+
+    private fun testClient(): SockudoClient =
+        SockudoClient(
+            "app-key",
+            SockudoOptions(
+                cluster = "local",
+                forceTls = false,
+                enabledTransports = listOf(SockudoTransport.ws),
+                wsHost = "127.0.0.1",
+                wsPort = 6001,
+            ),
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun inbox(client: SockudoClient): Channel<Any> {
+        val field = SockudoClient::class.java.getDeclaredField("inbox")
+        field.isAccessible = true
+        return field.get(client) as Channel<Any>
+    }
+
+    private fun onInboxOverflow(client: SockudoClient) {
+        val method = SockudoClient::class.java.getDeclaredMethod("onInboxOverflow")
+        method.isAccessible = true
+        try {
+            method.invoke(client)
+        } catch (error: InvocationTargetException) {
+            throw error.targetException
+        }
+    }
+
+    private suspend fun waitFor(timeoutMs: Long = 2_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) {
+                return
+            }
+            delay(20)
+        }
+        error("Timed out waiting for condition")
+    }
+}


### PR DESCRIPTION
Move decode and subscriber callbacks onto a dedicated sockudo-event thread so slow callbacks can't stall or block the socket reader. The queue is bounded: trySend never blocks, and overflow surfaces a client_overloaded error instead of dropping frames silently.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Protocol Change Checklist
<!-- Required when this PR touches wire payloads, event names, protocol constants, HTTP API shapes, SDK fixtures, or compatibility docs. Mark N/A only when no protocol-visible surface changed. -->
- [ ] N/A - no protocol-visible changes
- [ ] Change is additive under AI Transport wire-protocol v1
- [ ] `docs/specs/ai-transport-wire-protocol.md` updated or confirmed unchanged
- [ ] Golden transcripts / forward-compat fixtures updated or confirmed unchanged
- [ ] Default Protocol V1/Pusher output remains byte-identical

## Build Artifacts
<!-- A bot comment will appear with build instructions once this PR is created -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
