### PR TITLE
 fix(kotlin-sdk): downgrade Java/Kotlin target from 21 to 17 for broader JVM compatibility

### DIFF
--- a/client-sdks/sockudo-kotlin/CHANGELOG.md
+++ b/client-sdks/sockudo-kotlin/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added Pusher-style connection/error listeners (`SockudoConnectionEventListener`, `SockudoError`) while preserving the raw Pusher-compatible `state_change` event.
 - Added typed channel event and auth listeners (`SockudoChannelEventListener.onEvent`, `onSubscriptionSucceeded`, `onAuthenticationFailure`, `onError`) while preserving the raw `bind`/`on` event API.
 - Offloaded decoding and subscriber callbacks onto a dedicated `sockudo-event` thread, with a bounded queue so the WebSocket reader never blocks; queue overflow surfaces a `client_overloaded` error.
+- Lowered the JVM target from 21 to 17 for broader compatibility (no Java 21-specific features used).
 
 ## 2.2.0 - 2026-08-17
 

--- a/client-sdks/sockudo-kotlin/README.md
+++ b/client-sdks/sockudo-kotlin/README.md
@@ -19,6 +19,11 @@ Official Kotlin client for Sockudo.
 - Live integration tests against Sockudo on `127.0.0.1:6001`
 - Gradle CI and Maven Central publication workflow
 
+## Requirements
+
+- Java 17 or higher
+- Kotlin 1.9+
+
 ## Installation
 
 Install the published package from Maven Central:

--- a/client-sdks/sockudo-kotlin/lib/build.gradle.kts
+++ b/client-sdks/sockudo-kotlin/lib/build.gradle.kts
@@ -33,8 +33,8 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 
     withJavadocJar()
     withSourcesJar()
@@ -42,7 +42,7 @@ java {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
         freeCompilerArgs.add("-Xjsr305=strict")
     }
 }


### PR DESCRIPTION
 - Changed Java source/target compatibility from VERSION_21 to VERSION_17
 - Changed Kotlin JVM target from JVM_21 to JVM_17
 - No Java 21-specific features were used in the codebase, so this is a safe downgrade
 - Added a Requirements section to README.md specifying Java 17+ and Kotlin 1.9+
